### PR TITLE
micronaut: update to 4.5.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.4.3 v
+github.setup    micronaut-projects micronaut-starter 4.5.0 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  2ebdc4013eb48441d55a84b44419d7b5add77a40 \
-                 sha256  4c30a6ad50f4a2831ae0045de5d721528c0d7914d439a751e3da8a166f6ae290 \
-                 size    25720676
+    checksums    rmd160  921d342b2d78c59142da126c0b8fbd5c37c4c4c9 \
+                 sha256  98f98321b9e23c0e31a7a14a0a0fb496f1e1e02ef7444cf49c78802bfe6e3744 \
+                 size    25832484
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  8f55073daf3be604903685471688eb31825b59ab \
-                 sha256  2f77301e3a1f318bc303f5d53cb170a22b5d01401d88f75e63b1360e88ba84a2 \
-                 size    25446172
+    checksums    rmd160  57fb74126a54ac219ae0949983247d23e4ff903a \
+                 sha256  09b087c8271b14b3c7de6c38bfc436834d712026e301a0afdaf871aa6e3f3a04 \
+                 size    25557941
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.5.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?