### PR TITLE
openjdk17-sap: update to 17.0.12

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.11
+version      17.0.12
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  af080ec438a650040ce4cd97378dd5b13580e801 \
-                 sha256  c5ee60451b8781856417954c94c007e13df9b9af234b08a455514a4ecad5e8d5 \
-                 size    188478048
+    checksums    rmd160  ecdde02b8827db1624aff5a786e709d7c2945f92 \
+                 sha256  7879d4b1304793c25d7363d15068f6a8d81613b1abab89e48f5c26618c1f71ca \
+                 size    188626763
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  457cc70c55d00ffe2d10b722ba7453fec3d7aaad \
-                 sha256  8e06ed19f293e6f545723e7744b80545ee9400ce8ce5b8c3dbdcf6f49f211ae0 \
-                 size    186367644
+    checksums    rmd160  69bdd22e0fb6b5fbd24361d9e559febf61395e35 \
+                 sha256  27d7a62448f4dc95506a8a33e14accbd1ff0562fc24ed33644d0f64f13e01027 \
+                 size    186499707
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.12.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?