### PR TITLE
binutils: update notes

### DIFF
--- a/devel/binutils/Portfile
+++ b/devel/binutils/Portfile
@@ -69,5 +69,8 @@ post-extract {
 
 universal_variant   no
 
-notes "Having ${name} installed will cause some other ports to\
-fail to build. Consider uninstalling ${name}."
+notes "Some of the utilities that ${name} installs can cause some\
+other ports to fail to build, due to subtle differences with system\
+tools sharing their names. Consider using trace mode if such build\
+failures happen to you, or, if that is impossible, consider\
+uninstalling ${name}."


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/37921

#### Description
The current `port notes` for binutils are rather vague. This new wording should make the notes clearer and less scary-sounding.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
