### PR TITLE
apr-util: add postgresql16 variant

### DIFF
--- a/devel/apr-util/Portfile
+++ b/devel/apr-util/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name		apr-util
 version		1.6.3
-revision	1
+revision	2
 categories	devel
 maintainers	{geeklair.net:dluke @danielluke}
 description	utilities built with the apache group's portability library
@@ -84,49 +84,10 @@ pre-build {
     }
 }
 
-variant postgresql84	description {Build with postgres support (using postgresql v8.4)} conflicts postgresql82 postgresql83 {
-				depends_lib-append port:postgresql84
+variant postgresql16	description {Build with postgres support (using postgresql v16)} conflicts {
+				depends_lib-append port:postgresql16
 				configure.args-delete --without-pgsql
 				configure.args-append --with-pgsql=yes
-				configure.cppflags-append "-I${prefix}/include/postgresql84"
-				configure.ldflags-append "-L${prefix}/lib/postgresql84"
-				post-patch      {
-					set extralibs "${extralibs} -L${prefix}/lib/postgresql84"
-					reinplace "s|^INCLUDES = |INCLUDES = -I@prefix@/include/postgresql84 |" \
-						$worksrcpath/Makefile.in
-					reinplace "s|^APRUTIL_LDFLAGS = |APRUTIL_LDFLAGS = -L@prefix@/lib/postgresql84 |" \
-						$worksrcpath/Makefile.in
-				}
-			}
-
-variant postgresql83	description {Build with postgres support (using postgresql v8.3)} conflicts postgresql82 postgresql84 {
-				depends_lib-append port:postgresql83
-				configure.args-delete --without-pgsql
-				configure.args-append --with-pgsql=yes
-				configure.cppflags-append "-I${prefix}/include/postgresql83"
-				configure.ldflags-append "-L${prefix}/lib/postgresql83"
-				post-patch	{
-					set extralibs "${extralibs} -L${prefix}/lib/postgresql83"
-					reinplace "s|^INCLUDES = |INCLUDES = -I@prefix@/include/postgresql83 |" \
-						$worksrcpath/Makefile.in
-					reinplace "s|^APRUTIL_LDFLAGS = |APRUTIL_LDFLAGS = -L@prefix@/lib/postgresql83 |" \
-						$worksrcpath/Makefile.in
-				}
-			}
-
-variant postgresql82	description {Build with postgres support (using postgresql v8.2)} conflicts postgresql83 postgresql84 {
-				depends_lib-append port:postgresql82
-				configure.args-delete --without-pgsql
-				configure.args-append --with-pgsql=yes
-				configure.cppflags-append "-I${prefix}/include/postgresql82"
-				configure.ldflags-append "-L${prefix}/lib/postgresql82"
-				post-patch	{
-					set extralibs "${extralibs} -L${prefix}/lib/postgresql82"
-					reinplace "s|^INCLUDES = |INCLUDES = -I@prefix@/include/postgresql82 |" \
-						$worksrcpath/Makefile.in
-					reinplace "s|^APRUTIL_LDFLAGS = |APRUTIL_LDFLAGS = -L@prefix@/lib/postgresql82 |" \
-						$worksrcpath/Makefile.in
-				}
 			}
 
 variant mysql51 conflicts mysql55 mysql56 mariadb percona description {Enable MySQL 5.1 support} {


### PR DESCRIPTION
#### Description

The patching is not needed anymore, the build scripts correctly get what they need out of pg_config. I can confirm that the build was able to produce a `/lib/apr-util-1/apr_dbd_pgsql-1.so` that correctly linked against postgresql16.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
