### PR TITLE
znc: fix build on macOS <10.14

### DIFF
--- a/irc/znc/Portfile
+++ b/irc/znc/Portfile
@@ -2,12 +2,17 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           legacysupport 1.1
+PortGroup           compiler_blacklist_versions 1.0
+
+# On macOS <10.13 built-in libc++ has no support for std::variant
+legacysupport.newest_darwin_requires_legacy 16
+legacysupport.use_mp_libcxx yes
 
 name                znc
 version             1.9.1
 revision            0
 categories          irc
-platforms           darwin
 maintainers         nomaintainer
 license             Apache-2
 description         An advanced IRC bouncer
@@ -33,7 +38,11 @@ configure.args-append \
                         -DWANT_PYTHON=false \
                         -DWANT_TCL=true
 
-compiler.cxx_standard   2011
+# Translation.h:22:10: fatal error: 'variant'
+# file not found on macOS <10.14
+compiler.cxx_standard   2017
+compiler.blacklist-append \
+                    {clang < 1001}
 if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
     configure.ldflags-append -stdlib=${configure.cxx_stdlib}
 }


### PR DESCRIPTION
* remove platforms line

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
