### PR TITLE
CSXCAD: update to 20231216 and fix the build

### DIFF
--- a/textproc/CSXCAD/Portfile
+++ b/textproc/CSXCAD/Portfile
@@ -5,12 +5,12 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
-github.setup        thliebig CSXCAD c29742ba2cdec54de149c3deea268be1437aba8d
-version             20230102-[string range ${github.version} 0 7]
-checksums           rmd160  febc0095c9f8f4685c7e23b8626326fbd026da93 \
-                    sha256  58b95b7d1667c1567d184adcb1c118ce8d123f2cdabc63d9574a358e5eba196c \
-                    size    169859
-revision            3
+github.setup        thliebig CSXCAD c6a15872ff7d258e05f80dd81aa70b5828d85c1c
+version             20231216-[string range ${github.version} 0 7]
+checksums           rmd160  2ee23413b125b8f69b5eb95bf5b517c48ed8070f \
+                    sha256  fdfa181709d3fa10e4156a715342aaa95b1df60694ccb5cf18d380d312c326c6 \
+                    size    170544
+revision            0
 
 platforms           darwin macosx
 categories          textproc
@@ -22,6 +22,18 @@ description         ${name} is a C++ library to describe geometrical objects and
 long_description    {*}${description}
 
 compiler.cxx_standard 2011
+
+# Build fails to pass required C++ ABI flag, which breaks the linking:
+# Undefined symbols:
+# "__ZN18FunctionParserBaseIdE11AddFunctionERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFdPKdEj"
+# "__ZN13TiXmlDocumentC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE"
+# This happens because it clears cxxflags. Fix that:
+patchfiles-append \
+    patch-CMakeLists.diff
+
+# Also, it should either use mpi PG or disable MPICH.
+patchfiles-append \
+    patch-no-mpich.diff
 
 # remove when upstream
 patchfiles-append \
@@ -36,3 +48,6 @@ depends_lib-append \
     port:cgal4 \
     port:hdf5 \
     port:fparser
+
+configure.args-append \
+    -DFPARSER_ROOT_DIR=${prefix}

--- a/textproc/CSXCAD/Portfile
+++ b/textproc/CSXCAD/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           cmake 1.1
 PortGroup           boost 1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
 
 github.setup        thliebig CSXCAD c6a15872ff7d258e05f80dd81aa70b5828d85c1c
 version             20231216-[string range ${github.version} 0 7]
@@ -21,7 +21,7 @@ description         ${name} is a C++ library to describe geometrical objects and
                     physical or non-physical properties
 long_description    {*}${description}
 
-compiler.cxx_standard 2011
+compiler.cxx_standard   2011
 
 # Build fails to pass required C++ ABI flag, which breaks the linking:
 # Undefined symbols:
@@ -40,14 +40,14 @@ patchfiles-append \
     clocale_fix.patch
 
 depends_build-append \
-    port:pkgconfig
+    path:bin/pkg-config:pkgconfig
 
 depends_lib-append \
-    port:tinyxml \
-    port:vtk \
     port:cgal4 \
+    port:fparser \
     port:hdf5 \
-    port:fparser
+    port:tinyxml \
+    port:vtk
 
 configure.args-append \
     -DFPARSER_ROOT_DIR=${prefix}

--- a/textproc/CSXCAD/files/patch-CMakeLists.diff
+++ b/textproc/CSXCAD/files/patch-CMakeLists.diff
@@ -1,0 +1,11 @@
+--- CMakeLists.txt	2023-01-03 00:50:04.000000000 +0800
++++ CMakeLists.txt	2024-06-13 06:25:02.000000000 +0800
+@@ -11,7 +11,7 @@
+ cmake_minimum_required(VERSION 3.0)
+ 
+ if (NOT WIN32)
+- set (CMAKE_CXX_FLAGS -fPIC )
++ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+ endif()
+ 
+ # default

--- a/textproc/CSXCAD/files/patch-no-mpich.diff
+++ b/textproc/CSXCAD/files/patch-no-mpich.diff
@@ -1,0 +1,15 @@
+--- CMakeLists.txt	2023-01-03 00:50:04.000000000 +0800
++++ CMakeLists.txt	2024-06-13 06:25:02.000000000 +0800
+@@ -132,9 +132,9 @@
+ 
+ 
+ # vtk 9.1 needs MPI find to fail?????
+-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+-  find_package(MPI)
+-endif()
++#if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
++#  find_package(MPI)
++#endif()
+ 
+ find_package(VTK REQUIRED COMPONENTS vtkIOGeometry vtkIOPLY NO_MODULE)
+ 


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
