### PR TITLE
xournalpp: update to 1.2.3, fix build

### DIFF
--- a/x11/xournalpp/Portfile
+++ b/x11/xournalpp/Portfile
@@ -1,11 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           cmake 1.0
+PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
-github.setup        xournalpp xournalpp 1.0.20-hotfix
-categories          x11
+# filesystem
+legacysupport.newest_darwin_requires_legacy 18
+
+github.setup        xournalpp xournalpp 1.2.3 v
+categories          x11 sysutils
 maintainers         nomaintainer
 license             GPL-2
 
@@ -14,42 +18,45 @@ description         A hand note taking software
 long_description    Xournal++ is a hand note taking software written in C++ \
                     with the target of flexibility, functionality and speed.
 
-checksums           rmd160  58010bdc60112f2f6f693163a7d997c329814ed8 \
-                    sha256  1f6a297665ba9200d35bef9e03c480c0fe69036e71502674134d0a59b404d671 \
-                    size    14896961
+checksums           rmd160  35245219f0a0e4095ffeb548b342fa0c6817a129 \
+                    sha256  8817abd1794760c2a3be3a35e56a5588a51e517bc591384fa321994d50e14e7c \
+                    size    16708613
+github.tarball_from archive
+
+# Do not break the build.
+patchfiles-append   patch-CMakeLists.diff
 
 depends_build-append \
-                    port:pkgconfig \
-                    port:gtk-mac-bundler
+                    port:gettext \
+                    port:help2man \
+                    path:bin/pkgconfig:pkgconfig
 
-depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+depends_lib-append  port:adwaita-icon-theme \
+                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                    port:gtksourceview4 \
+                    path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
+                    port:libsndfile \
+                    port:libzip \
+                    port:lua \
                     path:lib/pkgconfig/poppler.pc:poppler \
                     port:portaudio \
-                    port:zlib \
-                    port:libzip \
-                    port:libsndfile \
-                    port:adwaita-icon-theme \
-                    port:lua
+                    port:xorg-libX11 \
+                    port:xorg-libXext \
+                    port:xorg-libXi \
+                    port:zlib
 
-set appName         Xournal++.app
+compiler.cxx_standard   2017
 
-post-build {
-    # Do not clutter $HOME/.local
-    reinplace "s|\$1/inst|${prefix}|g;s/make install/#make install/" ${worksrcpath}/mac-setup/build-app.sh
+# xournalpp(76272) malloc: *** error for object 0x2ff8034: Non-aligned pointer being freed
+legacysupport.redirect_bins xournalpp xournalpp-thumbnailer
 
-    reinplace "s|<main-binary>\${prefix}/bin/|<main-binary dest=\"\${bundle}/foobar\">${worksrcpath}/src/|;s|<launcher-script></launcher-script >|<!-- <launcher-script></launcher-script > -->|" ${worksrcpath}/mac-setup/xournalpp.bundle
-    system -W ${worksrcpath} "./mac-setup/build-app.sh ${prefix}"
-    reinplace "s/export DYLD_LIBRARY_PATH/#export DYLD_LIBRARY_PATH/" ${worksrcpath}/mac-setup/${appName}/Contents/MacOS/xournalpp
-}
+configure.args-append \
+                    -DCMAKE_REQUIRED_FIND_PACKAGE_X11=ON \
+                    -DENABLE_PLUGINS=ON \
+                    -DENABLE_PROFILING=OFF
 
 post-destroot {
     set docdir ${prefix}/share/doc/${subport}
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} AUTHORS LICENSE CHANGELOG.md README.md ${destroot}${docdir}
-
-    copy ${worksrcpath}/mac-setup/${appName} ${destroot}${applications_dir}
-
-    # Xournal++ is intended to be used through ${appName}, binary in
-    # $prefix/bin won't work properly
-    delete ${destroot}${prefix}/bin/xournalpp
 }

--- a/x11/xournalpp/files/patch-CMakeLists.diff
+++ b/x11/xournalpp/files/patch-CMakeLists.diff
@@ -1,0 +1,89 @@
+--- CMakeLists.txt
++++ CMakeLists.txt	2024-06-15 12:16:29.000000000 +0800
+@@ -1,9 +1,7 @@
+ cmake_minimum_required(VERSION 3.12)
+ cmake_policy(VERSION ${CMAKE_VERSION})
+-## The CMAKE_OSX_DEPLOYMENT_TARGET must be set before project(), so don't move the following line further down.
+-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version" FORCE)
+ 
+-if(NOT CMAKE_BUILD_TYPE) 
++if(NOT CMAKE_BUILD_TYPE)
+     # set default build type to RelWithDebInfo, we never supported multi config generators, therefore this is fine
+     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+ endif()
+@@ -50,9 +48,6 @@
+ core_find_git_rev(RELEASE_IDENTIFIER)
+ string(TIMESTAMP PACKAGE_TIMESTAMP "%Y%m%d.%H%M" UTC)
+ 
+-include(TargetArch)
+-target_architecture(PACKAGE_ARCH)
+-
+ configure_file(cmake/VERSION.in VERSION)
+ 
+ configure_file(
+@@ -90,7 +85,6 @@
+     add_library(backtrace INTERFACE)
+     target_include_directories(backtrace INTERFACE ${Backtrace_INCLUDE_DIRS})
+     target_link_libraries(backtrace INTERFACE ${Backtrace_LIBRARIES})
+-    target_link_options(backtrace INTERFACE $<$<AND:$<NOT:$<PLATFORM_ID:Windows>>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-rdynamic>)
+     add_library(Backtrace::backtrace ALIAS backtrace)
+ endif (Backtrace_FOUND)
+ 
+@@ -128,14 +122,6 @@
+     string(REPLACE "-framework;" "-framework " libs "${libs}")
+     # message(STATUS "PkgConfig::ExternalModules::INTERFACE_LINK_LIBRARIES fixed: ${libs}")
+     set_target_properties(PkgConfig::ExternalModules PROPERTIES INTERFACE_LINK_LIBRARIES "${libs}")
+-
+-
+-    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")
+-        # fix broken framework flags from pkgconfig
+-        get_target_property(opts PkgConfig::ExternalModules INTERFACE_LINK_OPTIONS)
+-        string(REPLACE "-framework;" "SHELL:-framework " opts "${opts}")
+-        set_target_properties(PkgConfig::ExternalModules PROPERTIES INTERFACE_LINK_OPTIONS "${opts}")
+-    endif ()
+ endif ()
+ 
+ find_package(ZLIB REQUIRED)
+@@ -201,9 +187,6 @@
+         GLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_32
+         GDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_18
+         $<$<TARGET_EXISTS:X11::X11>:X11_ENABLED>
+-        )
+-target_link_options(external_modules INTERFACE
+-        $<$<AND:$<NOT:$<PLATFORM_ID:Windows>>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-rdynamic>
+         )
+ add_library(xoj::external_modules ALIAS external_modules)
+ 
+@@ -402,32 +385,6 @@
+ set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+ set(CPACK_STRIP_FILES ON) # Debian packages must be stripped from debug messages, so lintian doesn't complain
+ 
+-# .deb package options
+-set(CPACK_DEBIAN_PACKAGE_RELEASE 2)
+-set(CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_PROJECT_VERSION}")
+-set(CPACK_DEBIAN_PACKAGE_SECTION "graphics")
+-set(CPACK_DEBIAN_PACKAGE_DEPENDS
+-        "libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6")
+-set(CPACK_DEBIAN_PACKAGE_SUGGESTS "texlive-base, texlive-latex-extra")  # Latex tool
+-# Use debian's arch scheme; we only care about x86/amd64 for now but feel free to add more
+-if (${PACKAGE_ARCH} STREQUAL "x86_64")
+-    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+-endif ()
+-
+-if (CPACK_GENERATOR MATCHES "DEB")
+-    message("Preparing documentation for DEB package")
+-    add_custom_target(package_documentation ALL)
+-
+-    #Compress changelog and save it as share/doc/xournalpp/changelog.Debian.gz
+-    add_custom_command(TARGET package_documentation PRE_BUILD
+-            COMMAND gzip -c -9 -n "${PROJECT_SOURCE_DIR}/debian/changelog" > "changelog.Debian.gz" VERBATIM)
+-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/changelog.Debian.gz" DESTINATION "share/doc/xournalpp/")
+-
+-    message("Install copyright for DEB package")
+-    #Copy copyright to share/doc/xournalpp/copyright
+-    install(FILES "${PROJECT_SOURCE_DIR}/debian/copyright" DESTINATION "share/doc/xournalpp/")
+-endif ()
+-
+ if (NOT DEFINED CPACK_GENERATOR)
+     set(CPACK_GENERATOR "TGZ")
+ endif ()


### PR DESCRIPTION
#### Description

The port is currently broken across the board: https://ports.macports.org/port/xournalpp/details
Fix it, update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

macOS 14.5
Xcode 15.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
