### PR TITLE
py-makelive: use python.pep517_backend

### DIFF
--- a/python/py-makelive/Portfile
+++ b/python/py-makelive/Portfile
@@ -33,6 +33,4 @@ checksums           rmd160  efe2a8db5b43e6ba40f4988e465f4f0911755acd \
 
 python.versions     312
 
-if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-flit
-}
+python.pep517_backend flit


### PR DESCRIPTION
#### Description

Use `python.pep517_backend`, as recommended via https://github.com/macports/macports-ports/pull/24446#pullrequestreview-2126807646.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?