### PR TITLE
ghidra: update to 11.1.1

### DIFF
--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -5,10 +5,10 @@ PortGroup           github 1.0
 PortGroup           java 1.0
 PortGroup           app 1.0
 
-github.setup        NationalSecurityAgency ghidra 11.0.3 Ghidra_ _build
-checksums           rmd160  77111ec42977e39a63afbdd525d771cc5a4e1b6f \
-                    sha256  0139f9c75c3d5fa51dd32ea89debeb69fbe309fdc21ca2eccc4b2426196dbed7 \
-                    size    68995027
+github.setup        NationalSecurityAgency ghidra 11.1.1 Ghidra_ _build
+checksums           rmd160  c67db1ba5175ff281d18f88c8b0710578c09f766 \
+                    sha256  e733a601cf4b8ac1482c07b1af827d2bcec7be6bd17c349cf8e049298bb5aa48 \
+                    size    70084743
 
 categories          devel
 license             Apache


### PR DESCRIPTION
#### Description
ghidra: update to 11.1.1
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
