### PR TITLE
openjdk21-corretto: update to 21.0.4.7.1

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      21.0.3.9.1
+version      21.0.4.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK 21 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  1860b8b8a6a9f7dd4a24378a8e6428b73635e880 \
-                 sha256  2c6497ced7b926d584243d512b3732a345eb1b5afefd416e6588c33a43c0fa70 \
-                 size    203301232
+    checksums    rmd160  f1cc5bfd6b81d7345754da378c5cd4090701666d \
+                 sha256  244a034c10774ae51f0b5c6fceed88f4afce6d60e9c560aa8c095bb463358541 \
+                 size    203411841
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  f027aa44a007636b82502abc8fd94aebf96e626f \
-                 sha256  db1df7a3fe5d481a2ec52ea3c12b51ba7e9121cdb3dd39e0cf7bc77fba88cd98 \
-                 size    201107917
+    checksums    rmd160  800f34644c7f5acfe5ed19594e42459393dc014d \
+                 sha256  d93750240e4b8a81999b32e002cb1a08e537f2fe29af16bec8229dcf3c520222 \
+                 size    201257714
 }
 
 worksrcdir   amazon-corretto-21.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 21.0.4.7.1.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?