### PR TITLE
py-tables: add py312 subport

### DIFF
--- a/python/py-tables/Portfile
+++ b/python/py-tables/Portfile
@@ -6,10 +6,11 @@ PortGroup           mpi 1.0
 
 name                py-tables
 version             3.9.2
+revision            1
 categories-append   science
 license             BSD
 
-python.versions     27 38 39 310 311
+python.versions     27 38 39 310 311 312
 
 maintainers         nomaintainer
 
@@ -36,19 +37,17 @@ if {${name} ne ${subport}} {
                     size   7825372
     } elseif {${python.version} == 38} {
         version     3.8.0
-        revision    3
+        revision    4
         checksums   md5 83b2e54523cd83f7a9efbfbb8aa37227 \
                     rmd160 dfdd6649c665416e919e221084c18c24421d74e8 \
                     sha256 34f3fa2366ce20b18f1df573a77c1d27306ce1f2a41d9f9eff621b5192ea8788
         patchfiles-append   pyproject.toml-3.8.0.patch
     }
 
-    build.env-append    BLOSC_DIR=${prefix} \
-                        BZIP2_DIR=${prefix} \
+    build.env-append    BZIP2_DIR=${prefix} \
                         HDF5_DIR=${prefix} \
                         LZO_DIR=${prefix}
-    destroot.env-append BLOSC_DIR=${prefix} \
-                        BZIP2_DIR=${prefix} \
+    destroot.env-append BZIP2_DIR=${prefix} \
                         HDF5_DIR=${prefix} \
                         LZO_DIR=${prefix}
 
@@ -71,15 +70,19 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-numexpr \
                         port:zlib \
                         port:bzip2 \
-                        port:lzo2 \
-                        port:blosc
+                        port:lzo2
 
     if {${python.version} >= 38} {
         depends_lib-append  port:py${python.version}-blosc2 \
                             port:py${python.version}-cpuinfo
 
-        build.env-append    BLOSC2_DIR=${python.prefix}
-        destroot.env-append BLOSC2_DIR=${python.prefix}
+        build.env-append    BLOSC2_DIR=${prefix}
+        destroot.env-append BLOSC2_DIR=${prefix}
+    } else {
+        depends_lib-append  port:blosc
+
+        build.env-append    BLOSC_DIR=${prefix}
+        destroot.env-append BLOSC_DIR=${prefix}
     }
 
     post-patch {


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
