### PR TITLE
Update to opendx -  fix warning/error compatibility issues with modern clang

### DIFF
--- a/science/opendx/Portfile
+++ b/science/opendx/Portfile
@@ -71,7 +71,8 @@ patchfiles              configure.ac.diff \
 patchfiles-append       patch-no_macos.diff \
                         patch-compile.diff \
                         patch-correct_compiler.diff \
-                        patch-destroot.diff
+                        patch-destroot.diff \
+                        patch-compiler_compat_2024.diff
 
 use_autoreconf          yes
 autoreconf.args         -fvi

--- a/science/opendx/files/patch-compiler_compat_2024.diff
+++ b/science/opendx/files/patch-compiler_compat_2024.diff
@@ -1,0 +1,560 @@
+diff -r -u opendx_src_orig/exec/dpexec/dpparse.c src/exec/dpexec/dpparse.c
+--- opendx_src_orig/exec/dpexec/dpparse.c	2004-06-03 12:45:20
++++ src/exec/dpexec/dpparse.c	2024-06-20 10:12:34
+@@ -45,7 +45,7 @@
+ static PFIP
+ node_methods[] =
+ {
+-    _dxf_ExNode__Delete
++    (PFIP) _dxf_ExNode__Delete
+ };
+ 
+ #if 0
+diff -r -u opendx_src_orig/exec/dpexec/exobject.c src/exec/dpexec/exobject.c
+--- opendx_src_orig/exec/dpexec/exobject.c	2004-06-03 12:45:20
++++ src/exec/dpexec/exobject.c	2024-06-20 10:02:37
+@@ -30,7 +30,7 @@
+ 
+ PFIP _dxd_EXO_default_methods[] =
+ {
+-    _dxf__EXO_delete
++    (PFIP) _dxf__EXO_delete
+ };
+ 
+ static lock_type *allocLock;
+diff -r -u opendx_src_orig/exec/dpexec/graph.c src/exec/dpexec/graph.c
+--- opendx_src_orig/exec/dpexec/graph.c	2006-01-05 17:55:42
++++ src/exec/dpexec/graph.c	2024-06-20 10:03:02
+@@ -120,12 +120,12 @@
+ 
+ static PFIP gvar_methods[] =
+ {
+-    GvarDelete
++    (PFIP) GvarDelete
+ };
+ 
+ static PFIP progobj_methods[] =
+ {
+-    progobjDelete
++    (PFIP) progobjDelete
+ };
+ 
+ void ResetSubGraphIds()
+diff -r -u opendx_src_orig/exec/dxmods/_grid.c src/exec/dxmods/_grid.c
+--- opendx_src_orig/exec/dxmods/_grid.c	2000-08-24 16:04:13
++++ src/exec/dxmods/_grid.c	2024-06-20 09:59:44
+@@ -404,6 +404,7 @@
+     float		*point;
+     float		*shape;
+     int			*density;
++    int                 dim;
+     Object		*outo;
+ {
+     int			count[3];
+@@ -660,6 +661,7 @@
+     float		*point;
+     float		*shape;
+     int			*density;
++    int                 dim;
+     Object		*outo;
+ {
+     int			count[3];
+@@ -944,6 +946,7 @@
+     float		*point;
+     float		*shape;
+     int			*count;
++    int                 dim;
+ {
+     double		delta;
+     int			i;
+diff -r -u opendx_src_orig/exec/dxmods/streamline.c src/exec/dxmods/streamline.c
+--- opendx_src_orig/exec/dxmods/streamline.c	2006-06-10 12:33:58
++++ src/exec/dxmods/streamline.c	2024-06-20 09:52:06
+@@ -1259,7 +1259,7 @@
+ }
+ 
+ static Stream
+-NewStream(nDim)
++NewStream(int nDim)
+ {
+     Stream s = NULL;
+ 
+diff -r -u opendx_src_orig/uipp/base/TreeView.C src/uipp/base/TreeView.C
+--- opendx_src_orig/uipp/base/TreeView.C	2003-07-11 20:12:15
++++ src/uipp/base/TreeView.C	2024-06-20 10:57:18
+@@ -316,9 +316,9 @@
+     }
+ 
+     if (TreeView::Plus == XmUNSPECIFIED_PIXMAP) {
+-	TreeView::Plus = XCreatePixmapFromBitmapData(d,win,plus_bits,plus_width,
++	TreeView::Plus = XCreatePixmapFromBitmapData(d,win,(char *)plus_bits,plus_width,
+ 	    plus_height,this->line_color,bg,depth);
+-	TreeView::Minus = XCreatePixmapFromBitmapData(d,win,minus_bits,minus_width,
++	TreeView::Minus = XCreatePixmapFromBitmapData(d,win,(char *)minus_bits,minus_width,
+ 	    minus_height,this->line_color,bg,depth);
+     }
+ 
+diff -r -u opendx_src_orig/uipp/base/minus.bm src/uipp/base/minus.bm
+--- opendx_src_orig/uipp/base/minus.bm	2003-07-11 20:12:15
++++ src/uipp/base/minus.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define minus_width 12
+ #define minus_height 14
+-static char minus_bits[] = {
++static unsigned char minus_bits[] = {
+    0x00, 0x00, 0x00, 0x00, 0xfe, 0x0f, 0x02, 0x08, 0x02, 0x08, 0x02, 0x08,
+    0x02, 0x08, 0xfa, 0x0b, 0x02, 0x08, 0x02, 0x08, 0x02, 0x08, 0x02, 0x08,
+    0xfe, 0x0f, 0x00, 0x00};
+Only in src/uipp/base: minus.bm-e
+diff -r -u opendx_src_orig/uipp/base/plus.bm src/uipp/base/plus.bm
+--- opendx_src_orig/uipp/base/plus.bm	2003-07-11 20:12:15
++++ src/uipp/base/plus.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define plus_width 12
+ #define plus_height 14
+-static char plus_bits[] = {
++static unsigned char plus_bits[] = {
+    0x00, 0x00, 0x00, 0x00, 0xfe, 0x0f, 0x02, 0x08, 0x42, 0x08, 0x42, 0x08,
+    0x42, 0x08, 0xfa, 0x0b, 0x42, 0x08, 0x42, 0x08, 0x42, 0x08, 0x02, 0x08,
+    0xfe, 0x0f, 0x00, 0x00};
+Only in src/uipp/base: plus.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/AutoAxesDialog.C src/uipp/dxuilib/AutoAxesDialog.C
+--- opendx_src_orig/uipp/dxuilib/AutoAxesDialog.C	2003-09-26 11:49:12
++++ src/uipp/dxuilib/AutoAxesDialog.C	2024-06-20 10:34:02
+@@ -1791,16 +1791,16 @@
+ 	    XmNdepth, &depth, XmNscreen, &scr, NULL);
+ 	Pixel fg = BlackPixelOfScreen(scr);
+ 	AutoAxesDialog::TicksIn = XCreatePixmapFromBitmapData (XtDisplay(root), 
+-	    XtWindow(root), ticks_in_bits, ticks_in_width, ticks_in_height,
++	    XtWindow(root), (char *) ticks_in_bits, ticks_in_width, ticks_in_height,
+ 	    fg, bg, depth);
+ 	AutoAxesDialog::TicksOut = XCreatePixmapFromBitmapData (XtDisplay(root), 
+-	    XtWindow(root), ticks_out_bits, ticks_out_width, ticks_out_height,
++	    XtWindow(root), (char *) ticks_out_bits, ticks_out_width, ticks_out_height,
+ 	    fg, bg, depth);
+ 	AutoAxesDialog::TicksInGrey = XCreatePixmapFromBitmapData (XtDisplay(root), 
+-	    XtWindow(root), ticks_in_ins_bits, ticks_in_ins_width, ticks_in_ins_height,
++	    XtWindow(root), (char *) ticks_in_ins_bits, ticks_in_ins_width, ticks_in_ins_height,
+ 	    fg, bg, depth);
+ 	AutoAxesDialog::TicksOutGrey = XCreatePixmapFromBitmapData (XtDisplay(root), 
+-	    XtWindow(root),ticks_out_ins_bits, ticks_out_ins_width, ticks_out_ins_height,
++	    XtWindow(root), (char *) ticks_out_ins_bits, ticks_out_ins_width, ticks_out_ins_height,
+ 	    fg, bg, depth);
+ 
+ 
+diff -r -u opendx_src_orig/uipp/dxuilib/DXWindow.C src/uipp/dxuilib/DXWindow.C
+--- opendx_src_orig/uipp/dxuilib/DXWindow.C	2006-06-29 14:21:22
++++ src/uipp/dxuilib/DXWindow.C	2024-06-20 10:43:21
+@@ -245,7 +245,7 @@
+             XCreatePixmapFromBitmapData
+                 (XtDisplay(this->menuBar),
+                  wind,
+-                 anchor_bits,
++                 (char *) anchor_bits,
+                  anchor_width,
+                  anchor_height,
+                  foreground,
+diff -r -u opendx_src_orig/uipp/dxuilib/EditorWindow.C src/uipp/dxuilib/EditorWindow.C
+--- opendx_src_orig/uipp/dxuilib/EditorWindow.C	2006-06-29 14:23:50
++++ src/uipp/dxuilib/EditorWindow.C	2024-06-20 10:42:57
+@@ -5997,7 +5997,7 @@
+     //
+     const char *tmpdir = theDXApplication->getTmpDirectory();
+     int tmpdirlen = STRLEN(tmpdir);
+-    if (!tmpdirlen) return FALSE;
++    if (!tmpdirlen) return (char *) FALSE;
+     if (tmpdir[tmpdirlen-1] == '/') {
+ 	sprintf(netfilename, "%sdx%d.net", tmpdir, getpid());
+ 	sprintf(cfgfilename, "%sdx%d.cfg", tmpdir, getpid());
+diff -r -u opendx_src_orig/uipp/dxuilib/PageTab.C src/uipp/dxuilib/PageTab.C
+--- opendx_src_orig/uipp/dxuilib/PageTab.C	2003-07-11 20:12:22
++++ src/uipp/dxuilib/PageTab.C	2024-06-20 10:49:06
+@@ -96,9 +96,9 @@
+         PageTab::DragIcon = this->createDragIcon(pagedrag_width, pagedrag_height,
+ 	     (char *)pagedrag_bits, (char *)pagedragmask_bits);
+ 	PageTab::AnimationPixmap = XCreateBitmapFromData(XtDisplay(p),
+-	      XtWindow(p), animation_bits, animation_width, animation_height);
++	      XtWindow(p), (char *) animation_bits, animation_width, animation_height);
+ 	      PageTab::AnimationMaskPixmap = XCreateBitmapFromData(XtDisplay(p),
+-	      XtWindow(p), anim_mask_bits, anim_mask_width, anim_mask_height);
++	      XtWindow(p), (char *) anim_mask_bits, anim_mask_width, anim_mask_height);
+ 	PageTab::ClassInitialized = TRUE;
+     }
+ 
+diff -r -u opendx_src_orig/uipp/dxuilib/VPEPostIt.C src/uipp/dxuilib/VPEPostIt.C
+--- opendx_src_orig/uipp/dxuilib/VPEPostIt.C	2002-10-24 00:37:59
++++ src/uipp/dxuilib/VPEPostIt.C	2024-06-20 10:50:59
+@@ -213,7 +213,7 @@
+ 	XFreePixmap(d, this->bg_pixmap);
+ 	this->bg_pixmap = NUL(Pixmap);
+     }
+-    this->bg_pixmap = XCreatePixmapFromBitmapData(d, w, postit_bits,
++    this->bg_pixmap = XCreatePixmapFromBitmapData(d, w, (char *) postit_bits,
+ 	postit_width, postit_height, fg, bg, depth);
+     XtVaSetValues (this->customPart,
+ 	XmNlabelType, XmPIXMAP,
+diff -r -u opendx_src_orig/uipp/dxuilib/anchor.bm src/uipp/dxuilib/anchor.bm
+--- opendx_src_orig/uipp/dxuilib/anchor.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/anchor.bm	2024-06-20 11:00:21
+@@ -2,7 +2,7 @@
+ #define anchor_height 17
+ #define anchor_x_hot -1
+ #define anchor_y_hot -1
+-static char anchor_bits[] = {
++static unsigned char anchor_bits[] = {
+    0x80, 0x03, 0x00, 0x40, 0x05, 0x00, 0xc0, 0x02, 0x00, 0x40, 0x05, 0x00,
+    0x80, 0x02, 0x00, 0x10, 0x11, 0x00, 0x30, 0x09, 0x00, 0x50, 0x15, 0x00,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x83, 0x82, 0x00, 0x85, 0x41, 0x01,
+Only in src/uipp/dxuilib: anchor.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/anim_mask.bm src/uipp/dxuilib/anim_mask.bm
+--- opendx_src_orig/uipp/dxuilib/anim_mask.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/anim_mask.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define anim_mask_width 90
+ #define anim_mask_height 23
+-static char anim_mask_bits[] = {
++static unsigned char anim_mask_bits[] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f, 0x00,
+Only in src/uipp/dxuilib: anim_mask.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/animation.bm src/uipp/dxuilib/animation.bm
+--- opendx_src_orig/uipp/dxuilib/animation.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/animation.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define animation_width 90
+ #define animation_height 23
+-static char animation_bits[] = {
++static unsigned char animation_bits[] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+Only in src/uipp/dxuilib: animation.bm-e
+Only in src/uipp/dxuilib: moduledrag.bm-e
+Only in src/uipp/dxuilib: moduledragmask.bm-e
+Only in src/uipp/dxuilib: ntractor.bm-e
+Only in src/uipp/dxuilib: ntractormask.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/pagedrag.bm src/uipp/dxuilib/pagedrag.bm
+--- opendx_src_orig/uipp/dxuilib/pagedrag.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/pagedrag.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define pagedrag_width 32
+ #define pagedrag_height 32
+-static char pagedrag_bits[] = {
++static unsigned char pagedrag_bits[] = {
+    0x00, 0x00, 0x00, 0x00, 0xfc, 0x3f, 0x00, 0x00, 0x04, 0x30, 0x00, 0x00,
+    0x04, 0xf0, 0x01, 0x00, 0x04, 0xb0, 0x01, 0x00, 0x07, 0xf0, 0xff, 0x0f,
+    0x01, 0x00, 0x00, 0x0c, 0x01, 0x00, 0x00, 0x0c, 0x01, 0x00, 0x00, 0x7c,
+Only in src/uipp/dxuilib: pagedrag.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/pagedragmask.bm src/uipp/dxuilib/pagedragmask.bm
+--- opendx_src_orig/uipp/dxuilib/pagedragmask.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/pagedragmask.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define pagedragmask_width 32
+ #define pagedragmask_height 32
+-static char pagedragmask_bits[] = {
++static unsigned char pagedragmask_bits[] = {
+    0x00, 0x00, 0x00, 0x00, 0xfc, 0x3f, 0x00, 0x00, 0xfc, 0x3f, 0x00, 0x00,
+    0x5c, 0xf5, 0x01, 0x00, 0xac, 0xfa, 0x01, 0x00, 0x5f, 0xf5, 0xff, 0x0f,
+    0xaf, 0xfa, 0xff, 0x0f, 0x57, 0x55, 0x55, 0x0d, 0xab, 0xaa, 0xaa, 0x7e,
+Only in src/uipp/dxuilib: pagedragmask.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/postit.bm src/uipp/dxuilib/postit.bm
+--- opendx_src_orig/uipp/dxuilib/postit.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/postit.bm	2024-06-20 11:00:21
+@@ -2,7 +2,7 @@
+ #define postit_height 24
+ #define postit_x_hot 11
+ #define postit_y_hot 0
+-static char postit_bits[] = {
++static unsigned char postit_bits[] = {
+    0x00, 0x00, 0x00, 0xaa, 0xaa, 0xaa, 0x54, 0x55, 0xd5, 0xaa, 0xaa, 0xaa,
+    0x54, 0x41, 0xd5, 0xaa, 0xa8, 0xaa, 0x54, 0x75, 0xd5, 0xaa, 0xbc, 0xaa,
+    0x54, 0x55, 0xd5, 0xaa, 0xaa, 0xaa, 0x54, 0x41, 0xd5, 0xaa, 0xa8, 0xaa,
+Only in src/uipp/dxuilib: postit.bm-e
+Only in src/uipp/dxuilib: saw_sol.bm-e
+Only in src/uipp/dxuilib: saw_sor.bm-e
+Only in src/uipp/dxuilib: square_sol.bm-e
+Only in src/uipp/dxuilib: square_sor.bm-e
+Only in src/uipp/dxuilib: step.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/ticks_in.bm src/uipp/dxuilib/ticks_in.bm
+--- opendx_src_orig/uipp/dxuilib/ticks_in.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/ticks_in.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define ticks_in_width 18
+ #define ticks_in_height 16
+-static char ticks_in_bits[] = {
++static unsigned char ticks_in_bits[] = {
+    0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x82, 0x20, 0x00,
+    0x82, 0x20, 0x00, 0x92, 0x24, 0x01, 0x92, 0x24, 0x01, 0x92, 0x24, 0x01,
+Only in src/uipp/dxuilib: ticks_in.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/ticks_in_ins.bm src/uipp/dxuilib/ticks_in_ins.bm
+--- opendx_src_orig/uipp/dxuilib/ticks_in_ins.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/ticks_in_ins.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define ticks_in_ins_width 18
+ #define ticks_in_ins_height 16
+-static char ticks_in_ins_bits[] = {
++static unsigned char ticks_in_ins_bits[] = {
+    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x82, 0x20, 0x00, 0x10, 0x04, 0x01, 0x82, 0x20, 0x00, 0x10, 0x04, 0x01,
+Only in src/uipp/dxuilib: ticks_in_ins.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/ticks_out.bm src/uipp/dxuilib/ticks_out.bm
+--- opendx_src_orig/uipp/dxuilib/ticks_out.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/ticks_out.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define ticks_out_width 18
+ #define ticks_out_height 16
+-static char ticks_out_bits[] = {
++static unsigned char ticks_out_bits[] = {
+    0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0xfe, 0xff, 0x03, 0x24, 0x49, 0x02,
+Only in src/uipp/dxuilib: ticks_out.bm-e
+diff -r -u opendx_src_orig/uipp/dxuilib/ticks_out_ins.bm src/uipp/dxuilib/ticks_out_ins.bm
+--- opendx_src_orig/uipp/dxuilib/ticks_out_ins.bm	1999-03-24 10:17:49
++++ src/uipp/dxuilib/ticks_out_ins.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define ticks_out_ins_width 18
+ #define ticks_out_ins_height 16
+-static char ticks_out_ins_bits[] = {
++static unsigned char ticks_out_ins_bits[] = {
+    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0xaa, 0x02, 0x04, 0x41, 0x00,
+Only in src/uipp/dxuilib: ticks_out_ins.bm-e
+Only in src/uipp/dxuilib: tooldrag.bm-e
+Only in src/uipp/dxuilib: tooldragmask.bm-e
+diff -r -u opendx_src_orig/uipp/prompter/col_insens.bm src/uipp/prompter/col_insens.bm
+--- opendx_src_orig/uipp/prompter/col_insens.bm	1999-04-05 09:33:49
++++ src/uipp/prompter/col_insens.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define col_insens_width 20
+ #define col_insens_height 20
+-static char col_insens_bits[] = {
++static unsigned char col_insens_bits[] = {
+    0x00, 0x00, 0x00, 0x55, 0x55, 0x05, 0x00, 0x00, 0x08, 0x00, 0x80, 0x02,
+    0x00, 0x28, 0x00, 0x80, 0x02, 0x00, 0x28, 0x00, 0x00, 0x02, 0x00, 0x00,
+    0x55, 0x55, 0x05, 0x00, 0x00, 0x08, 0x00, 0x80, 0x02, 0x00, 0x28, 0x00,
+Only in src/uipp/prompter: col_insens.bm-e
+diff -r -u opendx_src_orig/uipp/prompter/col_sens.bm src/uipp/prompter/col_sens.bm
+--- opendx_src_orig/uipp/prompter/col_sens.bm	1999-04-05 09:33:50
++++ src/uipp/prompter/col_sens.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define col_sens_width 20
+ #define col_sens_height 20
+-static char col_sens_bits[] = {
++static unsigned char col_sens_bits[] = {
+    0x00, 0x00, 0x00, 0xff, 0xff, 0x0f, 0x00, 0x00, 0x0c, 0x00, 0xc0, 0x03,
+    0x00, 0x3c, 0x00, 0xc0, 0x03, 0x00, 0x3c, 0x00, 0x00, 0x03, 0x00, 0x00,
+    0xff, 0xff, 0x0f, 0x00, 0x00, 0x0c, 0x00, 0xc0, 0x03, 0x00, 0x3c, 0x00,
+Only in src/uipp/prompter: col_sens.bm-e
+diff -r -u opendx_src_orig/uipp/prompter/grid1.bm src/uipp/prompter/grid1.bm
+--- opendx_src_orig/uipp/prompter/grid1.bm	1999-04-05 09:33:50
++++ src/uipp/prompter/grid1.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define grid1_width 37
+ #define grid1_height 37
+-static char grid1_bits[] = {
++static unsigned char grid1_bits[] = {
+    0xff, 0xff, 0xff, 0xff, 0x1f, 0x41, 0x10, 0x04, 0x41, 0x10, 0x41, 0x10,
+    0x04, 0x41, 0x10, 0x41, 0x10, 0x04, 0x41, 0x10, 0x41, 0x10, 0x04, 0x41,
+    0x10, 0x41, 0x10, 0x04, 0x41, 0x10, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x41,
+Only in src/uipp/prompter: grid1.bm-e
+diff -r -u opendx_src_orig/uipp/prompter/grid2.bm src/uipp/prompter/grid2.bm
+--- opendx_src_orig/uipp/prompter/grid2.bm	1999-04-05 09:33:50
++++ src/uipp/prompter/grid2.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define grid2_width 37
+ #define grid2_height 37
+-static char grid2_bits[] = {
++static unsigned char grid2_bits[] = {
+    0xff, 0xff, 0xff, 0xff, 0x1f, 0x41, 0x0a, 0x40, 0x02, 0x10, 0x41, 0x0a,
+    0x40, 0x02, 0x10, 0x41, 0x0a, 0x40, 0x02, 0x10, 0xff, 0xff, 0xff, 0xff,
+    0x1f, 0x41, 0x0a, 0x40, 0x02, 0x10, 0x41, 0x0a, 0x40, 0x02, 0x10, 0xff,
+Only in src/uipp/prompter: grid2.bm-e
+diff -r -u opendx_src_orig/uipp/prompter/grid3.bm src/uipp/prompter/grid3.bm
+--- opendx_src_orig/uipp/prompter/grid3.bm	1999-04-05 09:33:50
++++ src/uipp/prompter/grid3.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define grid3_width 37
+ #define grid3_height 37
+-static char grid3_bits[] = {
++static unsigned char grid3_bits[] = {
+    0x00, 0xf0, 0xff, 0x01, 0x00, 0x00, 0x0f, 0x04, 0x1e, 0x00, 0xe0, 0x00,
+    0x04, 0xe0, 0x00, 0x98, 0x00, 0x04, 0x20, 0x03, 0x86, 0x00, 0x04, 0x20,
+    0x0c, 0x01, 0x01, 0x04, 0x10, 0x10, 0x01, 0x01, 0x04, 0x10, 0x10, 0x02,
+Only in src/uipp/prompter: grid3.bm-e
+diff -r -u opendx_src_orig/uipp/prompter/grid4.bm src/uipp/prompter/grid4.bm
+--- opendx_src_orig/uipp/prompter/grid4.bm	1999-04-05 09:33:51
++++ src/uipp/prompter/grid4.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define grid4_width 37
+ #define grid4_height 37
+-static char grid4_bits[] = {
++static unsigned char grid4_bits[] = {
+    0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x06, 0x18, 0x00,
+    0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00,
+    0x00, 0x00, 0x30, 0x18, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00,
+Only in src/uipp/prompter: grid4.bm-e
+diff -r -u opendx_src_orig/uipp/prompter/row_insens.bm src/uipp/prompter/row_insens.bm
+--- opendx_src_orig/uipp/prompter/row_insens.bm	1999-04-05 09:33:51
++++ src/uipp/prompter/row_insens.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define row_insens_width 20
+ #define row_insens_height 20
+-static char row_insens_bits[] = {
++static unsigned char row_insens_bits[] = {
+    0x02, 0x81, 0x00, 0x80, 0x40, 0x00, 0x02, 0x81, 0x00, 0x40, 0x20, 0x00,
+    0x02, 0x81, 0x00, 0x40, 0x20, 0x00, 0x02, 0x81, 0x00, 0x20, 0x10, 0x00,
+    0x02, 0x81, 0x00, 0x20, 0x10, 0x00, 0x02, 0x81, 0x00, 0x10, 0x08, 0x00,
+Only in src/uipp/prompter: row_insens.bm-e
+diff -r -u opendx_src_orig/uipp/prompter/row_sens.bm src/uipp/prompter/row_sens.bm
+--- opendx_src_orig/uipp/prompter/row_sens.bm	1999-04-05 09:33:51
++++ src/uipp/prompter/row_sens.bm	2024-06-20 11:00:21
+@@ -1,6 +1,6 @@
+ #define row_sens_width 20
+ #define row_sens_height 20
+-static char row_sens_bits[] = {
++static unsigned char row_sens_bits[] = {
+    0x82, 0xc1, 0x00, 0x82, 0xc1, 0x00, 0x42, 0xa1, 0x00, 0x42, 0xa1, 0x00,
+    0x42, 0xa1, 0x00, 0x42, 0xa1, 0x00, 0x22, 0x91, 0x00, 0x22, 0x91, 0x00,
+    0x22, 0x91, 0x00, 0x22, 0x91, 0x00, 0x12, 0x89, 0x00, 0x12, 0x89, 0x00,
+Only in src/uipp/prompter: row_sens.bm-e
+Only in src/uipp/prompter: series1.bm-e
+Only in src/uipp/prompter: series1_insens.bm-e
+Only in src/uipp/prompter: series2.bm-e
+Only in src/uipp/prompter: series2_insens.bm-e
+Only in src/uipp/prompter: vector1.bm-e
+Only in src/uipp/prompter: vector1_insens.bm-e
+Only in src/uipp/prompter: vector2.bm-e
+Only in src/uipp/prompter: vector2_insens.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/backward.bm src/uipp/widgets/backward.bm
+--- opendx_src_orig/uipp/widgets/backward.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/backward.bm	2024-06-20 11:00:22
+@@ -33,7 +33,7 @@
+ 
+ #define backward_width 12
+ #define backward_height 15
+-static char backward_bits[] = {
++static unsigned char backward_bits[] = {
+    0x00, 0x08, 0x00, 0x0e, 0x00, 0x0f, 0xc0, 0x0f, 0xf0, 0x0f, 0xf8, 0x0f,
+    0xfe, 0x0f, 0xff, 0x0f, 0xfe, 0x0f, 0xf8, 0x0f, 0xf0, 0x0f, 0xc0, 0x0f,
+    0x00, 0x0f, 0x00, 0x0e, 0x00, 0x08 };
+Only in src/uipp/widgets: backward.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/forward.bm src/uipp/widgets/forward.bm
+--- opendx_src_orig/uipp/widgets/forward.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/forward.bm	2024-06-20 11:00:22
+@@ -33,7 +33,7 @@
+ 
+ #define forward_width 12
+ #define forward_height 15
+-static char forward_bits[] = {
++static unsigned char forward_bits[] = {
+    0x01, 0x00, 0x07, 0x00, 0x0f, 0x00, 0x3f, 0x00, 0xff, 0x00, 0xff, 0x01,
+    0xff, 0x07, 0xff, 0x0f, 0xff, 0x07, 0xff, 0x01, 0xff, 0x00, 0x3f, 0x00,
+    0x0f, 0x00, 0x07, 0x00, 0x01, 0x00 };
+Only in src/uipp/widgets: forward.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/frame.bm src/uipp/widgets/frame.bm
+--- opendx_src_orig/uipp/widgets/frame.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/frame.bm	2024-06-20 11:00:22
+@@ -33,7 +33,7 @@
+ 
+ #define frame_width 22
+ #define frame_height 16
+-static char frame_bits[] = {
++static unsigned char frame_bits[] = {
+    0xff, 0xff, 0xff, 0xcc, 0xcc, 0xcc, 0xff, 0xff, 0xff, 0x81, 0x40, 0xe0,
+    0x81, 0x40, 0xe0, 0x81, 0x40, 0xe0, 0x81, 0x40, 0xe0, 0x81, 0x40, 0xe0,
+    0x81, 0x40, 0xe0, 0x81, 0x40, 0xe0, 0x81, 0x40, 0xe0, 0x81, 0x40, 0xe0,
+Only in src/uipp/widgets: frame.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/loop.bm src/uipp/widgets/loop.bm
+--- opendx_src_orig/uipp/widgets/loop.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/loop.bm	2024-06-20 11:00:22
+@@ -33,7 +33,7 @@
+ 
+ #define loop_width 24
+ #define loop_height 16
+-static char loop_bits[] = {
++static unsigned char loop_bits[] = {
+    0x00, 0x00, 0x00, 0xf0, 0xff, 0x0f, 0xfc, 0xff, 0x3f, 0x1e, 0x00, 0x78,
+    0x06, 0x00, 0x60, 0x07, 0x00, 0xe0, 0x03, 0x00, 0xc0, 0x03, 0x00, 0xc0,
+    0x03, 0x00, 0xc0, 0x07, 0x00, 0xe0, 0xc6, 0x00, 0x60, 0x9e, 0x03, 0x78,
+Only in src/uipp/widgets: loop.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/palim.bm src/uipp/widgets/palim.bm
+--- opendx_src_orig/uipp/widgets/palim.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/palim.bm	2024-06-20 11:00:22
+@@ -33,7 +33,7 @@
+ 
+ #define palim_width 24
+ #define palim_height 15
+-static char palim_bits[] = {
++static unsigned char palim_bits[] = {
+    0x00, 0x00, 0x00, 0xff, 0x03, 0x02, 0xff, 0x07, 0x01, 0x00, 0x8e, 0x00,
+    0x18, 0x4c, 0x00, 0x0e, 0x2e, 0x00, 0xff, 0xd7, 0xff, 0xff, 0xeb, 0xff,
+    0x0e, 0x74, 0x00, 0x18, 0x32, 0x18, 0x00, 0x71, 0x70, 0x80, 0xe0, 0xff,
+Only in src/uipp/widgets: palim.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/pause.bm src/uipp/widgets/pause.bm
+--- opendx_src_orig/uipp/widgets/pause.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/pause.bm	2024-06-20 11:00:22
+@@ -33,6 +33,6 @@
+ 
+ #define pause_width 8
+ #define pause_height 15
+-static char pause_bits[] = {
++static unsigned char pause_bits[] = {
+    0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7,
+    0xe7, 0xe7, 0xe7, 0x00};
+Only in src/uipp/widgets: pause.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/step.bm src/uipp/widgets/step.bm
+--- opendx_src_orig/uipp/widgets/step.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/step.bm	2024-06-20 11:00:22
+@@ -33,7 +33,7 @@
+ 
+ #define step_width 24
+ #define step_height 10
+-static char step_bits[] = {
++static unsigned char step_bits[] = {
+    0x40, 0x66, 0x02, 0x70, 0x66, 0x0e, 0x78, 0x66, 0x1e, 0x7e, 0x66, 0x7e,
+    0x7f, 0x66, 0xfe, 0x7f, 0x66, 0xfe, 0x7e, 0x66, 0x7e, 0x78, 0x66, 0x1e,
+    0x70, 0x66, 0x0e, 0x40, 0x66, 0x02};
+Only in src/uipp/widgets: step.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/stepb.bm src/uipp/widgets/stepb.bm
+--- opendx_src_orig/uipp/widgets/stepb.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/stepb.bm	2024-06-20 11:00:21
+@@ -33,7 +33,7 @@
+ 
+ #define stepb_width 20
+ #define stepb_height 15
+-static char stepb_bits[] = {
++static unsigned char stepb_bits[] = {
+    0x00, 0xc8, 0x0c, 0x00, 0xce, 0x0c, 0x00, 0xcf, 0x0c, 0xc0, 0xcf, 0x0c,
+    0xf0, 0xcf, 0x0c, 0xf8, 0xcf, 0x0c, 0xfe, 0xcf, 0x0c, 0xff, 0xcf, 0x0c,
+    0xfe, 0xcf, 0x0c, 0xf8, 0xcf, 0x0c, 0xf0, 0xcf, 0x0c, 0xc0, 0xcf, 0x0c,
+Only in src/uipp/widgets: stepb.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/stepf.bm src/uipp/widgets/stepf.bm
+--- opendx_src_orig/uipp/widgets/stepf.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/stepf.bm	2024-06-20 11:00:22
+@@ -33,7 +33,7 @@
+ 
+ #define stepf_width 20
+ #define stepf_height 15
+-static char stepf_bits[] = {
++static unsigned char stepf_bits[] = {
+    0x33, 0x01, 0x00, 0x33, 0x07, 0x00, 0x33, 0x0f, 0x00, 0x33, 0x3f, 0x00,
+    0x33, 0xff, 0x00, 0x33, 0xff, 0x01, 0x33, 0xff, 0x07, 0x33, 0xff, 0x0f,
+    0x33, 0xff, 0x07, 0x33, 0xff, 0x01, 0x33, 0xff, 0x00, 0x33, 0x3f, 0x00,
+Only in src/uipp/widgets: stepf.bm-e
+diff -r -u opendx_src_orig/uipp/widgets/stop.bm src/uipp/widgets/stop.bm
+--- opendx_src_orig/uipp/widgets/stop.bm	1999-03-24 10:17:37
++++ src/uipp/widgets/stop.bm	2024-06-20 11:00:21
+@@ -33,6 +33,6 @@
+ 
+ #define stop_width 10
+ #define stop_height 10
+-static char stop_bits[] = {
++static unsigned char stop_bits[] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+Only in src/uipp/widgets: stop.bm-e


### PR DESCRIPTION
#### Description

Make opendx compile with current clang, which has made some things that were previously warnings into errors. This involves making some function arguments explicitly type `int`, casting some inconsistent function return types, and replacing various `static char []` in bitmaps (`*.bm` files) with `static unsigned char []`, and then casting them back to `char *` when passing to X functions that expect this data type.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
