### PR TITLE
py-urwid,py-pudb: add py312 subport

### DIFF
--- a/python/py-pudb/Portfile
+++ b/python/py-pudb/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  8255d1bae550efb63b1a1cf67981f1630b27b734 \
                     sha256  e8f0ea01b134d802872184b05bffc82af29a1eb2f9374a277434b932d68f58dc \
                     size    59548
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-urwid/Portfile
+++ b/python/py-urwid/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  4d8666717bee9d9fdabcc1c7b551ff583a28e307 \
                     sha256  c21112c3c524110dd5cad78f7987a9fe0c57a66b756e1e0385e572b946ec86d1 \
                     size    607749
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Tested the same way as in #18183 and #18184. For pudb I also ran a simple script through it.

There are updates to both packages, but py-urwid no longer supports Python 2.7 and there are other ports (`PIDA`, `alot`) that depend on the py27 subport. Updating pudb to a five year newer version without updating urwid might well break things, so I am leaving both packages on their current versions for now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
