### PR TITLE
ffmpeg7: new port

### DIFF
--- a/multimedia/ffmpeg7/Portfile
+++ b/multimedia/ffmpeg7/Portfile
@@ -1,0 +1,554 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           active_variants 1.1
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
+PortGroup           muniversal 1.0
+PortGroup           xcode_workaround 1.0
+PortGroup           xcodeversion 1.0
+
+name                ffmpeg7
+set my_name         ffmpeg
+
+version             7.0.1
+revision            0
+
+license             LGPL-2.1+
+categories          multimedia
+maintainers         {mascguy @mascguy} \
+                    {@barracuda156 gmail.com:vital.had} \
+                    openmaintainer
+
+description         FFmpeg is a complete solution to play, record, \
+                    convert and stream audio and video.
+long_description    {*}${description}. It includes libavcodec, \
+                    the leading audio/video codec library. \
+                    \
+                    The project is made of several components: \
+                    \
+                    ffmpeg is a command line tool to convert one video \
+                    file format to another. It also supports grabbing \
+                    and encoding in real time from a TV card. \
+                    \
+                    ffserver is an HTTP (RTSP is being developed) \
+                    multimedia streaming server for live broadcasts. \
+                    Time shifting of live broadcast is also supported. \
+                    \
+                    ffplay is a simple media player based on SDL \
+                    and on ffmpeg libraries. \
+                    \
+                    ffprobe gathers information from multimedia streams \
+                    and prints it in human- and machine-readable fashion. \
+                    \
+                    libavcodec is a library containing all the ffmpeg \
+                    audio/video encoders and decoders. Most codecs were \
+                    developed from scratch to ensure best performance \
+                    and high code reusability. \
+                    \
+                    libavformat is a library containing parsers and \
+                    generators for all common audio/video formats.
+homepage            https://ffmpeg.org/
+
+master_sites        ${homepage}releases/
+distname            ${my_name}-${version}
+dist_subdir         ${my_name}
+use_xz              yes
+
+checksums           rmd160  73bcbc990f78ac288d782113350baa92f3f76e2b \
+                    sha256  bce9eeb0f17ef8982390b1f37711a61b4290dc8c2a0c1a37b5857e85bfb0e4ff \
+                    size    10793572
+
+depends_build-append \
+                    port:cctools \
+                    port:gmake \
+                    path:bin/pkg-config:pkgconfig \
+                    port:texinfo
+
+depends_lib-append \
+                    port:bzip2 \
+                    port:dav1d \
+                    port:fontconfig \
+                    port:freetype \
+                    port:fribidi \
+                    path:lib/pkgconfig/gnutls.pc:gnutls \
+                    path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
+                    port:lame \
+                    port:lcms2 \
+                    path:lib/pkgconfig/libass.pc:libass \
+                    port:libbluray \
+                    port:libiconv \
+                    port:libmodplug \
+                    port:libogg \
+                    port:libopus \
+                    path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
+                    port:libtheora \
+                    port:libvorbis \
+                    path:lib/pkgconfig/vpx.pc:libvpx \
+                    port:lzo2 \
+                    port:openjpeg \
+                    port:soxr \
+                    path:lib/libspeex.dylib:speex \
+                    port:xz \
+                    port:zimg \
+                    port:zlib \
+                    port:zvbi
+
+patchfiles-append   patch-libavcodec-audiotoolboxenc.c.diff
+patchfiles-append   patch-avutil-builtin-available.diff
+
+# Additional fixes related to use of '__builtin_available'
+# TODO: Submit patches to upstream
+patchfiles-append   patch-libavcodec-profvidworkflow.diff
+
+# https://trac.macports.org/ticket/68973
+# TODO: Raise the issue to upstream
+patchfiles-append   patch-libavcodec-librsvgdec.diff
+
+# https://trac.macports.org/ticket/68720
+# Remove once upstream has included these in the next release
+# patchfiles-append   patch-issue-10695.diff
+
+# https://trac.macports.org/ticket/69678
+# patchfiles-append   patch-fix-vulkan.diff
+
+# enable auto configure of asm optimizations
+# requires Xcode 3.1 or better on Leopard
+minimum_xcodeversions {9 3.1}
+
+# requires a C11 compiler
+compiler.c_standard 2011
+
+# clang-3.1 hits https://trac.macports.org/ticket/30137 (<rdar://problem/11542429>)
+# clang-139 hits https://trac.macports.org/ticket/38141
+# warning: unknown warning option '-Werror=partial-availability'; did you mean '-Werror=availability'? [-Wunknown-warning-option]
+# warning: unknown warning option '-Wno-bool-operation'; did you mean '-Wno-bool-conversion'? [-Wunknown-warning-option]
+compiler.blacklist-append {clang < 800}
+
+# The old ffmpeg port was GPL-2+ as base and had a no_gpl variant, so this keeps us consistent
+# Also, -gpl2 causes other ports to fail to build due to the missing libpostproc (#35473)
+default_variants-append +gpl2
+
+if {[tbool configure.ccache]} {
+    set ccache_path ${prefix}/bin/ccache
+
+    configure.cc-prepend \
+                    ${ccache_path}
+    configure.cxx-prepend \
+                    ${ccache_path}
+}
+
+configure.cflags-append \
+                    -DHAVE_LRINTF \
+                    -Wno-deprecated-declarations \
+                    ${configure.cppflags}
+
+set port_ver_major  [lindex [split ${version} .] 0]
+set port_alias      ${my_name}${port_ver_major}
+set port_prefix     ${prefix}/libexec/${port_alias}
+set port_bindir     ${port_prefix}/bin
+set port_sharedir   ${port_prefix}/share
+set port_docdir     ${port_sharedir}/doc
+set port_datadir    ${port_sharedir}/data
+
+configure.pre_args-delete \
+                    --prefix=${prefix}
+configure.pre_args-append \
+                    --cc="${configure.cc}" \
+                    --datadir=${port_datadir} \
+                    --docdir=${port_docdir} \
+                    --progs-suffix=${port_ver_major} \
+                    --prefix=${port_prefix}
+
+configure.args-append \
+                    --disable-audiotoolbox \
+                    --disable-indev=jack \
+                    --disable-libjack \
+                    --disable-libopencore-amrnb \
+                    --disable-libopencore-amrwb \
+                    --disable-libplacebo \
+                    --disable-libvmaf \
+                    --disable-libwebp \
+                    --disable-libxcb \
+                    --disable-libxcb-shm \
+                    --disable-libxcb-xfixes \
+                    --disable-metal \
+                    --disable-opencl \
+                    --disable-outdev=xv \
+                    --disable-sdl2 \
+                    --disable-securetransport \
+                    --disable-videotoolbox \
+                    --disable-xlib \
+                    --enable-avfilter \
+                    --enable-fontconfig \
+                    --enable-gnutls \
+                    --enable-lcms2 \
+                    --enable-libass \
+                    --enable-libbluray \
+                    --enable-libdav1d \
+                    --enable-libfreetype \
+                    --enable-libfribidi \
+                    --enable-libmodplug \
+                    --enable-libmp3lame \
+                    --enable-libopenjpeg \
+                    --enable-libopus \
+                    --enable-librsvg \
+                    --enable-libsoxr \
+                    --enable-libspeex \
+                    --enable-libtheora \
+                    --enable-libvorbis \
+                    --enable-libvpx \
+                    --enable-libzimg \
+                    --enable-libzvbi \
+                    --enable-lzma \
+                    --enable-pthreads \
+                    --enable-shared \
+                    --enable-swscale \
+                    --enable-zlib
+
+post-extract {
+    # fix file perms; tarball contents deny group and world read
+    system "find ${worksrcpath} -type d -print0 | xargs -0 chmod a+rx"
+    system "find ${worksrcpath} -type f -print0 | xargs -0 chmod a+r"
+}
+
+platform darwin 8 {
+    post-patch {
+        reinplace "s:,-compatibility_version,$\(LIBMAJOR\)::" ${worksrcpath}/configure
+    }
+}
+
+platform darwin {
+    # disable asm on Tiger
+    # libblueray doesn't build on Tiger so disable for now (#39442)
+    if {${os.major} < 9} {
+        depends_lib-delete \
+                    port:libbluray
+        configure.args-replace \
+                    --enable-libbluray \
+                    --disable-libbluray
+        configure.args-append \
+                    --disable-asm
+    }
+
+    # as of 1.6.0 libvpx only supports darwin 10 or later
+    if {${os.major} < 10} {
+        depends_lib-delete \
+                    path:lib/pkgconfig/vpx.pc:libvpx
+        configure.args-replace \
+                    --enable-libvpx \
+                    --disable-libvpx
+    }
+
+    # filters coreimage and coreimagesrc don't build on 10.6
+    # and earlier due to use of bridged casts in Objective C (#51823)
+    if {${os.major} < 11} {
+        configure.args-append \
+                    --disable-filter=coreimage \
+                    --disable-filter=coreimagesrc
+    }
+
+    # AudioToolbox support requires CoreMedia Framework available on 10.7+
+    if {${os.major} > 10} {
+        configure.args-replace \
+                    --disable-audiotoolbox \
+                    --enable-audiotoolbox
+    }
+
+    if {${os.major} > 9 || ${configure.build_arch} in [list ppc ppc64]} {
+        # libsdl2 uses X11 backend on PowerPC and builds on 10.4+.
+        configure.args-replace \
+                    --disable-sdl2 \
+                    --enable-sdl2
+        depends_lib-append \
+                    port:libsdl2
+    }
+
+    # VideoToolbox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".
+    # It provides support for H265, H264, H263, MPEG1, MPEG2 and MPEG4.
+    if {${os.major} > 11} {
+        configure.args-replace \
+                    --disable-videotoolbox \
+                    --enable-videotoolbox
+    }
+
+    # OpenCL support requires version 1.2 available 10.8+
+    if {${os.major} > 11} {
+        configure.args-replace \
+                    --disable-opencl \
+                    --enable-opencl
+    }
+
+    # Apple GCC has problems with SIMD intrinsics and -Werror=no-missing-prototypes.
+    if {${os.major} < 11} {
+        patchfiles-append \
+                    patch-configure-no-error-on-missing-prototypes.diff
+    }
+
+    # avfoundation is only available on 10.7+
+    # as of ffmpeg 3.4.1 build fails on 10.7 as well
+    # libavdevice/avfoundation.m:207:14: error: expected method to read dictionary element not found on object of type 'NSDictionary *'
+    if {${os.major} < 12} {
+        configure.args-append \
+                    --disable-indev=avfoundation
+    }
+
+    # av1 codecs, available on 10.5+
+    if {${os.major} >= 9} {
+        configure.args-append \
+                    --enable-libaom \
+                    --enable-libsvtav1
+        depends_lib-append \
+                    port:aom \
+                    port:svt-av1
+    }
+
+    # rav1e available on 10.6+
+    if {(${os.major} < 10) || (${configure.build_arch} eq "ppc")} {
+        if {[variant_isset rav1e]} {
+            error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
+        }
+    }
+
+    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
+    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
+    #
+    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
+    if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+        configure.ldflags-append \
+                    -Wl,-ld_classic
+    }
+}
+
+platform powerpc {
+    # absence of altivec is not automatically detected
+    if {[catch {sysctl hw.vectorunit} result] || $result == 0} {
+        configure.args-append \
+                    --disable-altivec
+
+        # as this machine is a G3, force a local build so we don't download a buildbot-built
+        # version possibly built on a G4+ or cross-compiled from an Intel system
+        archive_sites
+    }
+
+    # might be needed for any gcc build...
+    #Undefined symbols:
+    #  "___atomic_fetch_sub_8", referenced from:
+    #      _fifo_thread_dispatch_message.part.4 in fifo.o
+    configure.ldflags-append \
+                    -latomic
+}
+
+# libavcodec/pcm-bluray.c: error: passing argument 2 of 'bytestream2_get_buffer' from incompatible pointer type [-Wincompatible-pointer-types]
+configure.cflags-append \
+                    -Wno-error=incompatible-pointer-types
+
+# configure isn't autoconf and they do use a dep cache
+configure.universal_args-delete \
+                    --disable-dependency-tracking
+
+if {${universal_possible} && [variant_isset universal]} {
+    foreach arch ${configure.universal_archs} {
+        set merger_host($arch) ""
+        lappend merger_configure_args($arch) \
+                    --arch=${arch}
+        lappend merger_configure_env($arch) \
+                    "ASFLAGS=-arch ${arch}"
+    }
+    if {[string match "*86*" ${configure.universal_archs}]} {
+        depends_build-append \
+                    port:nasm
+    }
+    lappend merger_configure_args(i386) \
+                    --enable-x86asm
+    lappend merger_configure_args(x86_64) \
+                    --enable-x86asm
+} else {
+    configure.args-append \
+                    --arch=${configure.build_arch}
+    configure.env-append \
+                    ASFLAGS=[get_canonical_archflags]
+    if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
+        depends_build-append \
+                    port:nasm
+        configure.args-append \
+                    --enable-x86asm
+    }
+}
+
+build.cmd           ${prefix}/bin/gmake
+build.env-append    V=1
+
+test.run            yes
+
+destroot.env-append V=1
+
+post-destroot {
+    # Copy docs
+    file mkdir ${destroot}${port_docdir}
+    file copy ${worksrcpath}/doc/APIchanges ${destroot}${port_docdir}
+    foreach f [glob ${worksrcpath}/doc/*.txt] {
+        file copy $f ${destroot}${port_docdir}
+    }
+
+    # Create bin symlinks
+    set port_bin_list \
+        [glob -type f -directory ${destroot}${port_bindir} *]
+    foreach f ${port_bin_list} {
+        set fname [file tail ${f}]
+        ui_info "Symlinking bin: ${prefix}/bin/${fname} -> ${port_bindir}/${fname}"
+        ln -s ${port_bindir}/${fname} ${destroot}${prefix}/bin/${fname}
+    }
+}
+
+variant x11 {
+    # enable x11grab_xcb input device
+    depends_lib-append \
+                    port:xorg-libxcb \
+                    port:xorg-libXext \
+                    port:xorg-libXfixes
+    configure.args-delete \
+                    --disable-xlib \
+                    --disable-libxcb \
+                    --disable-libxcb-shm \
+                    --disable-libxcb-xfixes
+}
+
+if {[variant_isset x11]} {
+    require_active_variants libsdl2 x11
+} else {
+    require_active_variants libsdl2 "" x11
+}
+
+variant libdc1394 description {Enable IIDC-1394 frame grabbing using libdc1394 (experimental)} {
+    depends_lib-append \
+                    port:libdc1394
+    configure.args-append \
+                    --enable-libdc1394
+}
+
+# Allow use of librtmp instead of ffmpeg's internal rtmp implementation
+# May address interoperability issues with CRtmpServer and others
+# https://trac.macports.org/ticket/32219
+# https://groups.google.com/forum/#!topic/c-rtmp-server/ywQPjvciPgc
+# https://trac.ffmpeg.org/ticket/1700
+variant librtmp description {Use librtmp (from rtmpdump) as rtmp[t][es]:// protocol handler} {
+    configure.args-append \
+                    --enable-librtmp
+    depends_lib-append \
+                    port:rtmpdump
+}
+
+variant jack description {Enable jack library and indev support} {
+    # jack will autoconfigure if not disabled
+    depends_lib-append \
+                    port:jack
+    configure.args-replace \
+                    --disable-libjack \
+                    --enable-libjack
+    configure.args-replace \
+                    --disable-indev=jack \
+                    --enable-indev=jack
+}
+
+variant darwinssl description {Enable https support using Apple built-in TLS library instead of GNU TLS} {
+    configure.args-delete \
+                    --disable-securetransport
+    configure.args-delete \
+                    --enable-gnutls
+    depends_lib-delete \
+                    path:lib/pkgconfig/gnutls.pc:gnutls
+}
+
+variant gpl2 description {Enable GPL code, license will be GPL-2+} {
+    license         GPL-2+
+
+    configure.args-append \
+                    --enable-gpl \
+                    --enable-libvidstab \
+                    --enable-libx264 \
+                    --enable-libx265 \
+                    --enable-libxvid \
+                    --enable-postproc
+    depends_lib-append \
+                    port:libvidstab \
+                    port:x264 \
+                    port:x265 \
+                    port:XviD
+}
+
+variant gpl3 requires gpl2 description {Enable GPL code, license will be GPL-3+} {
+    license         GPL-3+
+
+    configure.args-append \
+                    --enable-libaribb24 \
+                    --enable-libsmbclient \
+                    --enable-version3
+    depends_lib-append \
+                    port:libaribb24 \
+                    path:lib/pkgconfig/smbclient.pc:samba3
+}
+
+# the build server uses the default variants, and we want distributable binaries
+# nonfree code is disabled by default but can be enabled using the +nonfree variant
+variant nonfree description {enable nonfree code, libraries and binaries will not be redistributable} {
+    license         Restrictive
+
+    configure.args-append \
+                    --enable-libfdk-aac \
+                    --enable-nonfree
+    depends_lib-append \
+                    port:libfdk-aac
+}
+
+variant rav1e description {Enable codec rav1e} {
+    configure.args-append \
+                    --enable-librav1e
+    depends_lib-append \
+                    port:rav1e
+}
+
+variant flite description {Enable flite audio source} {
+    configure.args-append \
+                    --enable-libflite
+    depends_lib-append \
+                    port:flite
+}
+
+if {![variant_isset rav1e]} {
+    notes-append "Support for rav1e now disabled by default; enable via +rav1e"
+}
+
+if {[variant_isset nonfree]} {
+notes-append "
+This build of ${name} includes nonfree code as follows:
+  libfdk-aac
+The following libraries and binaries may not be redistributed:
+  ffmpeg libavcodec libavdevice libavfilter libavformat libavutil
+To remove this restriction remove the variant +nonfree
+"
+} elseif {[variant_isset gpl3]} {
+notes-append "
+This build of ${name} includes GPLed code and is therefore licensed under GPL v3 or later.\
+The following modules are GPLed:
+  libsambaclient libvidstab libx264 libx265 libxvid postproc
+To include all nonfree, GPLed and LGPL code use variant +nonfree.\
+To remove nonfree and GPLed code leaving only LGPL code remove the +gpl2 and +gpl3 variants.
+"
+} elseif {[variant_isset gpl2]} {
+notes-append "
+This build of ${name} includes GPLed code and is therefore licensed under GPL v2 or later.\
+The following modules are GPLed:
+  libvidstab libx264 libx265 libxvid postproc
+To include all nonfree, GPLed and LGPL code use variant +nonfree.\
+To remove nonfree and GPLed code leaving only LGPL code remove the +gpl2 variant.
+"
+} else {
+notes-append "
+This build of ${name} includes no GPLed or nonfree code and is therefore licensed under LGPL v2.1 or later.
+"
+}
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     "${my_name}-(${port_ver_major}(?:\\.\\d+)*)${extract.suffix}"

--- a/multimedia/ffmpeg7/files/patch-avutil-builtin-available.diff
+++ b/multimedia/ffmpeg7/files/patch-avutil-builtin-available.diff
@@ -1,0 +1,135 @@
+# =============================================================================
+# Source: https://www.mail-archive.com/ffmpeg-devel@ffmpeg.org/msg127034.html
+# -----------------------------------------------------------------------------
+# From: Limin Wang <lance.lmw...@gmail.com>
+#
+# OSX version: 10.11.6
+# Apple LLVM version 8.0.0 (clang-800.0.42.1)
+# Target: x86_64-apple-darwin15.6.0
+# =============================================================================
+--- libavutil/hwcontext_videotoolbox.c.old	2022-01-14 13:45:40.000000000 -0500
++++ libavutil/hwcontext_videotoolbox.c	2022-03-27 12:26:48.000000000 -0400
+@@ -415,12 +415,13 @@
+ {
+     switch (space) {
+     case AVCOL_SPC_BT2020_CL:
+     case AVCOL_SPC_BT2020_NCL:
+ #if HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020
+-        if (__builtin_available(macOS 10.11, iOS 9, *))
+-            return kCVImageBufferYCbCrMatrix_ITU_R_2020;
++        return kCVImageBufferYCbCrMatrix_ITU_R_2020;
++#else
++        return CFSTR("ITU_R_2020");
+ #endif
+         return CFSTR("ITU_R_2020");
+     case AVCOL_SPC_BT470BG:
+     case AVCOL_SPC_SMPTE170M:
+         return kCVImageBufferYCbCrMatrix_ITU_R_601_4;
+@@ -428,12 +429,13 @@
+         return kCVImageBufferYCbCrMatrix_ITU_R_709_2;
+     case AVCOL_SPC_SMPTE240M:
+         return kCVImageBufferYCbCrMatrix_SMPTE_240M_1995;
+     default:
+ #if HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG
+-        if (__builtin_available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *))
+-            return CVYCbCrMatrixGetStringForIntegerCodePoint(space);
++        return kCVImageBufferTransferFunction_ITU_R_2100_HLG;
++#else
++        return CFSTR("ITU_R_2100_HLG");
+ #endif
+     case AVCOL_SPC_UNSPECIFIED:
+         return NULL;
+     }
+ }
+@@ -441,24 +443,25 @@
+ CFStringRef av_map_videotoolbox_color_primaries_from_av(enum AVColorPrimaries pri)
+ {
+     switch (pri) {
+     case AVCOL_PRI_BT2020:
+ #if HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020
+-        if (__builtin_available(macOS 10.11, iOS 9, *))
+-            return kCVImageBufferColorPrimaries_ITU_R_2020;
+-#endif
++        return kCVImageBufferColorPrimaries_ITU_R_2020;
++#else
+         return CFSTR("ITU_R_2020");
++#endif
+     case AVCOL_PRI_BT709:
+         return kCVImageBufferColorPrimaries_ITU_R_709_2;
+     case AVCOL_PRI_SMPTE170M:
+         return kCVImageBufferColorPrimaries_SMPTE_C;
+     case AVCOL_PRI_BT470BG:
+         return kCVImageBufferColorPrimaries_EBU_3213;
+     default:
+ #if HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG
+-        if (__builtin_available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *))
+-            return CVColorPrimariesGetStringForIntegerCodePoint(pri);
++        return kCVImageBufferTransferFunction_ITU_R_2100_HLG;
++#else   
++        return CFSTR("ITU_R_2100_HLG");
+ #endif
+     case AVCOL_PRI_UNSPECIFIED:
+         return NULL;
+     }
+ }
+@@ -467,45 +470,46 @@
+ {
+ 
+     switch (trc) {
+     case AVCOL_TRC_SMPTE2084:
+ #if HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ
+-        if (__builtin_available(macOS 10.13, iOS 11, *))
+-            return kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ;
+-#endif
++        return kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ;
++#else
+         return CFSTR("SMPTE_ST_2084_PQ");
++#endif
+     case AVCOL_TRC_BT2020_10:
+     case AVCOL_TRC_BT2020_12:
+ #if HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020
+-        if (__builtin_available(macOS 10.11, iOS 9, *))
+-            return kCVImageBufferTransferFunction_ITU_R_2020;
+-#endif
++        return kCVImageBufferTransferFunction_ITU_R_2020;
++#else
+         return CFSTR("ITU_R_2020");
++#endif
+     case AVCOL_TRC_BT709:
+         return kCVImageBufferTransferFunction_ITU_R_709_2;
+     case AVCOL_TRC_SMPTE240M:
+         return kCVImageBufferTransferFunction_SMPTE_240M_1995;
+     case AVCOL_TRC_SMPTE428:
+ #if HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1
+-        if (__builtin_available(macOS 10.12, iOS 10, *))
+-            return kCVImageBufferTransferFunction_SMPTE_ST_428_1;
+-#endif
++        return kCVImageBufferTransferFunction_SMPTE_ST_428_1;
++#else
+         return CFSTR("SMPTE_ST_428_1");
++#endif
+     case AVCOL_TRC_ARIB_STD_B67:
+ #if HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG
+-        if (__builtin_available(macOS 10.13, iOS 11, *))
+-            return kCVImageBufferTransferFunction_ITU_R_2100_HLG;
+-#endif
++        return kCVImageBufferTransferFunction_ITU_R_2100_HLG;
++#else
+         return CFSTR("ITU_R_2100_HLG");
++#endif
+     case AVCOL_TRC_GAMMA22:
+         return kCVImageBufferTransferFunction_UseGamma;
+     case AVCOL_TRC_GAMMA28:
+         return kCVImageBufferTransferFunction_UseGamma;
+     default:
+ #if HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG
+-        if (__builtin_available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *))
+-            return CVTransferFunctionGetStringForIntegerCodePoint(trc);
++        return kCVImageBufferTransferFunction_ITU_R_2100_HLG;
++#else
++        return CFSTR("ITU_R_2100_HLG");
+ #endif
+     case AVCOL_TRC_UNSPECIFIED:
+         return NULL;
+     }
+ }

--- a/multimedia/ffmpeg7/files/patch-configure-no-error-on-missing-prototypes.diff
+++ b/multimedia/ffmpeg7/files/patch-configure-no-error-on-missing-prototypes.diff
@@ -1,0 +1,10 @@
+--- configure.old	2015-09-27 18:43:30.000000000 +0200
++++ configure	2015-09-27 18:44:18.000000000 +0200
+@@ -6788,7 +6788,6 @@
+     check_optflags -fno-tree-vectorize
+     check_cflags -Werror=format-security
+     check_cflags -Werror=implicit-function-declaration
+-    check_cflags -Werror=missing-prototypes
+     check_cflags -Werror=return-type
+     check_cflags -Werror=vla
+     check_cflags -Wformat

--- a/multimedia/ffmpeg7/files/patch-libavcodec-audiotoolboxenc.c.diff
+++ b/multimedia/ffmpeg7/files/patch-libavcodec-audiotoolboxenc.c.diff
@@ -1,0 +1,11 @@
+--- libavcodec/audiotoolboxenc.c.orig	2023-11-11 01:25:17
++++ libavcodec/audiotoolboxenc.c	2023-11-13 09:49:29
+@@ -69,7 +69,7 @@
+             return kAudioFormatMPEG4AAC_HE_V2;
+         case AV_PROFILE_AAC_LD:
+             return kAudioFormatMPEG4AAC_LD;
+-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+         case AV_PROFILE_AAC_ELD:
+             return kAudioFormatMPEG4AAC_ELD;
+ #endif

--- a/multimedia/ffmpeg7/files/patch-libavcodec-librsvgdec.diff
+++ b/multimedia/ffmpeg7/files/patch-libavcodec-librsvgdec.diff
@@ -1,0 +1,26 @@
+From a7bbfb137bbcf7ae37c72ace4b68b3ff6fb38a70 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 15 Mar 2024 23:13:19 +0800
+Subject: [PATCH] librsvgdec.c: unbreak compilation
+
+Commit 86ed68420d3b60439d0b7767c53d0fdc1deb7277 introduced a bug which has broken ffmpeg build. Allow it to compile.
+See: https://trac.macports.org/ticket/68973
+---
+ libavcodec/librsvgdec.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git libavcodec/librsvgdec.c libavcodec/librsvgdec.c
+index c328fbc774..756c26d868 100644
+--- libavcodec/librsvgdec.c
++++ libavcodec/librsvgdec.c
+@@ -90,8 +90,10 @@ static int librsvg_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+         goto end;
+ 
+     avctx->pix_fmt = AV_PIX_FMT_RGB32;
++#if LIBRSVG_MAJOR_VERSION > 2 || LIBRSVG_MAJOR_VERSION == 2 && LIBRSVG_MINOR_VERSION >= 52
+     viewport.width = dimensions.width;
+     viewport.height = dimensions.height;
++#endif
+ 
+     ret = ff_get_buffer(avctx, frame, 0);
+     if (ret < 0)

--- a/multimedia/ffmpeg7/files/patch-libavcodec-profvidworkflow.diff
+++ b/multimedia/ffmpeg7/files/patch-libavcodec-profvidworkflow.diff
@@ -1,0 +1,46 @@
+--- libavcodec/videotoolbox.c.orig	2022-07-21 13:09:43.000000000 -0400
++++ libavcodec/videotoolbox.c	2022-07-21 13:24:45.000000000 -0400
+@@ -36,6 +36,9 @@
+ #include <Availability.h>
+ #include <AvailabilityMacros.h>
+ #include <TargetConditionals.h>
++#if defined(MAC_OS_X_VERSION_10_9) && !TARGET_OS_IPHONE && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9)
++#include <VideoToolbox/VTProfessionalVideoWorkflow.h>
++#endif
+ 
+ #ifndef kVTVideoDecoderSpecification_RequireHardwareAcceleratedVideoDecoder
+ #  define kVTVideoDecoderSpecification_RequireHardwareAcceleratedVideoDecoder CFSTR("RequireHardwareAcceleratedVideoDecoder")
+--- libavcodec/videotoolboxenc.c.orig	2022-01-14 13:45:40.000000000 -0500
++++ libavcodec/videotoolboxenc.c	2022-07-21 14:14:29.000000000 -0400
+@@ -23,6 +23,7 @@
+ #include <CoreMedia/CoreMedia.h>
+ #include <TargetConditionals.h>
+ #include <Availability.h>
++#include <AvailabilityMacros.h>
+ #include "avcodec.h"
+ #include "libavutil/opt.h"
+ #include "libavutil/avassert.h"
+@@ -37,6 +38,9 @@
+ #include "h264.h"
+ #include "h264_sei.h"
+ #include <dlfcn.h>
++#if defined(MAC_OS_X_VERSION_10_9) && !TARGET_OS_IPHONE && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9)
++#include <VideoToolbox/VTProfessionalVideoWorkflow.h>
++#endif
+ 
+ #if !HAVE_KCMVIDEOCODECTYPE_HEVC
+ enum { kCMVideoCodecType_HEVC = 'hvc1' };
+@@ -1424,11 +1428,9 @@
+         return AVERROR(EINVAL);
+     }
+ 
+-#if defined(MAC_OS_X_VERSION_10_9) && !TARGET_OS_IPHONE && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9)
++#if defined(MAC_OS_X_VERSION_10_10) && !TARGET_OS_IPHONE && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10)
+     if (avctx->codec_id == AV_CODEC_ID_PRORES) {
+-        if (__builtin_available(macOS 10.10, *)) {
+-            VTRegisterProfessionalVideoWorkflowVideoEncoders();
+-        }
++        VTRegisterProfessionalVideoWorkflowVideoEncoders();
+     }
+ #endif
+ 


### PR DESCRIPTION
#### Description

New port.
Patches are copied from `ffmpeg6` port with no changes, but dropping unneeded ones.

@mascguy Christopher, I hope you do not mind being a primary maintainer? (If you would like not to, please let me know.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
