### PR TITLE
google-cloud-sdk: update to 484.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             483.0.0
+version             484.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  731da90118557a02f26dbdc1faeb653b0cacb1dc \
-                    sha256  bf389faacfcb4e1a77015a7695f80cc09179c2c65019235ef85700ce7bb56afc \
-                    size    51001393
+    checksums       rmd160  cbd7125d90b4d03d03f888cdb55fdc4cbeebf959 \
+                    sha256  367bea1c994dc14e187b74efedabe6d8825ee8065aec77311b70ccfe8c16eaed \
+                    size    51160326
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  d8fb7ad37d69a446394ddb8c56281fabd286f973 \
-                    sha256  410522737dec5b2e2576436adae855fb91758daefc35d650e8ddbc217ecacfb3 \
-                    size    52288502
+    checksums       rmd160  6cfb174e0a53d817952f9be6aa63689273b62e64 \
+                    sha256  fd1f9bd53f5cdc07bfe72bda042d1c94218e5d05535e5ab00446fb0d03504f5b \
+                    size    52513502
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  e8801c552b83ef730da6ad738e7c9b4e8ba746ef \
-                    sha256  6ffc62ea60c362a91cdf359a70bb2302654c97f94228024c4fd7a49cfcbfc0eb \
-                    size    52249149
+    checksums       rmd160  0340b709991160ea7da42d546c8d089c324dd4aa \
+                    sha256  e9f37781b052b3cda731bb0b729554f73b482dbeb40727f89faf3050fee31d11 \
+                    size    52460879
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 484.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?