### PR TITLE
dagger: update to 0.12.1

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.12.0 v
+github.setup        dagger dagger 0.12.1 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  ebf1238a5b21aa67dd2065ad6ecf6e6ae4bf215c \
-                            sha256  997bae069b44e0f1f91a861642904cc591d5cbe012e5924cccfc14acb0a3ef96 \
-                            size    10077079
+        checksums           rmd160  24fa4af0091d1edcdac6230f76978a20468405d0 \
+                            sha256  3164d330ed04e1a5579598d2ccc2be768193a6a04b4805f326f1668a0be6778c \
+                            size    10088442
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  e5443d6e37d145bc41b112c960c0250b86f3e24c \
-                            sha256  09ee7c53a156f8b52ffe68d0f726bfdcf988d08fa12ac9fb3f00be4061a68d32 \
-                            size    9518657
+        checksums           rmd160  f1b3cc68b37a6cff0aaaf4749ffaa88302f52ae0 \
+                            sha256  cb1357bddad854e16d540e38b4c33a16856155f0664f8b603a120d014a660dc1 \
+                            size    9530698
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Update to the latest version

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
