### PR TITLE
neomutt: fix build on old systems

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -7,7 +7,6 @@ PortGroup           legacysupport 1.1
 github.setup        neomutt neomutt 20240329
 revision            0
 categories          mail
-platforms           darwin
 license             GPL-2+
 maintainers         {l2dy @l2dy} openmaintainer
 
@@ -26,7 +25,7 @@ checksums           rmd160  b9721c5d480077d9a9a6b473a786d8393c2fb0da \
                     size    3832735
 
 depends_build-append \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 depends_lib         path:bin/perl:perl5 \
                     path:lib/libssl.dylib:openssl \
                     port:gettext \
@@ -60,6 +59,12 @@ configure.args      --disable-doc \
                     --with-ssl=${prefix} \
                     --with-zlib=${prefix} \
                     --zstd
+
+# enriched.c: error: ‘for’ loop initial declaration used outside C99 mode
+# Passing -std=c99 is not enough though:
+# index/index.c: error: initializer element is not constant
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
 # disable ccache, build issues with autosetup
 configure.ccache     no


### PR DESCRIPTION
#### Description

Fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
