### PR TITLE
ruby-build: Upgrade to 20240702

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20240612 v
+github.setup        rbenv ruby-build 20240702 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  29194e0849b779e7485f03b8700904c353c418fa \
-                    sha256  3502a4a744a95ceedd48cc9de8c171b808184b2a6ab1f6489fbd69d501c496be \
-                    size    89823
+checksums           rmd160  e40c48df1803c94fa7fe597d681e5a0e27db6415 \
+                    sha256  21b34a653ddbe29a4a5f3e9f71d3a634816295a549569899c6d1148a821b2273 \
+                    size    89950
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Upgrade to 20240702

##### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
