### PR TITLE
geographiclib: update to 2.4

### DIFF
--- a/gis/geographiclib/Portfile
+++ b/gis/geographiclib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        geographiclib geographiclib 2.3 v
+github.setup        geographiclib geographiclib 2.4 v
 revision            0
 categories          gis
 maintainers         {gmail.com:tlockhart1976 @lockhart} gmail.com:crmoore \
@@ -20,9 +20,9 @@ long_description \
 
 homepage            https://geographiclib.sourceforge.io/
 
-checksums           rmd160  9442f33f21db1464ce97a13049ad104667ae04e7 \
-                    sha256  15304369d74727b1bfb3f848a264dd2dd5bdd5d0c17ee05c2340a0244a9295d8 \
-                    size    1450621
+checksums           rmd160  12d95fa08349517fec9e1eeb483a331b2be93cff \
+                    sha256  d306693b14dc7fe3a3d6e85cb05ec6a67b13232c60261d22a4aab0c6a1e7a48a \
+                    size    1458638
 
 depends_build-append    path:bin/doxygen:doxygen
 


### PR DESCRIPTION
#### Description
https://github.com/geographiclib/geographiclib/blob/main/NEWS

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
