### PR TITLE
maven3: update to 3.9.8

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.9.7
+version         3.9.8
 revision        0
 
 categories      java devel
@@ -35,9 +35,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  411c13dd6c2f027e8399601f9c9fe7e23e7655ac \
-                sha256  c8fb9f620e5814588c2241142bbd9827a08e3cb415f7aa437f2ed44a3eeab62c \
-                size    9581488
+checksums       rmd160  4f47070c9b0e0269176ef453869789516714a1e3 \
+                sha256  067672629075b740e3d0a928e21021dd615a53287af36d4ccca44e87e081d102 \
+                size    9083702
 
 java.version    1.8+
 java.fallback   openjdk21


### PR DESCRIPTION
#### Description

Update to Maven 3.9.8.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?