### PR TITLE
sqlean: update to 0.23.0, fix build on old systems

### DIFF
--- a/databases/sqlean/Portfile
+++ b/databases/sqlean/Portfile
@@ -5,7 +5,9 @@ PortSystem          1.0
 PortGroup           github      1.0
 PortGroup           makefile    1.0
 
-github.setup        nalgeon sqlean 0.22.0
+# Update to 0.24.0 once this is fixed:
+# https://github.com/nalgeon/sqlean/issues/124
+github.setup        nalgeon sqlean 0.23.0
 github.tarball_from archive
 revision            0
 
@@ -29,6 +31,13 @@ depends_lib-append  port:sqlite3
 fetch.type          git
 
 patchfiles          patch-Makefile.diff
+
+# base32.c: error: ‘for’ loop initial declaration used outside C99 mode
+# However just passing -std= flag does not fix the build:
+# extension.c: error: ‘struct ipaddress’ has no member named ‘ipv4’
+# So still need to blacklist old Xcode gcc.
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
 build.target        prepare-dist compile-macos
 


### PR DESCRIPTION
#### Description

@herbygillot I do not update directly to 0.24.0 due to: https://github.com/nalgeon/sqlean/issues/124

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
