### PR TITLE
timewarrior: unbreak for systems with libstdc++

### DIFF
--- a/office/timewarrior/Portfile
+++ b/office/timewarrior/Portfile
@@ -29,6 +29,12 @@ checksums           rmd160  1c972cebf524ef94800b4975478fbcd215e3123d\
                     sha256  5e0817fbf092beff12598537c894ec1f34b0a21019f5a3001fe4e6d15c11bd94\
                     size    3102854
 
+# Hardcoding C++ runtime is either redundant or breaking.
+patchfiles-append       patch-fix-cxx.diff
+
+# Required by the build:
+compiler.cxx_standard   2017
+
 post-destroot {
     # Install bash completions
     set bash_comp_path ${prefix}/share/bash-completion/completions

--- a/office/timewarrior/files/patch-fix-cxx.diff
+++ b/office/timewarrior/files/patch-fix-cxx.diff
@@ -1,0 +1,10 @@
+--- cmake/CXXSniffer.cmake	2023-12-31 01:15:05.000000000 +0800
++++ cmake/CXXSniffer.cmake	2024-07-07 12:19:06.000000000 +0800
+@@ -4,7 +4,6 @@
+   set (LINUX true)
+ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+   set (DARWIN true)
+-  set (CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
+ elseif (${CMAKE_SYSTEM_NAME} MATCHES "kFreeBSD")
+   set (KFREEBSD true)
+ elseif (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")


### PR DESCRIPTION
#### Description

Set the required standard to fix compiler choice.
Drop hardcoded flag which breaks the build with libstdc++.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
