### PR TITLE
gjs: fix for systems where latest mozjs fails

### DIFF
--- a/gnome/gjs/Portfile
+++ b/gnome/gjs/Portfile
@@ -28,7 +28,7 @@ set py_ver          3.12
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build-append \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     port:python${py_ver_nodot}
 
 depends_lib-append \
@@ -65,6 +65,37 @@ configure.args-append \
                     -Dbsymbolic_functions=false
 
 gobject_introspection yes
+
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    # Fallback version for older systems.
+    gitlab.setup    GNOME gjs 1.63.3
+    revision        0
+    checksums       rmd160  60cbadb35bad345917b153dc115f2c84fc8e55d3 \
+                    sha256  63e97e3b76062c931fab1e0afa25f2db701e91e92653452df50e3ab3b51dfbbc \
+                    size    435576
+
+    # Use rust-free version of mozjs:
+    depends_lib-replace     port:mozjs115 port:mozjs60
+
+    patchfiles-delete       patch-gjs-test.diff patch-gjs-meson_options.diff
+
+    # LD_LIBRARY_PATH => DYLD_LIBRARY_PATH
+    patchfiles-append       patch-gjs-test-legacy.diff
+
+    # The gobject_introspection PG needs an 'introspection' option
+    patchfiles-append       patch-gjs-meson_options-legacy.diff
+
+    # Fix gsize/size_t mismatch on 32-bit systems
+    patchfiles-append       patch-gjs-gsize.diff
+
+    # Fix gint64/int64_t mismatch on x86_64
+    patchfiles-append       patch-gjs-gint64.diff
+
+    # gatomic.h: error: argument 2 of '__atomic_load' must not be a pointer to a 'volatile' type
+    patchfiles-append       patch-atomic_load.diff
+
+    compiler.cxx_standard   2014
+}
 
 # Note that a few tests in the "Scripts / CommandLine" category may fail as the
 # typelib (gobject-introspection) expects libgjs.0.dylib to be installed at the

--- a/gnome/gjs/files/patch-atomic_load.diff
+++ b/gnome/gjs/files/patch-atomic_load.diff
@@ -1,0 +1,23 @@
+--- gjs/error-types.cpp	2020-01-08 09:30:05.000000000 +0800
++++ gjs/error-types.cpp	2024-07-02 18:04:45.000000000 +0800
+@@ -31,7 +31,7 @@
+ // clang-format on
+ 
+ GType gjs_js_error_get_type(void) {
+-    static volatile GType g_type_id;
++    static GType g_type_id;
+ 
+     if (g_once_init_enter(&g_type_id)) {
+         static GEnumValue errors[] = {
+
+--- libgjs-private/gjs-util.c	2020-01-08 09:30:06.000000000 +0800
++++ libgjs-private/gjs-util.c	2024-07-02 18:06:57.000000000 +0800
+@@ -57,7 +57,7 @@
+ GType
+ gjs_locale_category_get_type(void)
+ {
+-  static volatile size_t g_define_type_id__volatile = 0;
++  static size_t g_define_type_id__volatile = 0;
+   if (g_once_init_enter(&g_define_type_id__volatile)) {
+       static const GEnumValue v[] = {
+           { GJS_LOCALE_CATEGORY_ALL, "GJS_LOCALE_CATEGORY_ALL", "all" },

--- a/gnome/gjs/files/patch-gjs-gint64.diff
+++ b/gnome/gjs/files/patch-gjs-gint64.diff
@@ -1,0 +1,18 @@
+Undefined symbols for architecture x86_64:
+  "_gjs_profiler_add_mark(_GjsProfiler*, long long, long long, char const*, char const*, char const*)", referenced from:
+      GjsContextPrivate::set_sweeping(bool) in gjs_context.cpp.o
+ld: symbol(s) not found for architecture x86_64
+
+--- gjs/profiler.cpp
++++ gjs/profiler.cpp
+@@ -673,8 +673,8 @@
+     self->filename = g_strdup(filename);
+ }
+ 
+-void _gjs_profiler_add_mark(GjsProfiler* self, gint64 time_nsec,
+-                            gint64 duration_nsec, const char* group,
++void _gjs_profiler_add_mark(GjsProfiler* self, int64_t time_nsec,
++                            int64_t duration_nsec, const char* group,
+                             const char* name, const char* message) {
+     g_return_if_fail(self);
+     g_return_if_fail(group);

--- a/gnome/gjs/files/patch-gjs-gsize.diff
+++ b/gnome/gjs/files/patch-gjs-gsize.diff
@@ -1,0 +1,97 @@
+On 32-bit systems, gsize is an int but size_t is a (32-bit) long. This
+discrepancy results in compilation errors when attempting to interchange their
+pointers. The patch below changes gsize to size_t, and vice versa, depending
+on the surrounding context.
+
+For a complete discussion, see:
+
+https://gitlab.gnome.org/GNOME/gjs/-/merge_requests/680
+
+--- gi/arg.cpp.orig
++++ gi/arg.cpp
+@@ -1267,7 +1267,7 @@
+                                      GITransfer       transfer,
+                                      bool             may_be_null,
+                                      gpointer        *contents,
+-                                     gsize           *length_p)
++                                     size_t          *length_p)
+ {
+     bool ret = false;
+     GITypeInfo *param_info;
+@@ -1960,7 +1960,7 @@
+ 
+     case GI_TYPE_TAG_ARRAY: {
+         gpointer data;
+-        gsize length;
++        size_t length;
+         GIArrayType array_type = g_type_info_get_array_type(type_info);
+ 
+         /* First, let's handle the case where we're passed an instance
+--- gi/function.cpp.orig
++++ gi/function.cpp
+@@ -831,12 +831,12 @@
+         GjsAutoChar name = format_function_name(function, is_method);
+         JS_ReportWarningUTF8(context, "Too many arguments to %s: expected %d, "
+                              "got %" G_GSIZE_FORMAT, name.get(),
+-                             function->expected_js_argc, args.length());
++                             function->expected_js_argc, (gsize)args.length());
+     } else if (args.length() < function->expected_js_argc) {
+         GjsAutoChar name = format_function_name(function, is_method);
+         gjs_throw(context, "Too few arguments to %s: "
+                   "expected %d, got %" G_GSIZE_FORMAT,
+-                  name.get(), function->expected_js_argc, args.length());
++                  name.get(), function->expected_js_argc, (gsize)args.length());
+         return false;
+     }
+ 
+@@ -991,7 +991,7 @@
+                 GIArgInfo array_length_arg;
+ 
+                 gint array_length_pos = g_type_info_get_array_length(&ainfo);
+-                gsize length;
++                size_t length;
+ 
+                 if (!gjs_value_to_explicit_array(context, args[js_arg_pos],
+                                                  &arg_info, in_value, &length)) {
+@@ -1239,7 +1239,7 @@
+                     arg->v_pointer = NULL;
+                 }
+             } else if (param_type == PARAM_ARRAY) {
+-                gsize length;
++                size_t length;
+                 GIArgInfo array_length_arg;
+                 GITypeInfo array_length_type;
+                 gint array_length_pos = g_type_info_get_array_length(&arg_type_info);
+--- gjs/byteArray.cpp.orig
++++ gjs/byteArray.cpp
+@@ -269,7 +269,7 @@
+ 
+     gbytes = (GBytes*) gjs_c_struct_from_boxed(context, bytes_obj);
+ 
+-    size_t len;
++    gsize len;
+     const void* data = g_bytes_get_data(gbytes, &len);
+     JS::RootedObject array_buffer(
+         context,
+--- gjs/context.cpp.orig
++++ gjs/context.cpp
+@@ -994,7 +994,7 @@
+                       GError       **error)
+ {
+     char *script;
+-    size_t script_len;
++    gsize script_len;
+     GjsAutoUnref<GFile> file = g_file_new_for_commandline_arg(filename);
+ 
+     if (!g_file_load_contents(file, nullptr, &script, &script_len, nullptr,
+--- gjs/module.cpp.orig
++++ gjs/module.cpp
+@@ -145,7 +145,7 @@
+     {
+         GError *error = nullptr;
+         char *unowned_script;
+-        size_t script_len = 0;
++        gsize script_len = 0;
+ 
+         if (!(g_file_load_contents(file, nullptr, &unowned_script, &script_len,
+                                    nullptr, &error)))

--- a/gnome/gjs/files/patch-gjs-meson_options-legacy.diff
+++ b/gnome/gjs/files/patch-gjs-meson_options-legacy.diff
@@ -1,0 +1,11 @@
+--- meson_options.txt
++++ meson_options.txt	2022-07-10 07:06:25.000000000 -0400
+@@ -6,6 +6,8 @@
+     description: 'Use readline for input in interactive shell and debugger')
+ option('profiler', type: 'feature', value: 'auto',
+     description: 'Build profiler (Linux only)')
++option('introspection', type: 'feature', value: 'auto',
++    description: 'Fake option so that the MacPorts gobject_introspection PortGroup does not barf')
+ 
+ # Flags
+ 

--- a/gnome/gjs/files/patch-gjs-test-legacy.diff
+++ b/gnome/gjs/files/patch-gjs-test-legacy.diff
@@ -1,0 +1,13 @@
+Darwin uses DYLD_LIBRARY_PATH, not LD_LIBRARY_PATH
+
+--- meson.build
++++ meson.build	2022-03-02 07:44:52.000000000 -0500
+@@ -574,7 +574,7 @@
+ tests_environment.set('GJS_PATH', '')
+ tests_environment.prepend('GI_TYPELIB_PATH', meson.current_build_dir(),
+     js_tests_builddir)
+-tests_environment.prepend('LD_LIBRARY_PATH', meson.current_build_dir(),
++tests_environment.prepend('DYLD_LIBRARY_PATH', meson.current_build_dir(),
+     js_tests_builddir)
+ tests_environment.set('G_FILENAME_ENCODING', 'latin1')
+ tests_environment.set('LSAN_OPTIONS', 'exitcode=23,suppressions=@0@'.format(


### PR DESCRIPTION
#### Description

Fix this finally.

I can confirm that it actually works: at least I can build apps requiring it:

![polari](https://github.com/macports/macports-ports/assets/92015510/79c6eb6d-992a-4067-bd60-c00ed8567883)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
