### PR TITLE
openjdk8-corretto: update to 8.422.05.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.412.08.1
+version      8.422.05.1
 revision     0
 
 description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  acb7d98a14a9dbe17c2195bde4d7e9ad62e76cfa \
-                 sha256  edb4b85d5ad81a4d1cb29516e15ec99d065537a7b9fed6001d7653a6fcece7a3 \
-                 size    118465453
+    checksums    rmd160  fd1623f5887cfe1ca2f1150a2f77ccef8ced9613 \
+                 sha256  5aaca055544ddcbae999a06729ca37e936ba672d8d35ae14a4dbace00e093ba7 \
+                 size    118471283
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  87e67ff3a925d13a2b2b13c99b5680c8e4be9c3c \
-                 sha256  9d328d143afefb3bb0612297aa0b339fc1afe390d9f1fde0fe750dacdd56f51d \
-                 size    102889992
+    checksums    rmd160  e17fe590bc03be1bcd9871f2e27e6867851af27e \
+                 sha256  1286deb303cbe3c49c670728eacfd03cfd088e7f81c7d2090f82dc4f51385793 \
+                 size    102898821
 }
 
 worksrcdir   amazon-corretto-8.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.422.05.1

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?