### PR TITLE
py-pyopenssl: use a fallback on legacy systems without Rust

### DIFF
--- a/python/py-openssl/Portfile
+++ b/python/py-openssl/Portfile
@@ -27,6 +27,9 @@ checksums           rmd160  d9a08c0c1d529ac98e5ac42e8b5d4ed64c3edbb5 \
 
 python.versions     27 37 38 39 310 311 312
 
+# Match py-cryptography setting here:
+set openssl_darwin_min_ver 13
+
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
 
@@ -45,7 +48,9 @@ if {${name} ne ${subport}} {
                 ${destroot}${prefix}/share/doc/${subport}
     }
 
-    if {${python.version} == 27} {
+    if {${python.version} == 27 \
+        || ${os.platform} eq "darwin" && ${os.major} < ${openssl_darwin_min_ver}} {
+        # TODO: see if we can upgrade this, reverting commits which rely on Rust.
         github.setup    pyca pyopenssl 21.0.0
         checksums       rmd160  5806276d4716458a77c32f91a0c7f8ee30fe1dfb \
                         sha256  5d1d93fb3d55be740e444b991bccc5db26b1cfd3666cbbd8b6d01dc7a6cc5430 \


### PR DESCRIPTION
#### Description

Use a fallback for systems without Rust. Match `py-cryptography` for the threshold.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
