### PR TITLE
x86_64-binutils: update to 2.42 and fix

### DIFF
--- a/cross/x86_64-binutils/Portfile
+++ b/cross/x86_64-binutils/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 name                x86_64-binutils
-version             2.41
+version             2.42
 revision            0
 maintainers         {@kamischi web.de:karl-michael.schindler} \
                     openmaintainer
 
 if {$subport eq $name} {
-    # sort of a dummy package. Download sources and install docs only
+    # Download sources and install docs for all subports
     crossbinutils.setup x86_64 ${version}
     depends_build
     depends_lib
@@ -24,9 +24,16 @@ if {$subport eq $name} {
 foreach ostarget {linux dragonfly freebsd netbsd openbsd} {
     subport x86_64-${ostarget}-binutils {
         crossbinutils.setup     x86_64-${ostarget} ${version}
+        # Depend on base package for installing the docs
+        depends_lib             port:$name
         configure.args-append   --disable-werror
         if {${ostarget} eq "linux"} {
             depends_build-append    port:bison
+        }
+        # Delete docs since already installed by the base package
+        # Resolves clash about identical docs from each subport
+        post-destroot {
+            delete ${destroot}${prefix}/share/doc/x86_64-binutils
         }
     }
 }
@@ -38,6 +45,8 @@ subport x86_64-embedded-binutils {
         --disable-werror
 
     post-destroot {
+        # See comment above about deleting docs
+        delete      ${destroot}${prefix}/share/doc/x86_64-binutils
         file rename ${destroot}${prefix}/x86_64-unknown-elf/bin \
                     ${destroot}${prefix}/x86_64-embedded
         file rename ${destroot}${prefix}/x86_64-unknown-elf/lib \


### PR DESCRIPTION
Also fixes clash of doc files https://trac.macports.org/ticket/70335

#### Description

x86_64-binutils:
update to 2.42
fix clash of doc files https://trac.macports.org/ticket/70335

###### Type(s)

- [x] bugfix
- [x] enhancement
- [] security fix

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? note: -t errors with at extract phase.
- [x] tested basic functionality of all binary files?
- [] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
