### PR TITLE
gdal: Fix builds for 10.7 through 10.12.

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 PortGroup           muniversal 1.0
 
 name                gdal
@@ -35,6 +35,13 @@ use_xz              yes
 
 # error: call to 'abs' is ambiguous
 compiler.blacklist-append {clang < 900}
+
+# Enable use of 'macports-libcxx' for macOS 10.14 and earlier, as port uses
+# libcxx features normally only available on 10.15 and later.
+legacysupport.use_mp_libcxx \
+                    yes
+legacysupport.newest_darwin_requires_legacy \
+                    18
 
 # https://trac.macports.org/ticket/70193
 compiler.cxx_standard 2017


### PR DESCRIPTION
#### Description

* Legacy support.  Use `macports-libcxx` on 10.12 and earlier.
* Maybe fixes https://trac.macports.org/ticket/70228.
* See discussion starting at comment no. 7 on that ticket.
* Patch copied from https://github.com/macports/macports-ports/commit/a261c62eb7c3293f83c245f927cfc5f344cafe5a.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS versions 12, 13, 14 only.
Need builders to test on the target older OS versions.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?