### PR TITLE
legacy-support-devel: update to latest master

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -34,19 +34,38 @@ subport ${name} {
     checksums           rmd160  91ac38ae5a7ac40eaae84163a3bc658c24fd976b \
                         sha256  1f59de824f9769fde0f154173ed0296390288b6b0a79eb073d21e35aa8b0a1f6 \
                         size    77763
+
+    # install Tiger-specific fixes
+    platform darwin 8 {
+        # there is no system copyfile.h, so find local copy
+        configure.cflags-append -isystem${worksrcpath}/tiger_only/include
+        post-destroot {
+            # use Tiger version of copyfile.h
+            delete ${destroot}${prefix}/include/LegacySupport/copyfile.h
+            # Copy all tiger specific 'binaries' and includes
+            tiger_copy ${worksrcpath}/tiger_only/bin  ${destroot}${prefix}/bin/
+            tiger_copy ${worksrcpath}/tiger_only/include  ${destroot}${prefix}/include/LegacySupport/
+        }
+    }
 }
 
 subport ${name}-devel {
     conflicts           ${name}
-    github.setup        macports macports-legacy-support 34e47c0a3bafc1693ce83d24f03264ba05cb7c86
-    version             20240516
+    github.setup        macports macports-legacy-support 8aad00879b78ad39522f65442ec75d5452fc2707
+    version             20240619
     revision            0
     livecheck.type      none
-    checksums           rmd160  91ac38ae5a7ac40eaae84163a3bc658c24fd976b \
-                        sha256  1f59de824f9769fde0f154173ed0296390288b6b0a79eb073d21e35aa8b0a1f6 \
-                        size    77763
+    checksums           rmd160  0726432db9db401a432bfdca947399d2ee3e6fa5 \
+                        sha256  273115e71c93d6bda886cf2815f546c4eeac7925961c1623e86501f18e401a3f \
+                        size    85736
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
+
+    # Install Tiger-specific additions
+    platform darwin 8 {
+        build.target-append     tiger-bins
+        destroot.target-append  install-tiger
+    }
 }
 
 # Until this can be fixed disable parallel builds...
@@ -54,7 +73,7 @@ subport ${name}-devel {
 use_parallel_build  no
 
 # This port doesn't use C++ at all, except for a couple of tests which may
-# fail to build with an non-OS-default stdlib setting.  Since the cxx_stdlib
+# fail to build with a non-OS-default stdlib setting.  Since the cxx_stdlib
 # selection is unimportant for the tests (which are actually only testing
 # the C-only interface to the library), we disable the cxx_stlib setting.
 # This also avoids depending on a MacPorts compiler in some OS versions.
@@ -72,19 +91,6 @@ build.env-append    LD=ld \
                     PLATFORM=${os.major} \
                     SOCURVERSION=${release_ver} \
                     SOCOMPATVERSION=${compat_ver}
-
-# install Tiger-specific fixes
-platform darwin 8 {
-    # there is no system copyfile.h, so find local copy
-    configure.cflags-append -isystem${worksrcpath}/tiger_only/include
-    post-destroot {
-        # use Tiger version of copyfile.h
-        delete ${destroot}${prefix}/include/LegacySupport/copyfile.h
-        # Copy all tiger specific 'binaries' and includes
-        tiger_copy ${worksrcpath}/tiger_only/bin      ${destroot}${prefix}/bin/
-        tiger_copy ${worksrcpath}/tiger_only/include  ${destroot}${prefix}/include/LegacySupport/
-    }
-}
 
 foreach arch ${muniversal.architectures} {
     build.env.${arch}-append    FORCE_ARCH=${arch}


### PR DESCRIPTION
- Adds optional security wrapper for stpncpy(). Re: https://trac.macports.org/ticket/69878

- Fixes most issues with mismatched SDKs. Re: https://trac.macports.org/ticket/69867

- Moves renameat() prototype to the proper header location.

Simplifies Tiger-only handling in the Portfile, though only for the devel subport until the next release.  In the interim, two different versions of this code are present.

TESTED:
Tested both normal and -devel versions on 10.4-10.5 ppc, 10.5-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-14.x arm64. Builds on all tested platforms except 10.4 ppc +universal. Passes all tests in all buildable cases.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.5 21H1222, x86_64, Xcode 14.2 14C18
macOS 12.7.5 21H1222, arm64, Xcode 14.2 14C18
macOS 13.6.7 22G720, arm64, Xcode 15.2 15C500b
macOS 14.5 23F79, arm64, Xcode 15.4 15F31d
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
