### PR TITLE
colima: Upgrade to 0.6.10

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.6.9 v
+go.setup            github.com/abiosoft/colima 0.6.10 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  cc2559fb2bb65674daf6320a2c0f3f87907d6c71 \
-                    sha256  97e04f0f28effcf519d76e5307a14e5d87da038946be0da980d9d7c9d95b3c11 \
-                    size    608586
+checksums           rmd160  65431f9b2b95b022ec4a14367d344b2d3ea3faa7 \
+                    sha256  619b87083826e97291d29254562c50bbc8c945099fa1d0b582896669c0338b1d \
+                    size    608988
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

colima: Upgrade to 0.6.10

##### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
