### PR TITLE
symfony-cli: update to 5.10.0

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.9.1
+version             5.10.0
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  8f9ecbd898bcf9aaf8444219b9f9d38169aa7fed \
-                        sha256  0a5dabe20f02e73fb8a31ff5e234e179297145785efe02b764c768a25d37a17d \
-                        size    268130
+    checksums           rmd160  1aefe2c46af018ecf1c854f0f3fc6166e522440d \
+                        sha256  8b3f738a868526e3d3511ac7a00d9ca30a1c1ca0d4657538150ec87dcb11e155 \
+                        size    273146
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  7de798cf8ea8a7dacac80d927a8dd3670ceb724e \
-                        sha256  98f9ef28a53c90ca55198dc3aa66defa8b30d65e5c4ce20f1a7fbe79b375f628 \
-                        size    11412604
+    checksums           rmd160  98f5e339d9f3b748d8a119135dae2f901d0f9a86 \
+                        sha256  c59869c28cb1470e4aa537a3293b46cc3b75788ba6a854a6d69b6528accfe39a \
+                        size    11531070
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.10.0

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
