### PR TITLE
flashrom: fix build for < 10.7

### DIFF
--- a/sysutils/flashrom/Portfile
+++ b/sysutils/flashrom/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
+
+# strndup
+legacysupport.newest_darwin_requires_legacy 10
 
 name                flashrom
 version             1.3.0
@@ -32,9 +36,9 @@ revision            3
 # which is also adding fixes for 10.5 adn 10.6.
 #
 # This fix is sufficient for 10.7-10.12, and a NOP on 10.13+.
-compiler.blacklist      *gcc* {clang < 1000}
+compiler.blacklist  *gcc-4.* {clang < 1000}
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 
 # NOTE: The build procedure tests for pci.h and libpci, even though all
 # programmers that would use libpci are disabled in this build.  Thus,
@@ -46,7 +50,9 @@ depends_lib         port:libftdi1 \
 use_configure       no
 build.args-append   CC=${configure.cc} \
                     CXX=${configure.cxx} \
-                    CPP=${configure.cpp}
+                    CPP=${configure.cpp} \
+                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
+                    LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
 
 build.env-append    CONFIG_ENABLE_LIBPCI_PROGRAMMERS=0 \
                     CONFIG_GFXNVIDIA=0 \


### PR DESCRIPTION
#### Description

Fix the build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
