### PR TITLE
openscop: fix linking of tests

### DIFF
--- a/devel/openscop/Portfile
+++ b/devel/openscop/Portfile
@@ -10,7 +10,6 @@ version             0.9.0
 categories          devel math
 
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
-platforms           darwin
 
 description         OpenScop is an open specification defining a file format and a set of data structures to represent a static control part (SCoP for short).
 
@@ -37,6 +36,12 @@ depends_lib         port:gmp
 
 configure.args-append \
                     --with-gmp=system
+
+# gcc-4.2 spits out a cryptic error:
+# ld: absolute address to symbol ___stdoutp in a different linkage unit not supported in _test_file from osl_test-osl_test.o
+# gcc13 is more helpful:
+# {standard input}:438:FATAL:incompatible feature used: directive .non_lazy_symbol_pointer (must specify "-dynamic" to be used)
+patchfiles-append   patch-fix-tests-linking.diff
 
 test.run            yes
 test.target         check

--- a/devel/openscop/files/patch-fix-tests-linking.diff
+++ b/devel/openscop/files/patch-fix-tests-linking.diff
@@ -1,0 +1,15 @@
+--- tests/Makefile.in
++++ tests/Makefile.in	2024-06-19 15:36:30.000000000 +0800
+@@ -339,9 +339,9 @@
+ 
+ #############################################################################
+ MAINTAINERCLEANFILES = Makefile.in
+-osl_test_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include -static
+-osl_int_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include -static
+-osl_pluto_unroll_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include -static
++osl_test_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include -dynamic
++osl_int_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include -dynamic
++osl_pluto_unroll_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include -dynamic
+ osl_test_LDADD = ../libosl.la
+ osl_int_LDADD = ../libosl.la
+ osl_pluto_unroll_LDADD = ../libosl.la


### PR DESCRIPTION
#### Description

Minor fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
