### PR TITLE
tree_sitter PG: prefer C++ source consistently

### DIFF
--- a/_resources/port1.0/group/tree_sitter-1.0.tcl
+++ b/_resources/port1.0/group/tree_sitter-1.0.tcl
@@ -10,10 +10,10 @@ use_configure       no
 build {
     system -W ${worksrcpath} "${configure.cc} ${configure.cppflags} ${configure.cflags} [get_canonical_archflags cc] -fPIC -c -I. parser.c"
 
-    if {[file exists ${worksrcpath}/scanner.c]} {
-        system -W ${worksrcpath} "${configure.cc} ${configure.cppflags} ${configure.cflags} [get_canonical_archflags cc] -fPIC -c -I. scanner.c"
-    } elseif {[file exists ${worksrcpath}/scanner.cc]} {
+    if {[file exists ${worksrcpath}/scanner.cc]} {
         system -W ${worksrcpath} "${configure.cxx} ${configure.cxxflags} ${configure.cflags} [get_canonical_archflags cxx] -fPIC -c -I. scanner.cc"
+    } elseif {[file exists ${worksrcpath}/scanner.c]} {
+        system -W ${worksrcpath} "${configure.cc} ${configure.cppflags} ${configure.cflags} [get_canonical_archflags cc] -fPIC -c -I. scanner.c"
     }
 
     if {[file exists ${worksrcpath}/scanner.cc]} {


### PR DESCRIPTION
#### Description
Before this change, If both `scanner.c` and `scanner.cc` exists, `scanner.c` will be compiled with `${configure.cc}` and linked with `${configure.cxx}`.

This change makes it consistently prefer C++ source files for compilation and linking.

Was there a particular reason to be inconsistent in the first place?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
