### PR TITLE
llvm-cx: Fix for Xcode16

### DIFF
--- a/lang/llvm-cx/Portfile
+++ b/lang/llvm-cx/Portfile
@@ -6,7 +6,7 @@ PortGroup                   cmake 1.1
 # This custom compiler toolchain is based on llvm|clang-8 but each release adds fixes for newer SDKs.
 name                        llvm-cx
 version                     22.1.1
-revision                    1
+revision                    2
 dist_subdir                 wine
 categories                  lang
 platforms                   {darwin >= 18}
@@ -79,5 +79,11 @@ configure.args-append       -DLLVM_ENABLE_TERMINFO=OFF \
 
 # remove need for port:libxml2 dependency
 configure.args-append       -DLIBXML2_LIBRARIES=IGNORE
+
+# We want to fallback on Xcode provided copy of libLTO.dylib
+# this resolves build issues with Xcode16 due to missing symbols
+post-destroot {
+  delete ${destroot}${prefix}/libexec/llvm-cx/lib/libLTO.dylib
+}
 
 livecheck.type              none


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

macOS 15 (beta 2)
Xcode Command Line Tools 16 (beta 2)

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
