### PR TITLE
game-porting-toolkit: Correct SDK check

### DIFF
--- a/devel/game-porting-toolkit/Portfile
+++ b/devel/game-porting-toolkit/Portfile
@@ -132,9 +132,9 @@ configure.ldflags-prepend   -Wl,-ld_classic
 
 # Xcode15.3 default SDK causes the build to fail so fallback to a working SDK
 configure.sdk_version       13
-if {${configure.sdkroot} eq ""} {
+if {${configure.sdkroot} != "${developer_dir}/SDKs/MacOSX${configure.sdk_version}.sdk"} {
     pre-fetch {
-        error "Building ${name} requires the MacOSX13.sdk to be present in ${developer_dir}/SDKs/"
+        error "Building ${name} requires the MacOSX${configure.sdk_version}.sdk to be present in ${developer_dir}/SDKs/"
     }
 }
 


### PR DESCRIPTION
#### Description

This make the SDK check work correctly so build will error out when required SDK isn't precent, `MacOSX13.sdk` is required to build on macOS Sequoia.

No rev-bump is required as installed files don't change, the build currently simply fails on macOS Sequoia (fixed by #24703) and this check being incorrect.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

macOS 15 (beta 2)
Xcode Command Line Tools 16 (beta 2)

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
