### PR TITLE
vitables: new port

### DIFF
--- a/python/vitables/Portfile
+++ b/python/vitables/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                vitables
+version             3.0.3
+revision            0
+
+categories-append   science
+platforms           {darwin any}
+supported_archs     noarch
+maintainers         nomaintainer
+license             GPL-3+
+
+description         ViTables is a graphical tool for PyTables.
+long_description    ViTables is a graphical browser for HDF5 and PyTables files. It allows you to \
+                    open HDF5 files, browse their contents and display datasets.
+
+homepage            https://github.com/uvemas/ViTables
+
+checksums           sha256  24570963c1a2fc8df3ecb39a736256a5384aff114b56540c6bdad7c4197881a0 \
+                    rmd160  f3f66b119afa25b018830f1d10d8c176e44164e3 \
+                    size    871792
+
+python.default_version  312
+python.pep517_backend   hatch
+
+depends_lib-append  port:py${python.version}-tables \
+                    port:py${python.version}-qtpy


### PR DESCRIPTION
#### Description

Note that vitables depends on tables. The subport of `py312-tables` is in #25000 

I've only tested `py312-vitables`. So I set the python version start from 3.8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
