### PR TITLE
openjdk22-graalvm: update to 22.0.2

### DIFF
--- a/java/openjdk22-graalvm/Portfile
+++ b/java/openjdk22-graalvm/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version     22.0.1
-set build 8
+version     22.0.2
+set build 9
 revision    0
 
 description  GraalVM Community Edition based on OpenJDK 22
@@ -26,14 +26,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-community-jdk-${version}_macos-x64_bin
-    checksums    rmd160  2e0d1339308e6f1b8a7c2ba44d486eabfb08fc4d \
-                 sha256  553c2dff3febd45f917e45f4dd620c194d8225bc28d13f5545ddffea9eeb30f8 \
-                 size    290983419
+    checksums    rmd160  3e86a8f62f29469341865ac057482c5638cda6f0 \
+                 sha256  0512dda1b1ea569b2a6c3dc6671e102a4d5457e3b2dfa47bf656bd32893d12e4 \
+                 size    291129024
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  4a4f0072289b0035989a7ace7b84ff152f104c40 \
-                 sha256  b96a16359c800374af5fbd3cb685aaa91cfc590ea4be35538c24b37e12c769c0 \
-                 size    303929385
+    checksums    rmd160  383704237c6b4fae4d6abd6f61272b3a80017979 \
+                 sha256  883dfd503f2bbf9cd824564763c49cafa6b3c5e9d8c024093962131b4ef5101f \
+                 size    304007229
 }
 
 worksrcdir   graalvm-community-openjdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 22.0.2.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?