### PR TITLE
yt-dlp: update to 2024.07.09

### DIFF
--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -37,11 +37,11 @@ if {${subport} eq ${name}} {
 }
 
 subport yt-dlp {
-    github.setup    yt-dlp ${subport} 2024.07.02
+    github.setup    yt-dlp ${subport} 2024.07.09
     revision        0
-    checksums       rmd160  4660c5b3758229cee176fd0f90fbf027d2927d9a \
-                    sha256  1094af3a5827a6a31269b97bd701456269af18595427c9905f3ffbe1a11582a0 \
-                    size    5671980
+    checksums       rmd160  9fbab94fab64137de69355b2c99bc2a7445170f2 \
+                    sha256  9e569e1c03a75c8d07850e8993eb5a30c33db5985060253108cc2afe3f4a6f98 \
+                    size    5689089
 
     dist_subdir     ${subport}/${version}
     distname        ${subport}


### PR DESCRIPTION
#### Description

yt-dlp: update to 2024.07.09

###### Type(s)

- [x] bugfix
- [x] enhancement


###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
