### PR TITLE
Emacs updates

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -107,11 +107,11 @@ platform darwin {
 }
 
 if {$subport eq $name || $subport eq "emacs-app"} {
-    version         29.3
-    revision        1
-    checksums       rmd160  74592d7dba2f02b2d827a74b5a5aa5e2077fc73f \
-                    sha256  2de8df5cab8ac697c69a1c46690772b0cf58fe7529f1d1999582c67d927d22e4 \
-                    size    78508272
+    version         29.4
+    revision        0
+    checksums       rmd160  b32b86be6f600ba745ad023efd7238088dfa5952 \
+                    sha256  1adb1b9a2c6cdb316609b3e86b0ba1ceb523f8de540cfdda2aec95b6a5343abf \
+                    size    78519074
 
     patchfiles-append \
                     patch-allow-powerpc.diff

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -122,16 +122,16 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs c637adbf32f2566b739eb96e68546201c55540af
+    github.setup    emacs-mirror emacs 9688fd6eb1d05e97c556cd53c53dd92220d9efaa
     epoch           5
-    version         20240615
+    version         20240623
     revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  cdc12864cae087498341cb68377106e558a1ae37 \
-                    sha256  5c12852bd275a39568e93fad88f3229206c3160e5e035a9c628cf2e6728d1d48 \
-                    size    50515273
+    checksums       rmd160  de2e1912e8b8a8e09c2b1bd243c26af06f8a2118 \
+                    sha256  6778dd5f8af6d69cc6b4e77c4e873093ebee8a2c6c043c815a3754e2d74279a2 \
+                    size    50586899
 
     patchfiles-append \
                     patch-allow-powerpc-devel.diff


### PR DESCRIPTION
#### Description

- Emacs 29.4: security update
- emacs{,-app}-devel: security update and move to 31.0.50

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
