### PR TITLE
openjdk22-zulu: update to 22.32.15

### DIFF
--- a/java/openjdk22-zulu/Portfile
+++ b/java/openjdk22-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-22-lts&os=macos&package=jdk#zulu
-version      22.30.13
+version      22.32.15
 revision     0
 
-set openjdk_version 22.0.1
+set openjdk_version 22.0.2
 
 description  Azul Zulu Community OpenJDK 22 (Short Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  e426c12470d470a3fef20db0605265f14a387c76 \
-                 sha256  a5af3434d9b283b55b41548f6de9d5d3dcb20c300254402cf8b02bbeecf3c37d \
-                 size    206862940
+    checksums    rmd160  68c7efcc2c22b5080f17a63d2fc06f69f3250655 \
+                 sha256  56e9bbeb7a04da3af97bba43ec11c9ba26e299952021303faa04765e4c50ab1b \
+                 size    206628898
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  32cb735987216d21ed4145b7f47454262ff382cb \
-                 sha256  d1b8282c032b55384dfda337dd97d424f69cc0dd0dbb196d870e7029acdad133 \
-                 size    204575444
+    checksums    rmd160  e489b37326c8a3af6d08b98a5bbdee3704d52aaf \
+                 sha256  e70f161f2d649cf24cdddc448daa39f3229cb73c509d8c231defef5960177b69 \
+                 size    204347346
 }
 
 worksrcdir   ${distname}/zulu-22.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 22.32.15.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?