### PR TITLE
unison: update to 2.52.0, fix build for powerpc; lablgtk2: update to 2.18.13

### DIFF
--- a/net/unison/Portfile
+++ b/net/unison/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        bcpierce00 unison 2.51.5 v
+github.setup        bcpierce00 unison 2.52.0 v
 revision            0
 categories          net
 maintainers         nomaintainer
@@ -16,14 +16,12 @@ long_description    Unison is a file-synchronization tool for Unix and \
                     modified separately, and then brought up to date by \
                     propagating the changes in each replica to the other.
 homepage            http://www.cis.upenn.edu/~bcpierce/unison/
-platforms           darwin
 
-checksums           rmd160  a1024b19350dee2cf952ed924eba1dc921485154 \
-                    sha256  77eb8bc28cec5eaa7ceb2011354f77f4a753fd033589497a56c8cb9306f9459f \
-                    size    1385506
+checksums           rmd160  034d7024768d856d7366e39805b00e0719e272d3 \
+                    sha256  a11389971212915328fe69101c92737b17664595c4318ebcb8da367e5ba63540 \
+                    size    1354200
+github.tarball_from archive
 
-# from ocaml port
-supported_archs     i386 x86_64 arm64
 universal_variant   no
 
 depends_build       port:ocaml
@@ -45,7 +43,7 @@ post-patch {
 
 # see https://trac.macports.org/ticket/57234
 if {[vercmp ${xcodeversion} 10.0] >= 0} {
-    build.env-append     XCODEFLAGS=-UseNewBuildSystem=NO
+    build.env-append    XCODEFLAGS=-UseNewBuildSystem=NO
 }
 
 build.env-append    CC=${configure.cc}
@@ -53,6 +51,16 @@ destroot.env-append PREFIX=${prefix}
 
 build.args          UISTYLE=text THREADS=true
 destroot.args       UISTYLE=text THREADS=true
+
+# ocamlopt not supported on powerpc. Notice, that OCaml 5
+# drops support for all 32-bit platforms in its native compiler.
+# So once OCaml is updated, i386 should be added here.
+if {${configure.build_arch} in [list ppc ppc64]} {
+    build.args-append \
+                    NATIVE=false
+    destroot.args-append \
+                    NATIVE=false
+}
 
 use_configure       no
 

--- a/x11/lablgtk2/Portfile
+++ b/x11/lablgtk2/Portfile
@@ -5,15 +5,15 @@ PortGroup           ocaml 1.0
 PortGroup           active_variants 1.1
 PortGroup           github 1.0
 
-github.setup        garrigue lablgtk 2.18.11
-revision            1
-checksums           rmd160  f119068f330f0c481a5e9ea3ef4014d04e10141d \
-                    sha256  ff3c551df4e220b0c0fb9a3da6429413bff14f8fc93f4dd6807a35463982c863 \
-                    size    1068587
+github.setup        garrigue lablgtk 2.18.13
+revision            0
+checksums           rmd160  db8f42ccbbc74ee35d04aee27b8a24d2f269a569 \
+                    sha256  7b9e680452458fd351cf8622230d62c3078db528446384268cd0dc37be82143c \
+                    size    1073083
+github.tarball_from archive
 
 name                lablgtk2
 categories          x11 ocaml
-platforms           darwin
 maintainers         {pmetzger @pmetzger} openmaintainer
 # the apps have a much more restrictive license than the library code
 license             {LGPL-2 Restrictive/Distributable}
@@ -29,7 +29,7 @@ github.tarball_from archive
 
 homepage            https://garrigue.github.io/lablgtk/
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 
 depends_lib         port:ocaml \
                     port:ocaml-findlib \


### PR DESCRIPTION
#### Description

Later versions of `unison` switch to `lablgtk3`, which is not a trivial upgrade and also in experimental status.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
