### PR TITLE
editorconfig-core-c: Update to 0.12.8

### DIFF
--- a/devel/editorconfig-core-c/Portfile
+++ b/devel/editorconfig-core-c/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cmake  1.1
 PortGroup               github 1.0
 
-github.setup            editorconfig editorconfig-core-c 0.12.7 v
+github.setup            editorconfig editorconfig-core-c 0.12.8 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -16,10 +16,16 @@ long_description        This code produces a program that accepts a filename as 
                         look for .editorconfig files with sections applicable to the given file, \
                         outputting any properties found.
 
-checksums               rmd160  6a089514e08e395033d5b152c73ef52216f617ac \
-                        sha256  f89d2e144fd67bdf0d7acfb2ac7618c6f087e1b3f2c3a707656b4180df422195 \
-                        size    77426
+checksums               rmd160  cdb83739f831dcbdda909e0e677cc17f96463b64 \
+                        sha256  508f7633416a2ce3c05104ea7daac61c4953803c9935cca6e059086cfa67ee63 \
+                        size    77676
 
 depends_build-append    path:bin/doxygen:doxygen
-
 depends_lib-append      port:pcre2
+
+use_parallel_build      no
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 ${worksrcpath}/LICENSE ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
#### Description

Update `editorconfig-core-c` to its latest released version, 0.12.8

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
