### PR TITLE
google-cloud-sdk: update to 481.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             480.0.0
+version             481.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  f33b9e203674c4293a3c84bc5ab75ab40614036f \
-                    sha256  7b16d2495d5e2d77eabddb1ef275f83f3644f92cc71573d7be5fdf0278709c06 \
-                    size    124993108
+    checksums       rmd160  bcc582ea64d8d273c3eba04cea44db85b14b8432 \
+                    sha256  4216165e6c7e87669db298568c1c7a14a8b4bfb03c3d0e1ea24278de3aa557ba \
+                    size    50821275
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  04b2f4bba7aaaf804b5b62b7d13b775c49feddaf \
-                    sha256  35ce3f89020fb1f97d173e4a9d05289026525d65b02b6e62c9d21313cc94ff54 \
-                    size    126278618
+    checksums       rmd160  98427be9b16cdb1b921361fc20ba8a52a049c76a \
+                    sha256  04fabf03671792a548058b74c9320f7ce225d562c7b5dda95dc7e5285508c0ef \
+                    size    52107194
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  b997d2eb04e3923f4b14cab43e58f241a0e6d873 \
-                    sha256  90905a9b760ab7a8933516dd7700ab3ecae38fabd3a1794f70575a288ef165e6 \
-                    size    122603494
+    checksums       rmd160  103daf4d4a8b637f0e7d3bde514bb292f3602f18 \
+                    sha256  482a99d0337db5e91f4af9dd46ae8a3c4e10a7643176aac754b301b02f7cb4d3 \
+                    size    52068620
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 481.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?