### PR TITLE
ruff: Update to 0.4.9

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.4.8 v
+github.setup        astral-sh ruff 0.4.9 v
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  7c8d2735ec6a97b0fd628e39e35613bf2f407f63 \
-                    sha256  983d61b9602b800e9118e9e52eeca4f8f2c3697e7d281e230619b39fa21e4c9b \
-                    size    4838096
+                    rmd160  ac8ebd14c78d5490f41e0a82bae3f5a91734cfc3 \
+                    sha256  815c5b9b316a4d72dc526c6b4b2421df708556294af514e6fe25ff99722d36e3 \
+                    size    4869311
 
 cargo.offline_cmd
 
@@ -59,6 +59,7 @@ cargo.crates \
     anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
     anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
     anyhow                          1.0.86  b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da \
+    arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     argfile                          0.2.0  b7c5c8e418080ef8aa932039d12eda7b6f5043baf48f1523c166fbc32d004534 \
     arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
     autocfg                          1.2.0  f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80 \
@@ -68,7 +69,9 @@ cargo.crates \
     bitflags                         2.5.0  cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1 \
     bstr                             1.9.1  05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706 \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
+    camino                           1.1.7  e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     cc                              1.0.95  d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
@@ -78,13 +81,13 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                             4.5.4  90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0 \
-    clap_builder                     4.5.2  ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4 \
+    clap                             4.5.6  a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7 \
+    clap_builder                     4.5.6  2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df \
     clap_complete                    4.5.2  dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e \
     clap_complete_command            0.5.1  183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d \
     clap_complete_fig                4.5.0  54b3e65f91fabdd23cac3d57d39d5d938b4daabd070c335c006dccb866a61110 \
     clap_complete_nushell           0.1.11  5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e \
-    clap_derive                      4.5.4  528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64 \
+    clap_derive                      4.5.5  c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6 \
     clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
     clearscreen                      3.0.0  2f8c93eb5f77c9050c7750e14f13ef1033a40a0aac70c6371535b6763a01438c \
     codspeed                         2.6.0  3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089 \
@@ -124,6 +127,7 @@ cargo.crates \
     env_logger                      0.11.3  38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9 \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
+    eyre                            0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
     fastrand                         2.0.2  658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984 \
     fern                             0.6.2  d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee \
     filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
@@ -139,6 +143,8 @@ cargo.crates \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
+    hashlink                         0.8.4  e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7 \
+    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
@@ -150,6 +156,7 @@ cargo.crates \
     ignore                          0.4.22  b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1 \
     imara-diff                       0.1.5  e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8 \
     imperative                       1.0.5  8b70798296d538cdaa6d652941fcc795963f8b9878b9e300c9fab7a522bd2fc0 \
+    indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
     indexmap                         2.2.6  168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26 \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
@@ -165,6 +172,7 @@ cargo.crates \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
+    jobserver                       0.1.31  d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e \
     jod-thread                       0.1.2  8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae \
     js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
     kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
@@ -221,7 +229,7 @@ cargo.crates \
     phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
     phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
     pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
-    pmutil                           0.6.1  52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6 \
+    pkg-config                      0.3.30  d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec \
     portable-atomic                  1.6.0  7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0 \
     ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
     pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
@@ -237,13 +245,11 @@ cargo.crates \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
     redox_users                      0.4.5  bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891 \
-    regex                           1.10.4  c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c \
+    regex                           1.10.5  b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                   0.4.6  86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.3  adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56 \
-    result-like                      0.5.0  abf7172fef6a7d056b5c26bf6c826570267562d51697f4982ff3ba4aec68a9df \
-    result-like-derive               0.5.0  a8d6574c02e894d66370cfc681e5d68fedbc9a548fb55b30a96b3f0ae22d0fe5 \
     ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
     rust-stemmers                    1.2.0  e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54 \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
@@ -281,8 +287,9 @@ cargo.crates \
     strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.26.2  5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29 \
-    strum_macros                    0.26.3  f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87 \
+    strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     subtle                           2.5.0  81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                             2.0.66  c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5 \
     tempfile                        3.10.1  85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1 \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
@@ -298,9 +305,9 @@ cargo.crates \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    toml                            0.8.13  a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba \
+    toml                            0.8.14  6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335 \
     toml_datetime                    0.6.6  4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf \
-    toml_edit                      0.22.13  c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c \
+    toml_edit                      0.22.14  f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38 \
     tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
     tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
     tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
@@ -376,4 +383,8 @@ cargo.crates \
     yansi-term                       0.1.2  fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1 \
     zerocopy                        0.7.32  74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be \
     zerocopy-derive                 0.7.32  9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6 \
-    zeroize                          1.7.0  525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d
+    zeroize                          1.7.0  525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d \
+    zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
+    zstd                 0.11.2+zstd.1.5.2  20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4 \
+    zstd-safe             5.0.2+zstd.1.5.2  1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db \
+    zstd-sys             2.0.10+zstd.1.5.6  c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.4.9

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
