### PR TITLE
osxphotos: update to 0.68.2

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.68.1
+version                 0.68.2
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  3593a91e90f2c8ec2d3e766335f3b407e3d0faf7 \
-                        sha256  e9729be53f752908037980cfa948a17e8f6afcd928496f71f446f6ead907313b \
-                        size    2152370
+checksums               rmd160  23506e14a93f60bfaffe5b4bf6f81da4b0b8a91a \
+                        sha256  79e2f92fc82505064e9d24a3885981ff9ae84c0bd78e39a7d9fcfcecb8d3829e \
+                        size    2152400
 
 python.default_version  312
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.68.2.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?