### PR TITLE
feh: update to 3.10.3

### DIFF
--- a/graphics/feh/Portfile
+++ b/graphics/feh/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                feh
-version             3.10.2
+version             3.10.3
 revision            0
 categories          graphics
 maintainers         nomaintainer
@@ -19,14 +19,15 @@ homepage            https://feh.finalrewind.org/
 master_sites        ${homepage}
 use_bzip2           yes
 
-checksums           rmd160  1cd3761e133fc0fb2f1dd273ad8c3088e7fa5edb \
-                    sha256  5f94a77de25c5398876f0cf431612d782b842f4db154d2139b778c8f196e8969 \
-                    size    2113183
+checksums           rmd160  876510ef4e18cb7487e3c193c1f4a5a7fa4c718f \
+                    sha256  5426e2799770217af1e01c2e8c182d9ca8687d84613321d8ab4a66fe4041e9c8 \
+                    size    2113623
 
-depends_lib-append  path:include/turbojpeg.h:libjpeg-turbo \
-                    port:curl \
+depends_lib-append  port:curl \
+                    port:desktop-file-utils \
                     port:imlib2 \
                     port:libexif \
+                    path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
                     port:xorg-libXinerama \
                     port:xorg-libXt \
@@ -50,6 +51,11 @@ build.args          PREFIX=${prefix} \
                     'exif=1' \
                     'verscmp=0'
 
+# filelist.c:255:40: error: passing argument 3 of 'scandir'
+# from incompatible pointer type [-Wincompatible-pointer-types]
+configure.cflags-append \
+                    -Wno-incompatible-pointer-types
+
 if {${universal_possible} && [variant_isset universal]} {
     foreach arch ${universal_archs_supported} {
         lappend merger_build_env(${arch}) \
@@ -66,6 +72,10 @@ if {${universal_possible} && [variant_isset universal]} {
 }
 
 destroot.args       PREFIX=${prefix}
+
+post-activate {
+    system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
+}
 
 livecheck.type      regex
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
