### PR TITLE
openjdk17: update to 17.0.12

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 
 name                openjdk17
 # See https://openjdk-sources.osci.io/openjdk17/ for the version and build number that matches the latest '-ga' version
-version             17.0.11
-set build 9
-revision            1
+version             17.0.12
+set build 7
+revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -20,9 +20,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  ddb86858821a2bd81ecf7067984dd6495337a093 \
-                    sha256  d16068baa8124125fb3dffd6a18fbea01df3f01658cfe4fbfcc85e4d48ab2bbb \
-                    size    65851368
+checksums           rmd160  411ea9d5a7d8b87317a8945e04fcc4c14cdb5086 \
+                    sha256  efeb07211d69b8b2abf2b8930b6fce359c0917def5646e78f95bd33e9cb425b2 \
+                    size    65821300
 
 depends_lib         port:freetype \
                     port:libiconv


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.12.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?