### PR TITLE
PNPM: Update to 9.4.0

### DIFF
--- a/devel/pnpm/Portfile
+++ b/devel/pnpm/Portfile
@@ -3,9 +3,11 @@
 PortSystem          1.0
 PortGroup           npm 1.0
 
+npm.nodejs_version  22
+
 name                pnpm
-version             8.15.5
-revision            1
+version             9.4.0
+revision            0
 
 categories          devel
 license             MIT
@@ -18,6 +20,6 @@ long_description    pnpm is a fast, disk space efficient package manager, \
 
 homepage            https://pnpm.io
 
-checksums           rmd160  8152acbfc0f63d87290862c594203a031bd1036f \
-                    sha256  4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589 \
-                    size    3821860
+checksums           rmd160  a0860add1a04fee8c8a83d6f747a4c9d39d644be \
+                    sha256  b6fd0bfda555e7e584ad7e56b30c68b01d5a04f9ee93989f4b93ca8473c49c74 \
+                    size    4190110


### PR DESCRIPTION
#### Description

Update PNPM to 9.4.0

This commit also adds an explicit dependency on Node.js 22, since the default Node and NPM versions in recent versions of the NPM PortGroup conflict with each-other and result in a build failure.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 16.0 16A5171c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
