### PR TITLE
eza: update to 0.18.21

### DIFF
--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        eza-community eza 0.18.20 v
+github.setup        eza-community eza 0.18.21 v
 github.tarball_from archive
 revision            0
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  17c6fb2eec771987e41d7adad5ca18534e430335 \
-                    sha256  f85a7c1a1859e4fb7913d9517bd5fd04714811562b631a71705077c5aceacd78 \
-                    size    1385525
+                    rmd160  f23eadb1b736db088188f37b3dd6b6ec3b9a1061 \
+                    sha256  53cee12706be2b5bedcf40b97e077a18b254f0f53f1aee52d1d74136466045bc \
+                    size    1385590
 
 depends_lib-append  port:libiconv \
                     path:lib/pkgconfig/libgit2.pc:libgit2 \


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
