### PR TITLE
mysql8: Add missing cmake PortGroup Flag OPENSSL_ROOT_DIR

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -13,7 +13,7 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     0
+set revision_client     1
 set revision_server     0
 
 set name_mysql          ${name}
@@ -169,7 +169,6 @@ if {$subport eq $name} {
         # to use the macports openssl / libcrypto libs in place. per the mysql8 devs, this is the
         # preferred method to the copy and update method
         configure.args-delete \
-            -DOPENSSL_ROOT_DIR=[openssl::install_area] \
             -DOPENSSL_INCLUDE_DIR=[openssl::include_dir] \
             -DWITH_SSL=[openssl::install_area]
     }


### PR DESCRIPTION
  On older versions of macOS, cmake does not automatically set the
  OPENSSL_ROOT_DIR flag.  This flag needs to be set to avoid tripping
  hard-coded Homebrew logic in the ssl.cmake cmake file.

Closes: https://trac.macports.org/ticket/70314

#### Description

This fixes a regression introduced in https://github.com/macports/macports-ports/pull/24696 (sorry about that)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
