### PR TITLE
spring-boot-cli: update to 3.3.1

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.3.0
+version         3.3.1
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  4eb79fdf9f94cd3452dff13facb16944e5ddd8dd \
-                sha256  334c0f1643ed1e61cf4c07d17abf46e9396e1c60f44c7912306859404598c25a \
-                size    5503646
+checksums       rmd160  de847c961409b07644954a55969c166299ee9f05 \
+                sha256  a5737e57fe938a9dbe9669ea5a914f2467dcfb7c034cd927894477f37e41f44a \
+                size    5504413
 
 worksrcdir      spring-${version}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.3.1.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?