### PR TITLE
openjdk17-temurin: update to 17.0.12

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.11
-set build    9
+version      17.0.12
+set build    7
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  c1f53690c250c5012029dec1af629c791ead4f6f \
-                 sha256  f8b96724618f4df557c47f11048d1084e98ed3eb87f0dbd5b84f768a80c3348e \
-                 size    180563846
+    checksums    rmd160  62505c5826d20b169a0ceff8289f496121b0a0ae \
+                 sha256  d5230eeec88739aa7133e4c8635bbd4ab226708c12deaafa13cf26b02bc8e8c4 \
+                 size    180640890
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  2c391fdfcb64a1ec0ac7b58479d772819aa52ba9 \
-                 sha256  09a162c58dd801f7cfacd87e99703ed11fb439adc71cfa14ceb2d3194eaca01c \
-                 size    178367345
+    checksums    rmd160  47a7408b4716a3f757845cce2bb339eae29bf0e1 \
+                 sha256  d7910b1acaeb290c5c5da21811d2b2b8635f806612a2d6e8d1953b2f77580f78 \
+                 size    178427485
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.12.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?