### PR TITLE
grace: fix outdated-behavior (implicit int function args) warning vs. error with clang

### DIFF
--- a/x11/grace/Portfile
+++ b/x11/grace/Portfile
@@ -32,7 +32,9 @@ depends_lib         lib:libXm:openmotif \
 
 depends_run         port:openbrowser
 
-patchfiles          implicit.patch
+patchfiles          implicit.patch \
+                    patch-implicit-Xbae.diff \
+                    patch-implicit-src.diff
 
 # The default optimization level apparently causes xmgrace to crash for some users.
 configure.optflags  -O1

--- a/x11/grace/files/patch-implicit-Xbae.diff
+++ b/x11/grace/files/patch-implicit-Xbae.diff
@@ -1,0 +1,12 @@
+diff -r -u Xbae_orig/Xbae/Draw.c Xbae/Xbae/Draw.c
+--- Xbae_orig/Xbae/Draw.c	1999-09-10 21:25:37
++++ Xbae/Xbae/Draw.c	2024-06-20 17:07:34
+@@ -236,7 +236,7 @@
+ static void
+ xbaeDrawCellString(mw, row, column, x, y, string, bg, fg)
+ XbaeMatrixWidget mw;
+-int row, column;
++int row, column, x, y;
+ String string;
+ Pixel bg, fg;
+ {

--- a/x11/grace/files/patch-implicit-src.diff
+++ b/x11/grace/files/patch-implicit-src.diff
@@ -1,0 +1,12 @@
+diff -r -u src_orig/utils.c src/utils.c
+--- src_orig/utils.c	2007-02-15 17:36:54
++++ src/utils.c	2024-06-20 17:10:36
+@@ -1389,7 +1389,7 @@
+     update_app_title();
+ }
+ 
+-void lock_dirtystate(flag)
++void lock_dirtystate(int flag)
+ {
+     dirtystate_lock = flag;
+ }


### PR DESCRIPTION
#### Description

Make grace compile with current clang, which has made some things that were previously warnings into errors. This involves making some function arguments explicitly type `int`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
