### PR TITLE
hdf4: Fix implicit int error; hdfeos: Fix implicit function declaration

### DIFF
--- a/science/hdf4/Portfile
+++ b/science/hdf4/Portfile
@@ -40,6 +40,7 @@ patchfiles          patch-configure.diff \
                     patch-mfhdf-test-tsd.c.diff \
                     patch-mfhdf-test-tszip.c.diff \
                     patch-hdf-test-mgr.c.diff \
+                    implicit-int.patch \
                     arm64.patch
 
 configure.args      --disable-netcdf --disable-fortran \

--- a/science/hdf4/files/implicit-int.patch
+++ b/science/hdf4/files/implicit-int.patch
@@ -1,0 +1,13 @@
+Fix:
+gen_sds_floats.c:26:1: error: type specifier missing, defaults to 'int' [-Werror,-Wimplicit-int]
+--- mfhdf/hdfimport/gen_sds_floats.c.orig	2020-03-03 11:40:50.000000000 -0600
++++ mfhdf/hdfimport/gen_sds_floats.c	2024-06-18 23:16:23.000000000 -0500
+@@ -23,7 +23,7 @@
+ #define RANK2          2  /* Number of dimensions of the SDS */
+ #define RANK3          3  /* Number of dimensions of the SDS */
+ 
+-main() 
++int main(void)
+ {
+     /************************* Variable declaration ************************/
+ 

--- a/science/hdfeos/Portfile
+++ b/science/hdfeos/Portfile
@@ -14,7 +14,6 @@ long_description \
     library designed built on HDF4 to support EOS-specific \
     data structures, namely Grid, Point, and Swath.
 homepage            https://git.earthdata.nasa.gov/projects/DAS/repos/${name}
-platforms           darwin
 distname            hdf-eos2-${version}
 distfiles           ${distname}-src${extract.suffix}
 master_sites        ${homepage}/raw/${distfiles}?at=refs%2Fheads%2FHDFEOS2_${version}&dummy=
@@ -25,7 +24,8 @@ checksums           rmd160  39f2b934fd05cbdd94465ac7edfa12bc2c72e814 \
                     sha256  3a5564b4d69b541139ff7dfdad948696cf31d9d1a6ea8af290c91a4c0ee37188 \
                     size    752290
 
-patchfiles          patch-configure.diff
+patchfiles          patch-configure.diff \
+                    implicit.patch
 
 configure.args      --with-hdf4=${prefix} \
                     --with-jpeg=${prefix} \

--- a/science/hdfeos/files/implicit.patch
+++ b/science/hdfeos/files/implicit.patch
@@ -1,0 +1,20 @@
+Fix:
+error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
+--- configure.orig	2024-06-18 23:12:44.000000000 -0500
++++ configure	2024-06-18 23:25:01.000000000 -0500
+@@ -17719,6 +17719,7 @@
+ /* end confdefs.h.  */
+ 
+                 #include <stddef.h>
++                #include <stdlib.h>
+                 #include <szlib.h>
+ 
+                 int main(void)
+@@ -17758,6 +17759,7 @@
+ /* end confdefs.h.  */
+ 
+                 #include <stddef.h>
++                #include <stdlib.h>
+                 #include <szlib.h>
+ 
+                 int main(void)


### PR DESCRIPTION
#### Description

hdf4: Fix implicit int error
hdfeos: Fix implicit function declaration

Closes: https://trac.macports.org/ticket/70234

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18
with MacPorts clang 18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
