### PR TITLE
gitu: Update to 0.22.1

### DIFF
--- a/devel/gitu/Portfile
+++ b/devel/gitu/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            altsem gitu 0.22.0 v
+github.setup            altsem gitu 0.22.1 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -16,9 +16,9 @@ description             A TUI Git client inspired by Magit
 long_description        {*}${description}, launched straight from the terminal.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  997e16eb3f6221fdd9a25c9f3edee1e733550bb3 \
-                        sha256  ccbdfba6af89644f8e0e900278d56505806cad1c9cad0313044ee00b4c898bbf \
-                        size    3917847
+                        rmd160  810e62477975d87828069aafe203ee64109a0b2d \
+                        sha256  55c28e1e3d393ad99f847a1b6aa6aaff2d2e03255f9b798494fc3ca7d23a3922 \
+                        size    3918721
 
 destroot {
     set bindir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -55,9 +55,9 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                             4.5.4  90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0 \
-    clap_builder                     4.5.2  ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4 \
-    clap_derive                      4.5.4  528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64 \
+    clap                             4.5.8  84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d \
+    clap_builder                     4.5.8  c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708 \
+    clap_derive                      4.5.8  2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085 \
     clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
     clipboard-win                    5.3.1  79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad \
     colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
@@ -73,7 +73,7 @@ cargo.crates \
     crossterm                       0.27.0  f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df \
     crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
-    derive_more                    0.99.17  4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321 \
+    derive_more                    0.99.18  5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     either                          1.10.0  11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a \
     encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
@@ -83,13 +83,23 @@ cargo.crates \
     etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
     figment                        0.10.19  8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
+    futures                         0.3.30  645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0 \
+    futures-channel                 0.3.30  eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78 \
+    futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
+    futures-executor                0.3.30  a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d \
+    futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
+    futures-macro                   0.3.30  87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac \
+    futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
+    futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
+    futures-timer                    3.0.3  f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24 \
+    futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
     gethostname                      0.4.3  0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818 \
     git-version                      0.3.9  1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19 \
     git-version-macro                0.3.9  53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0 \
-    git2                            0.18.3  232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70 \
+    git2                            0.19.0  b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724 \
+    glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
     half                             2.4.0  b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e \
     hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
-    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
@@ -107,12 +117,12 @@ cargo.crates \
     js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
-    libgit2-sys               0.16.2+1.7.2  ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8 \
+    libgit2-sys               0.17.0+1.8.1  10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224 \
     libz-sys                        1.1.16  5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9 \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
     lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
-    log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
+    log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
     lru                             0.12.3  d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc \
     memchr                           2.7.2  6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
@@ -134,22 +144,29 @@ cargo.crates \
     parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
     paste                           1.0.14  de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkg-config                      0.3.30  d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec \
     plotters                         0.3.5  d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45 \
     plotters-backend                 0.3.5  9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609 \
     plotters-svg                     0.3.5  38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab \
     pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
+    proc-macro-crate                 3.1.0  6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284 \
     proc-macro2                     1.0.79  e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e \
     quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
-    ratatui                         0.26.3  f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef \
+    ratatui                         0.27.0  d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3 \
+    ratatui-macros                   0.4.2  f8c61408e431e111a6fecee4270953cdbef8a0b363fd215a5dadd9b93ce0797d \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
     redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
-    regex                           1.10.4  c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c \
+    regex                           1.10.5  b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                   0.4.6  86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea \
     regex-syntax                     0.8.3  adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56 \
+    relative-path                    1.9.3  ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
+    rstest                          0.21.0  9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682 \
+    rstest_macros                   0.21.0  4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d \
     rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
     rustix                         0.38.32  65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89 \
     rustversion                     1.0.14  7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4 \
@@ -166,13 +183,13 @@ cargo.crates \
     signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
     similar                          2.5.0  fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640 \
     simple-logging                   2.0.2  b00d48e85675326bb182a2286ea7c1a0b264333ae10f27a937a72be08628b542 \
+    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
     stability                        0.2.0  2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.11.0  5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01 \
     strum                           0.26.2  5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29 \
-    strum_macros                    0.26.2  c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946 \
-    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+    strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     syn                             2.0.55  002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0 \
     temp-dir                        0.1.13  1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231 \
     thiserror                       1.0.58  03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297 \
@@ -181,9 +198,10 @@ cargo.crates \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    toml                            0.8.13  a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba \
+    toml                            0.8.14  6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335 \
     toml_datetime                    0.6.6  4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf \
-    toml_edit                      0.22.13  c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c \
+    toml_edit                       0.21.1  6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1 \
+    toml_edit                      0.22.14  f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38 \
     tree-sitter                    0.20.10  e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d \
     tree-sitter-bash                0.20.5  57da2032c37eb2ce29fd18df7d3b94355fec8d6d854d8f80934955df542b5906 \
     tree-sitter-c                   0.20.8  4bbd5f3d8658c08581f8f2adac6c391c2e9fa00fe9246bf6c5f52213b9cc6b72 \
@@ -205,14 +223,14 @@ cargo.crates \
     tree-sitter-scala               0.20.3  44fcf4628a88a3b5cbac3ff52658b924f3e545abddfa245ab9cf683c1adda350 \
     tree-sitter-toml                0.20.0  ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8 \
     tree-sitter-typescript          0.20.5  c8bc1d2c24276a48ef097a71b56888ac9db63717e8f8d0b324668a27fd619670 \
-    tui-prompts                     0.3.12  122bb001608c2f058fb3fc729614220a392eef4f2268c520a33b5ea8b422ce54 \
+    tui-prompts                     0.3.14  6c556950919aa64a6531f9f9c1246b7a21e8e5814a81ea62aed6dca932a346ef \
     uncased                         0.9.10  e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697 \
     unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
     unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
     unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
     unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
     unicode-truncate                 1.0.0  5a5fbabedabe362c618c714dbefda9927b5afc8e2a8102f47f081089a9019226 \
-    unicode-width                   0.1.12  68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6 \
+    unicode-width                   0.1.13  0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d \
     url                              2.5.0  31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633 \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
@@ -248,6 +266,7 @@ cargo.crates \
     windows_x86_64_gnullvm          0.52.4  77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177 \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.4  32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8 \
+    winnow                          0.5.40  f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876 \
     winnow                           0.6.5  dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8 \
     x11rb                           0.13.0  f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a \
     x11rb-protocol                  0.13.0  e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34 \


### PR DESCRIPTION
#### Description

Update `gitu` to its latest released version, 0.22.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
