### PR TITLE
MoarVM: enable mimalloc support in a separate variant

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                MoarVM
 version             2024.06
-revision            0
+revision            1
 categories          lang devel
 license             Artistic-2 BSD ISC MIT public-domain
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -73,7 +73,8 @@ configure.cmd       ${prefix}/bin/perl Configure.pl
 configure.args      --cc=${configure.cc} \
                     --has-dyncall \
                     --has-libatomic_ops \
-                    --has-libtommath
+                    --has-libtommath \
+                    --no-mimalloc
 
 configure.cflags-append \
                     -I${prefix}/include/libtommath
@@ -81,11 +82,6 @@ configure.cflags-append \
 # The dylib machinery uses -rpath, not available on Tiger
 platform darwin 8 {
     patchfiles-append patch-build-setup-tiger.diff
-}
-
-if {${os.platform} eq "darwin" && ${os.major} <= 10} {
-    configure.args-append \
-                    --no-mimalloc
 }
 
 # The build system puts CPPFLAGS and LDFLAGS before its own flags which leads to
@@ -110,6 +106,18 @@ variant macports_libuv description "Use MacPorts' libuv" {
     configure.args-append \
                     --has-libuv
 }
+
+variant mimalloc description "Build with mimalloc support" {
+    configure.args-delete \
+                    --no-mimalloc
+}
+
+# stats.c:569:31: error: variable has incomplete type 'struct mach_task_basic_info'
+# mimalloc code uses the API available on macOS 10.8+
+# not enabled at will by the maintainer, possibly to be fixed on older systems
+#if {${os.platform} eq "darwin" && ${os.major} > 11} {
+#    default_variants    +mimalloc
+#}
 
 # This can be enabled once libuv port is updated.
 # See: https://trac.macports.org/ticket/68464


### PR DESCRIPTION
#### Description

https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/197004/steps/install-port/logs/stdio
https://developer.apple.com/documentation/kernel/mach_task_basic_info_t

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
