### PR TITLE
dagger: update to 0.12.0

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.11.9 v
+github.setup        dagger dagger 0.12.0 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  16287b00ba69cc61d8143b3783fc73927e698ccc \
-                            sha256  ebd2fe899778dbe2f637c8671a2394bc0424f1098d9d0191f50c0af04f7a65cf \
-                            size    10038129
+        checksums           rmd160  ebf1238a5b21aa67dd2065ad6ecf6e6ae4bf215c \
+                            sha256  997bae069b44e0f1f91a861642904cc591d5cbe012e5924cccfc14acb0a3ef96 \
+                            size    10077079
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  17ef9e15bd1009a99be48fad490af61631f94ced \
-                            sha256  0c8dba771c73a34b2883b2e319d732b1d3645f9e93c41b772231f335901363a5 \
-                            size    9478927
+        checksums           rmd160  e5443d6e37d145bc41b112c960c0250b86f3e24c \
+                            sha256  09ee7c53a156f8b52ffe68d0f726bfdcf988d08fa12ac9fb3f00be4061a68d32 \
+                            size    9518657
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Update to the latest version

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
