### PR TITLE
google-cloud-sdk: update to 480.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             478.0.0
+version             480.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  90e497fa1b465e4b5a673ebef73e3c96769f1a6a \
-                    sha256  da30744f5c78fe91bded55db1bdf0232df8675bb7e12c491769eb14240740fc8 \
-                    size    124954609
+    checksums       rmd160  f33b9e203674c4293a3c84bc5ab75ab40614036f \
+                    sha256  7b16d2495d5e2d77eabddb1ef275f83f3644f92cc71573d7be5fdf0278709c06 \
+                    size    124993108
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  d2eade60d6e6684fc99f387614bc06c93bfebffd \
-                    sha256  3655177c0e208af8e0e3fd65b8e9dcf36d51a286005b00604fa32f83372c45f7 \
-                    size    126238060
+    checksums       rmd160  04b2f4bba7aaaf804b5b62b7d13b775c49feddaf \
+                    sha256  35ce3f89020fb1f97d173e4a9d05289026525d65b02b6e62c9d21313cc94ff54 \
+                    size    126278618
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  a932a08e97c69d5049681851dac0518ff27df94c \
-                    sha256  adab27657b4a8cca26bd56a3a0c7e8e1f73a75bfa4dc2037f97b1db3b12ce237 \
-                    size    122564471
+    checksums       rmd160  b997d2eb04e3923f4b14cab43e58f241a0e6d873 \
+                    sha256  90905a9b760ab7a8933516dd7700ab3ecae38fabd3a1794f70575a288ef165e6 \
+                    size    122603494
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 480.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?