### PR TITLE
nano: update to 8.1

### DIFF
--- a/editors/nano/Portfile
+++ b/editors/nano/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 8
 
 name                nano
-version             8.0
+version             8.1
 revision            0
 categories          editors
 license             GPL-3
@@ -23,10 +23,10 @@ long_description \
 homepage            https://www.nano-editor.org
 master_sites        ${homepage}/dist/v[strsed ${version} {/\.[0-9]*$//}]/ gnu
 
-checksums           rmd160  60a132efe3bdff080d57ec37e95e0b01c292c074 \
-                    sha256  96002251cc1998c1089c3617b46e6ae38ce0fd11fb277fcbb90fca1742d18028 \
-                    size    3461119
-
+checksums           rmd160  80f46e6f830f3f79f069ad14562ee097d5040fcf \
+                    sha256  6508bfbcfe38153ecbdc1b7d3479323564353f134acc8c501910220371390675 \
+                    size    3471172
+                    
 depends_lib         port:gettext \
                     port:libiconv \
                     port:libmagic \


### PR DESCRIPTION
#### Description

nano: update to 8.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
