### PR TITLE
deluge: switch to python312 and boost181 to match libtorrent-rasterbar, fix dependencies

### DIFF
--- a/net/deluge/Portfile
+++ b/net/deluge/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 
 name                deluge
 version             2.0.5
-revision            1
+revision            2
 
 categories          net gnome python
 license             {GPL-3+ OpenSSLException}
@@ -26,7 +26,7 @@ checksums           rmd160  4faabca4319fba02a35e70d441c22f1340d1a0fe \
                     sha256  c4bd04abfd211b65218be03f3c46d26f44024884de10e01859fb856fdd6f25d8 \
                     size    1895268
 
-boost.version       1.76
+boost.version       1.81
 
 depends_lib-append \
                     port:gettext \

--- a/net/deluge/Portfile
+++ b/net/deluge/Portfile
@@ -82,24 +82,28 @@ proc py_setup {python_branch} {
                     port:py${python_version}-zopeinterface
 }
 
-variant python38 conflicts python39 python310 python311 description {Build for Python 3.8} {
+variant python38 conflicts python39 python310 python311 python312 description {Build for Python 3.8} {
     py_setup 3.8
 }
 
-variant python39 conflicts python38 python310 python311 description {Build for Python 3.9} {
+variant python39 conflicts python38 python310 python311 python312 description {Build for Python 3.9} {
     py_setup 3.9
 }
 
-variant python310 conflicts python38 python39 python311 description {Build for Python 3.10} {
+variant python310 conflicts python38 python39 python311 python312 description {Build for Python 3.10} {
     py_setup 3.10
 }
 
-variant python311 conflicts python38 python39 python310 description {Build for Python 3.11} {
+variant python311 conflicts python38 python39 python310 python312 description {Build for Python 3.11} {
     py_setup 3.11
 }
 
-if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
-    default_variants +python311
+variant python312 conflicts python38 python39 python310 python311 description {Build for Python 3.12} {
+    py_setup 3.12
+}
+
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312]} {
+    default_variants +python312
 }
 
 post-destroot {

--- a/net/deluge/Portfile
+++ b/net/deluge/Portfile
@@ -6,9 +6,10 @@ PortGroup           boost 1.0
 PortGroup           active_variants 1.1
 
 name                deluge
-version             2.0.5
-revision            2
+version             2.1.1
+revision            0
 
+set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          net gnome python
 license             {GPL-3+ OpenSSLException}
 maintainers         {devans @dbevans} openmaintainer
@@ -19,12 +20,12 @@ description         A GNOME BitTorrent client.
 long_description    Deluge is a GNOME client for the BitTorrent network written in python.
 homepage            http://www.deluge-torrent.org
 
-master_sites        https://ftp.osuosl.org/pub/deluge/source/2.0/
+master_sites        https://ftp.osuosl.org/pub/deluge/source/${branch}/
 use_xz              yes
 
-checksums           rmd160  4faabca4319fba02a35e70d441c22f1340d1a0fe \
-                    sha256  c4bd04abfd211b65218be03f3c46d26f44024884de10e01859fb856fdd6f25d8 \
-                    size    1895268
+checksums           rmd160  bdee3ddf7e9dffd3fa150fcb4d1c433ceebef682 \
+                    sha256  768dd319802e42437ab3794ebe75b497142e08ed5b0fb2503bad62cef442dff7 \
+                    size    2541968
 
 boost.version       1.81
 
@@ -70,6 +71,7 @@ proc py_setup {python_branch} {
                     port:py${python_version}-asn1 \
                     port:py${python_version}-chardet \
                     port:py${python_version}-gobject3 \
+                    port:py${python_version}-ifaddr \
                     port:py${python_version}-mako \
                     port:py${python_version}-openssl \
                     port:py${python_version}-Pillow \

--- a/python/py-automat/Portfile
+++ b/python/py-automat/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  389126c3183fdd8ad34333d86490e2ba448ced94 \
                     sha256  7979803c74610e11ef0c0d68a2942b152df52da55336e0c9d58daf1831cbdf33 \
                     size    61679
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-constantly/Portfile
+++ b/python/py-constantly/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        twisted constantly 15.1.0
+github.setup        twisted constantly 23.10.4
 github.tarball_from archive
 name                py-constantly
 revision            0
@@ -19,13 +19,24 @@ long_description    {*}${description}. \
     It includes collections and constants with text, numeric, and bit flag values. \
     Originally twisted.python.constants from the Twisted project.
 
-checksums           rmd160  7a9d1776bb3b44b1982ba01ce50f269d67c1e4a7 \
-                    sha256  be63c40ef853ee785045a1d20327d8153db9291f9aaff552796bed5272f9dd60 \
-                    size    40635
+checksums           rmd160  4a8e84a1261f3d99045a3e9b073614c9743be2e2 \
+                    sha256  c158c7a71ced2a77471ae851089b4ea15c15fce968d3f0105a15819666cd641a \
+                    size    31228
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \
         port:py${python.version}-setuptools
+
+    if {${python.version} < 38} {
+        github.setup    twisted constantly 15.1.0
+        revision        0
+        checksums       rmd160  7a9d1776bb3b44b1982ba01ce50f269d67c1e4a7 \
+                        sha256  be63c40ef853ee785045a1d20327d8153db9291f9aaff552796bed5272f9dd60 \
+                        size    40635
+    } else {
+        depends_build-append \
+                    port:py${python.version}-versioneer
+    }
 }

--- a/python/py-incremental/Portfile
+++ b/python/py-incremental/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  58a17ce949f8b06c0efdd9f09e79d942f3318543 \
                     sha256  02f5de5aff48f6b9f665d99d48bfc7ec03b6e3943210de7cfc88856d755d6f57 \
                     size    17058
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     # see https://pypi.python.org/pypi/incremental/

--- a/python/py-m2r/Portfile
+++ b/python/py-m2r/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  a71cedf33366b78544c1f5488d57d879e16b87cd \
                     sha256  5864619db80a3470f2f535bd374d6bdf025806815b203e7e0c809b544106f249 \
                     size    24466
 
-python.versions 27 37 38 39 310 311
+python.versions 27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
 

--- a/python/py-pyhamcrest/Portfile
+++ b/python/py-pyhamcrest/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  0a0710b31bbdc3c6984d789f6d4b3188af16ec51 \
                     sha256  412e00137858f04bde0729913874a48485665f2d36fe9ee449f26be864af9316 \
                     size    44329
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {

--- a/python/py-twisted/Portfile
+++ b/python/py-twisted/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  96019de2a84e84b7d9d150b05432dc6418a5cbed \
                     sha256  32acbd40a94f5f46e7b42c109bfae2b302250945561783a8b7a059048f2d4d31 \
                     size    3524935
 
-python.versions 27 37 38 39 310 311
+python.versions 27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     # uses "from pkg_resources import load_entry_point"


### PR DESCRIPTION
#### Description

`libtorrent-rasterbar` has been switched to python312 earlier without considering `deluge`, which uses python311 by default. In addition, it uses a different Boost.
Also, on of its Python dependencies does not build at all, which leaves it broken.

Fix this.

P. S. Running `deluge` also requires these:
https://github.com/macports/macports-ports/pull/24679
https://github.com/macports/macports-ports/pull/24658

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
