### PR TITLE
gdal: fix arrow variant for 32-bit

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -323,6 +323,13 @@ variant arrow description {Enable (Geo)Arrow IPC File Format / Stream and (Geo)P
                             -DOGR_ENABLE_DRIVER_ARROW=OFF   -DOGR_ENABLE_DRIVER_ARROW=ON \
                             -DOGR_ENABLE_DRIVER_PARQUET=OFF -DOGR_ENABLE_DRIVER_PARQUET=ON
     configure.args-append   -DARROW_USE_STATIC_LIBRARIES=OFF
+
+    # https://trac.macports.org/ticket/70298
+    if {[string match *gcc* ${configure.compiler}] \
+        && (${configure.build_arch} in [list i386 ppc])} {
+        configure.ldflags-append \
+                                -latomic
+    }
 }
 
 variant cfitsio description {Enable FITS support} {


### PR DESCRIPTION
#### Description

No revbump needed here. It would simply not build with this variant otherwise.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
