### PR TITLE
openjdk21-zulu: update to 21.36.17

### DIFF
--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk#zulu
-version      21.34.19
+version      21.36.17
 revision     0
 
-set openjdk_version 21.0.3
+set openjdk_version 21.0.4
 
 description  Azul Zulu Community OpenJDK 21 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  2795a2025c810358ca124f7067eb146e1da50391 \
-                 sha256  148006a220a18922d7a9c52ac0bad099c5b4e60334a8d02b11f8c945e9ec9a34 \
-                 size    209294105
+    checksums    rmd160  70edc2c8d6937707028c37ad13945b9538575854 \
+                 sha256  5ce75a6a247c7029b74c4ca7cf6f60fd2b2d68ce1e8956fb448d2984316b5fea \
+                 size    209377702
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  0ba5c957dc9ce6019d80877cf258d27dcd4ac70f \
-                 sha256  4f42a561909d71868a700cf2efa1390e1b9e04863f3fa75ea30c4965e5a702f0 \
-                 size    206998775
+    checksums    rmd160  43b3edec1cfb1db971cc2ecf30633541a5e3917f \
+                 sha256  bc2750f81a166cc6e9c30ae8aaba54f253a8c8ec9d8cfc04a555fe20712c7bff \
+                 size    207089625
 }
 
 worksrcdir   ${distname}/zulu-21.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 21.36.17.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?