### PR TITLE
rb-numo-narray: fix the port to use right ruby

### DIFF
--- a/ruby/rb-numo-narray/Portfile
+++ b/ruby/rb-numo-narray/Portfile
@@ -5,6 +5,7 @@ PortGroup           ruby 1.0
 
 ruby.branches       3.3 3.2 3.1
 ruby.setup          numo-narray 0.9.2.1 gem {} rubygems
+revision            1
 categories-append   math
 license             BSD
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -14,3 +15,15 @@ homepage            https://ruby-numo.github.io/narray
 checksums           rmd160  58e1f5f9666bba0b4f67688418f372bac1fd291b \
                     sha256  eed76b47eebe1288ffd878b387f1882f4863d8e6ab5dd61453768139e14adceb \
                     size    121856
+
+# https://trac.macports.org/ticket/70129
+# https://github.com/ruby-numo/numo-narray/issues/215
+if {${name} ne ${subport}} {
+    depends_extract     port:rb${ruby.suffix}-gem-patch
+
+    post-patch {
+        copy ${filespath}/patch-use-right-ruby.diff ${worksrcpath}
+        reinplace "s|@RUBY@|${ruby.bin}|g" ${worksrcpath}/patch-use-right-ruby.diff
+        system -W ${worksrcpath} "${ruby.gem} patch ${ruby.filename}.gem patch-use-right-ruby.diff -o ${ruby.filename}.gem -p0"
+    }
+}

--- a/ruby/rb-numo-narray/files/patch-use-right-ruby.diff
+++ b/ruby/rb-numo-narray/files/patch-use-right-ruby.diff
@@ -1,0 +1,22 @@
+--- Rakefile
++++ Rakefile	2024-06-19 03:55:49.000000000 +0800
+@@ -5,7 +5,7 @@
+   src = %w[array.c data.c index.c math.c narray.c rand.c struct.c].
+     map{|s| File.join(dir,s)} +
+     [File.join(dir,"t_*.c"), "lib/numo/narray/extra.rb"]
+-  sh "cd ext/numo/narray; ruby extconf.rb; make src"
++  sh "cd ext/numo/narray; @RUBY@ extconf.rb; make src"
+   sh "rm -rf yard .yardoc; yard doc -o yard -m markdown -r README.md #{src.join(' ')}"
+ end
+ 
+--- ext/numo/narray/depend.erb
++++ ext/numo/narray/depend.erb	2024-06-19 04:14:53.000000000 +0800
+@@ -21,7 +21,7 @@
+      type_c << c = "t_"+File.basename(s,".rb")+".c"
+ %>
+ <%=c%>: <%=s%> $(DEPENDS)
+-	ruby $(COGEN) -l -o $@ <%=s%>
++	@RUBY@ $(COGEN) -l -o $@ <%=s%>
+ <% end %>
+ 
+ src : <%= type_c.join(" ") %>


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/70129

#### Description

Revbump, since it was building with a wrong ruby before.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5
Xcode 5.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
