### PR TITLE
mpich: 4.2.2

### DIFF
--- a/science/mpi-doc/Portfile
+++ b/science/mpi-doc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 # make sure to keep in sync with mpich
 name                mpi-doc
-version             4.1.2
+version             4.2.2
 revision            0
 
 license             BSD
@@ -22,9 +22,9 @@ master_sites        ${homepage}static/downloads/${version}/
 distname            mpich-${version}
 
 checksums \
-    rmd160  b4bc2115f5080ef93595597afc6d3f9f1665e051 \
-    sha256  3492e98adab62b597ef0d292fb2459b6123bc80070a8aa0a30be6962075a12f0 \
-    size    39250122
+    rmd160  158f1c23a1f646838bf87d4b2920c752d7f9d3ef \
+    sha256  883f5bb3aeabf627cb8492ca02a03b191d09836bbe0f599d8508351179781d41 \
+    size    40241352
 
 dist_subdir         mpich
 

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -20,8 +20,8 @@ PortGroup           mpiutil 1.0
 
 # make sure to keep in sync with mpi-doc
 name                mpich
-version             4.1.2
-revision            2
+version             4.2.2
+revision            0
 
 license             BSD
 categories          science parallel net
@@ -47,9 +47,9 @@ long_description    MPICH is a high-performance and widely portable\
 homepage            https://www.mpich.org/
 master_sites        ${homepage}static/downloads/${version}
 
-checksums           rmd160  b4bc2115f5080ef93595597afc6d3f9f1665e051 \
-                    sha256  3492e98adab62b597ef0d292fb2459b6123bc80070a8aa0a30be6962075a12f0 \
-                    size    39250122
+checksums           rmd160  158f1c23a1f646838bf87d4b2920c752d7f9d3ef \
+                    sha256  883f5bb3aeabf627cb8492ca02a03b191d09836bbe0f599d8508351179781d41 \
+                    size    40241352
 
 # Disable livecheck for all subports; only enabled for main port, at end of portfile
 livecheck.type      none
@@ -74,6 +74,7 @@ dict set clist gcc10   {macports-gcc-10}
 dict set clist gcc11   {macports-gcc-11}
 dict set clist gcc12   {macports-gcc-12}
 dict set clist gcc13   {macports-gcc-13}
+dict set clist gcc14   {macports-gcc-14}
 dict set clist clang11 {macports-clang-11}
 dict set clist clang12 {macports-clang-12}
 dict set clist clang13 {macports-clang-13}
@@ -81,6 +82,7 @@ dict set clist clang14 {macports-clang-14}
 dict set clist clang15 {macports-clang-15}
 dict set clist clang16 {macports-clang-16}
 dict set clist clang17 {macports-clang-17}
+dict set clist clang18 {macports-clang-18}
 
 # Only enable default (gcc), and Xcode clang, for MacOS 10.7 and later
 if { ${os.major} >= 11 } {
@@ -173,9 +175,10 @@ if {${subport_enabled}} {
                     --with-thread-package=posix      \
                     --with-hwloc-prefix=${prefix}    \
                     --disable-collalgo-tests         \
-                    --with-device=ch3:nemesis        \
-                    --enable-nemesis-shm-collectives
+                    --with-device=ch4:ofi:tcp
 
+    # Hopefully avoid double-rpath issues.
+    compilers.add_gcc_rpath_support no
 
     if {${os.major} < 12} {
         # MPICH requires OpenCL version 1.2, which was not introduced until OS X Mountain Lion
@@ -185,8 +188,8 @@ if {${subport_enabled}} {
 
     patchfiles-append \
                     patch-no_qmkshrobj.diff \
-                    patch-ch4-ipv6.diff \
-                    patch-mpich-darwin-powerpc.diff
+                    patch-mpich-darwin-powerpc.diff \
+                    patch-mpi-h.diff
 
     post-patch {
         reinplace \

--- a/science/mpich/files/patch-mpi-h.diff
+++ b/science/mpich/files/patch-mpi-h.diff
@@ -1,0 +1,40 @@
+--- src/include/mpi.h.in.orig	2024-07-05 09:57:10.000000000 -0500
++++ src/include/mpi.h.in	2024-07-05 09:58:12.000000000 -0500
+@@ -336,6 +336,18 @@
+ #define MPI_WIN_CREATE_FLAVOR 0x66000007
+ #define MPI_WIN_MODEL         0x66000009
+
++/* Definitions that are determined by configure. */
++typedef @MPI_AINT@ MPI_Aint;
++typedef @MPI_FINT@ MPI_Fint;
++typedef @MPI_COUNT@ MPI_Count;
++
++/* Let ROMIO know that MPI_Offset is already defined */
++#define HAVE_MPI_OFFSET
++/* MPI_OFFSET_TYPEDEF is set in configure and is
++      typedef $MPI_OFFSET MPI_Offset;
++   where $MPI_OFFSET is the correct C type */
++@MPI_OFFSET_TYPEDEF@
++
+ #ifdef MPICH_DEFINE_ATTR_TYPE_TYPES
+ static const MPI_Datatype mpich_mpi_datatype_null MPICH_ATTR_TYPE_TAG_MUST_BE_NULL() = MPI_DATATYPE_NULL;
+ static const MPI_Datatype mpich_mpi_char               MPICH_ATTR_TYPE_TAG(char)               = MPI_CHAR;
+@@ -408,18 +420,6 @@
+ static const MPI_Datatype mpich_mpi_offset MPICH_ATTR_TYPE_TAG(MPI_Offset) = MPI_OFFSET;
+ #endif
+
+-/* Definitions that are determined by configure. */
+-typedef @MPI_AINT@ MPI_Aint;
+-typedef @MPI_FINT@ MPI_Fint;
+-typedef @MPI_COUNT@ MPI_Count;
+-
+-/* Let ROMIO know that MPI_Offset is already defined */
+-#define HAVE_MPI_OFFSET
+-/* MPI_OFFSET_TYPEDEF is set in configure and is
+-      typedef $MPI_OFFSET MPI_Offset;
+-   where $MPI_OFFSET is the correct C type */
+-@MPI_OFFSET_TYPEDEF@
+-
+ /* The order of these elements must match that in mpif.h, mpi_f08_types.f90,
+    and mpi_c_interface_types.f90 */
+ typedef struct MPI_Status {

--- a/science/mpich/files/portselect/mpich-clang18
+++ b/science/mpich/files/portselect/mpich-clang18
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-clang16
+bin/mpichversion-mpich-clang18
+bin/mpicxx-mpich-clang18
+bin/mpiexec-mpich-clang18
+bin/mpirun-mpich-clang18
+-
+-
+bin/parkill-mpich-clang18
+lib/mpich-clang18/pkgconfig/mpich.pc
+-
+-

--- a/science/mpich/files/portselect/mpich-clang18
+++ b/science/mpich/files/portselect/mpich-clang18
@@ -1,4 +1,4 @@
-bin/mpicc-mpich-clang16
+bin/mpicc-mpich-clang18
 bin/mpichversion-mpich-clang18
 bin/mpicxx-mpich-clang18
 bin/mpiexec-mpich-clang18

--- a/science/mpich/files/portselect/mpich-clang18-fortran
+++ b/science/mpich/files/portselect/mpich-clang18-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-clang18
+bin/mpichversion-mpich-clang18
+bin/mpicxx-mpich-clang18
+bin/mpiexec-mpich-clang18
+bin/mpirun-mpich-clang18
+bin/mpif77-mpich-clang18
+bin/mpif90-mpich-clang18
+bin/parkill-mpich-clang18
+lib/mpich-clang18/pkgconfig/mpich.pc
+-
+bin/mpifort-mpich-clang18

--- a/science/mpich/files/portselect/mpich-gcc14-fortran
+++ b/science/mpich/files/portselect/mpich-gcc14-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-gcc14
+bin/mpichversion-mpich-gcc14
+bin/mpicxx-mpich-gcc14
+bin/mpiexec-mpich-gcc14
+bin/mpirun-mpich-gcc14
+bin/mpif77-mpich-gcc14
+bin/mpif90-mpich-gcc14
+bin/parkill-mpich-gcc14
+lib/mpich-gcc14/pkgconfig/mpich.pc
+-
+bin/mpifort-mpich-gcc14


### PR DESCRIPTION
Maintainer update.

Still working on #24812, but just to get this update in. Mayo also address issues with extra rpaths from gcc flavors.