### PR TITLE
py-makelive: update to 0.6.1

### DIFF
--- a/python/py-makelive/Portfile
+++ b/python/py-makelive/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-makelive
-version             0.5.0
-revision            1
+version             0.6.1
+revision            0
 
 supported_archs     noarch
 platforms           {darwin any}
 license             MIT
 
-maintainers         nomaintainer
+maintainers         {breun.nl:nils @breun} openmaintainer
 
 description         Convert an photo + video pair into a Live Photo.
 long_description    {*}${description} \
@@ -27,9 +27,9 @@ long_description    {*}${description} \
 
 homepage            https://pypi.org/project/makelive/
 
-checksums           rmd160  efe2a8db5b43e6ba40f4988e465f4f0911755acd \
-                    sha256  cce2f40a27ae447402868c97096e4107bd92de1a1f49786690db1b11a117c985 \
-                    size    14016
+checksums           rmd160  93af83a1dbe563fb03c07a370ce659bdb0d60b14 \
+                    sha256  06371ff4ea6a6046894632f62264c6563559733044c09707685feb4526954eb6 \
+                    size    18549
 
 python.versions     312
 


### PR DESCRIPTION
#### Description

Update to MakeLive 0.6.1.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?