### PR TITLE
qemu: enable +curses always

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
 version                 9.0.1
-revision                0
+revision                1
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -190,12 +190,7 @@ pre-configure {
 # disable silent rules
 build.args-append       V=1
 
-default_variants        +usb +spice +vnc
-
-# https://trac.macports.org/ticket/62164#comment:10
-if {${os.platform} eq "darwin" && ${os.major} < 18} {
-    default_variants-append +curses
-}
+default_variants        +usb +spice +vnc +curses
 
 foreach t {i386 x86_64 alpha {arm aarch64} cris hppa m68k {microblaze microblazeel} {mips mipsel mips64 mips64el} \
            nios2 or1k {ppc ppc64} riscv32 riscv64 rx s390x {sh4 sh4eb} {sparc sparc64} tricore {xtensa xtensaeb}} {
@@ -203,7 +198,8 @@ foreach t {i386 x86_64 alpha {arm aarch64} cris hppa m68k {microblaze microblaze
 }
 default_variants-append +target_i386 +target_x86_64 +target_arm
 
-if {![variant_isset curses]} {
+# https://trac.macports.org/ticket/62164#comment:10
+if {${os.platform} eq "darwin" && ${os.major} >= 18} {
     default_variants-append +cocoa
 }
 


### PR DESCRIPTION
#### Description

This is useful for server operating systems as it's easier to copy/paste from the terminal and not require a separate window. It also doesn't conflict with `+cocoa`.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?