### PR TITLE
medusa: remove postgresql variant

### DIFF
--- a/security/medusa/Portfile
+++ b/security/medusa/Portfile
@@ -64,13 +64,6 @@ variant subversion description "Build the Subversion module" {
                     --enable-module-svn=yes
 }
 
-variant postgresql description "Build the PostgreSQL module" {
-    depends_lib-append port:postgresql83
-    configure.args-replace \
-                    --enable-module-postgres=no \
-                    --enable-module-postgres=yes
-}
-
 # FIXME check building afpfs-ng, ncp
 
 livecheck.type      regex


### PR DESCRIPTION
autoconf does not support pg_config discovery of postgresql and its paths, a requirement for installation with modern versions of postgresql.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
