### PR TITLE
emacs{,-app}-devel: update to 20240615

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -122,16 +122,16 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs 2c887f497c723c2397888e2f406faa4de3a8208a
+    github.setup    emacs-mirror emacs c637adbf32f2566b739eb96e68546201c55540af
     epoch           5
-    version         20240118
-    revision        1
+    version         20240615
+    revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  ff0c37c5f8df3e7e0c8c65fdeca086d64a455129 \
-                    sha256  b8e0ae5ecca0d2f908759dacd00503f2d4e44562443ce2ac6c5f335dc8960f52 \
-                    size    49660683
+    checksums       rmd160  cdc12864cae087498341cb68377106e558a1ae37 \
+                    sha256  5c12852bd275a39568e93fad88f3229206c3160e5e035a9c628cf2e6728d1d48 \
+                    size    50515273
 
     patchfiles-append \
                     patch-allow-powerpc-devel.diff
@@ -329,7 +329,8 @@ variant treesitter description {Builds emacs with tree-sitter support} {
             port:tree-sitter-html \
             port:tree-sitter-heex \
             port:tree-sitter-elixir \
-            port:tree-sitter-lua
+            port:tree-sitter-lua \
+            port:tree-sitter-php
     }
 
     notes-append "


### PR DESCRIPTION
#### Description

Update to latest master

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
