### PR TITLE
gitu: Update to 0.21.0

### DIFF
--- a/devel/gitu/Portfile
+++ b/devel/gitu/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            altsem gitu 0.20.1 v
+github.setup            altsem gitu 0.21.0 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -16,9 +16,9 @@ description             A TUI Git client inspired by Magit
 long_description        {*}${description}, launched straight from the terminal.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  61d74888e8bd818f7c9d77cf0f96c6a48e72c9a0 \
-                        sha256  f36401daf3800ab1b52a0c07926262bae8e23b0e6c497a9d5077ae50022e6322 \
-                        size    3912475
+                        rmd160  fc0e908a73615ac6cd82143223c7013f97883845 \
+                        sha256  12a452b99b8e6b35aca810d093ea21fcfbacd29272eb70a72a5d67f99db7f31c \
+                        size    3917491
 
 destroot {
     set bindir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -37,12 +37,12 @@ cargo.crates \
     anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
     anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
     anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
-    arboard                          3.3.2  a2041f1943049c7978768d84e6d0fd95de98b76d6c4727b09e78ec253d29fa58 \
+    arboard                          3.4.0  9fb4009533e8ff8f1450a5bcbc30f4242a1d34442221f72314bea1f5dc9c7f89 \
     atomic                           0.6.0  8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994 \
     autocfg                          1.2.0  f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                         2.5.0  cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1 \
-    block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
+    block2                           0.5.1  2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f \
     bstr                            0.2.17  ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223 \
     bumpalo                         3.15.4  7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa \
     bytemuck                        1.15.0  5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15 \
@@ -59,7 +59,7 @@ cargo.crates \
     clap_builder                     4.5.2  ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4 \
     clap_derive                      4.5.4  528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64 \
     clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
-    clipboard-win                    5.3.0  d517d4b86184dbb111d3556a10f1c8a04da7428d2987bf1081602bf11c3aa9ee \
+    clipboard-win                    5.3.1  79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad \
     colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
     compact_str                      0.7.1  f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f \
     console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
@@ -81,7 +81,7 @@ cargo.crates \
     errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
     error-code                       3.2.0  a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b \
     etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
-    figment                        0.10.18  d032832d74006f99547004d49410a4b4218e4c33382d56ca3ff89df74f86b953 \
+    figment                        0.10.19  8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     gethostname                      0.4.3  0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818 \
     git-version                      0.3.9  1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19 \
@@ -97,11 +97,11 @@ cargo.crates \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
     indexmap                         2.2.6  168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26 \
-    indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
-    insta                           1.38.0  3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc \
+    insta                           1.39.0  810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5 \
     is-terminal                     0.4.12  f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
     itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
+    itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
     jobserver                       0.1.30  685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2 \
     js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
@@ -114,15 +114,20 @@ cargo.crates \
     lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
     log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
     lru                             0.12.3  d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc \
-    malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
     memchr                           2.7.2  6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     num-traits                      0.2.18  da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a \
-    objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
-    objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
-    objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
+    objc-sys                         0.3.5  cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310 \
+    objc2                            0.5.2  46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804 \
+    objc2-app-kit                    0.2.2  e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff \
+    objc2-core-data                  0.2.2  617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef \
+    objc2-core-image                 0.2.2  55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80 \
+    objc2-encode                     4.0.3  7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8 \
+    objc2-foundation                 0.2.2  0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8 \
+    objc2-metal                      0.2.2  dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6 \
+    objc2-quartz-core                0.2.2  e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a \
     once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
     parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
@@ -136,7 +141,7 @@ cargo.crates \
     pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
     proc-macro2                     1.0.79  e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e \
     quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
-    ratatui                         0.26.2  a564a852040e82671dc50a37d88f3aa83bbc690dfc6844cfe7a2591620206a80 \
+    ratatui                         0.26.3  f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
@@ -152,10 +157,10 @@ cargo.crates \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     semver                          1.0.22  92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca \
-    serde                          1.0.199  0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a \
-    serde_derive                   1.0.199  11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc \
+    serde                          1.0.203  7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094 \
+    serde_derive                   1.0.203  500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba \
     serde_json                     1.0.115  12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd \
-    serde_spanned                    0.6.5  eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1 \
+    serde_spanned                    0.6.6  79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0 \
     signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
     signal-hook-mio                  0.2.3  29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af \
     signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
@@ -176,9 +181,9 @@ cargo.crates \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    toml                            0.8.12  e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3 \
-    toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
-    toml_edit                       0.22.9  8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4 \
+    toml                            0.8.13  a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba \
+    toml_datetime                    0.6.6  4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf \
+    toml_edit                      0.22.13  c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c \
     tree-sitter                    0.20.10  e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d \
     tree-sitter-bash                0.20.5  57da2032c37eb2ce29fd18df7d3b94355fec8d6d854d8f80934955df542b5906 \
     tree-sitter-c                   0.20.8  4bbd5f3d8658c08581f8f2adac6c391c2e9fa00fe9246bf6c5f52213b9cc6b72 \
@@ -200,12 +205,13 @@ cargo.crates \
     tree-sitter-scala               0.20.3  44fcf4628a88a3b5cbac3ff52658b924f3e545abddfa245ab9cf683c1adda350 \
     tree-sitter-toml                0.20.0  ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8 \
     tree-sitter-typescript          0.20.5  c8bc1d2c24276a48ef097a71b56888ac9db63717e8f8d0b324668a27fd619670 \
-    tui-prompts                     0.3.11  581e0457c7a9f81db70431d3b6c82f8589bb556a722e414ca17d55367ce77c9d \
+    tui-prompts                     0.3.12  122bb001608c2f058fb3fc729614220a392eef4f2268c520a33b5ea8b422ce54 \
     uncased                         0.9.10  e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697 \
     unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
     unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
     unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
     unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
+    unicode-truncate                 1.0.0  5a5fbabedabe362c618c714dbefda9927b5afc8e2a8102f47f081089a9019226 \
     unicode-width                   0.1.12  68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6 \
     url                              2.5.0  31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633 \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \


### PR DESCRIPTION
#### Description

Update `gitu` to its latest released version, 0.21.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
