### PR TITLE
py-ptpython: update to 3.0.27

### DIFF
--- a/python/py-ptpython/Portfile
+++ b/python/py-ptpython/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 PortGroup               select 1.0
 
 name                    py-ptpython
-version                 3.0.25
+version                 3.0.27
 revision                0
 
 supported_archs         noarch
@@ -18,9 +18,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/prompt-toolkit/ptpython
 
-checksums               rmd160  66d6296142a63820cbe706bc5468827c956d519f \
-                        sha256  887f0a91a576bc26585a0dcec41cd03f004ac7c46a2c88576c87fc51d6c06cd7 \
-                        size    71126
+checksums               rmd160  547159b244219870e31905d68e22199bed1ec67a \
+                        sha256  24b0fda94b73d1c99a27e6fd0d08be6f2e7cda79a2db995c7e3c7b8b1254bad9 \
+                        size    72022
 
 python.versions         38 39 310 311 312
 


### PR DESCRIPTION
#### Description

Update to ptpython 3.0.27.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?