### PR TITLE
tmt: new port (1.34.0)

### DIFF
--- a/devel/tmt/Portfile
+++ b/devel/tmt/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                tmt
+version             1.34.0
+revision            0
+
+categories          devel python
+supported_archs     noarch
+platforms           {darwin any}
+license             MIT
+maintainers         {sub-pop.net:link @subpop} \
+                    openmaintainer
+
+description         Test Management Tool
+long_description    The tmt tool provides a user-friendly way to work with \
+                    tests. You can comfortably create new tests, safely and \
+                    easily run tests across different environments, review \
+                    test results, debug test code and enable tests in the CI \
+                    using a consistent and concise config. \
+                    The python module and command-line tool implement the \
+                    Metadata Specification which allows storing all needed \
+                    test execution data directly within a git repository. \
+                    Together with the possibility to reference remote \
+                    repositories, it makes it easy to share test coverage \
+                    across projects and distros. \
+                    The Flexible Metadata Format fmf is used to store data in \
+                    both human and machine readable way close to the source \
+                    code. Thanks to inheritance and elasticity metadata are \
+                    organized in the structure efficiently, preventing \
+                    unnecessary duplication.
+
+homepage            https://tmt.readthedocs.io
+
+checksums           rmd160  08aac1c5b146b5b8d0fa2dfd638ac319e68da6f9 \
+                    sha256  e3b8b0d0af1dd5d56522c9ebc8c6ccb4bfb04e6cf3e54f31402cf8dbc1717cc4 \
+                    size    605318
+
+python.default_version 312
+python.pep517_backend  hatch
+
+depends_build-append \
+                port:py${python.version}-hatch-vcs
+
+depends_lib-append \
+                port:py${python.version}-click \
+                port:py${python.version}-docutils \
+                port:py${python.version}-fmf \
+                port:py${python.version}-jinja2 \
+                port:py${python.version}-pint \
+                port:py${python.version}-pygments \
+                port:py${python.version}-requests \
+                port:py${python.version}-ruamel-yaml \
+                port:py${python.version}-urllib3

--- a/python/py-fmf/Portfile
+++ b/python/py-fmf/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        teemtee fmf 1.4.1
+github.tarball_from archive
+
+name                py-fmf
+revision            0
+
+categories-append   devel
+supported_archs     noarch
+platforms           {darwin any}
+license             GPL-2
+maintainers         {sub-pop.net:link @subpop} openmaintainer
+
+description         Flexible Metadata Format
+long_description    {*}${description}
+
+homepage            https://github.com/psss/fmf
+
+checksums           rmd160  e75d1593c80b8766d66eb38dd1f2a8cb606267eb \
+                    sha256  3a81da682f6d50f686420ff25e89bee339c2405639d15959ffac34df0dc75185 \
+                    size    86392
+
+python.versions     312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-filelock \
+                    port:py${python.version}-jsonschema \
+                    port:py${python.version}-ruamel-yaml
+}
+


### PR DESCRIPTION
#### Description

Add a new port for the `tmt` test management tool.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] new package

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
