### PR TITLE
eza: update to 0.18.22

### DIFF
--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        eza-community eza 0.18.21 v
+github.setup        eza-community eza 0.18.22 v
 github.tarball_from archive
 revision            0
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f23eadb1b736db088188f37b3dd6b6ec3b9a1061 \
-                    sha256  53cee12706be2b5bedcf40b97e077a18b254f0f53f1aee52d1d74136466045bc \
-                    size    1385590
+                    rmd160  b40fcb9b9baaa2352a8ca9f42184cb82a927a362 \
+                    sha256  552fe9997ed4fc6e11dafebffc2aa249ab3fb465a05c614181c7b62e8a0df698 \
+                    size    1385466
 
 depends_lib-append  port:libiconv \
                     path:lib/pkgconfig/libgit2.pc:libgit2 \


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
