### PR TITLE
py-cryptography: update to 3.4.8 for legacy systems

### DIFF
--- a/python/py-cryptography/Portfile
+++ b/python/py-cryptography/Portfile
@@ -30,7 +30,7 @@ checksums           ${distname}${extract.suffix} \
 # * https://ports.macports.org/port/rust/summary
 set cryptography_darwin_min_ver 13
 
-if {${name} ne ${subport}
+if {${name} ne ${subport} \
     && [string match "py*-${github.project}" ${subport}]} {
     depends_build-append \
                     port:py${python.version}-setuptools
@@ -39,24 +39,45 @@ if {${name} ne ${subport}
                     port:py${python.version}-cffi
 
     # legacy support
-    if {${python.version} eq 27
+    if {${python.version} eq 27 \
         || ${os.platform} eq "darwin" && ${os.major} < ${cryptography_darwin_min_ver}} {
-        PortGroup       openssl 1.0
-        github.setup    pyca cryptography 3.3.2
-        revision        0
+        PortGroup           openssl 1.0
+
+        if {${python.version} eq 27} {
+            # Needs the same OpenSSL version as Python itself was built with.
+            openssl.branch  1.1
+
+            github.setup    pyca cryptography 3.3.2
+            revision        0
+            checksums       rmd160  13380349b4a5559153c1e8a328fd4629b81e134d \
+                            sha256  2c8af64316fa1c09162c6e99dba9c23c76a07c3466dbbf62db8df970b45f935f \
+                            size    35729139
+
+            depends_lib-append \
+                            port:py${python.version}-enum34 \
+                            port:py${python.version}-ipaddress
+        } else {
+            github.setup    pyca cryptography 3.4.8
+            revision        0
+            checksums       rmd160  01ea4549ac0dc751bf7a81bfeb4b3c942303f254 \
+                            sha256  cce7ee0b1082753df56c6bbbbe3c4122daba3b821b0d2129537d058624e67198 \
+                            size    35736917
+
+            # CRYPTOGRAPHY_DONT_BUILD_RUST is not respected by the build.
+            # So just remove Rust stuff from setup.py, it is optional in 3.4.x.
+            patchfiles-append \
+                            patch-build-no-rust.diff
+            # We do not want a build conflict with OpenSSL 3 here.
+            # Thise version is easily fixable to build against it.
+            patchfiles-append \
+                            patch-openssl3.diff
+        }
 
         python.pep517   no
-
-        # Build fails with OpenSSL 3; use 1.1 for now
-        openssl.branch  1.1
 
         description     Legacy support of Python cryptography.
 
         long_description    {*}${description}
-
-        checksums       rmd160  13380349b4a5559153c1e8a328fd4629b81e134d \
-                        sha256  2c8af64316fa1c09162c6e99dba9c23c76a07c3466dbbf62db8df970b45f935f \
-                        size    35729139
 
         if {${os.platform} eq "darwin" && ${os.major} < 11} {
             # https://trac.macports.org/ticket/54519
@@ -69,11 +90,6 @@ if {${name} ne ${subport}
         depends_lib-append \
                         port:py${python.version}-six
 
-        if {${python.version} eq 27} {
-            depends_lib-append \
-                        port:py${python.version}-enum34 \
-                        port:py${python.version}-ipaddress
-        }
     } else {
         PortGroup   rust 1.0
 

--- a/python/py-cryptography/files/patch-build-no-rust.diff
+++ b/python/py-cryptography/files/patch-build-no-rust.diff
@@ -1,0 +1,72 @@
+--- setup.py	2021-08-25 01:01:04.000000000 +0800
++++ setup.py	2024-06-23 11:42:01.000000000 +0800
+@@ -10,22 +10,6 @@
+ 
+ from setuptools import find_packages, setup
+ 
+-try:
+-    from setuptools_rust import RustExtension
+-except ImportError:
+-    print(
+-        """
+-        =============================DEBUG ASSISTANCE==========================
+-        If you are seeing an error here please try the following to
+-        successfully install cryptography:
+-
+-        Upgrade to the latest pip and try again. This will fix errors for most
+-        users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
+-        =============================DEBUG ASSISTANCE==========================
+-        """
+-    )
+-    raise
+-
+ 
+ base_dir = os.path.dirname(__file__)
+ src_dir = os.path.join(base_dir, "src")
+@@ -41,27 +25,9 @@
+ 
+ # `install_requirements` and `setup_requirements` must be kept in sync with
+ # `pyproject.toml`
+-setuptools_rust = "setuptools-rust>=0.11.4"
+ install_requirements = ["cffi>=1.12"]
+-setup_requirements = install_requirements + [setuptools_rust]
++setup_requirements = install_requirements
+ 
+-if os.environ.get("CRYPTOGRAPHY_DONT_BUILD_RUST"):
+-    rust_extensions = []
+-else:
+-    rust_extensions = [
+-        RustExtension(
+-            "_rust",
+-            "src/rust/Cargo.toml",
+-            py_limited_api=True,
+-            # Enable abi3 mode if we're not using PyPy.
+-            features=(
+-                []
+-                if platform.python_implementation() == "PyPy"
+-                else ["pyo3/abi3-py36"]
+-            ),
+-            rust_version=">=1.41.0",
+-        )
+-    ]
+ 
+ with open(os.path.join(base_dir, "README.rst")) as f:
+     long_description = f.read()
+@@ -129,9 +95,6 @@
+                 "twine >= 1.12.0",
+                 "sphinxcontrib-spelling >= 4.0.1",
+             ],
+-            "sdist": [
+-                setuptools_rust,
+-            ],
+             "pep8test": [
+                 "black",
+                 "flake8",
+@@ -149,7 +112,6 @@
+             "src/_cffi_src/build_openssl.py:ffi",
+             "src/_cffi_src/build_padding.py:ffi",
+         ],
+-        rust_extensions=rust_extensions,
+     )
+ except:  # noqa: E722
+     # Note: This is a bare exception that re-raises so that we don't interfere

--- a/python/py-cryptography/files/patch-openssl3.diff
+++ b/python/py-cryptography/files/patch-openssl3.diff
@@ -1,0 +1,38 @@
+--- src/_cffi_src/openssl/fips.py	2021-08-25 01:01:04.000000000 +0800
++++ src/_cffi_src/openssl/fips.py	2024-06-23 11:54:00.000000000 +0800
+@@ -22,6 +22,8 @@
+ int (*FIPS_mode_set)(int) = NULL;
+ int (*FIPS_mode)(void) = NULL;
+ #else
+-static const long Cryptography_HAS_FIPS = 1;
++static const long Cryptography_HAS_FIPS = 0;
++int (*FIPS_mode_set)(int) = NULL;
++int (*FIPS_mode)(void) = NULL;
+ #endif
+ """
+
+--- src/_cffi_src/openssl/err.py	2021-08-25 01:01:04.000000000 +0800
++++ src/_cffi_src/openssl/err.py	2024-06-23 11:54:39.000000000 +0800
+@@ -39,7 +39,6 @@
+ void ERR_put_error(int, int, int, const char *, int);
+ 
+ int ERR_GET_LIB(unsigned long);
+-int ERR_GET_FUNC(unsigned long);
+ int ERR_GET_REASON(unsigned long);
+ 
+ """
+
+--- src/cryptography/hazmat/bindings/openssl/binding.py	2021-08-25 01:01:04.000000000 +0800
++++ src/cryptography/hazmat/bindings/openssl/binding.py	2024-06-23 11:54:44.000000000 +0800
+@@ -43,10 +43,9 @@
+             break
+ 
+         err_lib = lib.ERR_GET_LIB(code)
+-        err_func = lib.ERR_GET_FUNC(code)
+         err_reason = lib.ERR_GET_REASON(code)
+ 
+-        errors.append(_OpenSSLError(code, err_lib, err_func, err_reason))
++        errors.append(_OpenSSLError(code, err_lib, err_reason))
+ 
+     return errors
+ 


### PR DESCRIPTION
#### Description

Current `py3*-cryptography` are broken since they link to OpenSSL 3 but use symbols from OpenSSL 1.1. While I found a way to build 3.3.2 against OpenSSL 1.1, wasting a lot of time, and solution is simple but ugly, rather update them to 3.4.8.

`py27` subport uses OpenSSL 1.1 by default and is not supported in 3.4 branch. (So nothing to fix for it, and it cannot be updated along.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
