### PR TITLE
py-wurlitzer: update to 3.1.1

### DIFF
--- a/python/py-wurlitzer/Portfile
+++ b/python/py-wurlitzer/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-wurlitzer
-version             3.1.0
+version             3.1.1
 revision            0
 
 categories-append   devel
@@ -18,9 +18,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/minrk/wurlitzer
 
-checksums           rmd160  f06236a9cf8d187c26b1a2ce6af1c9b85420de46 \
-                    sha256  b31d3b18ab6b8394b3adb8b21841ad6d4b6bb195b9b642953872dbbab4c29b2a \
-                    size    11571
+checksums           rmd160  ad73845f328610d0e2385b76907ab724de768f4a \
+                    sha256  bfb9144ab9f02487d802b9ff89dbd3fa382d08f73e12db8adc4c2fb00cd39bd9 \
+                    size    11867
 
 python.versions     38 39 310 311 312
 


### PR DESCRIPTION
#### Description

Update to Wurlitzer 3.1.1.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?