### PR TITLE
libiio: add a fallback version for old systems

### DIFF
--- a/science/libiio/Portfile
+++ b/science/libiio/Portfile
@@ -10,7 +10,6 @@ maintainers         {michaelld @michaelld} openmaintainer
 description         ${name} is used to interface to the Industrial Input/Output (IIO) Subsystem
 long_description    ${description}. The IIO subsystem is intended to provide support for devices that in some sense are analog to digital or digital to analog converters (ADCs, DACs). This includes, but is not limited to ADCs, Accelerometers, Gyros, IMUs, Capacitance to Digital Converters (CDCs), Pressure Sensors, Color, Light and Proximity Sensors, Temperature Sensors, Magnetometers, DACs, DDS (Direct Digital Synthesis), PLLs (Phase Locked Loops), Variable/Programmable Gain Amplifiers (VGA, PGA), and RF transceivers. You can use libiio natively on an embedded Linux target (local mode), or use libiio to communicate remotely to that same target from a host Linux, Windows, or MAC over USB or Ethernet or Serial.
 license             LGPL-2+
-platforms           darwin
 
 # release
 github.setup        analogdevicesinc libiio 0.24 v
@@ -75,7 +74,7 @@ depends_lib-append \
     path:lib/pkgconfig/icu-uc.pc:icu
 
 depends_build-append \
-    port:pkgconfig \
+    path:bin/pkg-config:pkgconfig \
     path:bin/doxygen:doxygen
 
 # remove top-level library path, such that internal libraries are used

--- a/science/libiio/Portfile
+++ b/science/libiio/Portfile
@@ -32,6 +32,34 @@ patchfiles-append   patch-fix_build.diff
 
 patchfiles-append   patch-disable-install-libiio-check.diff
 
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    PortGroup       legacysupport 1.1
+
+    # strnlen
+    legacysupport.newest_darwin_requires_legacy 10
+
+    # This is the last commit which builds.
+    github.setup    analogdevicesinc libiio 027919e318aacbe56c4a4a64803b6dead068180c
+    version         0.19
+    revision        1
+    checksums       rmd160  1ace55fd89616d3a79d4ef70b99e517f17e6addd \
+                    sha256  b0efca3544cd106d9e3ef3957cff658fdd525af0a2f98aef2c00e8cc24277d7e \
+                    size    236403
+    github.tarball_from archive
+
+    patchfiles-replace \
+                    patch-fix_build.diff patch-fix_build-0.19.diff
+
+    if {${os.major} < 15} {
+        patchfiles-append \
+                    patch-fix-headers.diff
+    }
+
+    # Uses endianness macros and built-ins requiring newer gcc.
+    compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
+}
+
 # additional arguments
 configure.args-append \
     -DCMAKE_INSTALL_DOCDIR=${prefix}/share/doc/${github.project} \

--- a/science/libiio/files/patch-fix-headers.diff
+++ b/science/libiio/files/patch-fix-headers.diff
@@ -1,0 +1,11 @@
+--- dns_sd_bonjour.c	2020-06-05 22:39:34.000000000 +0800
++++ dns_sd_bonjour.c	2024-07-13 10:43:55.000000000 +0800
+@@ -17,7 +17,7 @@
+  *
+  * */
+ 
+-#include <CFNetwork/CFNetwork.h>
++#include <CoreServices/CoreServices.h>
+ 
+ #include "iio-lock.h"
+ #include "iio-private.h"

--- a/science/libiio/files/patch-fix_build-0.19.diff
+++ b/science/libiio/files/patch-fix_build-0.19.diff
@@ -1,0 +1,61 @@
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -14,18 +14,22 @@
+ 	set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "default install path" FORCE)
+ endif()
+ 
+-set(CMAKE_INSTALL_DOCDIR "" CACHE PATH "documentation root (DATAROOTDIR/doc/${PROJECT_NAME}${LIBIIO_VERSION_MAJOR}-doc)")
+ include(GNUInstallDirs)
+ if(ENABLE_SHARED AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+ 	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
+ 	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ endif()
+-set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}${LIBIIO_VERSION_MAJOR}-doc")
++
++# Set the default install DOCDIR if not provided
++if (NOT CMAKE_INSTALL_DOCDIR)
++	set (CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}${LIBIIO_VERSION_MAJOR}-doc")
++endif ()
+ 
+ set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+ 	CACHE PATH "Installation directory for pkgconfig (.pc) files")
+ mark_as_advanced(INSTALL_PKGCONFIG_DIR)
+ 
++# Set the default build type if not provided
+ if (NOT CMAKE_BUILD_TYPE)
+ 	set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
+ 		"Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel."
+@@ -35,16 +39,23 @@
+ 
+ set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
+ 
++# Darwin-specific settings
+ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+ 	option(OSX_PACKAGE "Create a OSX package" ON)
+ 
+-	set(OSX_INSTALL_FRAMEWORKSDIR "/Library/Frameworks" CACHE STRING "Installation directory for frameworks")
++        # Set the default install location if not provided
++        if (NOT OSX_INSTALL_FRAMEWORKSDIR)
++		set (OSX_INSTALL_FRAMEWORKSDIR "/Library/Frameworks" CACHE STRING "Installation directory for frameworks")
++        endif ()
+ 	get_filename_component(OSX_INSTALL_FRAMEWORKSDIR "${OSX_INSTALL_FRAMEWORKSDIR}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+ 
+ 	set(CMAKE_MACOSX_RPATH ON)
+ 	set(SKIP_INSTALL_ALL ${OSX_PACKAGE})
+ endif()
+ 
++# set these before any external include directories
++include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
++
+ option(WITH_NETWORK_BACKEND "Enable the network backend" ON)
+ option(WITH_TESTS "Build the test programs" ON)
+ option(WITH_EXAMPLES "Build examples" OFF)
+@@ -265,8 +276,6 @@
+ 	message(STATUS "Looking for libserialport : Failed; building without serial")
+ endif()
+ 
+-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+-
+ if(WITH_NETWORK_BACKEND)
+ 	message(STATUS "Building with Network back end support")
+ 	if (WIN32)


### PR DESCRIPTION
#### Description

Skipping CI, there is nothing to test, since no changes to the code for current systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
