### PR TITLE
openssh: update to 9.8p1, update patchfiles

### DIFF
--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -5,8 +5,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
-version             9.7p1
-revision            1
+version             9.8p1
 categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD
@@ -28,9 +27,9 @@ long_description    OpenSSH is a FREE version of the SSH protocol suite of \
 
 homepage            https://www.openbsd.org/openssh/
 
-checksums           rmd160  5cad750b5779e16f1336fa38cec904411184d813 \
-                    sha256  490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd \
-                    size    1848766
+checksums           rmd160  8e9bc65c953590fd755febf4282f4bb04150b00d \
+                    sha256  dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3 \
+                    size    1910393
 
 master_sites        openbsd:OpenSSH/portable \
                     ftp://ftp.cise.ufl.edu/pub/mirrors/openssh/portable/ \
@@ -53,7 +52,7 @@ if {${name} eq ${subport}} {
                         agent.patch \
                         pam.patch \
                         patch-sandbox-darwin.c-apple-sandbox-named-external.diff \
-                        patch-sshd.c-apple-sandbox-named-external.diff \
+                        patch-sshd-session.c-apple-sandbox-named-external.diff \
                         macports-config.patch \
 
     # We need a couple of patches

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -11,7 +11,7 @@ categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD
 installs_libs       no
-conflicts           lsh pkixssh
+conflicts           pkixssh
 
 description         OpenSSH secure login server
 

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,6 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             9.8p1
+revision            0
 categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD

--- a/net/openssh/files/launchd.patch
+++ b/net/openssh/files/launchd.patch
@@ -43,7 +43,7 @@
  		strlcpy(proto, SSH_X11_PROTO, sizeof proto);
 --- a/channels.c	2023-03-15 16:28:19.000000000 -0500
 +++ b/channels.c	2023-03-16 13:56:15.000000000 -0500
-@@ -5066,7 +5066,7 @@
+@@ -5127,7 +5127,7 @@
  }
  
  #ifdef __APPLE__

--- a/net/openssh/files/pam.patch
+++ b/net/openssh/files/pam.patch
@@ -1,11 +1,10 @@
 --- a/servconf.c	2019-10-09 02:31:03.000000000 +0200
 +++ b/servconf.c	2019-10-11 11:43:39.000000000 +0200
-@@ -276,7 +276,7 @@ fill_default_server_options(ServerOption
+@@ -295,7 +295,7 @@
  
  	/* Portable-specific options */
  	if (options->use_pam == -1)
 -		options->use_pam = 0;
 +		options->use_pam = 1;
- 
- 	/* Standard Options */
- 	if (options->num_host_key_files == 0) {
+ 	if (options->pam_service_name == NULL)
+ 		options->pam_service_name = xstrdup(SSHD_PAM_SERVICE);

--- a/net/openssh/files/patch-sshd-session.c-apple-sandbox-named-external.diff
+++ b/net/openssh/files/patch-sshd-session.c-apple-sandbox-named-external.diff
@@ -1,5 +1,5 @@
---- a/sshd.c	2019-10-09 02:31:03.000000000 +0200
-+++ b/sshd.c	2019-11-08 15:35:54.000000000 +0100
+--- a/sshd-session.c	2019-10-09 02:31:03.000000000 +0200
++++ b/sshd-session.c	2019-11-08 15:35:54.000000000 +0100
 @@ -534,10 +534,79 @@ privsep_preauth(struct ssh *ssh)
  		/* Arrange for logging to be sent to the monitor */
  		set_log_handler(mm_log_handler, pmonitor);


### PR DESCRIPTION
#### Description

Update OpenSSH to 9.8p1, update patches so they apply

###### Type(s)

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?