### PR TITLE
paho.mqtt.cpp: update to 1.4.0

### DIFF
--- a/net/paho.mqtt.cpp/Portfile
+++ b/net/paho.mqtt.cpp/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           openssl 1.0
 
-github.setup        eclipse paho.mqtt.cpp 1.3.2 v
+github.setup        eclipse paho.mqtt.cpp 1.4.0 v
 revision            0
 categories          net
 maintainers         nomaintainer
@@ -27,6 +27,6 @@ depends_lib-append \
 configure.args-append \
                     -DPAHO_WITH_SSL=ON
 
-checksums           rmd160  e5e06a63f3554ef1b16acc999fee472ec7c50534 \
-                    sha256  923ef82641ec1a516f25f59bd7f9d341449cfcbf4b4e0fb3d6fcd38ec0665b31 \
-                    size    230647
+checksums           rmd160  816f4c4e4c9a54ed90799d5da9c65ca81a4037f6 \
+                    sha256  876b57942bd1299dc80aceafb27897a490bf3e4163b73e73d8dce7a12b2256aa \
+                    size    235642


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/eclipse/paho.mqtt.cpp/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
