### PR TITLE
quickfix: update to 1.15.1

### DIFF
--- a/devel/quickfix/Portfile
+++ b/devel/quickfix/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           openssl 1.0
 
 name                quickfix
-version             1.14.3
+version             1.15.1
 license             Permissive
 # http://www.quickfixengine.org/quickfix/doc/html/license.html
 categories          devel finance
@@ -15,61 +16,50 @@ description         FIX engine implementation
 long_description    QuickFIX is a full-featured open source FIX engine, \
                     currently compatible with the FIX 4.0-4.4 spec.
 
-homepage            http://www.quickfixengine.org/
+homepage            https://www.quickfixengine.org/
 master_sites        sourceforge:project/quickfix/quickfix/${version}
 worksrcdir          ${name}
 
-checksums           rmd160  369d5bf7044fa4c90d2d74e4470e50c0ad82951b \
-                    sha256  f6e8bdb004eaf45e50f63005b8c2611cb0afd42cf70f110f600c852aa572342d \
-                    size    21803784
+checksums           rmd160  63b491915df6e9b1809a97a4ba252bfc29219e26 \
+                    sha256  9842e71b5abc71f744aeacf65d8264cad2f360e32fa70d0c34f8b239384eb49c \
+                    size    46100428
 
 compiler.cxx_standard 2011
+supported_archs     x86_64
 
-depends_lib         port:libxml2
+depends_lib         port:libxml2 \
+                    port:openssl3
 
 patchfiles          patch-UnitTest++-Makefile.diff
 
 post-patch {
     reinplace "s|@CXX@|${configure.cxx}|g" ${worksrcpath}/UnitTest++/Makefile
     reinplace "s|@ARCHFLAGS@|[get_canonical_archflags cxx]|g" ${worksrcpath}/UnitTest++/Makefile
+    reinplace "s|`python3|`${prefix}/bin/python3.12|g" ${worksrcpath}/configure
 }
 
-configure.args      --with-java \
+configure.args      --without-java \
+                    --with-openssl \
                     --with-mysql-config=false \
                     --without-postgresql \
                     --without-python \
                     --without-ruby
-configure.env       JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Home
 
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/${name}/sql
     copy ${worksrcpath}/src/sql/postgresql ${destroot}${prefix}/share/${name}/sql
 }
 
-variant postgresql84 conflicts postgresql90 description {Include PostgreSQL 8.4 support} {
-    depends_lib-append      port:postgresql84
-    configure.args-replace  --without-postgresql --with-postgresql=${prefix}/lib/postgresql84/bin/pg_config
+variant postgresql16 description {Include PostgreSQL 16 support} {
+    depends_lib-append      port:postgresql16
+    configure.args-replace  --without-postgresql --with-postgresql=${prefix}/lib/postgresql16/bin/pg_config
 }
 
-variant postgresql90 conflicts postgresql84 description {Include PostgreSQL 9.0 support} {
-    depends_lib-append      port:postgresql90
-    configure.args-replace  --without-postgresql --with-postgresql=${prefix}/lib/postgresql90/bin/pg_config
-}
-
-variant python27 conflicts python35 python37 description {Include Python 2.7 support} {
-    depends_lib-append      port:python27
-    configure.python        ${prefix}/bin/python2.7
-    configure.args-replace  --without-python --with-python
-}
-
-variant python35 conflicts python27 python37 description {Include Python 3.5 support} {
-    depends_lib-append      port:python35
-    configure.python        ${prefix}/bin/python3.5
-    configure.args-replace  --without-python --with-python
-}
-
-variant python37 conflicts python27 python35 description {Include Python 3.7 support} {
-    depends_lib-append      port:python37
-    configure.python        ${prefix}/bin/python3.7
-    configure.args-replace  --without-python --with-python
+variant python312 description {Include Python 3.12 support} {
+    depends_lib-append      port:python312
+    configure.python        ${prefix}/bin/python3.12
+    configure.args-replace  --without-python --with-python3
+    configure.env-append \
+        "LDFLAGS=-L${prefix}/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/config-3.12-darwin -lpython3.12" \
+        PYTHON3_PREFIX=${prefix}
 }

--- a/devel/quickfix/files/patch-UnitTest++-Makefile.diff
+++ b/devel/quickfix/files/patch-UnitTest++-Makefile.diff
@@ -2,10 +2,10 @@
 +++ UnitTest++/Makefile	2014-09-03 15:24:07.000000000 -0500
 @@ -1,6 +1,6 @@
 -CXX = g++
--CXXFLAGS ?= -g -Wall -W -Winline -Wno-unused-private-field -Wno-overloaded-virtual -ansi 
+-CXXFLAGS ?= -g -Wall -W -Winline -Wno-overloaded-virtual -Wno-unused-private-field -ansi 
 -LDFLAGS ?= 
 +CXX = @CXX@
-+CXXFLAGS ?= -g -Wall -W -Winline -Wno-overloaded-virtual -ansi @ARCHFLAGS@
++CXXFLAGS ?= -g -Wall -W -Winline -Wno-overloaded-virtual -Wno-unused-private-field -ansi @ARCHFLAGS@
 +LDFLAGS ?= @ARCHFLAGS@
  SED = sed
  MV = mv


### PR DESCRIPTION
#### Description

The unreleased master branch drops python 2.x and java support so I've also dropped it here. The java support was only for building examples that were not shipped with the port.

I can confirm this produces a libquickfix.17.dylib that links against python 3.12 and postgresql 16. I was also able to import the quickfix Python packages that it installed but didn't exercise them beyond that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
