### PR TITLE
xdg-utils: Update to 1.2.1

### DIFF
--- a/sysutils/xdg-utils/Portfile
+++ b/sysutils/xdg-utils/Portfile
@@ -1,9 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           gitlab 1.0
 
-name                xdg-utils
-version             1.1.3
+gitlab.instance     https://gitlab.freedesktop.org
+gitlab.setup        xdg xdg-utils 1.2.1 v
+revision            0
 categories          sysutils
 platforms           any
 maintainers         nomaintainer
@@ -16,16 +18,14 @@ long_description    Xdg-utils is a set of command line tools that \
                     assist applications with a variety of desktop integration tasks.
 
 homepage            https://www.freedesktop.org/wiki/Software/xdg-utils/
-master_sites        https://portland.freedesktop.org/download/
 
-checksums           rmd160  e09d258c26834555307d6edd6261514d546587ee \
-                    sha256  d798b08af8a8e2063ddde6c9fa3398ca81484f27dec642c5627ffcaa0d4051d9 \
-                    size    297170
+checksums           rmd160  1e05be5815a756e5155fcd99222a42f5d2d6cfe6 \
+                    sha256  3288aad73c764569e1d06d8368af28688bbba0549cf727e2278886fe66605c81 \
+                    size    293209
 
 depends_build       port:xmlto
 
-license_noconflict  xmlto
+patch.pre_args-replace  -p0 -p1
+patchfiles-append   patch-xdg-realpath.diff
 
-livecheck.type      regex
-livecheck.url       [lindex ${master_sites} 0]
-livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)"
+license_noconflict  xmlto

--- a/sysutils/xdg-utils/files/patch-xdg-realpath.diff
+++ b/sysutils/xdg-utils/files/patch-xdg-realpath.diff
@@ -1,0 +1,20 @@
+diff --git a/scripts/Makefile.in b/scripts/Makefile.in
+index 7939a4e5749534ec61793fab2ad4c3689c064533..88c25d6ea4286e052e6848a945699b2ec005d0f3 100644
+--- a/scripts/Makefile.in
++++ b/scripts/Makefile.in
+@@ -20,6 +20,7 @@ SCRIPTS		= \
+     xdg-icon-resource \
+     xdg-open \
+     xdg-email \
++    xdg-realpath \
+     xdg-screensaver \
+     xdg-settings
+ #    xdg-su
+@@ -91,6 +92,7 @@ xdg-desktop-icon: xdg-desktop-icon.in xdg-utils-common.in
+ xdg-email: xdg-email.in xdg-utils-common.in
+ xdg-mime: xdg-mime.in xdg-utils-common.in
+ xdg-open: xdg-open.in xdg-utils-common.in
++xdg-realpath: xdg-realpath.in xdg-utils-common.in
+ xdg-screensaver: xdg-screensaver.in xdg-utils-common.in
+ xdg-settings: xdg-settings.in xdg-utils-common.in
+ xdg-icon-resource: xdg-icon-resource.in xdg-utils-common.in


### PR DESCRIPTION
#### Description
Draft, because
1. `xdg-realpath` does not seem to be installed/working for some reason (`xdg-realpath: command not found`)
2. `port livecheck xdg-utils` fails (is this expected?)
   - `Error: cannot check if xdg-utils was updated (regex didn't match)`
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1 23E224 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
