### PR TITLE
openjdk8-zulu: update to 8.80.0.17

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      8.78.0.19
+version      8.80.0.17
 revision     0
 
-set openjdk_version 8.0.412
+set openjdk_version 8.0.422
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  c395ef28a9cef9236d9adac2b6bd9d96f7707011 \
-                 sha256  2bfa0506196962bddb21a604eaa2b0b39eaf3383d0bdad08bdbe7f42f25d8928 \
-                 size    106646303
+    checksums    rmd160  00d2f4eae53352d82528bcf075edc931eecf0e81 \
+                 sha256  bf207515ea67a70b22f4a8f0163105f986e20a09aa65c8ab66ed33991029f0f0 \
+                 size    106718712
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  da308c2de7d9e9b85b1b4be5ea46114b1633ad93 \
-                 sha256  35bc35808379400e4a70e1f7ee379778881799b93c2cc9fe1ae515c03c2fb057 \
-                 size    104517359
+    checksums    rmd160  45b480242fe9f758043f07f5d5c5bc861b41565b \
+                 sha256  43f854d88095c2625e86b5e60029b8fd7e3c50b4ea33a592739e490d582406f3 \
+                 size    104540856
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 8.80.0.17.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?