### PR TITLE
pcraster: fix conflict with mapserver; default to +py312

### DIFF
--- a/gis/pcraster/Portfile
+++ b/gis/pcraster/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 PortGroup           qt5 1.0
 
 github.setup        pcraster pcraster 4.4.1 v
-revision            0
+revision            1
 
 categories          gis
 license             GPL
@@ -78,5 +78,11 @@ foreach pyver ${python_suffixes} {
     set python_default "${python_default}!\[variant_isset python${pyver}\] && "
 }
 set python_default [string range ${python_default} 0 end-4]
-set python_default "${python_default}} { default_variants +python311}"
+set python_default "${python_default}} { default_variants +python312}"
 eval ${python_default}
+
+post-destroot {
+    move ${destroot}${prefix}/bin/legend ${destroot}${prefix}/bin/pcrlegend
+}
+
+notes "The utility 'legend' is renamed to 'pcrlegend' due to conflict with mapserver."


### PR DESCRIPTION
#### Description

The binary file 'legend' is renamed to 'pcrlegend', due to conflict with mapserver.

Bump default Python variant to version 3.12 (which now is the case for most other GIS ports).

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
