### PR TITLE
lirc: fix build on older systems

### DIFF
--- a/sysutils/lirc/Portfile
+++ b/sysutils/lirc/Portfile
@@ -77,6 +77,15 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     patchfiles-append   patch-nodocs-snowleopard.diff
 }
 
+if {[string match *gcc* ${configure.compiler}]} {
+    # USB.h: error: too many '#pragma options align=reset'
+    PortGroup       legacysupport 1.1
+
+    # ircd.cpp: error: invalid conversion from 'gid_t*' {aka 'unsigned int*'} to 'int*' [-fpermissive]
+    configure.cxxflags-append \
+                    -fpermissive
+}
+
 post-patch {
     reinplace -locale C "s|@PREFIX@|${prefix}|g" ${worksrcpath}/lirc_options.conf
     reinplace -locale C "s|#!/usr/bin/env python3\$|#!${configure.python}|" \


### PR DESCRIPTION
#### Description

Fix build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
