### PR TITLE
ruby-devel: update to upstream, fix build on < 10.7

### DIFF
--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -68,11 +68,13 @@ depends_build-append \
                     port:cctools \
                     port:gperf \
                     port:libtool \
+                    path:bin/pkg-config:pkgconfig \
                     port:ruby${baseruby_ver_nodot}
 
 depends_run-append  port:ruby_select
 
-depends_skip_archcheck pkgconfig
+depends_skip_archcheck \
+                    path:bin/pkg-config:pkgconfig
 
 select.group        ruby
 select.file         ${filespath}/ruby${ruby_ver_nodot}

--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -86,6 +86,8 @@ post-patch {
     #  ENV["GEM_COMMAND"]&.shellsplit || ["gem"]
     # end
     reinplace -E "s/(shellsplit .. .)(\"gem\")/\\1\"gem${ruby_ver}\"/g" ${worksrcpath}/lib/bundler/gem_helper.rb
+    # get meaningful output during the build:
+    reinplace "s/\$(Q) \$(CC)/\$(CC)/g" ${worksrcpath}/template/Makefile.in
 }
 
 compiler.blacklist-append {clang < 901}

--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -176,7 +176,7 @@ variant gmp description "use gmp" {
 
 variant jemalloc description "use jemalloc" {
         configure.args-delete   --without-jemalloc
-        depends_lib-append      port:jemalloc
+        depends_lib-append      path:lib/pkgconfig/jemalloc.pc:jemalloc
 }
 
 variant yjit description "use YJIT" {

--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -130,6 +130,11 @@ platform darwin {
         configure.cflags-append -std=c99
     }
 
+    # Until this is fixed: https://trac.macports.org/ticket/70350
+    if {${os.major} < 10 || ${configure.build_arch} eq "ppc"} {
+        configure.args-append   ac_cv_func_fgetattrlist=no
+    }
+
     if {${os.major} < 9} {
         known_fail   yes
         pre-fetch {

--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -127,7 +127,11 @@ platform darwin {
         depends_build-append    port:gmake
         build.cmd               ${prefix}/bin/gmake
         configure.args-append   --disable-dtrace
-        configure.cflags-append -std=c99
+        if {[string match *gcc* ${configure.compiler}]} {
+            configure.cflags-append -std=gnu99
+        } else {
+            configure.cflags-append -std=c99
+        }
     }
 
     # Until this is fixed: https://trac.macports.org/ticket/70350

--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -15,13 +15,13 @@ legacysupport.newest_darwin_requires_legacy 14
 # ruby/openssl since ruby-3.2 supports openssl-3
 openssl.branch      3
 
-github.setup        ruby ruby 182822683f86c8f8d63b05765addf5a04d112aa2
+github.setup        ruby ruby 7472fff7f1b5296fbfcde0e2b7411a1d87781f3f
 
 set ruby_ver        3.4
 set ruby_patch      0
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby-devel
-version             2024.07.10
+version             2024.07.14
 revision            0
 
 categories          lang ruby
@@ -37,9 +37,9 @@ long_description    Ruby is the interpreted scripting language \
 homepage            https://www.ruby-lang.org
 license             {Ruby BSD}
 
-checksums           rmd160  91b9a9e1c074545dc2c9d8cfaf9b994a46f8775c \
-                    sha256  a6f13a0e459b230b1f9ab2704574054a00b4b66fd69e8ffd3879f46db2f01ca2 \
-                    size    16519915
+checksums           rmd160  94f8f5e8960d57ae4034f573dc1e5866d24187a2 \
+                    sha256  a45c69ef10d14dd08c0beb0a7f156b79c7c56fd65454032b0ff43fdbe3dbff6a \
+                    size    16472175
 github.tarball_from archive
 
 universal_variant   no

--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -15,13 +15,13 @@ legacysupport.newest_darwin_requires_legacy 14
 # ruby/openssl since ruby-3.2 supports openssl-3
 openssl.branch      3
 
-github.setup        ruby ruby 478ada0e2bb11c5aaac0f8d30cdef12a967c2c03
+github.setup        ruby ruby 182822683f86c8f8d63b05765addf5a04d112aa2
 
 set ruby_ver        3.4
 set ruby_patch      0
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby-devel
-version             2024.07.04
+version             2024.07.10
 revision            0
 
 categories          lang ruby
@@ -37,9 +37,9 @@ long_description    Ruby is the interpreted scripting language \
 homepage            https://www.ruby-lang.org
 license             {Ruby BSD}
 
-checksums           rmd160  d9ac9fcfbb46fed60011416d68d6b55482653fab \
-                    sha256  cf797f282ab9bc2f4ee1425c4806d5dd92ef2e9ec9078b5f80f03ff1c6ecfd3e \
-                    size    16515586
+checksums           rmd160  91b9a9e1c074545dc2c9d8cfaf9b994a46f8775c \
+                    sha256  a6f13a0e459b230b1f9ab2704574054a00b4b66fd69e8ffd3879f46db2f01ca2 \
+                    size    16519915
 github.tarball_from archive
 
 universal_variant   no


### PR DESCRIPTION
#### Description

Earlier warnings are now errors with gcc14, and anyway these should have been fixed regardless:
1. Drop `-std=c99` which breaks inclusion of `lgamma_r`.
2. Fix misdetection of `fgetattrlist` as being available where it is not (`legacysupport` misleads autoconf, it seems).

Also enable proper output on building C sources, this is a -devel port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
