### PR TITLE
osxphotos: update to 0.68.0

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.67.10
+version                 0.68.0
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  9cdf7c9c75053e4ae46252d89670c2b7badf8ebc \
-                        sha256  96ae4830cd09b1cc40491c06269ddf8c7d96cf492cd4468cd0c88bdad91601bb \
-                        size    2104706
+checksums               rmd160  4562f0fe7706ccee7d97aa15be48f98b21abe546 \
+                        sha256  4d921aa2a0860183081d4db00d3733562da3cdf2765fbdff414dc4cb798a7edf \
+                        size    2122421
 
 python.default_version  312
 
@@ -36,8 +36,10 @@ depends_build-append    port:py${python.version}-setuptools
 
 depends_lib-append      port:py${python.version}-bitmath \
                         port:py${python.version}-bpylist2 \
+                        port:py${python.version}-cgmetadata \
                         port:py${python.version}-click \
                         port:py${python.version}-mac-alias \
+                        port:py${python.version}-makelive \
                         port:py${python.version}-mako \
                         port:py${python.version}-more-itertools \
                         port:py${python.version}-objexplore \


### PR DESCRIPTION
#### Description

Update to osxphotos 0.68.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?