### PR TITLE
py-cgmetadata: new submission

### DIFF
--- a/python/py-cgmetadata/Portfile
+++ b/python/py-cgmetadata/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cgmetadata
+version             0.1.6
+revision            0
+
+supported_archs     noarch
+platforms           {darwin any}
+license             MIT
+
+maintainers         nomaintainer
+
+description         Read and write image metadata on macOS from Python using \
+                    the native ImageIO / Core Graphics frameworks.
+long_description    {*}${description} \
+                    \n\
+                    CGMetadata is a Python wrapper around the macOS ImageIO \
+                    and Core Graphics frameworks. It provides a simple \
+                    interface for reading and writing image metadata, \
+                    including EXIF, IPTC, and XMP data. Reading is supported \
+                    for all image formats supported by ImageIO. Reading is \
+                    also supported for video formats using AVFoundation. \
+                    \n\
+                    Writing is not currently supported for RAW file formats \
+                    nor for video formats. Writing of metadata has been \
+                    tested on JPEG, PNG, TIFF, and HEIC files however it \
+                    should be considered experimental. If you are using \
+                    CGMetadata to write metadata to image files, please make \
+                    sure you have tested the results before using it in \
+                    production.
+
+homepage            https://pypi.org/project/cgmetadata/
+
+checksums           rmd160  d68d8cf24e4d83f4236422346282089e86ce14db \
+                    sha256  e9c16e3e905947ba0b54978bf04cb3f8c5fa9dadf56467f1e559a25b8e00c359 \
+                    size    20669
+
+python.versions     312
+
+depends_build-append    port:py312-flit


### PR DESCRIPTION
#### Description

New port for CGMetadata.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?