### PR TITLE
tzdiff: update to 1.2.1

### DIFF
--- a/sysutils/tzdiff/Portfile
+++ b/sysutils/tzdiff/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        belgianbeer tzdiff 1.2
+github.setup        belgianbeer tzdiff 1.2.1
 revision            0
-checksums           rmd160  66b3cab8884b0127535f5af975530945d9cb8172 \
-                    sha256  edbdb6bf36ee74ed6ee97a93535a5026b67c94f037fb4b825800a7ef12e0a91f \
-                    size    5867
+checksums           rmd160  d2e25f4511f5446a4378438026510e934b6bf311 \
+                    sha256  ca320c3b3c09dd55d6265045f1dc8d7a06be707cc72e5cf97c081a1bc0122e05 \
+                    size    6247
 
 categories          sysutils
 platforms           any
 supported_archs     noarch
 license             BSD
-maintainers         {@belgianbeer aj.admwt.jp:belgianbeer} openmaintainer
+maintainers         {@minmin wide.ad.jp:minmin} openmaintainer
 
 description         displays timezone differences with localtime.
 long_description    {*}${description}


### PR DESCRIPTION
#### Description

tzdiff 1.2.1 released

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5
FreeBSD 13.3 / 14.1
Debian 12.5

