### PR TITLE
openjdk11: update to 11.0.24

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 
 name                openjdk11
 # See https://openjdk-sources.osci.io/openjdk11/ for the version and build number that matches the latest '-ga' version
-version             11.0.23
-set build 9
-revision            1
+version             11.0.24
+set build 8
+revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -20,9 +20,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  0b31aa900cefffb02d0fea57c81e49ed7e442484 \
-                    sha256  f51be67721f6cb8d14b0cd75cc9b53634e7d83e808148940d64e67c8b77accfc \
-                    size    71402820
+checksums           rmd160  af111ef6eb5258d12d6e60abcb8ebd1f2786a773 \
+                    sha256  7a261e4140ee301dfa7c8cdbf0e09f1dc62c653723561ba3f9ca1851958ada81 \
+                    size    72182240
 
 depends_lib         port:freetype \
                     port:libiconv


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.24.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?