### PR TITLE
jdk22: update to 22.0.2

### DIFF
--- a/java/jdk22/Portfile
+++ b/java/jdk22/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk22-mac
-version      22.0.1
+version      22.0.2
 revision     0
 
 description  Oracle Java SE Development Kit 22
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/22/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  c0517acc27c4041e642652e398c445b52dd75bae \
-                 sha256  77fe51266240dbae4d12cf8116894132b22fb65b5d28190da179cf20e21560ad \
-                 size    191062144
+    checksums    rmd160  c0bfab1acdaf29cf856887b892272e51f59a1697 \
+                 sha256  82801dbf7db32cace20f6215398e5231e96cc9de967b8bff79c81d0b058e8d64 \
+                 size    190827456
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  e8166b6e0858ef5a2240e15d4a17a4323256a60f \
-                 sha256  48a6ed00e051cdb87f36ad861ee30e9ba11c9101ef14619d603985bfded8d796 \
-                 size    188772318
+    checksums    rmd160  626433c37a8fcee79d7c3ced97c3cd100c41dbd7 \
+                 sha256  907b3b378e0715d321c5c1d57ed375956043f3eada0e15ef11fe4d099c9b8eb4 \
+                 size    188547780
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update Oracle JDK 22.0.2.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?