### PR TITLE
ocaml-*: revbump JaneStreet ports for ocaml-sexplib0 update

### DIFF
--- a/ocaml/ocaml-async/Portfile
+++ b/ocaml/ocaml-async/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-async
 github.setup        janestreet async 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-async_kernel/Portfile
+++ b/ocaml/ocaml-async_kernel/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-async_kernel
 github.setup        janestreet async_kernel 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-async_rpc_kernel/Portfile
+++ b/ocaml/ocaml-async_rpc_kernel/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-async_rpc_kernel
 github.setup        janestreet async_rpc_kernel 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-async_unix/Portfile
+++ b/ocaml/ocaml-async_unix/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-async_unix
 github.setup        janestreet async_unix 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-base/Portfile
+++ b/ocaml/ocaml-base/Portfile
@@ -6,6 +6,7 @@ PortGroup ocaml     1.1
 
 name                ocaml-base
 github.setup        janestreet base 0.16.3 v
+revision            1
 github.tarball_from archive
 
 categories          ocaml devel

--- a/ocaml/ocaml-base_bigstring/Portfile
+++ b/ocaml/ocaml-base_bigstring/Portfile
@@ -27,6 +27,10 @@ github.tarball_from archive
 # Use legacysupport to provide it.
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     patchfiles      patch-memmem.diff
+
+    post-patch {
+        reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/src/dune
+    }
 }
 
 depends_lib-append  port:ocaml-base \

--- a/ocaml/ocaml-base_bigstring/Portfile
+++ b/ocaml/ocaml-base_bigstring/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                ocaml-base_bigstring
 github.setup        janestreet base_bigstring 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-base_bigstring/files/patch-memmem.diff
+++ b/ocaml/ocaml-base_bigstring/files/patch-memmem.diff
@@ -1,25 +1,9 @@
---- src/base_bigstring.h	2023-04-25 21:12:24.000000000 +0800
-+++ src/base_bigstring.h	2023-10-25 15:23:59.000000000 +0800
-@@ -3,6 +3,13 @@
- 
- #include <caml/bigarray.h>
- 
-+#ifdef __APPLE__
-+#include <AvailabilityMacros.h>
-+#if MAC_OS_X_VERSION_MAX_ALLOWED <= 1060
-+#include <LegacySupport/string.h>
-+#endif
-+#endif
-+
- /* Bigarray flags for creating a [Bigstring.t] */
- #define BASE_BIGSTRING_FLAGS (CAML_BA_CHAR | CAML_BA_C_LAYOUT)
- 
 --- src/dune	2023-04-25 21:12:24.000000000 +0800
-+++ src/dune	2023-10-25 19:59:56.000000000 +0800
-@@ -1,3 +1,3 @@
++++ src/dune	2024-07-06 23:12:51.000000000 +0800
+@@ -1,3 +1,4 @@
  (library (name base_bigstring) (public_name base_bigstring)
-- (js_of_ocaml (javascript_files runtime.js)) (libraries base int_repr)
+  (js_of_ocaml (javascript_files runtime.js)) (libraries base int_repr)
 - (c_names base_bigstring_stubs) (preprocess (pps ppx_jane)))
 \ No newline at end of file
-+ (js_of_ocaml (javascript_files runtime.js)) (libraries base int_repr) (c_library_flags -lMacportsLegacySupport)
++ (c_flags -I@PREFIX@/include/LegacySupport) (c_library_flags -lMacportsLegacySupport)
 + (c_names base_bigstring_stubs) (preprocess (pps ppx_jane)))

--- a/ocaml/ocaml-base_quickcheck/Portfile
+++ b/ocaml/ocaml-base_quickcheck/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-base_quickcheck
 github.setup        janestreet base_quickcheck 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-bin_prot/Portfile
+++ b/ocaml/ocaml-bin_prot/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-bin_prot
 github.setup        janestreet bin_prot 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-bisect_ppx/Portfile
+++ b/ocaml/ocaml-bisect_ppx/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-bisect_ppx
 github.setup        aantron bisect_ppx 2.8.3
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-core/Portfile
+++ b/ocaml/ocaml-core/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-core
 github.setup        janestreet core 0.16.2 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-core_extended/Portfile
+++ b/ocaml/ocaml-core_extended/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-core_extended
 github.setup        janestreet core_extended 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-core_kernel/Portfile
+++ b/ocaml/ocaml-core_kernel/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-core_kernel
 github.setup        janestreet core_kernel 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-core_unix/Portfile
+++ b/ocaml/ocaml-core_unix/Portfile
@@ -33,11 +33,16 @@ depends_lib-append  port:ocaml-core \
                     port:ocaml-spawn \
                     port:ocaml-timezone
 
-# FIXME: review the following.
 patch.pre_args-replace  -p0 -p1
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
     patchfiles      0001-time_stamp_counter_stubs.c-add-legacysupport-header-.patch \
                     0002-core_unix_stubs.c-add-legacysupport-header-for-strnl.patch
+
+    post-patch {
+        reinplace "s|@PREFIX@|${prefix}|g" \
+                    ${worksrcpath}/core_unix/src/dune \
+                    ${worksrcpath}/time_stamp_counter/src/dune
+    }
 }
 
 ocaml.build_type    dune

--- a/ocaml/ocaml-core_unix/Portfile
+++ b/ocaml/ocaml-core_unix/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                ocaml-core_unix
 github.setup        janestreet core_unix 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-core_unix/files/0001-time_stamp_counter_stubs.c-add-legacysupport-header-.patch
+++ b/ocaml/ocaml-core_unix/files/0001-time_stamp_counter_stubs.c-add-legacysupport-header-.patch
@@ -4,35 +4,15 @@ Date: Mon, 21 Nov 2022 01:08:19 +0800
 Subject: [PATCH 1/2] time_stamp_counter_stubs.c: add legacysupport header for
  clock_gettime
 
----
- time_stamp_counter/src/time_stamp_counter_stubs.c | 5 +++++
- 1 file changed, 5 insertions(+)
-
-diff --git a/time_stamp_counter/src/time_stamp_counter_stubs.c b/time_stamp_counter/src/time_stamp_counter_stubs.c
-index 5d5ec32..1cf0ee1 100644
---- a/time_stamp_counter/src/time_stamp_counter_stubs.c
-+++ b/time_stamp_counter/src/time_stamp_counter_stubs.c
-@@ -17,6 +17,11 @@
- #ifdef __MACH__
- #include <mach/clock.h>
- #include <mach/mach.h>
-+
-+#include <AvailabilityMacros.h>
-+#if MAC_OS_X_VERSION_MAX_ALLOWED <= 101100
-+#include <LegacySupport/time.h>
-+#endif
- #endif
- 
- #include "ocaml_utils.h"
-
 --- a/time_stamp_counter/src/dune	2023-04-25 21:12:26.000000000 +0800
-+++ b/time_stamp_counter/src/dune	2023-10-25 20:10:11.000000000 +0800
++++ b/time_stamp_counter/src/dune	2024-07-06 22:52:24.000000000 +0800
 @@ -1,7 +1,7 @@
  (library (name time_stamp_counter) (public_name core_unix.time_stamp_counter)
   (preprocess (pps ppx_jane ppx_optcomp)) (preprocessor_deps config.h)
 - (c_names time_stamp_counter_stubs)
-+ (c_names time_stamp_counter_stubs) (c_library_flags -lMacportsLegacySupport)
-  (libraries core core_unix ocaml_intrinsics))
+- (libraries core core_unix ocaml_intrinsics))
++ (c_names time_stamp_counter_stubs) (c_flags -I@PREFIX@/include/LegacySupport)
++ (c_library_flags -lMacportsLegacySupport) (libraries core core_unix ocaml_intrinsics))
  
  (rule (targets config.h) (deps)
 - (action (bash "cp %{lib:jst-config:config.h} %{targets}")))

--- a/ocaml/ocaml-core_unix/files/0002-core_unix_stubs.c-add-legacysupport-header-for-strnl.patch
+++ b/ocaml/ocaml-core_unix/files/0002-core_unix_stubs.c-add-legacysupport-header-for-strnl.patch
@@ -3,37 +3,15 @@ From: barracuda156 <vital.had@gmail.com>
 Date: Mon, 21 Nov 2022 01:13:02 +0800
 Subject: [PATCH 2/2] core_unix_stubs.c: add legacysupport header for strnlen
 
----
- core_unix/src/core_unix_stubs.c | 7 +++++++
- 1 file changed, 7 insertions(+)
-
-diff --git a/core_unix/src/core_unix_stubs.c b/core_unix/src/core_unix_stubs.c
-index 4beba77..20976d2 100644
---- a/core_unix/src/core_unix_stubs.c
-+++ b/core_unix/src/core_unix_stubs.c
-@@ -64,6 +64,13 @@
- #include <wordexp.h>
- #endif
- 
-+#if defined(__APPLE__)
-+#include <AvailabilityMacros.h>
-+#if MAC_OS_X_VERSION_MAX_ALLOWED <= 1060
-+#include <LegacySupport/string.h>
-+#endif
-+#endif
-+
- CAMLprim value core_unix_error_of_code(value code)
- {
-   return unix_error_of_code(Int_val(code));
-
 --- a/core_unix/src/dune	2023-04-25 21:12:26.000000000 +0800
-+++ b/core_unix/src/dune	2023-10-25 20:09:45.000000000 +0800
++++ b/core_unix/src/dune	2024-07-06 22:50:49.000000000 +0800
 @@ -1,10 +1,10 @@
  (library (name core_unix) (public_name core_unix)
   (libraries core error_checking_mutex core_kernel.flags sexplib.unix
 -  signal_unix spawn)
+- (c_flags (:standard -D_LARGEFILE64_SOURCE) ())
 +  signal_unix spawn) (c_library_flags -lMacportsLegacySupport)
-  (c_flags (:standard -D_LARGEFILE64_SOURCE) ())
++ (c_flags (:standard -D_LARGEFILE64_SOURCE) -I@PREFIX@/include/LegacySupport ())
   (c_names nss_stubs timespec core_unix_stubs core_unix_time_stubs)
   (preprocess (pps ppx_jane ppx_optcomp)) (preprocessor_deps config.h))
  

--- a/ocaml/ocaml-expect_test_helpers_core/Portfile
+++ b/ocaml/ocaml-expect_test_helpers_core/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-expect_test_helpers_core
 github.setup        janestreet expect_test_helpers_core 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-expect_test_helpers_kernel/Portfile
+++ b/ocaml/ocaml-expect_test_helpers_kernel/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-expect_test_helpers_kernel
 github.setup        janestreet expect_test_helpers_kernel 0.13.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-fieldslib/Portfile
+++ b/ocaml/ocaml-fieldslib/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-fieldslib
 github.setup        janestreet fieldslib 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-int_repr/Portfile
+++ b/ocaml/ocaml-int_repr/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-int_repr
 github.setup        janestreet int_repr 0.16.0 v
-revision            0
+revision            1
 categories          ocaml
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-js_of_ocaml/Portfile
+++ b/ocaml/ocaml-js_of_ocaml/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-js_of_ocaml
 github.setup        ocsigen js_of_ocaml 5.8.2
-revision            0
+revision            1
 categories          ocaml devel lang
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             {GPL-2+ LGPL-2.1+}

--- a/ocaml/ocaml-jst-config/Portfile
+++ b/ocaml/ocaml-jst-config/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-jst-config
 github.setup        janestreet jst-config 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-lwt/Portfile
+++ b/ocaml/ocaml-lwt/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           ocaml 1.1
 
 github.setup        ocsigen lwt 5.7.0
+revision            1
 
 name                ocaml-lwt
 categories          ocaml devel
@@ -40,6 +41,8 @@ post-patch {
 ocaml.build_type    dune
 
 subport ${name}_ppx {
+    revision        1
+
     depends_lib-append \
                     port:${name} \
                     port:ocaml-ppxlib
@@ -47,6 +50,7 @@ subport ${name}_ppx {
 
 subport ${name}_react {
     version         1.2.0
+    revision        1
     description     Helpers for using React with Lwt
 
     depends_build-append \

--- a/ocaml/ocaml-ocamlformat/Portfile
+++ b/ocaml/ocaml-ocamlformat/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ocamlformat
 github.setup        ocaml-ppx ocamlformat 0.26.2
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             {LGPL-2.1 MIT}
@@ -27,6 +27,8 @@ if {${subport} eq ${name} } {
 }
 
 subport ocaml-ocamlformat-lib {
+    revision        1
+
     depends_lib-append \
                     port:ocaml-astring \
                     port:ocaml-base \

--- a/ocaml/ocaml-parsexp/Portfile
+++ b/ocaml/ocaml-parsexp/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-parsexp
 github.setup        janestreet parsexp 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-patdiff/Portfile
+++ b/ocaml/ocaml-patdiff/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-patdiff
 github.setup        janestreet patdiff 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-patience_diff/Portfile
+++ b/ocaml/ocaml-patience_diff/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-patience_diff
 github.setup        janestreet patience_diff 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_assert/Portfile
+++ b/ocaml/ocaml-ppx_assert/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_assert
 github.setup        janestreet ppx_assert 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_base/Portfile
+++ b/ocaml/ocaml-ppx_base/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_base
 github.setup        janestreet ppx_base 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_bench/Portfile
+++ b/ocaml/ocaml-ppx_bench/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_bench
 github.setup        janestreet ppx_bench 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_bin_prot/Portfile
+++ b/ocaml/ocaml-ppx_bin_prot/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_bin_prot
 github.setup        janestreet ppx_bin_prot 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_cold/Portfile
+++ b/ocaml/ocaml-ppx_cold/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_cold
 github.setup        janestreet ppx_cold 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_compare/Portfile
+++ b/ocaml/ocaml-ppx_compare/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_compare
 github.setup        janestreet ppx_compare 0.16.0 v
-revision            0
+revision            1
 categories          ocaml
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_custom_printf/Portfile
+++ b/ocaml/ocaml-ppx_custom_printf/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_custom_printf
 github.setup        janestreet ppx_custom_printf 0.16.0 v
-revision            0
+revision            1
 categories          ocaml
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_disable_unused_warnings/Portfile
+++ b/ocaml/ocaml-ppx_disable_unused_warnings/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_disable_unused_warnings
 github.setup        janestreet ppx_disable_unused_warnings 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_enumerate/Portfile
+++ b/ocaml/ocaml-ppx_enumerate/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_enumerate
 github.setup        janestreet ppx_enumerate 0.16.0 v
-revision            0
+revision            1
 categories          ocaml
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_expect/Portfile
+++ b/ocaml/ocaml-ppx_expect/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_expect
 github.setup        janestreet ppx_expect 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_fields_conv/Portfile
+++ b/ocaml/ocaml-ppx_fields_conv/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_fields_conv
 github.setup        janestreet ppx_fields_conv 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_fixed_literal/Portfile
+++ b/ocaml/ocaml-ppx_fixed_literal/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_fixed_literal
 github.setup        janestreet ppx_fixed_literal 0.16.0 v
-revision            0
+revision            1
 categories          ocaml
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_globalize/Portfile
+++ b/ocaml/ocaml-ppx_globalize/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_globalize
 github.setup        janestreet ppx_globalize 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_hash/Portfile
+++ b/ocaml/ocaml-ppx_hash/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_hash
 github.setup        janestreet ppx_hash 0.16.0 v
-revision            0
+revision            1
 categories          ocaml
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_here/Portfile
+++ b/ocaml/ocaml-ppx_here/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_here
 github.setup        janestreet ppx_here 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_ignore_instrumentation/Portfile
+++ b/ocaml/ocaml-ppx_ignore_instrumentation/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_ignore_instrumentation
 github.setup        janestreet ppx_ignore_instrumentation 0.16.0 v
-revision            0
+revision            1
 categories          ocaml
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_inline_test/Portfile
+++ b/ocaml/ocaml-ppx_inline_test/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_inline_test
 github.setup        janestreet ppx_inline_test 0.16.1 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_jane/Portfile
+++ b/ocaml/ocaml-ppx_jane/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_jane
 github.setup        janestreet ppx_jane 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_let/Portfile
+++ b/ocaml/ocaml-ppx_let/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_let
 github.setup        janestreet ppx_let 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_log/Portfile
+++ b/ocaml/ocaml-ppx_log/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_log
 github.setup        janestreet ppx_log 0.16.0 v
-revision            0
+revision            1
 categories          ocaml
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_module_timer/Portfile
+++ b/ocaml/ocaml-ppx_module_timer/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_module_timer
 github.setup        janestreet ppx_module_timer 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_optcomp/Portfile
+++ b/ocaml/ocaml-ppx_optcomp/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_optcomp
 github.setup        janestreet ppx_optcomp 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_optional/Portfile
+++ b/ocaml/ocaml-ppx_optional/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_optional
 github.setup        janestreet ppx_optional 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_pipebang/Portfile
+++ b/ocaml/ocaml-ppx_pipebang/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_pipebang
 github.setup        janestreet ppx_pipebang 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_sexp_conv/Portfile
+++ b/ocaml/ocaml-ppx_sexp_conv/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_sexp_conv
 github.setup        janestreet ppx_sexp_conv 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_sexp_message/Portfile
+++ b/ocaml/ocaml-ppx_sexp_message/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_sexp_message
 github.setup        janestreet ppx_sexp_message 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_sexp_value/Portfile
+++ b/ocaml/ocaml-ppx_sexp_value/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_sexp_value
 github.setup        janestreet ppx_sexp_value 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_stable/Portfile
+++ b/ocaml/ocaml-ppx_stable/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_stable
 github.setup        janestreet ppx_stable 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_stable_witness/Portfile
+++ b/ocaml/ocaml-ppx_stable_witness/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_stable_witness
 github.setup        janestreet ppx_stable_witness 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_string/Portfile
+++ b/ocaml/ocaml-ppx_string/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_string
 github.setup        janestreet ppx_string 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_tydi/Portfile
+++ b/ocaml/ocaml-ppx_tydi/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_tydi
 github.setup        janestreet ppx_tydi 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         nomaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_typerep_conv/Portfile
+++ b/ocaml/ocaml-ppx_typerep_conv/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_typerep_conv
 github.setup        janestreet ppx_typerep_conv 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-ppx_variants_conv/Portfile
+++ b/ocaml/ocaml-ppx_variants_conv/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-ppx_variants_conv
 github.setup        janestreet ppx_variants_conv 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-protocol_version_header/Portfile
+++ b/ocaml/ocaml-protocol_version_header/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-protocol_version_header
 github.setup        janestreet protocol_version_header 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-record_builder/Portfile
+++ b/ocaml/ocaml-record_builder/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-record_builder
 github.setup        janestreet record_builder 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-sedlex/Portfile
+++ b/ocaml/ocaml-sedlex/Portfile
@@ -6,7 +6,7 @@ PortGroup ocaml     1.1
 
 name                ocaml-sedlex
 github.setup        ocaml-community sedlex 3.2 v
-revision            0
+revision            1
 
 github.tarball_from archive
 

--- a/ocaml/ocaml-sexp_pretty/Portfile
+++ b/ocaml/ocaml-sexp_pretty/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-sexp_pretty
 github.setup        janestreet sexp_pretty 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-sexplib/Portfile
+++ b/ocaml/ocaml-sexplib/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-sexplib
 github.setup        janestreet sexplib 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-shell/Portfile
+++ b/ocaml/ocaml-shell/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-shell
 github.setup        janestreet shell 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-spawn/Portfile
+++ b/ocaml/ocaml-spawn/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-spawn
 github.setup        janestreet spawn 0.15.1 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-splittable_random/Portfile
+++ b/ocaml/ocaml-splittable_random/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-splittable_random
 github.setup        janestreet splittable_random 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-stdio/Portfile
+++ b/ocaml/ocaml-stdio/Portfile
@@ -6,6 +6,7 @@ PortGroup ocaml     1.1
 
 name                ocaml-stdio
 github.setup        janestreet stdio 0.16.0 v
+revision            1
 
 categories          ocaml devel
 maintainers         {landonf @landonf} openmaintainer

--- a/ocaml/ocaml-textutils/Portfile
+++ b/ocaml/ocaml-textutils/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-textutils
 github.setup        janestreet textutils 0.16.0 v
-revision            0
+revision            1
 categories          ocaml textproc
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-textutils_kernel/Portfile
+++ b/ocaml/ocaml-textutils_kernel/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-textutils_kernel
 github.setup        janestreet textutils_kernel 0.16.0 v
-revision            0
+revision            1
 categories          ocaml textproc
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-time_now/Portfile
+++ b/ocaml/ocaml-time_now/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-time_now
 github.setup        janestreet time_now 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-timezone/Portfile
+++ b/ocaml/ocaml-timezone/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-timezone
 github.setup        janestreet timezone 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-typerep/Portfile
+++ b/ocaml/ocaml-typerep/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-typerep
 github.setup        janestreet typerep 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-variantslib/Portfile
+++ b/ocaml/ocaml-variantslib/Portfile
@@ -6,7 +6,7 @@ PortGroup           ocaml 1.1
 
 name                ocaml-variantslib
 github.setup        janestreet variantslib 0.16.0 v
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/ocaml/ocaml-visitors/Portfile
+++ b/ocaml/ocaml-visitors/Portfile
@@ -7,7 +7,7 @@ PortGroup ocaml     1.1
 name                ocaml-visitors
 gitlab.instance     https://gitlab.inria.fr
 gitlab.setup        fpottier visitors 20210608
-revision            0
+revision            1
 
 categories          ocaml devel
 maintainers         {landonf @landonf} openmaintainer


### PR DESCRIPTION
#### Description

@pmetzger Could you review this please?

Not that I do this happily, but an alternative is to revbump a lot of OCaml packages: everything JaneStreet, potentially other as well.

Upstream did a weird thing: while `ocaml-sexplib0` 0.17.0 is compatible with OCaml 4.14, all subsequent updates to 0.17.x require OCaml 5.x.
I tried rebuilding `ocaml-base`, `ocaml-ppxlib` and a few other dependents, and it works fine. But there are a lot of dependents, and determining sequentially which need a rebuild will be ridiculously time-consuming. We can just revbump everything that in some way depends indirectly on `ocaml-sexplib0`, but we will need to rebuild everything.

I am fine with just revbump of everything, but not sure it is justified.

Leaving things as they are is not an option though, since nothing builds now, and I cannot update `stanc3`, for example.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
