### PR TITLE
py-managesieve: update to 0.8; add py38-py311 subports

### DIFF
--- a/python/py-managesieve/Portfile
+++ b/python/py-managesieve/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-managesieve
-version             0.7.1
+version             0.8
 revision            0
 
 categories-append   mail
@@ -20,18 +20,19 @@ long_description    A Protocol for remotely managing Sieve Scripts. A \
 
 homepage            https://managesieve.readthedocs.io/
 
-checksums           rmd160  0a6de2209614cae4a6a536404e5a760655167138 \
-                    sha256  44930a3b48332d23b35a5305ae7ba47904d4485ed1b7a22208b7d5ad9d60427a \
-                    size    68710
+checksums           rmd160  35a25045c0ff505afc2c3cbcb62100fff3b56980 \
+                    sha256  d8209bea1ebd1f9f184f56f28ff7e4adfcc6b0c51baf4187a492dc329b1213f3 \
+                    size    44089
 
-python.versions	    312
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} README.txt \
-            TODO HISTORY ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst \
+            HISTORY ${destroot}${docdir}
     }
 
     test.run        yes


### PR DESCRIPTION
#### Description

py-managesieve: update to 0.8; add py38-py311 subports

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? This fails due to [#66358](https://trac.macports.org/ticket/66358)
- [x] tested basic functionality of all binary files?
