### PR TITLE
sbcl-bootstrap: update powerpc boot binary

### DIFF
--- a/lang/sbcl-bootstrap/Portfile
+++ b/lang/sbcl-bootstrap/Portfile
@@ -21,13 +21,13 @@ homepage            http://www.sbcl.org
 use_bzip2           yes
 
 if {${build_arch} eq "ppc"} {
-    version         1.0.47
+    version         2.4.6
     revision        0
 
-    distfiles       sbcl-${version}-powerpc-darwin-binary${extract.suffix}
-    checksums       rmd160  85c76296a1c62db5affdff7e72e61e558bb5c819 \
-                    sha256  6971a64c0706894f217da676081874088f50f84daa66d89b653b065f83563f3b \
-                    size    8217590
+    distfiles       sbcl-${version}-powerpc-darwin-binary${extract.suffix}:macppc
+    checksums       rmd160  361a26c6fd929bb8062973e9296ed20245a4d86e \
+                    sha256  20edb91e641cd956c1515746c02695f13c0b22679129dae7de84e9ac0ef080db \
+                    size    7705023
 
 } elseif {${build_arch} eq "i386"} {
     version         1.1.6
@@ -74,6 +74,9 @@ if {${build_arch} eq "ppc"} {
 }
 
 master_sites        sourceforge:project/sbcl/sbcl/${version}
+
+# https://sourceforge.net/p/sbcl/mailman/message/58774549/
+master_sites-append https://macos-powerpc.org/compilers/sbcl/boot/:macppc
 
 extract.rename      yes
 use_configure       no


### PR DESCRIPTION
#### Description

Update later, since 2.4.6 fails on macOS 13. Here update powerpc boot binary, which is required to support powerpc now (2.4.4 has been broken, since the old boot binary cannot build it).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
