### PR TITLE
openjdk17-zulu: update to 17.52.17

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.50.19
+version      17.52.17
 revision     0
 
-set openjdk_version 17.0.11
+set openjdk_version 17.0.12
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  21dab02b17acb3981665b0135817d7aace0b66b6 \
-                 sha256  b384991e93af39abe5229c7f5efbe912a7c5a6480674a6e773f3a9128f96a764 \
-                 size    194484713
+    checksums    rmd160  44c021b44b5ce7043b7ccaa3b0c9653f343583e5 \
+                 sha256  f159461548429f7344d80e36c62ebd2b366abb446818e5756588fca1aa829d37 \
+                 size    194566320
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  3674f400958b0ec378a081f49261930c7922d890 \
-                 sha256  dd1a82d57e80cdefb045066e5c28b5bd41e57eea9c57303ec7e012b57230bb9c \
-                 size    192349922
+    checksums    rmd160  d76ec32564931b9bd3f8e1d263b39ee250794dff \
+                 sha256  459de135040513eb294d3f651472e39a4a254a4a470e0d87beba3ac62eee370c \
+                 size    192418508
 }
 
 worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 17.52.17.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?