### PR TITLE
openjdk22: update to 22.0.2

### DIFF
--- a/java/openjdk22/Portfile
+++ b/java/openjdk22/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk22
 # See https://github.com/openjdk/jdk22u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             22.0.1
-set build 8
+version             22.0.2
+set build 9
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,9 +19,9 @@ master_sites        https://github.com/openjdk/jdk22u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk22u-${distname}
 
-checksums           rmd160  226bab2be0f7ad89322619194925c726b2096730 \
-                    sha256  dd2d8acd685c07e0ccf5f8b4ac562f50ff31421db90f121be36f06e54dfe41f1 \
-                    size    112021509
+checksums           rmd160  d35f730994d41932b50b568429530e709f127d71 \
+                    sha256  c423015bda77bea13e0a13f4dc705972c2185c3c6e6e30b183f733f2b95aa1a4 \
+                    size    112048249
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 22.0.2.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?