### PR TITLE
uv: Update to 0.2.27

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.2.26
+github.setup            astral-sh uv 0.2.27
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -17,9 +17,9 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for common pip and pip-tools workflows.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  e6ca29047b2d93a74fff2c28ec9ea063fa9b6878 \
-                        sha256  4ae92e7625499049671fd48e20b528da73f02214cec471531c7a776b6e1bdd19 \
-                        size    1401835
+                        rmd160  5239fc430692e6c982d086c90ef7abcc378c1dba \
+                        sha256  3b1db2e23d4e996c025e617e41c2fed2debe80d9bea14906c1cb3db28cb09baf \
+                        size    1421504
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.2.27

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
