### PR TITLE
mysql8, p5-dbd-mysql: Fix my_openssl / mysqlclient.dylib link errors

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -13,8 +13,8 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     2
-set revision_server     2
+set revision_client     3
+set revision_server     3
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
@@ -142,7 +142,9 @@ if {$subport eq $name} {
     patch.pre_args-replace  -p0 -p1
     patchfiles      patch-cmake-install_layout.cmake.diff \
                     patch-readline.cmake.diff \
-                    patch-scripts-cmakelists.diff
+                    patch-scripts-cmakelists.diff \
+                    patch-ssl.cmake.diff \
+                    patch-copy_openssl_binary.cmake.diff
 
     post-extract {
         file mkdir ${cmake.build_dir}/macports

--- a/databases/mysql8/files/patch-cmake-install_layout.cmake.diff
+++ b/databases/mysql8/files/patch-cmake-install_layout.cmake.diff
@@ -28,8 +28,8 @@
 +SET(INSTALL_SBINDIR_MACPORTS                      "lib/@NAME@/bin")
 +SET(INSTALL_SCRIPTDIR_MACPORTS                    "lib/@NAME@/bin")
 +#
-+SET(INSTALL_LIBDIR_MACPORTS                       "lib/@NAME@/lib")
-+SET(INSTALL_PRIV_LIBDIR_MACPORTS                  "lib/@NAME@/lib")
++SET(INSTALL_LIBDIR_MACPORTS                       "lib/@NAME@/mysql")
++SET(INSTALL_PRIV_LIBDIR_MACPORTS                  "lib/@NAME@/mysql")
 +SET(INSTALL_PLUGINDIR_MACPORTS                    "lib/@NAME@/plugin")
 +#
 +SET(INSTALL_INCLUDEDIR_MACPORTS                   "include/@NAME@/mysql")

--- a/databases/mysql8/files/patch-copy_openssl_binary.cmake.diff
+++ b/databases/mysql8/files/patch-copy_openssl_binary.cmake.diff
@@ -1,0 +1,55 @@
+--- a/cmake/copy_openssl_binary.cmake	2024-06-21 09:47:38
++++ b/cmake/copy_openssl_binary.cmake	2024-06-21 09:49:11
+@@ -68,6 +68,23 @@
+ ENDIF(LINUX)
+ 
+ IF(APPLE)
++  execute_process(
++    COMMAND which port
++    RESULT_VARIABLE DETECT_MACPORTS
++    OUTPUT_VARIABLE PKGMGR_PREFIX
++    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
++  execute_process(
++    COMMAND brew --prefix
++    RESULT_VARIABLE DETECT_HOMEBREW
++    OUTPUT_VARIABLE PKGMGR_PREFIX
++    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
++
++  IF(DETECT_MACPORTS EQUAL 0)
++    SET(MYSQL_LIB_DIR "../mysql")
++  ELSEIF(DETECT_HOMEBREW EQUAL 0)
++    SET(MYSQL_LIB_DIR "../lib")
++  ENDIF()
++
+   MESSAGE(STATUS "CRYPTO_VERSION is ${CRYPTO_VERSION}")
+   MESSAGE(STATUS "OPENSSL_VERSION is ${OPENSSL_VERSION}")
+   EXECUTE_PROCESS(
+@@ -92,11 +109,11 @@
+   IF(BUILD_IS_SINGLE_CONFIG)
+     # install_name_tool -change old new file
+     EXECUTE_PROCESS(COMMAND install_name_tool -change
+-      "${LIBSSL_MATCH}" "@loader_path/../lib/${OPENSSL_VERSION}"
++      "${LIBSSL_MATCH}" "@loader_path/${MYSQL_LIB_DIR}/${OPENSSL_VERSION}"
+       "./${executable_name}"
+       )
+     EXECUTE_PROCESS(COMMAND install_name_tool -change
+-      "${LIBCRYPTO_MATCH}" "@loader_path/../lib/${CRYPTO_VERSION}"
++      "${LIBCRYPTO_MATCH}" "@loader_path/${MYSQL_LIB_DIR}/${CRYPTO_VERSION}"
+       "./${executable_name}"
+       )
+     EXECUTE_PROCESS(
+@@ -106,12 +123,12 @@
+     # install_name_tool -change old new file
+     EXECUTE_PROCESS(COMMAND install_name_tool -change
+       "${LIBSSL_MATCH}"
+-      "@loader_path/../../lib/${CMAKE_CFG_INTDIR}/${OPENSSL_VERSION}"
++      "@loader_path/../../${MYSQL_LIB_DIR}/${CMAKE_CFG_INTDIR}/${OPENSSL_VERSION}"
+       "./${CMAKE_CFG_INTDIR}/${executable_name}"
+       )
+     EXECUTE_PROCESS(COMMAND install_name_tool -change
+       "${LIBCRYPTO_MATCH}"
+-      "@loader_path/../../lib/${CMAKE_CFG_INTDIR}/${CRYPTO_VERSION}"
++      "@loader_path/../${MYSQL_LIB_DIR}/${CMAKE_CFG_INTDIR}/${CRYPTO_VERSION}"
+       "./${CMAKE_CFG_INTDIR}/${executable_name}"
+       )
+     EXECUTE_PROCESS(

--- a/databases/mysql8/files/patch-ssl.cmake.diff
+++ b/databases/mysql8/files/patch-ssl.cmake.diff
@@ -1,0 +1,153 @@
+--- a/cmake/ssl.cmake	2024-06-21 09:47:38
++++ b/cmake/ssl.cmake	2024-06-21 09:49:11
+@@ -46,19 +46,21 @@
+ #     https://brew.sh
+ #     https://formulae.brew.sh/formula/openssl@1.1
+ #     https://formulae.brew.sh/formula/openssl@3
+-#     we give a hint ${HOMEBREW_HOME}/openssl to find_package(OpenSSL)
++#     we give a hint ${HOMEBREW_HOME}/openssl
+ #
+ # On Windows, we treat this "system" library as if cmake had been
+ # invoked with -DWITH_SSL=</path/to/custom/openssl>
+ #
+ # On macOS we treat it as a system library, which means that the generated
+-# binaries end up having dependencies on Homebrew libraries.
++# binaries end up having dependencies on Homebrew or MacPorts libraries.
+ # Note that 'cmake -DWITH_SSL=<some path>'
+ # is NOT handled in the same way as 'cmake -DWITH_SSL=system'
+ # which means that for
+ # 'cmake -DWITH_SSL=/usr/local/opt/openssl'
+ #    or, on Apple silicon:
+ # 'cmake -DWITH_SSL=/opt/homebrew/opt/openssl'
++#     or, on MacPorts
++# 'cmake -DWITH_SSL=/opt/local/libexec/openssl3'
+ # we will treat the libraries as external, and copy them into our build tree.
+ #
+ # On el7:
+@@ -350,9 +352,26 @@
+ # For all non-windows platforms, use the standard FIND_PACKAGE utility
+ # to locate OpenSSL.
+ FUNCTION(FIND_SYSTEM_OPENSSL)
+-  # For APPLE we set the hint ${HOMEBREW_HOME}/openssl
+-  IF(APPLE AND NOT OPENSSL_ROOT_DIR)
+-    SET(OPENSSL_ROOT_DIR "${HOMEBREW_HOME}/openssl")
++  # MacPorts or Homebrew?
++  execute_process(
++    COMMAND which port
++    RESULT_VARIABLE DETECT_MACPORTS
++    OUTPUT_VARIABLE PKGMGR_PREFIX
++    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
++  execute_process(
++    COMMAND brew --prefix
++    RESULT_VARIABLE DETECT_HOMEBREW
++    OUTPUT_VARIABLE PKGMGR_PREFIX
++    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
++
++  IF(DETECT_MACPORTS EQUAL 0)
++    SET(OPENSSL_ROOT_DIR "${PKGMGR_PREFIX}/libexec/openssl3")
++    SET(OPENSSL_ALT_ROOT_DIR "${PKGMGR_PREFIX}/openssl11")
++    SET(MYSQL_LIB_DIR "${PKGMGR_PREFIX}/libexec/mysql8/mysql")
++  ELSEIF(DETECT_HOMEBREW EQUAL 0)
++    SET(OPENSSL_ROOT_DIR "${PKGMGR_PREFIX}/openssl")
++    SET(OPENSSL_ALT_ROOT_DIR "${PKGMGR_PREFIX}/openssl@1.1")
++    SET(MYSQL_LIB_DIR "../lib")
+   ENDIF()
+ 
+   # Will set OPENSSL_FOUND, OPENSSL_INCLUDE_DIR and others.
+@@ -360,8 +379,8 @@
+ 
+   # Re-try, in case the symlink is not found.
+   IF(NOT OPENSSL_FOUND AND APPLE AND
+-      OPENSSL_ROOT_DIR STREQUAL "${HOMEBREW_HOME}/openssl")
+-    SET(OPENSSL_ROOT_DIR "${HOMEBREW_HOME}/openssl@1.1")
++      OPENSSL_ROOT_DIR STREQUAL "${OPENSSL_ROOT_DIR}")
++    SET(OPENSSL_ROOT_DIR "${OPENSSL_ALT_ROOT_DIR}")
+     FIND_PACKAGE(OpenSSL)
+   ENDIF()
+ 
+@@ -372,7 +391,7 @@
+ 
+   FIND_OPENSSL_VERSION()
+ 
+-  # Homebrew "system" OpenSSL needs:
++  # Homebrew/Macports "system" OpenSSL needs:
+   IF(NOT OPENSSL_INCLUDE_DIR STREQUAL "/usr/include")
+     INCLUDE_DIRECTORIES(BEFORE SYSTEM ${OPENSSL_INCLUDE_DIR})
+   ENDIF()
+@@ -632,8 +651,13 @@
+     ENDIF(APPLE)
+ 
+     IF(APPLE_WITH_CUSTOM_SSL)
++      # on Homebrew
+       # CRYPTO_LIBRARY is .../lib/libcrypto.dylib
+-      # CRYPTO_VERSION is .../lib/libcrypto.1.0.0.dylib
++      # CRYPTO_VERSION is .../lib/libcrypto.3.dylib
++      # on Macports
++      # CRYPTO_LIBRARY is ${MACPORTS_PREFIX}/lib/libcrypto.dylib
++      # CRYPTO_VERSION is ${MACPORTS_PREFIX}/lib/libcrypto.3.dylib
++
+       EXECUTE_PROCESS(
+         COMMAND readlink "${CRYPTO_LIBRARY}" OUTPUT_VARIABLE CRYPTO_VERSION
+         OUTPUT_STRIP_TRAILING_WHITESPACE)
+@@ -641,7 +665,7 @@
+         COMMAND readlink "${OPENSSL_LIBRARY}" OUTPUT_VARIABLE OPENSSL_VERSION
+         OUTPUT_STRIP_TRAILING_WHITESPACE)
+ 
+-      # Replace dependency "/Volumes/.../lib/libcrypto.1.0.0.dylib
++      # Replace dependency "*/libcrypto.3.dylib
+       EXECUTE_PROCESS(
+         COMMAND otool -L "${OPENSSL_LIBRARY}"
+         OUTPUT_VARIABLE OTOOL_OPENSSL_DEPS)
+@@ -702,9 +726,9 @@
+       # Create symlinks for plugins, see MYSQL_ADD_PLUGIN/install_name_tool
+       ADD_CUSTOM_TARGET(link_openssl_dlls ALL
+         COMMAND ${CMAKE_COMMAND} -E create_symlink
+-          "../lib/${CRYPTO_VERSION}" "${CRYPTO_VERSION}"
++          "${MYSQL_LIB_DIR}/${CRYPTO_VERSION}" "${CRYPTO_VERSION}"
+         COMMAND ${CMAKE_COMMAND} -E create_symlink
+-          "../lib/${OPENSSL_VERSION}" "${OPENSSL_VERSION}"
++          "${MYSQL_LIB_DIR}/${OPENSSL_VERSION}" "${OPENSSL_VERSION}"
+         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/plugin_output_directory"
+ 
+         BYPRODUCTS
+@@ -715,9 +739,9 @@
+       IF(NOT BUILD_IS_SINGLE_CONFIG)
+         ADD_CUSTOM_TARGET(link_openssl_dlls_cmake_cfg_intdir ALL
+           COMMAND ${CMAKE_COMMAND} -E create_symlink
+-          "../../lib/${CMAKE_CFG_INTDIR}/${CRYPTO_VERSION}" "${CRYPTO_VERSION}"
++          "../${MYSQL_LIB_DIR}/${CMAKE_CFG_INTDIR}/${CRYPTO_VERSION}" "${CRYPTO_VERSION}"
+           COMMAND ${CMAKE_COMMAND} -E create_symlink
+-          "../../lib/${CMAKE_CFG_INTDIR}/${OPENSSL_VERSION}" "${OPENSSL_VERSION}"
++          "../${MYSQL_LIB_DIR}/${CMAKE_CFG_INTDIR}/${OPENSSL_VERSION}" "${OPENSSL_VERSION}"
+           WORKING_DIRECTORY
+           "${CMAKE_BINARY_DIR}/plugin_output_directory/${CMAKE_CFG_INTDIR}"
+ 
+@@ -728,13 +752,13 @@
+       ENDIF()
+ 
+       # Directory layout after 'make install' is different.
+-      # Create some symlinks from lib/plugin/*.dylib to ../../lib/*.dylib
++      # Create some symlinks from mysql/plugin/*.dylib to ../../mysql/*.dylib
+       FILE(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/plugin_output_directory/plugin")
+       ADD_CUSTOM_TARGET(link_openssl_dlls_for_install ALL
+         COMMAND ${CMAKE_COMMAND} -E create_symlink
+-          "../../lib/${CRYPTO_VERSION}" "${CRYPTO_VERSION}"
++          "../${MYSQL_LIB_DIR}/${CRYPTO_VERSION}" "${CRYPTO_VERSION}"
+         COMMAND ${CMAKE_COMMAND} -E create_symlink
+-          "../../lib/${OPENSSL_VERSION}" "${OPENSSL_VERSION}"
++          "../${MYSQL_LIB_DIR}/${OPENSSL_VERSION}" "${OPENSSL_VERSION}"
+         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/plugin_output_directory/plugin"
+         )
+       # See INSTALL_DEBUG_TARGET used for installing debug versions of plugins.
+@@ -742,9 +766,9 @@
+         FILE(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/plugin_output_directory/plugin/debug")
+         ADD_CUSTOM_TARGET(link_openssl_dlls_for_install_debug ALL
+           COMMAND ${CMAKE_COMMAND} -E create_symlink
+-            "../../../lib/${CRYPTO_VERSION}" "${CRYPTO_VERSION}"
++            "../../${MYSQL_LIB_DIR}/${CRYPTO_VERSION}" "${CRYPTO_VERSION}"
+           COMMAND ${CMAKE_COMMAND} -E create_symlink
+-            "../../../lib/${OPENSSL_VERSION}" "${OPENSSL_VERSION}"
++            "../../${MYSQL_LIB_DIR}/${OPENSSL_VERSION}" "${OPENSSL_VERSION}"
+           WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/plugin_output_directory/plugin/debug"
+         )
+       ENDIF()

--- a/perl/p5-dbd-mysql/Portfile
+++ b/perl/p5-dbd-mysql/Portfile
@@ -23,10 +23,10 @@ platforms           darwin
 # }
 ###############################################################################
 array set version_current {
-    version     5.003
-    rmd160      750b4a31d358a7c5ae5a3f9905df80357dbc1f3b
-    sha256      21554443d60e294cc0ac00adaef53ccb7de55d4fae66a38372a5adf0a0f1edda
-    size        154242
+    version     5.006
+    rmd160      983a5431e91b9c87bd2dfa14ed2ed60c471d675b
+    sha256      4ca6c6415552a8acd3d8e01a96d0ac5a4a936e845c4c0e6a7ac6a10ad3798db7
+    size        155023
 }
 array set version_4 {
     version     4.052
@@ -89,7 +89,7 @@ checksums                   rmd160  [lindex [array get $install_version rmd160] 
                                     size    [lindex [array get $install_version size] 1]
 # version gets set to the "current version" values to prevenet constant upgraing by port upgrade
 version                     [perl5_convert_version [lindex [array get version_current version] 1]]
-revision                    1
+revision                    0
 
 if {${perl5.major} != ""} {
     depends_build-append \


### PR DESCRIPTION
  mysql8:
  In more recent mysql8 releases, some of the cmake files have are
  hard coded to the homebrew install locations.  This commit resolves
  the issues when using the macports openssl / libcrypto packages.
  This commit also resolved issues where mysql_config produced the
  incorrect path for the installed mysql support libraries.

  p5-dbd-mysql:
  This commit additionally updates p5-dbd-mysql to 5.006

Closes: https://trac.macports.org/ticket/70001

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Renders [PR 24232](https://github.com/macports/macports-ports/pull/24232) obsolete
QT6 will require an update that reverses [dd5b391](https://github.com/macports/macports-ports/commit/dd5b391e5a3c4263f3457732b5f7c09ceec089b9)
GDAL will require an update that reverses [a7a4334](https://github.com/macports/macports-ports/commit/a7a4334c2169af6db0a69c8b1627bcc196acd69d)

