### PR TITLE
xa: update to 2.4.1

### DIFF
--- a/devel/xa/Portfile
+++ b/devel/xa/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                xa
-version             2.4.0
+version             2.4.1
 revision            0
 categories          devel
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ license             GPL-2+
 
 master_sites        https://www.floodgap.com/retrotech/xa/dists/
 
-checksums           rmd160  1b47b24e250f96d153e3a1bfea66e68d0c794b38 \
-                    sha256  9e587a0ca8ff791009880bfa331f6ed36935e08ef9c123822ca175285f8c030c \
-                    size    197862
+checksums           rmd160  aca3fea4a428a0cd30555d66b8b27355bfe55238 \
+                    sha256  63c12a6a32a8e364f34f049d8b2477f4656021418f08b8d6b462be0ed3be3ac3 \
+                    size    208553
 
 use_configure       no
 variant universal {}


### PR DESCRIPTION
#### Description

Update to xa 2.4.1.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?