### PR TITLE
afio: fix build with Xcode gcc

### DIFF
--- a/archivers/afio/Portfile
+++ b/archivers/afio/Portfile
@@ -27,6 +27,9 @@ github.tarball_from archive
 patchfiles          Makefile.patch \
                     implicit.patch
 
+# cc1: error: unrecognized command line option "-Wno-unused-result"
+patchfiles-append   patch-cflags.diff
+
 makefile.override-append \
                     PREFIX
 

--- a/archivers/afio/files/patch-cflags.diff
+++ b/archivers/afio/files/patch-cflags.diff
@@ -1,0 +1,11 @@
+--- Makefile	2018-11-30 22:25:04.000000000 +0800
++++ Makefile	2024-07-17 22:18:35.000000000 +0800
+@@ -74,7 +74,7 @@
+ #code can be reviewed manually
+ #MW=-Wtraditional -Wcast-qual -Wcast-align -Wconversion -pedantic -Wlong-long -Wimplicit -Wuninitialized -W -Wshadow -Wsign-compare -Wstrict-prototypes -Wmissing-declarations
+ 
+-CFLAGS1 = -Wall -Wstrict-prototypes -s -O2 -fomit-frame-pointer -Wno-unused-result $(LARGEFILEFLAGS) $(MW)
++CFLAGS1 = -Wall -Wstrict-prototypes -s -O2 -fomit-frame-pointer $(LARGEFILEFLAGS) $(MW)
+ 
+ CC=gcc
+ 


### PR DESCRIPTION
#### Description

Small fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
