### PR TITLE
py-matplotlib: fix condition to disable native backend on old systems

### DIFF
--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -178,7 +178,11 @@ if {${name} ne ${subport}} {
 
     # additionally on Leopard the macosx backend cannot be compiled anymore, see Trac ticket:
     # https://trac.macports.org/ticket/61757
-    if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    # this is a compiler issue, not OS version issue; this backend should be disabled for gcc.
+    # cc1obj: error: '-Werror=unguarded-availability': no option '-Wunguarded-availability'
+    # src/_macosx.m: error: incompatible type for argument 1 of 'updateDevicePixelRatio'
+    # src/_macosx.m: error: incompatible types when initializing type 'CGFloat' {aka 'float'} using type 'id'
+    if {[string match *gcc* ${configure.compiler}]} {
         post-patch {
             reinplace "s|^macosx=True|macosx=False|" ${worksrcpath}/${configfile}
         }


### PR DESCRIPTION
#### Description

Fix the condition. The issue is not SDK but compiler: amazing Apple ObjC does not compile with GCC.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
