### PR TITLE
gdal: Update to 3.9.1

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -8,12 +8,12 @@ PortGroup           legacysupport 1.0
 PortGroup           muniversal 1.0
 
 name                gdal
-version             3.9.0
-revision            1
+version             3.9.1
+revision            0
 
-checksums           rmd160  985c6815be054cad493c7b931c679bb8516ee774 \
-                    sha256  577f80e9d14ff7c90b6bfbc34201652b4546700c01543efb4f4c3050e0b3fda2 \
-                    size    9081116
+checksums           rmd160  8dd9e368cfacc39dfad3b5f42b713b61e23bab15 \
+                    sha256  aff3086fee75f5773e33a5598df98d8a4d10be411f777d3ce23584b21d8171ca \
+                    size    9098844
 
 categories          gis
 license             MIT BSD
@@ -47,7 +47,7 @@ configure.optflags  -DGDAL_COMPILATION
 
 depends_build-append \
                     port:bash-completion \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append \
                     port:blosc \
@@ -238,6 +238,7 @@ configure.args-append                                        \
                     -DBUILD_JAVA_BINDINGS=OFF                \
                     -DBUILD_PYTHON_BINDINGS=OFF              \
                     -DGDAL_USE_ARCHIVE=OFF                   \
+                    -DGDAL_USE_ARMADILLO=OFF                 \
                     -DGDAL_USE_CFITSIO=OFF                   \
                     -DGDAL_USE_CRYPTOPP=OFF                  \
                     -DGDAL_USE_CURL=ON                       \
@@ -323,6 +324,13 @@ variant arrow description {Enable (Geo)Arrow IPC File Format / Stream and (Geo)P
                             -DOGR_ENABLE_DRIVER_ARROW=OFF   -DOGR_ENABLE_DRIVER_ARROW=ON \
                             -DOGR_ENABLE_DRIVER_PARQUET=OFF -DOGR_ENABLE_DRIVER_PARQUET=ON
     configure.args-append   -DARROW_USE_STATIC_LIBRARIES=OFF
+
+    # https://trac.macports.org/ticket/70298
+    if {[string match *gcc* ${configure.compiler}] \
+        && (${configure.build_arch} in [list i386 ppc])} {
+        configure.ldflags-append \
+                                -latomic
+    }
 }
 
 variant cfitsio description {Enable FITS support} {

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -8,12 +8,12 @@ PortGroup           legacysupport 1.0
 PortGroup           muniversal 1.0
 
 name                gdal
-version             3.9.0
-revision            1
+version             3.9.1
+revision            0
 
-checksums           rmd160  985c6815be054cad493c7b931c679bb8516ee774 \
-                    sha256  577f80e9d14ff7c90b6bfbc34201652b4546700c01543efb4f4c3050e0b3fda2 \
-                    size    9081116
+checksums           rmd160  8dd9e368cfacc39dfad3b5f42b713b61e23bab15 \
+                    sha256  aff3086fee75f5773e33a5598df98d8a4d10be411f777d3ce23584b21d8171ca \
+                    size    9098844
 
 categories          gis
 license             MIT BSD

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -8,12 +8,12 @@ PortGroup           legacysupport 1.0
 PortGroup           muniversal 1.0
 
 name                gdal
-version             3.9.1
-revision            0
+version             3.9.0
+revision            1
 
-checksums           rmd160  8dd9e368cfacc39dfad3b5f42b713b61e23bab15 \
-                    sha256  aff3086fee75f5773e33a5598df98d8a4d10be411f777d3ce23584b21d8171ca \
-                    size    9098844
+checksums           rmd160  985c6815be054cad493c7b931c679bb8516ee774 \
+                    sha256  577f80e9d14ff7c90b6bfbc34201652b4546700c01543efb4f4c3050e0b3fda2 \
+                    size    9081116
 
 categories          gis
 license             MIT BSD
@@ -47,7 +47,7 @@ configure.optflags  -DGDAL_COMPILATION
 
 depends_build-append \
                     port:bash-completion \
-                    path:bin/pkg-config:pkgconfig
+                    port:pkgconfig
 
 depends_lib-append \
                     port:blosc \
@@ -238,7 +238,6 @@ configure.args-append                                        \
                     -DBUILD_JAVA_BINDINGS=OFF                \
                     -DBUILD_PYTHON_BINDINGS=OFF              \
                     -DGDAL_USE_ARCHIVE=OFF                   \
-                    -DGDAL_USE_ARMADILLO=OFF                 \
                     -DGDAL_USE_CFITSIO=OFF                   \
                     -DGDAL_USE_CRYPTOPP=OFF                  \
                     -DGDAL_USE_CURL=ON                       \
@@ -324,13 +323,6 @@ variant arrow description {Enable (Geo)Arrow IPC File Format / Stream and (Geo)P
                             -DOGR_ENABLE_DRIVER_ARROW=OFF   -DOGR_ENABLE_DRIVER_ARROW=ON \
                             -DOGR_ENABLE_DRIVER_PARQUET=OFF -DOGR_ENABLE_DRIVER_PARQUET=ON
     configure.args-append   -DARROW_USE_STATIC_LIBRARIES=OFF
-
-    # https://trac.macports.org/ticket/70298
-    if {[string match *gcc* ${configure.compiler}] \
-        && (${configure.build_arch} in [list i386 ppc])} {
-        configure.ldflags-append \
-                                -latomic
-    }
 }
 
 variant cfitsio description {Enable FITS support} {

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -47,7 +47,7 @@ configure.optflags  -DGDAL_COMPILATION
 
 depends_build-append \
                     port:bash-completion \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append \
                     port:blosc \
@@ -238,6 +238,7 @@ configure.args-append                                        \
                     -DBUILD_JAVA_BINDINGS=OFF                \
                     -DBUILD_PYTHON_BINDINGS=OFF              \
                     -DGDAL_USE_ARCHIVE=OFF                   \
+                    -DGDAL_USE_ARMADILLO=OFF                 \
                     -DGDAL_USE_CFITSIO=OFF                   \
                     -DGDAL_USE_CRYPTOPP=OFF                  \
                     -DGDAL_USE_CURL=ON                       \

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -324,6 +324,13 @@ variant arrow description {Enable (Geo)Arrow IPC File Format / Stream and (Geo)P
                             -DOGR_ENABLE_DRIVER_ARROW=OFF   -DOGR_ENABLE_DRIVER_ARROW=ON \
                             -DOGR_ENABLE_DRIVER_PARQUET=OFF -DOGR_ENABLE_DRIVER_PARQUET=ON
     configure.args-append   -DARROW_USE_STATIC_LIBRARIES=OFF
+
+    # https://trac.macports.org/ticket/70298
+    if {[string match *gcc* ${configure.compiler}] \
+        && (${configure.build_arch} in [list i386 ppc])} {
+        configure.ldflags-append \
+                                -latomic
+    }
 }
 
 variant cfitsio description {Enable FITS support} {


### PR DESCRIPTION
#### Description

* Update gdal 3.9.0 --> 3.9.1.
* Includes numerous upstream bug fixes, including compile fixes.
* Includes fixes for the new plugin capability introduced in 3.9.0.
* See release announcement and release notes:
* https://lists.osgeo.org/pipermail/gdal-announce/2024-June/000119.html
* Replaces previous broken PR #24691.

* Also merge in two other current gdal pull requests.
* Fix arrow variant for 32-bit.  See PR #24690.
* Do not opportunistically link to armadillo.  See PR #24687.
* Switch to path-style dependency for `pkgconfig`.

Fixes: https://trac.macports.org/ticket/70298

###### Type(s)

###### Tested on

CI only. OS 12, 13, 14 only.
Maintainer also tested the RC2.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
