### PR TITLE
py-meson: Update patch-meson64-32bit-apple.diff

### DIFF
--- a/python/py-meson/Portfile
+++ b/python/py-meson/Portfile
@@ -8,7 +8,7 @@ name                py-meson
 # update version and revision also in the meson port
 github.setup        mesonbuild meson 1.5.0
 github.tarball_from releases
-revision            0
+revision            1
 
 checksums           rmd160  a344eeb69d38eff4e54334caf1ca25941b08a6f4 \
                     sha256  45d7b8653c1e5139df35b33be2dd5b2d040c5b2c6129f9a7c890d507e33312b8 \

--- a/python/py-meson/files/patch-meson64-32bit-apple.diff
+++ b/python/py-meson/files/patch-meson64-32bit-apple.diff
@@ -1,5 +1,13 @@
 --- mesonbuild/environment.py.orig	2020-07-05 13:13:14.000000000 -0700
 +++ mesonbuild/environment.py	2020-07-14 13:46:43.000000000 -0700
+@@ -14,6 +14,7 @@
+ 
+ import itertools
+ import os, platform, re, sys, shutil
++import subprocess
+ import typing as T
+ import collections
+ 
 @@ -314,6 +314,23 @@
              return 'x86'
      return os_arch


### PR DESCRIPTION
#### Description

"sudo port install glib2" was failing on OS X 10.4 Tiger (32-bit) with meson build reporting "subprocess" being an undefined symbol.

The above used to happen because patch-meson64-32bit-apple.diff introduces some code which depends on "subprocess" python module but the module itself was not imported.

This change updates patch-meson64-32bit-apple.diff file to include an import statement for the "subprocess" module to resolve the described failure.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.4.11 8S2169 i386
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?