### PR TITLE
gcc12–14: fix triple for powerpc (no revbump)

### DIFF
--- a/lang/gcc12/Portfile
+++ b/lang/gcc12/Portfile
@@ -72,6 +72,8 @@ set major           [lindex [split ${version} .-] 0]
 proc gcc_arch {arch} {
     switch ${arch} {
         arm64       {return aarch64}
+        ppc64       {return powerpc64}
+        ppc         {return powerpc}
         default     {return ${arch}}
     }
 }

--- a/lang/gcc13/Portfile
+++ b/lang/gcc13/Portfile
@@ -72,6 +72,8 @@ set major           [lindex [split ${version} .-] 0]
 proc gcc_arch {arch} {
     switch ${arch} {
         arm64       {return aarch64}
+        ppc64       {return powerpc64}
+        ppc         {return powerpc}
         default     {return ${arch}}
     }
 }

--- a/lang/gcc14/Portfile
+++ b/lang/gcc14/Portfile
@@ -73,6 +73,8 @@ set major           [lindex [split ${version} .-] 0]
 proc gcc_arch {arch} {
     switch ${arch} {
         arm64       {return aarch64}
+        ppc64       {return powerpc64}
+        ppc         {return powerpc}
         default     {return ${arch}}
     }
 }


### PR DESCRIPTION
#### Description

@cjones051073 I am only adding this where you have added a fix for `arm64`.

No revbump needed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
