### PR TITLE
ruby32–33: fix build with gcc14

### DIFF
--- a/lang/ruby32/Portfile
+++ b/lang/ruby32/Portfile
@@ -99,6 +99,13 @@ if {[string match *clang* ${configure.compiler}] \
                     configure.cxxflags-append -std=c++03
 }
 
+# time.c: In function 'zone_timelocal':
+# time.c:2325:35: error: passing argument 3 of 'split_second'
+# from incompatible pointer type [-Wincompatible-pointer-types]
+if {[string match macports-gcc* ${configure.compiler}]} {
+                    configure.cflags-append -Wno-incompatible-pointer-types
+}
+
 configure.args      --enable-shared \
                     --enable-install-static-library \
                     --disable-install-doc \

--- a/lang/ruby33/Portfile
+++ b/lang/ruby33/Portfile
@@ -104,6 +104,13 @@ if {[string match *clang* ${configure.compiler}] \
                     configure.cxxflags-append -std=c++03
 }
 
+# time.c: In function 'zone_timelocal':
+# time.c:2325:35: error: passing argument 3 of 'split_second'
+# from incompatible pointer type [-Wincompatible-pointer-types]
+if {[string match macports-gcc* ${configure.compiler}]} {
+                    configure.cflags-append -Wno-incompatible-pointer-types
+}
+
 configure.args      --enable-shared \
                     --enable-install-static-library \
                     --disable-install-doc \


### PR DESCRIPTION
#### Description

The only remaining issue is a breakage of ruby32–33 with gcc14. Everything else is solved and removed from here.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
