### PR TITLE
google-cloud-sdk: update to 482.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             481.0.0
+version             482.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  bcc582ea64d8d273c3eba04cea44db85b14b8432 \
-                    sha256  4216165e6c7e87669db298568c1c7a14a8b4bfb03c3d0e1ea24278de3aa557ba \
-                    size    50821275
+    checksums       rmd160  4ec78013347eccb4c25d14f52175889cd9ecffb8 \
+                    sha256  4b4c4d661da675b2011d96538fc1682c14cd22f2c629ac5839607d3fe4adae2d \
+                    size    50932574
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  98427be9b16cdb1b921361fc20ba8a52a049c76a \
-                    sha256  04fabf03671792a548058b74c9320f7ce225d562c7b5dda95dc7e5285508c0ef \
-                    size    52107194
+    checksums       rmd160  81b94d225d93c8cf5e2ae23b7280c8083ee20b27 \
+                    sha256  6f73704d8ed27615fe88c536c2c5a9bc522f3d46e9eb46226bf348aacc7f0cff \
+                    size    52217650
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  103daf4d4a8b637f0e7d3bde514bb292f3602f18 \
-                    sha256  482a99d0337db5e91f4af9dd46ae8a3c4e10a7643176aac754b301b02f7cb4d3 \
-                    size    52068620
+    checksums       rmd160  1614e76c28ba650dffc1d5e1f35d374f6979f0ec \
+                    sha256  73acf124eb6a1a612e46faaf4048ba90df7114116785d1e836b761a03ccf7d7a \
+                    size    52176101
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 482.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?