### PR TITLE
openjdk22-temurin: update to 22.0.2

### DIFF
--- a/java/openjdk22-temurin/Portfile
+++ b/java/openjdk22-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.1
-set build    8
+version      ${feature}.0.2
+set build    9
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature}
@@ -27,14 +27,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  64a21ef7bf13e885923492fc54387c53ee8d0ea7 \
-                 sha256  9445952d4487451af024a9a3f56373df76fbd928d9ff9186988aa27be2e4f10c \
-                 size    192732365
+    checksums    rmd160  7c8c329a7ebc8138e64de2463bc4084be2668be1 \
+                 sha256  f3f411a4c685699980ad0ef2cac994d0450fc40d4a75d3d16b73857f76c9a982 \
+                 size    192757195
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  d9180cd45f1f7b9f07f6d603ea05c8c86c4a63e3 \
-                 sha256  80d6fa75e87280202ae7660139870fe50f07fca9dc6c4fbd3f2837cbd70ec902 \
-                 size    190213165
+    checksums    rmd160  272cb7a6bf31de7e149426ea4eead80e0b816516 \
+                 sha256  6f7bd166c46094cf48018b018b161eae838a01dddce9d6fc5800eed353d37b84 \
+                 size    190244281
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 22.0.2.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?