### PR TITLE
peg: Downgrade to latest stable version 0.1.19

### DIFF
--- a/devel/peg/Portfile
+++ b/devel/peg/Portfile
@@ -4,10 +4,19 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                peg
-version             0.1.20
+epoch               1
+# As of June 2024, 0.1.20 is a development version subject to change and
+# incompatible with ngs.
+# https://github.com/ngs-lang/ngs/issues/662
+# If updating to 0.1.20 in the future, remember that version 0.1.20 revision 0
+# has already existed in MacPorts and corresponded to the November 2023 version
+# of 0.1.20. If a future final version of 0.1.20 differs from that, then the
+# MacPorts revision should start at 1 and dist_subdir must also be changed.
+version             0.1.19
 revision            0
-
-homepage            https://www.piumarta.com/software/peg
+checksums           rmd160  e7962ebef366f96f7ab27b8c3aead7a78cd085e1 \
+                    sha256  0013dd83a6739778445a64bced3d74b9f50c07553f86ea43333ae5fab5c2bbb4 \
+                    size    136241
 
 description         \
     recursive-descent parser generators for C
@@ -30,18 +39,13 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  5f8afd1d713a9a491cbb655719984e3be6c9f3bf \
-                    sha256  b8b717bc93a59768a35d6525679a4e0ce94e6bf66f92bacf2979c6474572b45a \
-                    size    137305
-
+homepage            https://www.piumarta.com/software/peg/
 master_sites        ${homepage}
 
-patch {
-    # make PREFIX overridable
-    reinplace -E {s|PREFIX([^=]+)=|PREFIX\1?=|} ${worksrcpath}/Makefile
+makefile.override-append \
+                    PREFIX
 
-    # correct path to man pages
-    reinplace -E {s|/man/man|/share/man/man|g}  ${worksrcpath}/Makefile
-}
+destroot.destdir    ROOT=${destroot}
+destroot.args       MANDIR=${destroot}${prefix}/share/man/man1
 
-makefile.has_destdir no
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)</a>\\s+\\(stable\\)


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/70239

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
