### PR TITLE
wine-stable.wine-devel: Swap from MoltenVK stub to MoltenVK-latest

### DIFF
--- a/emulators/wine-devel/Portfile
+++ b/emulators/wine-devel/Portfile
@@ -52,7 +52,7 @@ depends_lib \
     port:freetype \
     port:gettext-runtime \
     path:lib/pkgconfig/gnutls.pc:gnutls \
-    path:lib/libMoltenVK.dylib:MoltenVK \
+    path:lib/libMoltenVK.dylib:MoltenVK-latest \
     port:libpcap \
     port:libsdl2
 

--- a/emulators/wine-stable/Portfile
+++ b/emulators/wine-stable/Portfile
@@ -51,7 +51,7 @@ depends_lib \
     port:freetype \
     port:gettext-runtime \
     path:lib/pkgconfig/gnutls.pc:gnutls \
-    path:lib/libMoltenVK.dylib:MoltenVK \
+    path:lib/libMoltenVK.dylib:MoltenVK-latest \
     port:libpcap \
     port:libsdl2
 


### PR DESCRIPTION
#### Description

Instead of using the stub just directly call `MoltenVK-latest`

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
