### PR TITLE
R, R PG: ensure correct gcc picked when gcc is the primary compiler (no revbump)

### DIFF
--- a/_resources/port1.0/group/R-1.0.tcl
+++ b/_resources/port1.0/group/R-1.0.tcl
@@ -107,7 +107,8 @@ compiler.blacklist-append   {macports-clang-1[7-9]}
 # Similarly, for gcc select the gcc13 variant of the compilers PG.
 # This setting should also be kept in sync with that in the R Port.
 # Updates should be coordinated with the R maintainers.
-# NOTE: upon the update to gcc14, please add a blacklist of newer gccs,
+compiler.blacklist-append   {macports-gcc-1[4-9]}
+# NOTE: upon the update to gcc14, please update the blacklist accordingly,
 # like it is done for clangs. We would prefer using the same version of gcc and gfortran.
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     # Until old platforms are switched to the new libgcc.

--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -48,7 +48,8 @@ compiler.blacklist-append   {macports-clang-1[7-9]}
 # Similarly, for gcc select the gcc13 variant of the compilers PG.
 # This setting should also be kept in sync with that in the R Portgroup.
 # Updates should be coordinated with the R maintainers.
-# NOTE: upon the update to gcc14, please add a blacklist of newer gccs,
+compiler.blacklist-append   {macports-gcc-1[4-9]}
+# NOTE: upon the update to gcc14, please update the blacklist accordingly,
 # like it is done for clangs. We would prefer using the same version of gcc and gfortran.
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     # Until old platforms are switched to the new libgcc.
@@ -56,6 +57,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
 } else {
     default_variants-append +gcc13
 }
+# When switching to gcc14, make sure to add this flag when gcc is used
+# as the primary compiler: -Wno-error=incompatible-pointer-types
+# devQuartz.c:3049:35: error: passing argument 2 of 'CGContextSetFont'
+# from incompatible pointer type [-Wincompatible-pointer-types]
 
 compilers.choose            fc f77
 compilers.setup             require_fortran


### PR DESCRIPTION
#### Description

Setting a variant works for systems with clang, where gcc is only providing gfortran.
It is not sufficient when gcc is used as the primary compiler.

(No need to revbump, since there are no systems in MacPorts which use modern gcc instead of clang by default.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
