### PR TITLE
KeePassXC: update to 2.7.9

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -30,7 +30,7 @@ license_noconflict      openssl openssl10 openssl11 openssl3
 
 if {${subport} eq ${name}} {
     # stable
-    github.setup        keepassxreboot keepassxc 2.7.8
+    github.setup        keepassxreboot keepassxc 2.7.9
     revision            0
     github.tarball_from releases
     distname            keepassxc-${version}-src
@@ -42,12 +42,12 @@ if {${subport} eq ${name}} {
 
     # See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
     checksums           ${distname}${extract.suffix} \
-                        rmd160  873c1405ad711451fdd5ac48c872c12e7a2f85f8 \
-                        sha256  87d3101712b3c8656a24b908ad5b7e2529bc01717cb4156f53ba195fb81783a3 \
-                        size    9764860 \
+                        rmd160  0ac59defa184907036007f57d55e97ab8b422ce6 \
+                        sha256  3c44e45f22c00ddac63d8bc11054b4b0ada0222ffac08d3ed70f196cb9ed46fd \
+                        size    9789312 \
                         ${distname}${extract.suffix}.sig \
-                        rmd160  38112c11a26f653db3d5a2a52249b286d7e108d0 \
-                        sha256  aafbc45db589e234ea0243652d49a5b6f4fd5b06431d8e8989bbdd48de48897d \
+                        rmd160  1ca16506c6bd2abbf3e30e3cb91b5d9a06139ec0 \
+                        sha256  f3a51f4cbb7f4b3574cf3201d84427ebec59461eb5db516065bf282ba9b16a8b \
                         size    488
 
     gpg_verify.use_gpg_verification \
@@ -104,12 +104,6 @@ depends_lib-append      port:argon2 \
                         port:qrencode \
                         port:ykpers \
                         port:zlib
-
-# unknown xattrs make older BSD tar fail
-if {${os.platform} eq "darwin" && ${os.major} <= 18} {
-    depends_extract port:libarchive
-    extract.post_args | ${prefix}/bin/bsdtar -xf -
-}
 
 patchfiles-append       patch-no-deployqt.diff \
                         patch-no-findpackage-path.diff \


### PR DESCRIPTION
xattr error does not occur in this update

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
