### PR TITLE
py-more-itertools: update to 10.3.0

### DIFF
--- a/python/py-more-itertools/Portfile
+++ b/python/py-more-itertools/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-more-itertools
-version             10.2.0
+version             10.3.0
 revision            0
 categories-append   devel
 license             MIT
@@ -21,9 +21,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/more-itertools/more-itertools
 
-checksums           rmd160  e934a36294ed005f64663a8e4a910a218f6b7caa \
-                    sha256  8fccb480c43d3e99a00087634c06dd02b0d50fbf088b380de5a41a015ec239e1 \
-                    size    114449
+checksums           rmd160  7a0cc7cb7c7c7c166ed6f3aa71b1dddb45199134 \
+                    sha256  e5d93ef411224fbcef366a6e8ddc4c5781bc6359d43412a65dd5964e46111463 \
+                    size    118147
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Update to More Itertools 10.3.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?