### PR TITLE
gdal: enable MacPort's libc++ on macOS 10.12 and earlier

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 PortGroup           muniversal 1.0
 
 name                gdal
@@ -39,6 +39,14 @@ compiler.blacklist-append {clang < 900}
 # https://trac.macports.org/ticket/70193
 compiler.cxx_standard 2017
 cmake.set_cxx_standard yes
+
+# Enable use of 'macports-libcxx' for macOS 10.12 and earlier, as port uses
+# libc++ features normally only available on 10.13 and later.
+# https://trac.macports.org/ticket/70228#comment:7
+legacysupport.use_mp_libcxx \
+                    yes
+legacysupport.newest_darwin_requires_legacy \
+                    16
 
 # See https://trac.macports.org/ticket/56908
 compiler.thread_local_storage yes


### PR DESCRIPTION
#### Description

`gdal` is currently broken on macOS 10.12 and earlier, because of too old libc++. This PR upgrades to PortGroup `legacysupport 1.1` and enable the use of MacPort's libc++ for macOS earlier than 10.13.

See: https://trac.macports.org/ticket/70228#comment:7

Replaces #24726

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
