### PR TITLE
jsoncons: update to 0.176.0

### DIFF
--- a/devel/jsoncons/Portfile
+++ b/devel/jsoncons/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            danielaparker jsoncons 0.175.0 v
+github.setup            danielaparker jsoncons 0.176.0 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -15,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             A C++, header-only library for constructing JSON and JSON-like data formats
 long_description        {*}${description}
 
-checksums               rmd160  48008e1423843655cb4147cd1ba1c1c8a7d743f4 \
-                        sha256  7f8a04cfd25a73d2ba2283be8eb98a39780df1e90600d8c75ddf19d52bd2c2c9 \
-                        size    1478943
+checksums               rmd160  bacc92fdbb6d06fc0fb3dea89bd1948f72445e0b \
+                        sha256  2eb50b5cbe204265fef96c052511ed6e3b8808935c6e2c8d28e0aba7b08fda33 \
+                        size    1478086
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description
https://github.com/danielaparker/jsoncons/releases/tag/v0.176.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
