### PR TITLE
hut: update to 0.6.0

### DIFF
--- a/devel/hut/Portfile
+++ b/devel/hut/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            git.sr.ht/~emersion/hut 0.3.0 v
+go.setup            git.sr.ht/~xenrox/hut 0.6.0 v
 revision            0
 
 description         A CLI tool for sr.ht.
@@ -18,9 +18,9 @@ license             AGPL-3
 maintainers         {woolsweater.net:macports @woolsweater} \
                     openmaintainer
 
-checksums           rmd160  6d031cf9704c4645e0f1036989000126ae78d482 \
-                    sha256  ca191d663be81000c8ac0e952cd1b95fbded8c1d918d6d89ff08adbcd3d75289 \
-                    size    116316
+checksums           rmd160  49ba521e86f3dda47beacebfb9f16d8be5403dfa \
+                    sha256  f6abe54b433c30557c49aa41d351ec97ef24b4bee3f9dbc91e7db8f366592f99 \
+                    size    137077
 
 depends_build-append \
                     port:scdoc


### PR DESCRIPTION
#### Description

Update the hut tool to its latest version, 0.6.0. Per [the README](https://git.sr.ht/~emersion/hut/tree/master/item/README.md), the repo's home has also changed to another user on sourcehut.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
