### PR TITLE
jdk22-graalvm: update to 22.0.2

### DIFF
--- a/java/jdk22-graalvm/Portfile
+++ b/java/jdk22-graalvm/Portfile
@@ -15,7 +15,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava22-mac
 supported_archs  x86_64 arm64
 
-version     22.0.1
+version     22.0.2
+set build 9
 revision    0
 
 master_sites https://download.oracle.com/graalvm/22/archive/
@@ -33,17 +34,17 @@ long_description Oracle GraalVM for JDK 22 compiles your Java applications ahead
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  d0545dc7b2ce5a5478ba5d6055a0c6beab3ab766 \
-                 sha256  c1a477f4be38130f30ce745cebbb580f71c6159d94503e3e10b7ab5a7c4da66b \
-                 size    324653544
+    checksums    rmd160  b66b7812d79fd2a0ba71d408a76bc0ffb6a52df7 \
+                 sha256  9fcbf3ff96f38f31e2f590bb62adf19e065535c82e27b5fd742def005bef3528 \
+                 size    324730076
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  cb0d8fa067ce137bb28abe33bd34cdf92c5a31c8 \
-                 sha256  7735153e287cd63a29bb1031f2c018770a2734e5c7cb28ab5143a1bd2b4ad45f \
-                 size    337075904
+    checksums    rmd160  2f5f08b20e451f79ed119d4c1be7a579bf746ace \
+                 sha256  3b821806404325746b0a3de32128123d58def395b691df1c42679d9737d587e7 \
+                 size    337171895
 }
 
-worksrcdir   graalvm-jdk-${version}+8.1
+worksrcdir   graalvm-jdk-${version}+${build}.1
 
 variant Applets \
     description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM 22.0.2.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?