### PR TITLE
mingw-w64: Update to 12.0.0

### DIFF
--- a/cross/i686-w64-mingw32-gcc/Portfile
+++ b/cross/i686-w64-mingw32-gcc/Portfile
@@ -11,7 +11,7 @@ set mingw_target    ${mingw_arch}-${mingw_name}
 crossgcc.setup      ${mingw_target} 14.1.0
 crossgcc.languages  {c c++ fortran objc obj-c++}
 dist_subdir         gcc[lindex [split ${version} .] 0]
-revision            0
+revision            1
 
 maintainers         {mojca @mojca} {@Gcenx gmail.com:gcenx83} openmaintainer
 

--- a/cross/mingw-w64/Portfile
+++ b/cross/mingw-w64/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        mingw-w64 mingw-w64 11.0.1 v
+github.setup        mingw-w64 mingw-w64 12.0.0 v
 revision            0
 set mingw_name      w64-mingw32
 
 license             ZPL-2.1
 categories          cross devel
-maintainers         {mojca @mojca} openmaintainer
+maintainers         {mojca @mojca} {@Gcenx gmail.com:gcenx83} openmaintainer
 
 description         GCC cross-compiler for Windows 64 & 32 bits
 long_description    Mingw-w64 is an advancement of the original mingw.org project, \
@@ -18,9 +18,9 @@ long_description    Mingw-w64 is an advancement of the original mingw.org projec
 
 homepage            https://mingw-w64.sourceforge.net/
 
-checksums           rmd160  124722990dd68875683a9ce8d20eaa75d2ef544b \
-                    sha256  493cb0bde1e470a281c7a633fcc1158de3b8919f687020c60a936e7b2512398d \
-                    size    13919536
+checksums           rmd160  9b83d3c266c95ce0a246ee6ca065413a258557f3 \
+                    sha256  9434d487060b2158a984a460ae050e9e72637a2d135af7b052413715856bf209 \
+                    size    14459303
 
 # needs an out-of-source build
 configure.dir       ${workpath}/build

--- a/cross/x86_64-w64-mingw32-gcc/Portfile
+++ b/cross/x86_64-w64-mingw32-gcc/Portfile
@@ -11,7 +11,7 @@ set mingw_target    ${mingw_arch}-${mingw_name}
 crossgcc.setup      ${mingw_target} 14.1.0
 crossgcc.languages  {c c++ fortran objc obj-c++}
 dist_subdir         gcc[lindex [split ${version} .] 0]
-revision            0
+revision            1
 
 maintainers         {mojca @mojca} {@Gcenx gmail.com:gcenx83} openmaintainer
 


### PR DESCRIPTION
UCRT is now the default CRT runtime instead of MSVCRT, so need to rev-bump *-w64-mingw32-gcc Ports at the same time.

See https://www.mingw-w64.org/changelog/#v1200-2024-05-29

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
