### PR TITLE
imagemagick7: Update to 7.1.1-34

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -21,12 +21,12 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-github.setup        ImageMagick ImageMagick 7.1.1-30
+github.setup        ImageMagick ImageMagick 7.1.1-34
 revision            0
 
-checksums           rmd160  9b492a0a5188441c97f1743ebf39fc017ca0d95a \
-                    sha256  84ada00d3ff1d5b5ac98da9058080fbed2cf8fd875c2e153994dbb5efec0203f \
-                    size    15688269
+checksums           rmd160  7b1518c89c3ba420470825d63d1d77b6a76e1e63 \
+                    sha256  69f6c7d1043e96d68e80fb3df2c248d189b3374552ae1cfe8e3913a88239e742 \
+                    size    15659326
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \
@@ -37,8 +37,8 @@ use_parallel_build  yes
 description         Tools and libraries to manipulate images in many formats
 
 long_description    For the ImageMagick-6 legacy version, please see \
-                    port https://ports.macports.org/port/ImageMagick . \
-                    <br>\n<br>\n \
+                    port https://ports.macports.org/port/ImageMagick. \
+                    \
                     ImageMagick is a robust collection of tools and \
                     libraries to create, edit and compose bitmap images \
                     in a wide variety of formats. You can crop, resize, \


### PR DESCRIPTION
#### Description

* Update ImageMagick7.1.1-30 --> 7.1.1-34
* Clean up long_description

###### Type(s)

###### Tested on

macOS 14.4.1 23E224 x86_64
Xcode 15.4 / Command Line Tools 15.1.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `port -s install`?
- [ ] tested basic functionality of all binary files?
- [x] tested basic functionality of ONE binary file?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
