### PR TITLE
jdk17-graalvm: update to 17.0.12

### DIFF
--- a/java/jdk17-graalvm/Portfile
+++ b/java/jdk17-graalvm/Portfile
@@ -15,7 +15,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava17-mac
 supported_archs  x86_64 arm64
 
-version     17.0.11
+version     17.0.12
+set build 8
 revision    0
 
 master_sites https://download.oracle.com/graalvm/17/archive/
@@ -33,17 +34,17 @@ long_description Oracle GraalVM for JDK 17 compiles your Java applications ahead
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  45f92e1b1f21880f4a9f3fc69e87f19ef51aa9f7 \
-                 sha256  abd6fa23985256debb82463352db090d28b86cf124ce9928782e59cb17ea2517 \
-                 size    314075766
+    checksums    rmd160  bbc1eeb1d6a24837af4a982075fa388ade7bbdda \
+                 sha256  3ecac1471f3fa95a56c5b75c65db9e60ac4551f56eda09eb9da95e6049ea77d7 \
+                 size    311753514
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  4b5d70d731d3ab26c2be480c4e0cb675a2e0d168 \
-                 sha256  a3804609f9c3db90156301b53a5fb678354282207e9a4e08d490488f21132bab \
-                 size    367727166
+    checksums    rmd160  328a306cc99e33708b12f83319f31f53b3ae690d \
+                 sha256  4cdfdc6c9395f6773efcd191b6605f1b7c8e1b78ab900ab5cff34720a3feffc5 \
+                 size    365044599
 }
 
-worksrcdir   graalvm-jdk-${version}+7.1
+worksrcdir   graalvm-jdk-${version}+${build}.1
 
 variant Applets \
     description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM 17.0.12.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?