### PR TITLE
freac, MacPass, portfolio-performance +deps: Remove myself as maintainer

### DIFF
--- a/aqua/smooth/Portfile
+++ b/aqua/smooth/Portfile
@@ -13,7 +13,7 @@ checksums           rmd160  b8198a8253df694da3a766061c065eea708192c0 \
 categories          aqua
 platforms           darwin
 license             Artistic-2
-maintainers         {@janosch mailbox.org:janosch1} openmaintainer
+maintainers         nomaintainer
 description         ${name} is a class library for user interfaces written in C++
 long_description    ${name} is an object oriented C++ class library for Windows, \
                     macOS, Linux and most Unix-like operating systems. \

--- a/audio/BoCA/Portfile
+++ b/audio/BoCA/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  c54406a93d4069536af90b1a15d012ffd2bd4331 \
 
 categories          audio
 license             GPL-2
-maintainers         {@janosch mailbox.org:janosch1} openmaintainer
+maintainers         nomaintainer
 description         The component framework behind the fre:ac audio converter.
 long_description    ${name} provides unified interfaces for components like \
                     encoders, decoders, taggers and extensions as well as code \

--- a/audio/freac/Portfile
+++ b/audio/freac/Portfile
@@ -12,7 +12,7 @@ checksums           rmd160  fcb567a70e5f204292bfb4721e4e5413cd9a6b60 \
 
 categories          audio
 license             GPL-2
-maintainers         {@janosch mailbox.org:janosch1} openmaintainer
+maintainers         nomaintainer
 description         An open source audio converter.
 long_description    ${name} is a free audio converter and CD ripper with support \
                     for various popular formats and encoders. It converts freely \

--- a/audio/proxy-audio-device/Portfile
+++ b/audio/proxy-audio-device/Portfile
@@ -8,7 +8,7 @@ github.setup        briankendall proxy-audio-device 1.0.6 v
 revision            0
 github.tarball_from archive
 categories          audio
-maintainers         {@janosch mailbox.org:janosch1} openmaintainer
+maintainers         nomaintainer
 license             public-domain
 
 description         A HAL virtual audio driver for macOS that sends all output to another audio device.

--- a/devel/HNHUi/Portfile
+++ b/devel/HNHUi/Portfile
@@ -9,7 +9,7 @@ github.tarball_from     archive
 categories              devel
 platforms               darwin
 license                 BSD
-maintainers             {@janosch mailbox.org:janosch1} openmaintainer
+maintainers             nomaintainer
 description             Reusable Cocoa UI Components
 long_description        ${description}
 homepage                https://github.com/mstarke/${name}

--- a/devel/KissXML/Portfile
+++ b/devel/KissXML/Portfile
@@ -9,7 +9,7 @@ github.tarball_from     archive
 categories              devel
 platforms               darwin
 license                 BSD
-maintainers             {@janosch mailbox.org:janosch1} openmaintainer
+maintainers             nomaintainer
 description             ${name} provides a drop-in replacement for Apple's NSXML class cluster in environments without NSXML (e.g. iOS).
 long_description        ${name} provides a drop-in replacement for Apple's NSXML class cluster in environments without NSXML (e.g. iOS). \
                         It is implemented atop the defacto libxml2 C library, which comes pre-installed on Mac & iOS. \

--- a/devel/TransformerKit/Portfile
+++ b/devel/TransformerKit/Portfile
@@ -9,7 +9,7 @@ github.tarball_from     archive
 categories              devel
 platforms               darwin
 license                 MIT
-maintainers             {@janosch mailbox.org:janosch1} openmaintainer
+maintainers             nomaintainer
 description             A block-based API for NSValueTransformer, with a \
                         growing collection of useful examples.
 long_description        NSValueTransformer, while perhaps obscure to most iOS \

--- a/finance/portfolio-performance/Portfile
+++ b/finance/portfolio-performance/Portfile
@@ -8,7 +8,7 @@ name                    portfolio-performance
 categories              finance
 platforms               darwin
 license                 EPL-1
-maintainers             {@janosch mailbox.org:janosch1} openmaintainer
+maintainers             nomaintainer
 description             A simple tool to calculate the overall performance \
                         of an investment portfolio.
 long_description        An open source tool to calculate the overall performance \

--- a/security/KeePassKit/Portfile
+++ b/security/KeePassKit/Portfile
@@ -10,7 +10,7 @@ github.setup            MacPass KeePassKit 3.2.1
 categories              security
 platforms               darwin
 license                 GPL-3+
-maintainers             {@janosch mailbox.org:janosch1} openmaintainer
+maintainers             nomaintainer
 description             KeePass database loading, storing and manipulation framework.
 long_description        ${name} is a framework to offer support for the Keepass database format. \
                         You can use it to work with KDB and KDBX files. Supported formats are KDB3, KDBX3.1 and KDBX4.

--- a/security/MacPass/Portfile
+++ b/security/MacPass/Portfile
@@ -9,7 +9,7 @@ revision            1
 categories          security
 platforms           darwin
 license             GPL-3
-maintainers         {@janosch mailbox.org:janosch1} openmaintainer
+maintainers         nomaintainer
 description         KeePass client for macOS
 long_description    ${name} is a native macOS port of KeePass. Key features are automatic \
                     form filling and regex matching of window titles to detect the correct target application. \


### PR DESCRIPTION
#### Description

Remove myself as a maintainer from all my ports. 

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Not tested. Port metadata change only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
