### PR TITLE
libimobiledevice-glue: Update to 1.3.0

### DIFF
--- a/devel/libimobiledevice-glue/Portfile
+++ b/devel/libimobiledevice-glue/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        libimobiledevice libimobiledevice-glue 1.2.0
-revision            1
+github.setup        libimobiledevice libimobiledevice-glue 1.3.0
+revision            0
 
 categories          devel
 
@@ -22,15 +22,12 @@ long_description    The main functionality provided by this library are socket h
 
 homepage            https://www.libimobiledevice.org/
 
-checksums           rmd160  6591bf26bcea03d30ebb8c069088df3770ebce2f \
-                    sha256  ff9cbc240c9780edfa43914a057b86362054053721b65fb04f54a25023b92b62 \
-                    size    330690
-
-# stealth upgrade
-dist_subdir         ${name}/${version}_${revision}
+checksums           rmd160  15edfc0c8784d9a5f03ddb2076325e32c0d95815 \
+                    sha256  96ec4eb2b1e217392149eafb2b5c3cd3e7110200f0e2bb5003c37d3ead7244ef \
+                    size    340138
 
 depends_build-append \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append  port:libplist
 


### PR DESCRIPTION
#### Description

Update `libimobiledevice-glue` to its latest released version, 1.3.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
