### PR TITLE
openjdk17-corretto: update to 17.0.12.7.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.11.9.1
+version      17.0.12.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  c7333a969cea060988c3e79902d00ebdf90b69b8 \
-                 sha256  b447e0c5e121c3f912c72bc8cdc86569a5d198d86a979b87948ac908fe1c7520 \
-                 size    188644158
+    checksums    rmd160  c350f80ae93a83263e83fe633092b0a484273b7f \
+                 sha256  11d8732af8a184db085411cd8153a73b6e535324ff115c175504a7233b858961 \
+                 size    188713291
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  f6a83a7b555664d0392898a756102d318782dea1 \
-                 sha256  e2d4b5e34f4903278c8a8ba0582072a862fc6d6923ec6ce9f90130cf3cf787f8 \
-                 size    186719854
+    checksums    rmd160  e9cb4c8c868666060d2b7ac3e023c447ed023c75 \
+                 sha256  0c0b2b7dabc2b55bd9c1a71d18f375c3570d507613633e861daea3958bd1bf75 \
+                 size    186817195
 }
 
 worksrcdir   amazon-corretto-17.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.12.7.1.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?