### PR TITLE
xeus: set cxx_standard 2017

### DIFF
--- a/devel/xeus/Portfile
+++ b/devel/xeus/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               cmake 1.1
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               github 1.0
 
 github.setup            jupyter-xeus xeus 5.1.1
@@ -20,8 +19,8 @@ checksums               rmd160  5e5140174b3f22c1e4e49f68e9a936eade67da42 \
                         sha256  c69585b5c652444c63b16c11a5ac140d8b376f71b51a38f988476c99a7a4b48c \
                         size    9048257
 
-compiler.cxx_standard   2014
-compiler.blacklist-append {clang < 900}
+# fatal error: 'any' file not found
+compiler.cxx_standard   2017
 
 depends_build-append    port:pkgconfig \
                         port:cctools


### PR DESCRIPTION
#### Description

https://build.macports.org/builders/ports-10.13_x86_64-builder/builds/239315/steps/install-port/logs/stdio
As in #24831, it now [also targets C++ 17](https://github.com/jupyter-xeus/xeus/commit/089f18026ff4ae5939c8de95f258061ae2926a80).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
