### PR TITLE
gitu: Update to 0.21.1

### DIFF
--- a/devel/gitu/Portfile
+++ b/devel/gitu/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            altsem gitu 0.21.0 v
+github.setup            altsem gitu 0.21.1 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -16,9 +16,9 @@ description             A TUI Git client inspired by Magit
 long_description        {*}${description}, launched straight from the terminal.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  fc0e908a73615ac6cd82143223c7013f97883845 \
-                        sha256  12a452b99b8e6b35aca810d093ea21fcfbacd29272eb70a72a5d67f99db7f31c \
-                        size    3917491
+                        rmd160  64989d434767ec2c909f9cf8a7971a5a6072c7a6 \
+                        sha256  bca4575ecc2b00c3147f23761fac807ab4836b119efd6823fe5ab741cd17dfdb \
+                        size    3917733
 
 destroot {
     set bindir ${worksrcpath}/target/[cargo.rust_platform]/release


### PR DESCRIPTION
#### Description

Update `gitu` to its latest released version, 0.21.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
