### PR TITLE
gmic*: use legacysupport for strnlen

### DIFF
--- a/science/gmic/Portfile
+++ b/science/gmic/Portfile
@@ -4,6 +4,10 @@ PortSystem          1.0
 
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           conflicts_build 1.0
+PortGroup           legacysupport 1.1
+
+# CImg.h: error: 'strnlen' was not declared in this scope; did you mean 'strlen'?
+legacysupport.newest_darwin_requires_legacy 10
 
 if {${subport} eq "gmic-gimp" || ${subport} eq "gmic-qt"} {
     PortGroup       cmake           1.1
@@ -121,6 +125,11 @@ if {${subport} eq ${name}} {
     build.args-append           NO_STDLIB=Yes \
                                 OPT_CFLAGS=""
 
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        build.args-replace      OPT_CFLAGS="" OPT_CFLAGS="-I${prefix}/include/LegacySupport"
+        build.args-append       OPT_LIBS="-L${prefix}/lib -lMacportsLegacySupport"
+    }
+
     post-destroot {
         delete ${destroot}${prefix}/include/gmic_libc.h
         delete ${destroot}/plug-ins
@@ -172,6 +181,11 @@ if {${subport} eq ${name}} {
                                 OPT_CFLAGS="" \
                                 SOVERSION=${soversion}
 
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        build.args-replace      OPT_CFLAGS="" OPT_CFLAGS="-I${prefix}/include/LegacySupport"
+        build.args-append       OPT_LIBS="-L${prefix}/lib -lMacportsLegacySupport"
+    }
+
     destroot {
         xinstall -m 0644 ${worksrcpath}/src/gmic_libc.h                 ${destroot}${prefix}/include
         xinstall -m 0644 ${worksrcpath}/src/libcgmic.a                  ${destroot}${prefix}/lib
@@ -214,6 +228,11 @@ if {${subport} eq ${name}} {
     build.args-append           NO_STDLIB=Yes \
                                 OPT_CFLAGS="" \
                                 SOVERSION=${soversion}
+
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        build.args-replace      OPT_CFLAGS="" OPT_CFLAGS="-I${prefix}/include/LegacySupport"
+        build.args-append       OPT_LIBS="-L${prefix}/lib -lMacportsLegacySupport"
+    }
 
     destroot {
         xinstall -m 0644 ${worksrcpath}/src/gmic.h                      ${destroot}${prefix}/include


### PR DESCRIPTION
#### Description

Self-explanatory

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
