### PR TITLE
xfce4-appfinder: Update to 4.18.1

### DIFF
--- a/xfce/xfce4-appfinder/Portfile
+++ b/xfce/xfce4-appfinder/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            xfce4-appfinder
-version         4.16.1
+version         4.18.1
 revision        0
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      xfce
@@ -16,9 +16,9 @@ homepage        https://docs.xfce.org/xfce/xfce4-appfinder/start
 master_sites    https://archive.xfce.org/src/xfce/${name}/${branch}/
 use_bzip2       yes
 
-checksums       rmd160  811d530bd4751f147075bba3d2420f9d42685f41 \
-                sha256  bfe3e9bd92695014ee74a2fbb7f5fd1b4c29cf043c4a11598b8958324c81e7ec \
-                size    579984
+checksums       rmd160  2b9ebb7a5be2d00ef30df714ec8f0a1d3173f23b \
+                sha256  9854ea653981be544ad545850477716c4c92d0c43eb47b75f78534837c0893f9 \
+                size    564600
 
 depends_build   port:intltool port:xfce4-dev-tools port:pkgconfig
 depends_lib     port:libxfce4ui port:garcon port:Thunar


### PR DESCRIPTION
#### Description
Sadly the application is currently broken due to https://gitlab.xfce.org/xfce/xfce4-appfinder/-/issues/90, but the old version is broken in the same way, so might as well at least update to a current version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
