### PR TITLE
libstaroffice: needs C++11

### DIFF
--- a/devel/libstaroffice/Portfile
+++ b/devel/libstaroffice/Portfile
@@ -8,7 +8,6 @@ github.tarball_from releases
 use_xz              yes
 
 categories          devel textproc
-platforms           darwin
 license             MPL-2
 maintainers         {gmail.com:audvare @Tatsh} openmaintainer
 
@@ -19,7 +18,7 @@ checksums           rmd160  96d41ee09185a39d1dbd5c418705603424e6f66f \
                     sha256  f94fb0ad8216f97127bedef163a45886b43c62deac5e5b0f5e628e234220c8db \
                     size    707920
 
-depends_build       port:pkgconfig
+depends_build       port:bin/pkg-config:pkgconfig
 depends_lib         port:librevenge \
                     port:zlib
 
@@ -27,3 +26,6 @@ configure.args      --disable-debug \
                     --without-docs \
                     --disable-tools \
                     --enable-zip
+
+# configure: error: *** A compiler with support for C++11 language features is required.
+compiler.cxx_standard   2011


### PR DESCRIPTION
#### Description

Fix compiler choice

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
