### PR TITLE
gtk3, gtk3-devel: fix build with gcc14; gtk3-devel: update to 3.24.42

### DIFF
--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -118,6 +118,12 @@ configure.cppflags-append \
 configure.cflags-append \
                     -fstrict-aliasing
 
+# https://trac.macports.org/ticket/70351
+if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    configure.cflags-append \
+                    -Wno-error=implicit-function-declaration
+}
+
 configure.args-append \
                     -Dtests=false \
                     -Dgtk_doc=false \

--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -12,8 +12,8 @@ PortGroup           debug 1.0
 name                gtk3-devel
 conflicts           gtk3
 set my_name         gtk3
-version             3.24.41
-revision            2
+version             3.24.42
+revision            0
 epoch               0
 
 set proj_name       gtk+
@@ -35,9 +35,9 @@ dist_subdir         ${my_name}
 use_xz              yes
 master_sites        gnome:sources/${proj_name}/${branch}/
 
-checksums           rmd160  779c36a8ea9a2f81ce6709e70d8af7628c47406e \
-                    sha256  47da61487af3087a94bc49296fd025ca0bc02f96ef06c556e7c8988bd651b6fa \
-                    size    13188312
+checksums           rmd160  e6f60dce30ea49d8a5dc0f0d91337d4978016797 \
+                    sha256  50f89f615092d4dd01bbd759719f8bd380e5f149f6fd78a94725e2de112377e2 \
+                    size    13226980
 
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload

--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -118,6 +118,12 @@ configure.cppflags-append \
 configure.cflags-append \
                     -fstrict-aliasing
 
+# https://trac.macports.org/ticket/70351
+if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    configure.cflags-append \
+                    -Wno-error=implicit-function-declaration
+}
+
 configure.args-append \
                     -Dtests=false \
                     -Dgtk_doc=false \


### PR DESCRIPTION
#### Description

1. `legacy-support` implementation of `sincos` does not work as it should, and the compiler considers the function implicitly defined. With gcc14 it breaks the build. Since `sincos` appears in system `math.h` in 10.9, use the flag for < 10.9.
2. Forgotten update of -devel subport.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
