### PR TITLE
wc2: use -pedantic instead of -Wpedantic

### DIFF
--- a/textproc/wc2/Portfile
+++ b/textproc/wc2/Portfile
@@ -34,6 +34,9 @@ checksums           rmd160  8bf38fa4b3f2a96f4e1c5191cbbfe2024463d523 \
                     sha256  f7d8cc810c4a4a61ada54996b523fe4877f040d3b33dc77df57cb3687d4ae3b0 \
                     size    31172
 
+# cc1: error: unrecognized command line option "-Wpedantic"
+patchfiles-append   patch-pedantic.diff
+
 build.target        ${name}
 
 destroot {

--- a/textproc/wc2/files/patch-pedantic.diff
+++ b/textproc/wc2/files/patch-pedantic.diff
@@ -1,0 +1,10 @@
+--- Makefile	2022-11-03 02:42:08.000000000 +0800
++++ Makefile	2024-06-22 09:20:20.000000000 +0800
+@@ -1,6 +1,6 @@
+ TIMEFORMAT=%U
+ 
+-CFLAGS += -Wall -Wpedantic -Wextra -O2
++CFLAGS += -Wall -pedantic -Wextra -O2
+ 
+ all: wc2 wc2o wcdiff wctool wcstream
+ 


### PR DESCRIPTION
#### Description

Minor fix.
(If does not work unconditionally, I make it only for Xcode gcc.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
