### PR TITLE
google-cloud-sdk: update to 483.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             482.0.0
+version             483.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4ec78013347eccb4c25d14f52175889cd9ecffb8 \
-                    sha256  4b4c4d661da675b2011d96538fc1682c14cd22f2c629ac5839607d3fe4adae2d \
-                    size    50932574
+    checksums       rmd160  731da90118557a02f26dbdc1faeb653b0cacb1dc \
+                    sha256  bf389faacfcb4e1a77015a7695f80cc09179c2c65019235ef85700ce7bb56afc \
+                    size    51001393
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  81b94d225d93c8cf5e2ae23b7280c8083ee20b27 \
-                    sha256  6f73704d8ed27615fe88c536c2c5a9bc522f3d46e9eb46226bf348aacc7f0cff \
-                    size    52217650
+    checksums       rmd160  d8fb7ad37d69a446394ddb8c56281fabd286f973 \
+                    sha256  410522737dec5b2e2576436adae855fb91758daefc35d650e8ddbc217ecacfb3 \
+                    size    52288502
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  1614e76c28ba650dffc1d5e1f35d374f6979f0ec \
-                    sha256  73acf124eb6a1a612e46faaf4048ba90df7114116785d1e836b761a03ccf7d7a \
-                    size    52176101
+    checksums       rmd160  e8801c552b83ef730da6ad738e7c9b4e8ba746ef \
+                    sha256  6ffc62ea60c362a91cdf359a70bb2302654c97f94228024c4fd7a49cfcbfc0eb \
+                    size    52249149
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 483.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?