### PR TITLE
jdk21: update to 21.0.4

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      21.0.3
+version      21.0.4
 revision     0
 
 description  Oracle Java SE Development Kit 21
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/21/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  da48a77db7daa2a1773ff9784a73b1e43ef4a0f0 \
-                 sha256  f51a83c6328d1327aac38eb7345e0846fea8e859ef5bcf65f98a5793aa027253 \
-                 size    193323870
+    checksums    rmd160  db61c69287582fad46bf8ed2487072d24e3e3ef7 \
+                 sha256  b4818ec569fe91372bdd8c68409d391b048217642a6cd15c2f56c1bcde4f00a3 \
+                 size    193407206
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  0f39082d6c4b242512001cbe0ea0814a5011f7de \
-                 sha256  ca48fd25426061754f4c54eef98edd0e1ac4fe57ef17358afdb935ef6e6f6c46 \
-                 size    190976481
+    checksums    rmd160  437909c42a6578d1ac9faaeab66a3c4729ca88b6 \
+                 sha256  70aae35540e8d450bf00502f6bb40867142058ef8307e2e987048ac5b97aa4c2 \
+                 size    191050003
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 21.0.4.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?