### PR TITLE
cppcheck: fix build on macOS <10.12

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem                  1.0
 PortGroup                   github 1.0
+PortGroup                   compiler_blacklist_versions 1.0
 
 github.setup                danmar cppcheck 2.14.2
 revision                    0
@@ -45,6 +46,9 @@ post-patch {
 
 compiler.cxx_standard       2011
 compiler.thread_local_storage yes
+# build/valueflow.cpp:10973:124: error: call
+# to deleted function 'toString' on macOS <10.12
+compiler.blacklist-append   {clang < 900}
 
 use_configure               no
 


### PR DESCRIPTION
#### Description

https://build.macports.org/builders/ports-10.11_x86_64-builder/builds/270063/steps/install-port/logs/stdio
Doesn't happen on other buildbots that use the newer Clang.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
