### PR TITLE
eza: update to 0.18.18

### DIFF
--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        eza-community eza 0.18.17 v
+github.setup        eza-community eza 0.18.18 v
 github.tarball_from archive
 revision            0
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  bf8f755907bf02c648ea0ead75ffe7462bb6108c \
-                    sha256  fb9eea00bff8ad0283c046398259f03b1ce2830a49cdd7417b65c9dade07d709 \
-                    size    1384962
+                    rmd160  d988411aaae9e8686575777f4b132be6407a288f \
+                    sha256  437ea76838fea2464b9592f1adef7df0412e27c9fc2a3e7ff47efcdfb17457f5 \
+                    size    1385066
 
 depends_lib-append  port:libiconv \
                     path:lib/pkgconfig/libgit2.pc:libgit2 \
@@ -242,7 +242,7 @@ cargo.crates \
     unicode-bidi                     0.3.5  eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0 \
     unicode-ident                   1.0.11  301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c \
     unicode-normalization           0.1.17  07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef \
-    unicode-width                   0.1.12  68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6 \
+    unicode-width                   0.1.13  0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d \
     url                              2.2.1  9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     uutils_term_grid                 0.6.0  f89defb4adb4ba5703a57abc879f96ddd6263a444cacc446db90bf2617f141fb \


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
