### PR TITLE
py-mako: update to 1.3.5

### DIFF
--- a/python/py-mako/Portfile
+++ b/python/py-mako/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-mako
 python.rootname     Mako
-version             1.3.4
+version             1.3.5
 revision            0
 categories-append   www
 license             MIT
@@ -35,9 +35,9 @@ long_description    Mako is a template library written in Python. \
 
 homepage            https://www.makotemplates.org/
 
-checksums           rmd160  7dada7a220f664268a3e71135c8de5656c6412c7 \
-                    sha256  029a10f5fc497f5be7f7754e4ef5bcf26cb93044798de31fd1303f777f360916 \
-                    size    392377
+checksums           rmd160  3e1f732cd2262d59c0b36be630be5c37bce4b912 \
+                    sha256  48dbc20568c1d276a2698b36d968fa76161bf127194907ea6fc594fa81f943bc \
+                    size    392738
 
 if {${name} ne ${subport}} {
 


### PR DESCRIPTION
#### Description

Update to Mako 1.3.5.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?