### PR TITLE
libzdb-mysql55: add postgresql16 variant

### DIFF
--- a/databases/libzdb-mysql55/Portfile
+++ b/databases/libzdb-mysql55/Portfile
@@ -26,7 +26,8 @@ master_sites        ${homepage}dist/
 distname            ${name_package}-${version}
 
 checksums           rmd160  1838d7b7058db6a7dae155bd89912f660380818a \
-                    sha256  37e6bd3d8254be7d8fe1419cf0500b9006783d0e3544eeeffc5e6954cbcd07d4
+                    sha256  37e6bd3d8254be7d8fe1419cf0500b9006783d0e3544eeeffc5e6954cbcd07d4 \
+                    size    599160
 
 configure.args      --with-sysroot=${prefix} \
                     --enable-optimized \
@@ -86,12 +87,7 @@ foreach mp.name ${mp.names} {
 }
 
 set mp.ports {
-    postgresql82
-    postgresql83
-    postgresql84
-    postgresql90
-    postgresql91
-    postgresql92
+    postgresql16
 }
 set mp.names        {}
 foreach mp.port ${mp.ports} {
@@ -113,10 +109,7 @@ foreach mp.name ${mp.names} {
         configure.args-delete \
                             --without-postgresql
         configure.args-append \
-                            --with-postgresql=${prefix}/lib/${mp.port}/bin/pg_config \
-                            --libdir=${prefix}/lib/${subport} \
-                            --includedir=${prefix}/include/${subport} \
-                            --datarootdir=${prefix}/share/${subport}
+                            --with-postgresql=${prefix}/lib/${mp.port}/bin/pg_config
     }
 
 }


### PR DESCRIPTION
#### Description

I can confirm this builds and links against PostgreSQL 16 but can't test its functionality.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
