### PR TITLE
dwdiff: fix build on < 10.7

### DIFF
--- a/textproc/dwdiff/Portfile
+++ b/textproc/dwdiff/Portfile
@@ -1,13 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
 PortGroup           legacysupport 1.1
+
+# _getline
+legacysupport.newest_darwin_requires_legacy 10
 
 name                dwdiff
 version             2.1.4
 revision            4
 categories          textproc
-platforms           darwin
 maintainers         {@catap korins.ky:kirill} openmaintainer
 license             GPL-3
 description         diff program that operates at the word level
@@ -18,8 +20,8 @@ long_description    \
     takes an optional list of characters that should be considered delimiters. \
     Delimiters are single characters that are treated as if they are words, \
     even when there is no whitespace separating them from preceding words or \
-    delimiters. dwdiff is mostly commandline compatible with wdiff. Only the \
-    --autopager, --terminal and --avoid-wraps options are not supported.
+    delimiters. dwdiff is mostly commandline compatible with wdiff. Only \
+    the --autopager, --terminal and --avoid-wraps options are not supported.
 
 homepage            https://os.ghalkes.nl/dwdiff.html
 master_sites        https://os.ghalkes.nl/dist/
@@ -31,7 +33,7 @@ checksums           rmd160  a856e73129ca652197daf61bf92c1491ca4d8328 \
 use_bzip2           yes
 
 depends_build-append \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append  port:gettext \
                     path:lib/pkgconfig/icu-uc.pc:icu

--- a/textproc/dwdiff/Portfile
+++ b/textproc/dwdiff/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup           legacysupport 1.1
 
 name                dwdiff
 version             2.1.4
@@ -34,6 +35,11 @@ depends_build-append \
 
 depends_lib-append  port:gettext \
                     path:lib/pkgconfig/icu-uc.pc:icu
+
+# src/definitions.h: error: expected identifier before numeric constant
+# src/definitions.h: error: two or more data types in declaration specifiers
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
 configure.ldflags-append \
                     -lintl


### PR DESCRIPTION
#### Description

Fix the build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
