### PR TITLE
openjdk21-sap: update to 21.0.4

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/21
-version      21.0.3
+version      21.0.4
 revision     0
 
 description  SAP Machine 21
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  a1aae58a4313c03b721ab473a6bed61bc32cc747 \
-                 sha256  ec510e2d281273f9a8df78c984ca180a720583d113a18162d1b1778301603536 \
-                 size    203153038
+    checksums    rmd160  af5c18e8fe88b5582f28316877829e77e354acce \
+                 sha256  bf6f6ed13e8064da6a3ee0c799940ca66fd89a82699dc63f07601e8828b97e2e \
+                 size    203297114
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  2448cdb227404584672134dec1e57624a2148073 \
-                 sha256  beb695bbacc1b9a2b598859f0cf58e426ea6ca965456a85704462c4ec63428aa \
-                 size    200814103
+    checksums    rmd160  8d03af478b7c19b0d19984a0c9cdbf20368d2d12 \
+                 sha256  6fcf1c1b4adbfdfdb359e687b2707a16410e5b884eb2026f96e7356b195aa1eb \
+                 size    200958486
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 21.0.4.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?