### PR TITLE
pdfjam: update to 3.12

### DIFF
--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            rrthomas pdfjam 3.11 v
+github.setup            rrthomas pdfjam 3.12 v
 categories              textproc pdf
 maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 license                 GPL-2
@@ -22,9 +22,9 @@ long_description \
 
 github.tarball_from     releases
 
-checksums               rmd160  f1a2fc4482c72704c7b947b05bbce13d6cdaf36f \
-                        sha256  fcc85ec14fbb2363f02866b119aaada05b6b44af1c45224c22d407fffe0a8a2a \
-                        size    162801
+checksums               rmd160  2422c5a576a5dbcf38745213d85b6a281672847f \
+                        sha256  c8c227d10abd0e787c1c2da290bb5ddb77c19eebfd434649e8cbb2c5152feb31 \
+                        size    162802
 
 depends_run \
     bin:pdflatex:texlive-latex \


### PR DESCRIPTION
#### Description

Update to pdfjam 3.12.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
