### PR TITLE
openjdk11-corretto: update to 11.0.24.8.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      11.0.23.9.1
+version      11.0.24.8.1
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  aa3a5de78de49e7c1664f13435eb614d888f8bed \
-                 sha256  da2bd4fd790efce6a75eb81180734806dc5dd6d050da02242d9f8017ccaafaa1 \
-                 size    187782886
+    checksums    rmd160  4b95640f074d4c9ab08db82fa1f8fb62517fe5fa \
+                 sha256  e3d636242b60b5628b3f3078fe9616bdc312e41af5d628349bfd61e3233a2f39 \
+                 size    187851684
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  e0868906aa4cefe736d3fbb70733208508ea6141 \
-                 sha256  f4a33483955730105b3364ccd0a59b7e1047407895acf445625783794b7f7ecf \
-                 size    185369910
+    checksums    rmd160  044ffb419f6e8142e6d4fcf113b3686cfb1e1f7f \
+                 sha256  d3739f98b2573eaa0f6a8b2ee073c95ccb7fa80f34c2d6eff20db4f40ee4272d \
+                 size    185400257
 }
 
 worksrcdir   amazon-corretto-11.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.24.8.1.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?