### PR TITLE
py-gmpy2: update to 2.2.0, add py312 subport

### DIFF
--- a/python/py-gmpy2/Portfile
+++ b/python/py-gmpy2/Portfile
@@ -5,28 +5,29 @@ PortGroup           python 1.0
 
 name                py-gmpy2
 epoch               1
-version             2.1.5
+version             2.2.0
 maintainers         {@mndavidoff alluvialsw.com:md14-macports} openmaintainer
 license             LGPL-2.1+
 description         General multiple precision arithmetic module for Python
 long_description \
     GMPY2 is a C-coded Python extension module that supports fast \
-    multiple-precision arithmetic.  GMPY2 supports the GMP library \
-    for integer and rational arithmetic and multiple-precision real \
-    and complex arithmetic as provided by the MPFR and MPC libraries.
+    multiple-precision arithmetic.  GMPY2 supports integer and \
+    rational arithmetic (using the GMP library), correctly rounded \
+    multiple-precision real arithmetic (using the MPFR library), \
+    and complex arithmetic (using the MPC library).
 
 homepage            https://github.com/aleaxit/gmpy
-checksums           rmd160  7ad0106dae052c4d9b3f332ef3d070dec29d3883 \
-                    sha256  bc297f1fd8c377ae67a4f493fc0f926e5d1b157e5c342e30a4d84dc7b9f95d96 \
-                    size    261709
+checksums           rmd160  a3fa993fddc6dae80eeb8d751719498c09b9ec01 \
+                    sha256  e19e62dfeb1e4a57079f0bf51c51dec30633d9fe9e89cb9a083e05e4823afa70 \
+                    size    233943
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:gmp port:libmpc port:mpfr
 
     post-destroot {
-        xinstall -m 0644 -W ${worksrcpath} README \
+        xinstall -m 0644 -W ${worksrcpath} README.rst \
             ${destroot}${prefix}/share/doc/${subport}
     }
 }


### PR DESCRIPTION
#### Description

py-gmpy2: update to 2.2.0, add py312 subport

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
