### PR TITLE
ruff: Update to 0.5.1

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.5.0
+github.setup        astral-sh ruff 0.5.1
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  8c31d22d81697725425c33769dd9ac27f482fdc9 \
-                    sha256  d82f44f45fc310345cb7d4ce3fc5c9a39556515062002804bb4ae9f6e191c2b2 \
-                    size    4944255
+                    rmd160  66fc9bdf5e5bd351c18de15335524b06a143029f \
+                    sha256  4e31c38d800601cb13349cb9c6b29cd0a37bb505e467abb4492a1ae255eb5a48 \
+                    size    4909124
 
 cargo.offline_cmd
 
@@ -86,13 +86,14 @@ cargo.crates \
     base64                          0.22.0  9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51 \
     bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                         2.5.0  cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1 \
+    bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     bstr                             1.9.1  05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706 \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
     camino                           1.1.7  e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
+    castaway                         0.2.2  8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc \
     cc                              1.0.95  d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.1.1  fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e \
@@ -101,19 +102,20 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                             4.5.7  5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f \
-    clap_builder                     4.5.7  f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f \
+    clap                             4.5.8  84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d \
+    clap_builder                     4.5.8  c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708 \
     clap_complete                    4.5.2  dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e \
     clap_complete_command            0.5.1  183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d \
     clap_complete_fig                4.5.0  54b3e65f91fabdd23cac3d57d39d5d938b4daabd070c335c006dccb866a61110 \
     clap_complete_nushell           0.1.11  5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e \
-    clap_derive                      4.5.5  c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6 \
+    clap_derive                      4.5.8  2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085 \
     clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
     clearscreen                      3.0.0  2f8c93eb5f77c9050c7750e14f13ef1033a40a0aac70c6371535b6763a01438c \
     codspeed                         2.6.0  3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089 \
     codspeed-criterion-compat        2.6.0  722c36bdc62d9436d027256ce2627af81ac7a596dfc7d13d849d0d212448d7fe \
     colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
     colored                          2.1.0  cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8 \
+    compact_str                      0.7.1  f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f \
     console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
     console_error_panic_hook         0.1.7  a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc \
     console_log                      1.0.0  be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f \
@@ -134,6 +136,7 @@ cargo.crates \
     darling_core                    0.20.8  9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f \
     darling_macro                   0.20.8  a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f \
     dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
+    dashmap                          6.0.1  804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28 \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     dirs                             4.0.0  ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059 \
     dirs                             5.0.1  44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225 \
@@ -148,7 +151,6 @@ cargo.crates \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
     etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
-    eyre                            0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
     fastrand                         2.0.2  658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984 \
     fern                             0.6.2  d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee \
     filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
@@ -165,7 +167,6 @@ cargo.crates \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashlink                         0.8.4  e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7 \
-    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
@@ -177,7 +178,6 @@ cargo.crates \
     ignore                          0.4.22  b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1 \
     imara-diff                       0.1.5  e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8 \
     imperative                       1.0.5  8b70798296d538cdaa6d652941fcc795963f8b9878b9e300c9fab7a522bd2fc0 \
-    indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
     indexmap                         2.2.6  168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26 \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
@@ -207,11 +207,11 @@ cargo.crates \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
     lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
-    log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
+    log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
     lsp-server                       0.7.6  248f65b78f6db5d8e1b1604b4098a28b43d21a8eb1deeca22b1c421b276c7095 \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
     matches                         0.1.10  2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5 \
-    matchit                          0.8.2  540f1c43aed89909c0cc0cc604e3bb2f7e7a341a3728a9e6cfe760e733cd11ed \
+    matchit                          0.8.3  8d3c2fcf089c060eb333302d80c5f3ffa8297abecf220f788e4a09ef85f59420 \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     mimalloc                        0.1.43  68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633 \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
@@ -291,18 +291,17 @@ cargo.crates \
     serde-wasm-bindgen               0.6.5  8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b \
     serde_derive                   1.0.203  500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba \
     serde_derive_internals          0.29.0  330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3 \
-    serde_json                     1.0.117  455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3 \
+    serde_json                     1.0.119  e8eddb61f0697cc3989c5d64b452f5488e2b8a60fd7d5076a3045076ffef8cb0 \
     serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
     serde_spanned                    0.6.6  79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0 \
     serde_test                     1.0.176  5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab \
-    serde_with                       3.8.1  0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20 \
-    serde_with_macros                3.8.1  65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2 \
+    serde_with                       3.8.2  079f3a42cd87588d924ed95b533f8d30a483388c4e400ab736a7058e34f16169 \
+    serde_with_macros                3.8.2  bc03aad67c1d26b7de277d51c86892e7d9a0110a2fe44bf6b26cc569fba302d6 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shellexpand                      3.1.0  da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b \
     similar                          2.5.0  fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640 \
     siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
     smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
-    smol_str                         0.2.2  dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strip-ansi-escapes               0.2.0  55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa \
@@ -354,8 +353,8 @@ cargo.crates \
     ureq                             2.9.7  d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd \
     url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
-    uuid                             1.8.0  a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0 \
-    uuid-macro-internal              1.8.0  9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2 \
+    uuid                             1.9.1  5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439 \
+    uuid-macro-internal              1.9.1  a3ff64d5cde1e2cb5268bdb497235b6bd255ba8244f910dbc3574e59593de68c \
     valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
     version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
     vt100                           0.15.2  84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.5.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
