### PR TITLE
mvnd: update to 1.0.1

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem      1.0
 
-version         1.0.0
+version         1.0.1
 revision        0
 name            mvnd
 categories      java
@@ -38,14 +38,14 @@ use_configure   no
 
 if {${configure.build_arch} eq "x86_64"} {
     distname        maven-mvnd-${version}-darwin-amd64
-    checksums       rmd160  1f58bb895606bccc9b79857d05711e62fa2f47ec \
-                    sha256  32d0007578368fb911ca3f80e60f2d53824c374986dd60ff82e30556aeeba367 \
-                    size    22670535
+    checksums       rmd160  c750ca87b6b495df16286b95cd522b92102cb427 \
+                    sha256  83c953218474ecefbcf829ff999a7d5ce717d4ed641bd8d7e9461368384a0c03 \
+                    size    23185002
 } elseif {${configure.build_arch} eq "arm64"} {
     distname        maven-mvnd-${version}-darwin-aarch64
-    checksums       rmd160  3e95eff1c491cfdc110d6ce5721d71446d0450cc \
-                    sha256  b68c213b8071d2a138e9c4b2532b45f5f9a2b4192055a4a71d1bd29547902596 \
-                    size    22571212
+    checksums       rmd160  eeea760a046fa32a8c11910aec748fe432d03c2b \
+                    sha256  685ee0017014ed413ca7aef9fc40759a15bddc64e9dbaaea152a1672ab9eaf5a \
+                    size    23316945
 }
 
 build {}


### PR DESCRIPTION
#### Description

Update to mvnd 1.0.1.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?