### PR TITLE
openjdk22-oracle: update to 22.0.2

### DIFF
--- a/java/openjdk22-oracle/Portfile
+++ b/java/openjdk22-oracle/Portfile
@@ -14,24 +14,24 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://jdk.java.net/22/
-version      22.0.1
+version      22.0.2
 revision     0
 
 description  Oracle OpenJDK 22
 long_description Open-source Oracle build of OpenJDK 22, the Java Development Kit, an implementation of the Java SE Platform.
 
-master_sites https://download.java.net/java/GA/jdk${version}/c7ec1332f7bb44aeba2eb341ae18aca4/8/GPL/
+master_sites https://download.java.net/java/GA/jdk${version}/c9ecb94cd31b495da20a27d4581645e8/9/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  c72e3e0d16de1537ffd5270959ce4e66c22c135c \
-                 sha256  5daa4f9894cc3a617a5f9fe2c48e5391d3a2e672c91e1597041672f57696846f \
-                 size    198190735
+    checksums    rmd160  9b7bea595c3e5b433e87f7d454fb71771c1dab79 \
+                 sha256  e8b3ec7a7077711223d31156e771f11723cd7af31c2017f1bd2eda20855940fb \
+                 size    197954845
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  6f4003c186f8542b80102890fd9cb20b70305c5f \
-                 sha256  b949a3bc13e3c5152ab55d12e699dfa6c8b00bedeb8302b13be4aec3ee734351 \
-                 size    195900042
+    checksums    rmd160  b47aaf914ca1d05010c105d40a14b5b5df220065 \
+                 sha256  3dab98730234e1a87aec14bcb8171d2cae101e96ff4eed1dab96abbb08e843fd \
+                 size    195674824
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 22.0.2.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?