### PR TITLE
openjdk11-zulu: update to 11.74.15

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.72.19
+version      11.74.15
 revision     0
 
-set openjdk_version 11.0.23
+set openjdk_version 11.0.24
 
 description  Azul Zulu Community OpenJDK 11 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  03a61d920ecf64515329ff9bd347c7d41865aa84 \
-                 sha256  e5b19b82045826ae09c9d17742691bc9e40312c44be7bd7598ae418a3d4edb1c \
-                 size    194631852
+    checksums    rmd160  79c3b26a31948ae8b5e27767acd1642fe20d9250 \
+                 sha256  087ea956e8b43c89c732df8024e1344f686b02611c2c5449be6478299b9a9dac \
+                 size    194770067
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  11d3f6e570bda3d34d08b496a699de87ea449b90 \
-                 sha256  40fb1918385e03814b67b7608c908c7f945ccbeddbbf5ed062cdfb2602e21c83 \
-                 size    192715919
+    checksums    rmd160  a0af7f89624f7ae5c5fa03efa2e8efc5a68a3fce \
+                 sha256  f8ac458076c10f13753b7342033aaa073b715ef798023acf155ba814bff67514 \
+                 size    192746319
 }
 
 worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 11.74.15.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?