### PR TITLE
rsgislib, py-rsgislib: update to 5.1.6

### DIFF
--- a/gis/rsgislib/Portfile
+++ b/gis/rsgislib/Portfile
@@ -11,7 +11,7 @@ PortGroup           active_variants   1.1
 # Same std::__and_ error as in: https://trac.macports.org/ticket/68014
 boost.version       1.81
 
-github.setup        remotesensinginfo rsgislib 5.1.3
+github.setup        remotesensinginfo rsgislib 5.1.6
 revision            0
 categories          gis
 license             GPL-3
@@ -24,9 +24,9 @@ homepage            http://www.rsgislib.org
 
 github.tarball_from archive
 
-checksums           rmd160  4632f4dc8d10f4a6e426c9763a7686f7c946fc6e \
-                    sha256  2e22314ca1dff28e7d27f38acbd0391c46ab7a840aec1c57bf66add7cd851335 \
-                    size    126180071
+checksums           rmd160  6a948eda0c7f13d2cbf163b4599a122e398a3190 \
+                    sha256  9547c0b00f963dcd9babaf679dc356a36e05c179f82bb55aa1e45268ce2bd1a4 \
+                    size    126188294
 
 depends_lib-append  port:gdal
 depends_lib-append  port:gsl


### PR DESCRIPTION
#### Description

Update `rsgislib`, `py-rsgislib` to version 5.1.6.

`rsgislib` previously installed a version of the utility `flip`, which conflicted with the port of the same name.
The rsgislib's version of flip has now been renamed to `rsgisflip` and the conflict is now solved.

Closes: https://trac.macports.org/ticket/70213



<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
