### PR TITLE
py-makelive: fix build

### DIFF
--- a/python/py-makelive/Portfile
+++ b/python/py-makelive/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-makelive
 version             0.5.0
-revision            0
+revision            1
 
 supported_archs     noarch
 platforms           {darwin any}
@@ -32,3 +32,7 @@ checksums           rmd160  efe2a8db5b43e6ba40f4988e465f4f0911755acd \
                     size    14016
 
 python.versions     312
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-flit
+}


### PR DESCRIPTION
#### Description

Add previously missing build dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?