### PR TITLE
openssl3: Make obsoleteness of -devel subport explicit.

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -53,6 +53,18 @@ checksums           rmd160  f7d3736a023dcf7d40db016182ca6d1de5a6fa69 \
                     sha256  777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e \
                     size    18055752
 
+# Old obsolete subport for overriding version holdback
+# Make it explicitly obsolete for now
+#
+if {${os.platform} eq "darwin" && ${os.major} < 18} {
+
+    subport ${name}-devel {
+        PortGroup           obsolete 1.0
+
+        replaced_by         ${name}
+    }
+}
+
 # Use timegm() in crypto/asn1/a_time.c
 # Fixes build on 10.4, and is generally preferable, anyway
 #


### PR DESCRIPTION
This was negelected in the update, and ensures better handling of existing -devel installs (only applicable to OS <10.14).

TESTED:
On 10.9, the openssl3-devel port correctly reports as obsolete, doesn't refuse "port clean", and installs openssl-3.3.1_1 on "port upgrade".

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [NO] tried existing tests with `sudo port test`?
- [NO] tried a full install with `sudo port -vst install`?
- [NO] tested basic functionality of all binary files?
- [NO] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

NOTE: Abbreviated testing since the only change is adding the obsolete -devel subport.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
