### PR TITLE
mvnd: update to 1.0.0

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem      1.0
 
-version         0.9.0
+version         1.0.0
 revision        0
 name            mvnd
 categories      java
@@ -38,14 +38,14 @@ use_configure   no
 
 if {${configure.build_arch} eq "x86_64"} {
     distname        maven-mvnd-${version}-darwin-amd64
-    checksums       rmd160  55c61ba1091fdba6ada6f5bf31eb694e862ea964 \
-                    sha256  b94fb24d92cd971b6368df14f44bf77b5614a422dfe9f6f115b32b11860c1d6b \
-                    size    19693811
+    checksums       rmd160  1f58bb895606bccc9b79857d05711e62fa2f47ec \
+                    sha256  32d0007578368fb911ca3f80e60f2d53824c374986dd60ff82e30556aeeba367 \
+                    size    22670535
 } elseif {${configure.build_arch} eq "arm64"} {
     distname        maven-mvnd-${version}-darwin-aarch64
-    checksums       rmd160  765eceeacc278517900fe0b5f0907ce783528b95 \
-                    sha256  bca67a44cc3716a7da46926acff41b3864d62e5da6982b9e998eca42d2f9bfac \
-                    size    19882709
+    checksums       rmd160  3e95eff1c491cfdc110d6ce5721d71446d0450cc \
+                    sha256  b68c213b8071d2a138e9c4b2532b45f5f9a2b4192055a4a71d1bd29547902596 \
+                    size    22571212
 }
 
 build {}


### PR DESCRIPTION
#### Description

Update to mvnd 1.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?