### PR TITLE
py-makelive: new submission

### DIFF
--- a/python/py-makelive/Portfile
+++ b/python/py-makelive/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-makelive
+version             0.5.0
+revision            0
+
+supported_archs     noarch
+platforms           {darwin any}
+license             MIT
+
+maintainers         nomaintainer
+
+description         Convert an photo + video pair into a Live Photo.
+long_description    {*}${description} \
+                    \n\
+                    This is a simple command line tool that will apply the \
+                    necessary metadata to a photo + video pair so that when \
+                    they are imported into the Apple Photos, they will be \
+                    treated as a Live Photo. \
+                    \n\
+                    This is useful for converting images taken an Android \
+                    phone into Live Photos that can be imported into Apple \
+                    Photos.
+
+homepage            https://pypi.org/project/makelive/
+
+checksums           rmd160  efe2a8db5b43e6ba40f4988e465f4f0911755acd \
+                    sha256  cce2f40a27ae447402868c97096e4107bd92de1a1f49786690db1b11a117c985 \
+                    size    14016
+
+python.versions     312


### PR DESCRIPTION
#### Description

New port for MakeLive.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?