### PR TITLE
dnsviz: update to 0.10.0

### DIFF
--- a/net/dnsviz/Portfile
+++ b/net/dnsviz/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        dnsviz dnsviz 0.9.3 v
-revision            1
+github.setup        dnsviz dnsviz 0.10.0 v
+revision            0
 github.tarball_from releases
 
 categories          net
@@ -20,12 +20,12 @@ long_description    DNSViz is a tool suite for measurement, diagnostic, and \
                     visualization of Domain Name System (DNS) behavior, \
                     including its security extensions (DNSSEC).
 
-checksums           rmd160 d996637d61539e778cf4035f5c7afefcc03a47ad \
-                    sha256 6f38f3d71b2b9ca3f4cffb003c828574d0c413bcc5112bb52921fa9db4e69259 \
-                    size 388653
+checksums           rmd160 f48389ae74f642a3b25a0690c9760bffcfa0c236 \
+                    sha256 8e2c4d0636296acf704f7eca1ca8fea98b022c920c5517b39dfdc982ce685cd3 \
+                    size 404126
 
-python.default_version  38
 
+python.pep517       no
 depends_build       path:bin/dot:graphviz
 
 depends_run         port:py${python.version}-dnspython \


### PR DESCRIPTION
#### Description

dnsviz: update to 0.10.0

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?