### PR TITLE
dcw-gmt: update to 2.2.0

### DIFF
--- a/science/dcw-gmt/Portfile
+++ b/science/dcw-gmt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 name                dcw-gmt
-github.setup        GenericMappingTools dcw-gmt 2.1.2
+github.setup        GenericMappingTools dcw-gmt 2.2.0
 categories          science
 platforms           any
 supported_archs     noarch
@@ -23,9 +23,9 @@ long_description    DCW-GMT is an enhancement to the \
 
 github.tarball_from releases
 
-checksums           rmd160  730f9ac8cd730a18ab6d1194e76c728428cd53e0 \
-                    sha256  4bb840d075c8ba3e14aeb41cf17c24236bff787566314f9ff758ab9977745d99 \
-                    size    22326188
+checksums           rmd160  d57eea9dc7ebeb3378a4821b87072b5798600a1a \
+                    sha256  f2a8a7b7365bdd17269aa1d412966a871528eefa9b2a7409815832a702ff7dcb \
+                    size    22487044
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.2.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
