### PR TITLE
libvterm: fix pedantic flag, fixes build with Xcode gcc

### DIFF
--- a/devel/libvterm/Portfile
+++ b/devel/libvterm/Portfile
@@ -29,9 +29,12 @@ checksums           rmd160  757be59cf6b79f92bd8f45c95eb47276c04b4394 \
 compiler.c_standard 1999
 
 depends_build       port:libtool \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 patchfiles-append   patch-disable-silent-rules.diff
+
+# cc1: error: unrecognized command line option "-Wpedantic"
+patchfiles-append   patch-fix-pedantic.diff
 
 use_configure no
 

--- a/devel/libvterm/files/patch-fix-pedantic.diff
+++ b/devel/libvterm/files/patch-fix-pedantic.diff
@@ -1,0 +1,11 @@
+--- Makefile
++++ Makefile	2024-07-17 04:36:00.000000000 +0800
+@@ -8,7 +8,7 @@
+   LIBTOOL +=--quiet
+ endif
+ 
+-override CFLAGS +=-Wall -Iinclude -std=c99 -Wpedantic
++override CFLAGS +=-Wall -Iinclude -std=c99 -pedantic
+ 
+ ifeq ($(shell uname),SunOS)
+   override CFLAGS +=-D__EXTENSIONS__ -D_XPG6 -D__XOPEN_OR_POSIX


### PR DESCRIPTION
#### Description

Fix the build with Xcode gcc

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
