### PR TITLE
gnucash: update depends

### DIFF
--- a/gnome/gnucash/Portfile
+++ b/gnome/gnucash/Portfile
@@ -13,6 +13,7 @@ name              gnucash
 conflicts         gnucash gnucash-devel
 conflicts-delete  ${subport}
 version           5.8
+revision          1
 perl5.branches    5.34
 categories        gnome x11
 license           GPL-2+
@@ -88,8 +89,7 @@ depends_build-append     port:pkgconfig \
                          port:libtool \
                          port:gtest \
                          port:swig-guile \
-                         port:swig-python \
-                         path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk
+                         port:swig-python
 
 depends_lib       port:guile \
                   port:perl${perl5.major} \
@@ -97,12 +97,14 @@ depends_lib       port:guile \
                   port:p${perl5.major}-finance-quote \
                   port:p${perl5.major}-json-parse \
                   path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                  path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk \
                   port:libdbi \
                   port:libdbi-drivers \
                   port:aqbanking6-gtk3 \
                   port:libofx \
                   port:python${py_ver_nodot} \
                   path:lib/pkgconfig/icu-uc.pc:icu \
+                  port:libsecret \
                   port:libxml2
 
 variant docs description "Install documentation" {


### PR DESCRIPTION
Those dependencies were formerly satisfied implicitly via gnucash-docs. Since we are now able to build the `-docs` variant (#24764), they need to be explicitly specified so that `port reclaim` won't clean them away.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.5 21H1222 x86_64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
