### PR TITLE
skaffold: update to 2.13.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.12.0 v
+github.setup        GoogleContainerTools skaffold 2.13.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  018275822dc6218873467325bbae787f7e33cda4 \
-                    sha256  3c0900ce41df0f3ec7956c15b66af73dbbf5eedd5077f7136eb69225cfa9bfa8 \
-                    size    61145914
+checksums           rmd160  a51e888ab836c6fc29cf8899e505ed3f657b5701 \
+                    sha256  0aaf85009ceafec5e6f129f0f84c31b5c4375410638f1668761a82e56f2f2ccc \
+                    size    61151531
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.13.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?