### PR TITLE
iverilog: Update to v12.0

### DIFF
--- a/science/iverilog/Portfile
+++ b/science/iverilog/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        steveicarus iverilog 11_0 v
+github.setup        steveicarus iverilog 12_0 v
 version             [string map {_ .} ${github.version}]
 revision            0
 set major           [lindex [split ${version} .] 0]
@@ -24,18 +24,18 @@ long_description    Icarus Verilog is a Verilog simulation and synthesis tool. \
                     desired format.
 
 homepage            http://iverilog.icarus.com/
-master_sites        ftp://ftp.icarus.com/pub/eda/verilog/v${major}/
-distname            verilog-${version}
 
-checksums           rmd160  d5ce7247745c2d047d51e7f9f125d8a97fca946c \
-                    sha256  d54785616b63fe6739948e9967499624f29ded54adb57e1e00eb897567a655d5 \
-                    size    1784307
+checksums           rmd160  56a9fa32ae1b8b5240b0770bff6dc7a72fb05f4f \
+                    sha256  8be4bc86aa97013dd16eb7d63c6a5bdd896eddcf760a05b309d633647b7eb2eb \
+                    size    2995764
 
 depends_lib-append  port:bzip2 \
                     port:readline \
                     port:zlib
 
 depends_build       port:bison
+
+use_autoconf        yes
 
 compiler.cxx_standard 2011
 


### PR DESCRIPTION
#### Description

* Update to v12.0
* Move to github and autoconf as suggested for by https://steveicarus.github.io/iverilog/usage/installation.html and ftp://ftp.icarus.com times out

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.0 24A5289h arm64
Xcode 16.0 16A5202i
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
