### PR TITLE
symfony-cli: update to 5.10.1

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.10.0
+version             5.10.1
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  1aefe2c46af018ecf1c854f0f3fc6166e522440d \
-                        sha256  8b3f738a868526e3d3511ac7a00d9ca30a1c1ca0d4657538150ec87dcb11e155 \
-                        size    273146
+    checksums           rmd160  41798f60a2d0c179d86a53215cce5d863f025406 \
+                        sha256  913a7c14f043c73fe17f6e499973caad29db90c321e8046f0a62278829accc9d \
+                        size    273155
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  98f5e339d9f3b748d8a119135dae2f901d0f9a86 \
-                        sha256  c59869c28cb1470e4aa537a3293b46cc3b75788ba6a854a6d69b6528accfe39a \
-                        size    11531070
+    checksums           rmd160  3241ae84c26705fa4aa4e776b6726b22a1e601cc \
+                        sha256  2fd5a8a9eec41bd234d9d31d66fdf2f4f3e966b08ba0aeef90510fc0276267fe \
+                        size    11531248
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.10.1

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
