### PR TITLE
albafetch: fix build on macOS <10.9, refactor patch

### DIFF
--- a/sysutils/albafetch/Portfile
+++ b/sysutils/albafetch/Portfile
@@ -9,7 +9,7 @@ PortGroup           makefile 1.0
 legacysupport.newest_darwin_requires_legacy 14
 
 github.setup        alba4k albafetch 4.1 v
-revision            0
+revision            1
 
 description         Faster neofetch alternative, written in C
 long_description    ${name} is a simple and fast program to display \
@@ -27,7 +27,7 @@ checksums           rmd160  62266e581315914385ecaa1558641f4fb9e9312a \
 github.tarball_from archive
 
 # https://github.com/alba4k/albafetch/pull/85
-patchfiles-append   0001-macos_infos.c-fix-for-i386-and-ppc.patch \
+patchfiles-append   0001-fix-macos_infos.patch \
                     0002-Fix-Makefile.patch
 
 # cc1: error: invalid option argument ‘-Ofast’

--- a/sysutils/albafetch/files/0001-fix-macos_infos.patch
+++ b/sysutils/albafetch/files/0001-fix-macos_infos.patch
@@ -1,13 +1,6 @@
-From 6362e1d3538b5aeb61e02d6564802f9b536f81e8 Mon Sep 17 00:00:00 2001
-From: barracuda156 <vital.had@gmail.com>
-Date: Mon, 20 May 2024 13:43:36 +0800
-Subject: [PATCH] macos_infos.c: fix for i386 and ppc
-
-diff --git src/macos_infos.c src/macos_infos.c
-index a1b4d19..8b90eb0 100644
 --- src/macos_infos.c
 +++ src/macos_infos.c
-@@ -17,6 +17,22 @@
+@@ -17,6 +17,22 @@ static vm_size_t page_size(mach_port_t host) {
   * Original source: 
   * https://opensource.apple.com/source/system_cmds/system_cmds-496/vm_stat.tproj/vm_stat.c.auto.html
   */
@@ -30,7 +23,7 @@ index a1b4d19..8b90eb0 100644
  static int get_stats(struct vm_statistics64 *stat, mach_port_t host) {
      int error;
  
-@@ -31,6 +47,7 @@
+@@ -31,6 +47,7 @@ static int get_stats(struct vm_statistics64 *stat, mach_port_t host) {
  
      return 0;
  }
@@ -38,11 +31,11 @@ index a1b4d19..8b90eb0 100644
  
  /* EXPORTS */ 
  
-@@ -49,6 +66,20 @@
+@@ -49,6 +66,20 @@ bytes_t system_mem_size() {
  }
  
  bytes_t used_mem_size() {
-+#if defined(__i386__) || defined(__ppc__)
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
 +    pages_t active, wired, inactive;
 +    mach_port_t host = mach_host_self();
 +
@@ -59,9 +52,19 @@ index a1b4d19..8b90eb0 100644
      pages_t internal, wired, compressed;
      mach_port_t host = mach_host_self();
  
-@@ -61,4 +92,5 @@
+@@ -61,4 +92,5 @@ bytes_t used_mem_size() {
      compressed = vm_stat.compressor_page_count;
  
      return (internal + wired + compressed) * page_size(host);
 +#endif
  }
+--- src/macos_infos.h
++++ src/macos_infos.h
+@@ -8,6 +8,7 @@
+ #include <stdlib.h>
+ 
+ #include <mach/mach.h>
++#include <AvailabilityMacros.h>
+ 
+ #include "bsdwrap.h"
+ 


### PR DESCRIPTION
#### Description

Tweaked the patch a bit, I'll do a PR in the upstream later.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
