### PR TITLE
kube-ps1: update to 0.9.0

### DIFF
--- a/sysutils/kube-ps1/Portfile
+++ b/sysutils/kube-ps1/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonmosco kube-ps1 0.8.0 v
+github.setup        jonmosco kube-ps1 0.9.0 v
 revision            0
 categories          sysutils
 platforms           {darwin any}
@@ -15,11 +15,11 @@ description         Kubernetes prompt info for bash and zsh
 long_description    A script that lets you add the current Kubernetes context and namespace \
                     configured on kubectl to your Bash/Zsh prompt strings (i.e. the \$PS1).
 
-checksums           rmd160  749bab8ee2c1bd9972e028a3f97e46a57d8c45ba \
-                    sha256  05ad37ad615c76d4c74b8933c71c97a0b1569a6c739d3362b4f31862ad5a859a \
+checksums           rmd160  1264feb645b03920523583b547a33ef95cd5a375 \
+                    sha256  665f7cef9d941152ac809e09632127e5276e288b595e76b2d10e879993df689b \
                     size    512934
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.25
+depends_run         path:${prefix}/bin/kubectl:kubectl
 
 use_configure       no
 build {}

--- a/sysutils/kube-ps1/Portfile
+++ b/sysutils/kube-ps1/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  1264feb645b03920523583b547a33ef95cd5a375 \
                     sha256  665f7cef9d941152ac809e09632127e5276e288b595e76b2d10e879993df689b \
                     size    512934
 
-depends_run         path:${prefix}/bin/kubectl:kubectl
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.30
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update to kube-ps1 0.9.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?