### PR TITLE
nghttp2: allow build on older systems

### DIFF
--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           clang_dependency 1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
@@ -35,7 +36,19 @@ patchfiles-append   patch-src-shrpx_client_handler.cc.diff \
 # https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
 configure.checks.implicit_function_declaration.whitelist-append strchr
 
-compiler.c_standard 1999
+# nghttp2 is a dependency of Clang, so we must avoid circular dependencies.
+# If building the library only, C++ is not used.
+# The library seems to use one C11 feature, redefinition of typedef.
+# See https://trac.macports.org/ticket/66743 for a similar issue.
+# No version of Apple provided GCC seems to work.
+# All versions of Apple provided Clang seem to work.
+# However, the Apple version of Clang on 10.6 requires `-Wtypedef-redefinition`.
+compiler.cxx_standard
+compiler.c_standard         1999
+compiler.blacklist-append   *gcc-4.0 *gcc-4.2
+if { ${subport} eq ${name} && ${configure.compiler} eq "clang" && ${os.platform} eq "darwin" && ${os.major} <= 10 } {
+    configure.cflags-append -Wtypedef-redefinition
+}
 
 configure.args      --disable-silent-rules \
                     --disable-threads \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
