### PR TITLE
ansible: update to 2.17.2

### DIFF
--- a/python/py-ansible-core/Portfile
+++ b/python/py-ansible-core/Portfile
@@ -5,7 +5,8 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-ansible-core
-version             2.16.3
+version             2.17.2
+distname            ansible_core-${version}
 revision            0
 license             GPL-3+
 
@@ -18,11 +19,9 @@ maintainers         {adfernandes @adfernandes} {gmail.com:pedro.salgado @steenzo
 homepage            https://github.com/ansible/ansible
 description         SSH-based configuration management and deployment system
 
-checksums           rmd160  8740d3ba6592f85035a7a211fd6dae141832caee \
-                    sha256  76a8765a8586064ef073a299562e308fa2c180a75b5f7569bbd0f61d4171cdb3 \
-                    size    3168893
-
-conflicts           ansible
+checksums           rmd160  da4eca386dddf6d08294d416de116141dcf37bde \
+                    sha256  3dfa15249069ea0d001257902c968ddf9bb71d965769b8802bce85187556c5d8 \
+                    size    3125313
 
 long_description \
     Ansible is a radically simple model-driven configuration \

--- a/python/py-ansible/Portfile
+++ b/python/py-ansible/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-ansible
-version             9.2.0
+version             10.2.0
 revision            0
 license             GPL-3+
 
@@ -17,11 +17,9 @@ maintainers         {adfernandes @adfernandes} {gmail.com:pedro.salgado @steenzo
 homepage            https://github.com/ansible/ansible
 description         SSH-based configuration management and deployment system
 
-checksums           rmd160  f7d815265962968473172dcf887deb105026fdef \
-                    sha256  a207a4a00a45e5cd178a7f94ca42afe26f23c9d27be49901ea8c45d18a07b7c6 \
-                    size    41217761
-
-conflicts           ansible
+checksums           rmd160  44dc3a47200f857db6246e89b9f8bce7830deea6 \
+                    sha256  8aa0629ba8eced6465e2ceb49029e93d337c4a6fc5a3e6e98825c258dd6a7057 \
+                    size    39352378
 
 long_description \
     Ansible is a radically simple model-driven configuration \


### PR DESCRIPTION
#### Description

Update **py-ansible** _and_ **py-ansible-core** to latest version.

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->

```
>ansible

ansible [core 2.17.2]
  config file = None
  configured module search path = ['/Users/emre/.ansible/plugins/modules', '/opt/local/share/ansible/plugins/modules']
  ansible python module location = /opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/ansible
  ansible collection location = /Users/emre/.ansible/collections:/opt/local/share/ansible/collections
  executable location = /opt/local/bin/ansible
  python version = 3.12.4 (main, Jun  8 2024, 04:51:36) [Clang 15.0.0 (clang-1500.1.0.2.5)] (/opt/local/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12)
  jinja version = 3.1.4
  libyaml = True
```

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
