### PR TITLE
kokkos-devel: do not use aligned allocation on macOS <10.13 with Clang

### DIFF
--- a/devel/kokkos/Portfile
+++ b/devel/kokkos/Portfile
@@ -27,6 +27,14 @@ subport kokkos-devel {
                             size    2450033
     github.tarball_from     archive
     github.livecheck.branch develop
+    # Kokkos_HostSpace.cpp:79:11: error: aligned allocation function
+    # of type 'void *(std::size_t, std::align_val_t, const std::nothrow_t &)
+    # noexcept' is only available on macOS 10.13 or newer
+    if {${os.platform} eq "darwin" && ${os.major} < 17} {
+        if {${configure.cxx_stdlib} eq "libc++"} {
+            configure.cxxflags-append -fno-aligned-allocation
+        }
+    }
 }
 
 compiler.cxx_standard       2017


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68371

Actually "available on macOS 10.14" is not true, perhaps the reason is a typo in the Clang 11 source code.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
