### PR TITLE
openjdk21-temurin: update to 21.0.4

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      21.0.3
-set build    9
+version      21.0.4
+set build    7
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 21
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin21-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK21U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  b463ba38acf005041f1f0db0212725f657b2580c \
-                 sha256  f777103aab94330d14a29bd99f3a26d60abbab8e2c375cec9602746096721a7c \
-                 size    194512621
+    checksums    rmd160  80c32d2faf305235166539047a0e5bc429e684f8 \
+                 sha256  e368e5de7111aa88e6bbabeff6f4c040772b57fb279cc4e197b51654085bbc18 \
+                 size    194603417
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK21U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e1f623f8b1345a8e5a4c6147a2fed3d3e955b88d \
-                 sha256  b6be6a9568be83695ec6b7cb977f4902f7be47d74494c290bc2a5c3c951e254f \
-                 size    192027805
+    checksums    rmd160  5c2b2789ac884083614a599767c4777a55080269 \
+                 sha256  dcf69a21601d9b1b25454bbad4f0f32784bb42cdbe4063492e15a851b74cb61e \
+                 size    192096746
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 21.0.4.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?