### PR TITLE
libgpg-error: Fix build on Mac OS X 10.7 and earlier

### DIFF
--- a/devel/libgpg-error/Portfile
+++ b/devel/libgpg-error/Portfile
@@ -20,7 +20,7 @@ revision        0
 categories      devel
 license         LGPL-2.1+
 maintainers     {mps @Schamschula} openmaintainer
-homepage        https://www.gnupg.org/
+
 description     Common error values for all GnuPG components
 
 long_description \
@@ -28,6 +28,7 @@ long_description \
     Among these are GPG, GPGSM, GPGME, GPG-Agent, libgcrypt, pinentry, SmartCard Daemon \
     and possibly more in the future.
 
+homepage        https://www.gnupg.org
 master_sites    gnupg
 
 use_bzip2       yes

--- a/devel/libgpg-error/files/patch-src-spawn-posix.c.diff
+++ b/devel/libgpg-error/files/patch-src-spawn-posix.c.diff
@@ -1,10 +1,31 @@
---- src/spawn-posix.c.orig	2024-06-19 02:33:41
-+++ src/spawn-posix.c	2024-06-20 10:01:26
-@@ -57,6 +57,7 @@
+Fix:
+
+error: use of undeclared identifier 'environ'
+
+https://dev.gnupg.org/T7169
+--- src/spawn-posix.c.orig	2024-06-19 02:33:41.000000000 -0500
++++ src/spawn-posix.c	2024-06-21 01:54:38.000000000 -0500
+@@ -57,6 +57,11 @@
  
  #include "gpgrt-int.h"
  
++#ifdef __APPLE__
++# include <crt_externs.h>
++#else
 +extern char **environ;
++#endif
  
  /* Definition for the gpgrt_spawn_actions_t.  Note that there is a
   * different one for Windows.  */
+@@ -342,7 +347,11 @@
+   _gpgrt_close_all_fds (3, act->except_fds);
+ 
+   if (act->environ)
++#ifdef __APPLE__
++    *_NSGetEnviron() = act->environ;
++#else
+     environ = act->environ;
++#endif
+ 
+   if (act->atfork)
+     act->atfork (act->atfork_arg);


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/70267

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
