### PR TITLE
symfony-cli: update to 5.10.2

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.10.0
+version             5.10.2
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  1aefe2c46af018ecf1c854f0f3fc6166e522440d \
-                        sha256  8b3f738a868526e3d3511ac7a00d9ca30a1c1ca0d4657538150ec87dcb11e155 \
-                        size    273146
+    checksums           rmd160  0a3619526259dc3348bc650f997a4d0339e1bfd9 \
+                        sha256  631d7c781f6d8ba51b7043dcdb0be6a8f3162c4d98981e94bbf119d56d9823f2 \
+                        size    273136
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  98f5e339d9f3b748d8a119135dae2f901d0f9a86 \
-                        sha256  c59869c28cb1470e4aa537a3293b46cc3b75788ba6a854a6d69b6528accfe39a \
-                        size    11531070
+    checksums           rmd160  1f0d2226f5909977deb9ecd845601b3d2526de83 \
+                        sha256  a1d6e6dafe4b83152657af12509191e5126964affae3c0b1362b75815f62cc71 \
+                        size    11530854
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.10.2

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
