### PR TITLE
libcec: fix build with gcc

### DIFF
--- a/multimedia/libcec/Portfile
+++ b/multimedia/libcec/Portfile
@@ -1,8 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake  1.1
 PortGroup           github 1.0
-PortGroup           cmake  1.0
 
 github.setup        Pulse-Eight libcec 6.0.2 libcec-
 checksums           rmd160  cc0ddc71fb0fda221096e99752b96414018dd6dd \
@@ -35,8 +35,6 @@ if {[string match *gcc* ${configure.compiler}]} {
     PortGroup       legacysupport 1.1
 
 }
-
-cmake.out_of_source yes
 
 set docdir          ${prefix}/share/doc/${name}
 

--- a/multimedia/libcec/Portfile
+++ b/multimedia/libcec/Portfile
@@ -5,9 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake  1.0
 
 github.setup        Pulse-Eight libcec 6.0.2 libcec-
-checksums           md5     1b4b3bd6636cb4dbdb2359a36337ae07 \
-                    sha1    281f868d8a44860e5fd1909653db81f4c187ed40 \
-                    rmd160  cc0ddc71fb0fda221096e99752b96414018dd6dd \
+checksums           rmd160  cc0ddc71fb0fda221096e99752b96414018dd6dd \
                     sha256  c7edf2cae761fe4f8e19067afff3260b87b80f67ad116e435fa8509f296c191c \
                     size    355834
 
@@ -17,12 +15,12 @@ maintainers         {ctreleaven @ctreleaven} openmaintainer
 description         USB CEC Adapter communication Library
 long_description    libCEC, in combination with the right hardware, permits control of \
                     other devices with the TV remote control via existing HDMI cabling
-platforms           darwin
-homepage            http://libcec.pulse-eight.com/
+homepage            https://libcec.pulse-eight.com
+
 compiler.cxx_standard  2011
 
 depends_build-append \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     port:swig-python
 
 depends_lib         port:ncurses \

--- a/multimedia/libcec/Portfile
+++ b/multimedia/libcec/Portfile
@@ -31,6 +31,13 @@ depends_lib         port:ncurses \
                     port:xorg-libX11 \
                     port:xorg-libXrandr
 
+if {[string match *gcc* ${configure.compiler}]} {
+    # USB.h: error: too many '#pragma options align=reset'
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=50909
+    PortGroup       legacysupport 1.1
+
+}
+
 cmake.out_of_source yes
 
 set docdir          ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Fix build with gcc via legacysupport.
Switch to cmake 1.1 PG.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
