### PR TITLE
wren-cli: Update to 0.4.0; fix conflict with libuv; fix universal variant and enable non-Intel archs; fix whitespace

### DIFF
--- a/lang/wren-cli/Portfile
+++ b/lang/wren-cli/Portfile
@@ -27,6 +27,8 @@ github.tarball_from archive
 maintainers       {gmail.com:herby.gillot @herbygillot} \
                   openmaintainer
 
+# Avoid conflict with libuv port
+configure.cppflags-delete -I${prefix}/include
 
 build.dir           ${worksrcpath}/projects/make.mac
 

--- a/lang/wren-cli/Portfile
+++ b/lang/wren-cli/Portfile
@@ -3,6 +3,7 @@
 PortSystem        1.0
 PortGroup         github 1.0
 PortGroup         makefile 1.0
+PortGroup           muniversal 1.1
 
 github.setup        wren-lang wren-cli 0.4.0
 revision            0
@@ -12,8 +13,6 @@ checksums           rmd160  9df6eeab574a1081bf4a7ce50a96263a09b8e0ca \
 
 categories        lang
 license           MIT
-platforms         darwin
-supported_archs   x86_64 i386
 
 description       A command line tool for the Wren programming language
 
@@ -34,11 +33,11 @@ build.dir           ${worksrcpath}/projects/make.mac
 
 build.args-append verbose=1
 
-if {${build_arch} eq "x86_64"} {
-    build.args-append config=release_64bit
-} else {
-    build.args-append config=release_32bit
-}
+build.args.arm64    config=release_64bit
+build.args.i386     config=release_32bit
+build.args.ppc      config=release_32bit
+build.args.ppc64    config=release_64bit
+build.args.x86_64   config=release_64bit
 
 destroot {
     copy ${worksrcpath}/bin/wren_cli ${destroot}${prefix}/bin/

--- a/lang/wren-cli/Portfile
+++ b/lang/wren-cli/Portfile
@@ -1,8 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem        1.0
-PortGroup         github 1.0
-PortGroup         makefile 1.0
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
 PortGroup           muniversal 1.1
 
 github.setup        wren-lang wren-cli 0.4.0
@@ -11,20 +11,20 @@ checksums           rmd160  9df6eeab574a1081bf4a7ce50a96263a09b8e0ca \
                     sha256  fafdc5d6615114d40de3956cd3a255e8737dadf8bd758b48bac00db61563cb4c \
                     size    522379
 
-categories        lang
-license           MIT
+categories          lang
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
-description       A command line tool for the Wren programming language
+description         A command line tool for the Wren programming language
 
-long_description  The CLI project is a small and simple REPL and CLI tool for \
-                  running Wren scripts. It is backed by libuv to implement IO \
-                  functionality, and is a work in progress.
+long_description    The CLI project is a small and simple REPL and CLI tool \
+                    for running Wren scripts. It is backed by libuv to \
+                    implement IO functionality, and is a work in progress.
 
-homepage          https://wren.io/cli/
+homepage            https://wren.io/cli/
 github.tarball_from archive
 
-maintainers       {gmail.com:herby.gillot @herbygillot} \
-                  openmaintainer
 
 # Avoid conflict with libuv port
 configure.cppflags-delete -I${prefix}/include

--- a/lang/wren-cli/Portfile
+++ b/lang/wren-cli/Portfile
@@ -4,7 +4,11 @@ PortSystem        1.0
 PortGroup         github 1.0
 PortGroup         makefile 1.0
 
-github.setup      wren-lang wren-cli 0.3.0
+github.setup        wren-lang wren-cli 0.4.0
+revision            0
+checksums           rmd160  9df6eeab574a1081bf4a7ce50a96263a09b8e0ca \
+                    sha256  fafdc5d6615114d40de3956cd3a255e8737dadf8bd758b48bac00db61563cb4c \
+                    size    522379
 
 categories        lang
 license           MIT
@@ -18,15 +22,13 @@ long_description  The CLI project is a small and simple REPL and CLI tool for \
                   functionality, and is a work in progress.
 
 homepage          https://wren.io/cli/
+github.tarball_from archive
 
 maintainers       {gmail.com:herby.gillot @herbygillot} \
                   openmaintainer
 
-checksums         rmd160  f92affe56d28b0697ec3e618e3b1fbfd515b2ccc \
-                  sha256  6ded2552c919f41b6e6c37801e1b2f29691de534c0d5328641d4daa6184cd850 \
-                  size    509880
 
-worksrcdir        ${worksrcdir}/projects/make.mac
+build.dir           ${worksrcpath}/projects/make.mac
 
 build.args-append verbose=1
 
@@ -37,5 +39,5 @@ if {${build_arch} eq "x86_64"} {
 }
 
 destroot {
-    copy ${worksrcpath}/../../bin/wren_cli ${destroot}${prefix}/bin/
+    copy ${worksrcpath}/bin/wren_cli ${destroot}${prefix}/bin/
 }


### PR DESCRIPTION
#### Description

* Update to 0.4.0
* Fix build failure when libuv port is active (https://trac.macports.org/ticket/68057)
* Fix universal variant and enable non-Intel archs (I tried an x86_64/arm64 universal build on macOS 12 and it succeeded but I don't know whether the arm64 part works; the port gave no explanation for why it had been limited to Intel archs so I've speculatively removed the limit)
* Fix whitespace to conform to modeline (4 spaces per indent)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
