### PR TITLE
R-rstan: fix older systems with libc++

### DIFF
--- a/R/R-rstan/Portfile
+++ b/R/R-rstan/Portfile
@@ -29,6 +29,18 @@ depends_lib-append  port:R-BH \
 
 patchfiles          patch-no-v8.diff
 
+platform darwin {
+    # _task_handle.h:56:5: error: aligned deallocation function of type
+    # 'void (void *, std::align_val_t) noexcept' is only available on macOS 10.13 or newer
+    if {${os.major} < 17} {
+        # Clang-specific flag, also unneeded with libstdc++.
+        if {[string match *clang* ${configure.compiler}]} {
+            patchfiles-append \
+                    patch-aligned-deallocation.diff
+        }
+    }
+}
+
 depends_test-append port:R-bayesplot \
                     port:R-coda \
                     port:R-knitr \

--- a/R/R-rstan/files/patch-aligned-deallocation.diff
+++ b/R/R-rstan/files/patch-aligned-deallocation.diff
@@ -1,0 +1,11 @@
+--- src/Makevars	2024-03-05 06:14:59.000000000 +0800
++++ src/Makevars	2024-06-19 05:06:09.000000000 +0800
+@@ -7,6 +7,8 @@
+ SHLIB_LD = $(SHLIB_CXXLD)
+ PKG_LIBS += $(shell "${R_HOME}/bin/Rscript" -e "RcppParallel::RcppParallelLibs()" | tail -n 1)
+ 
++PKG_CXXFLAGS += -fno-aligned-allocation
++
+ SOURCES_STATIC = stan_fit.cpp stan_fit_base.cpp
+ OBJECTS_STATIC = $(SOURCES_STATIC:.cpp=.o)
+ 


### PR DESCRIPTION
#### Description

Fix this finally too.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5
Xcode 5.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
