### PR TITLE
openjdk11-temurin: update to 11.0.24

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.23
-set build    9
+version      11.0.24
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  a39272c7d33cceb6070f5503cc23be4e3d7b2ded \
-                 sha256  4dbd21d9a0311d321f5886eda50c3086026ed61d02e1a85f7b8c2e9ad557bf03 \
-                 size    187689918
+    checksums    rmd160  d9223baa629fe84d82bbe9a1a811784f3cc7dde2 \
+                 sha256  07a1be21f45f0951db05516e57602c414295c51a920f7e9b6ddeaa325d619b28 \
+                 size    187710109
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  dba939a7f9d8affb5bcfd06c28d70d2b75955e55 \
-                 sha256  49122443bdeab2c9f468bd400f58f85a9ea462846faa79084fd6fd786d9b492d \
-                 size    184991537
+    checksums    rmd160  651a5dda4c260e6d0574e973264fbb2c91a3cfc2 \
+                 sha256  8bcbb98e293fb3c4d5cae3539f240ed478fae85962311fccd4c628ebad3a90e4 \
+                 size    185018067
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.24.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?