### PR TITLE
jdk21-graalvm: update to 21.0.4

### DIFF
--- a/java/jdk21-graalvm/Portfile
+++ b/java/jdk21-graalvm/Portfile
@@ -15,7 +15,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava21-mac
 supported_archs  x86_64 arm64
 
-version     21.0.3
+version     21.0.4
+set build 8
 revision    0
 
 master_sites https://download.oracle.com/graalvm/21/archive/
@@ -33,17 +34,17 @@ long_description Oracle GraalVM for JDK 21 compiles your Java applications ahead
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  3fc32a68c1aed57d2898f09b2df22dff3061f715 \
-                 sha256  6d29cacd2e3b46ee33d573757f1098fec5b487a89a98f68a5315d45a4f89a1bb \
-                 size    313490466
+    checksums    rmd160  8caf50183e31942bdf0b7da6017721699ce7c912 \
+                 sha256  4cfe4037fbb4190c27899e13ebdee8a034309f7a96e9e20f73fc94b28783a98d \
+                 size    313581138
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  11bae340ae9c1478561e200732edb18c8c1e6c63 \
-                 sha256  501b3163e663f154bd816fa889810f94004530e6fcef62e6e87554247d0952c0 \
-                 size    326113782
+    checksums    rmd160  88e8a4ec1ad1865e7ae65358bb7b0cd8480d7e38 \
+                 sha256  1a38609765bb7f985783b438c0488dca1a03ee2d418c2d94a1aaabd6ea9960be \
+                 size    326407555
 }
 
-worksrcdir   graalvm-jdk-${version}+7.1
+worksrcdir   graalvm-jdk-${version}+${build}.1
 
 variant Applets \
     description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM 21.0.4.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?