### PR TITLE
openjdk22-sap: update to 22.0.2

### DIFF
--- a/java/openjdk22-sap/Portfile
+++ b/java/openjdk22-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/22
-version      22.0.1
+version      22.0.2
 revision     0
 
 description  SAP Machine 22
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  8cb43d58796a4e9b5b12f3bb69fcdf7f208e24fb \
-                 sha256  99d49029c3fd6afaf8630ddb6444e879b203fe50c868b2e24c6b738330ed9876 \
-                 size    201398827
+    checksums    rmd160  02c3c87b690d8096e4ed3b158ab0cce3c45c1021 \
+                 sha256  db4671e0798d2dd8dc0f5ab74d15aea28bbb2b2bad3c63fd83d4d2be82f051a5 \
+                 size    201225057
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  20e216cc4681d1afdf9f4b0e6e62456924d18132 \
-                 sha256  cce91a02f4a2c6cc7f6be169794df9b18d462f1daaa200b3475df7936929562c \
-                 size    199028008
+    checksums    rmd160  e1b030a8782b8e480f45a8f89916815bc7eb22ba \
+                 sha256  ef1216876c5416e0ca9b07413696cc1f4f8a1cf23c38e70b4d210c7d116c77ef \
+                 size    198850198
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 22.0.2.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?