### PR TITLE
pgpool-II: update to 4.5.2

### DIFF
--- a/databases/pgpool-II/Portfile
+++ b/databases/pgpool-II/Portfile
@@ -1,42 +1,36 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
 
-name			pgpool-II
-version			3.1
-categories		databases
-platforms		darwin
-maintainers		nomaintainer
-description		PostgreSQL connection pool server
-long_description	pgpool is a connection server program for PostgreSQL. \
-			It runs between PostgreSQL's client(frontend) and \
-			server(backend). Any PostgreSQL clients can connect to \
-			pgpool as if it's a real PostgreSQL server. It \
-			supports connection pooling, failover and replication.
+name                pgpool-II
+version             4.5.2
+categories          databases
+platforms           darwin
+license             MIT
+maintainers         nomaintainer
+description         PostgreSQL connection pool server
+long_description    pgpool is a connection server program for PostgreSQL. \
+                    It runs between PostgreSQL's client(frontend) and \
+                    server(backend). Any PostgreSQL clients can connect to \
+                    pgpool as if it's a real PostgreSQL server. It \
+                    supports connection pooling, failover and replication.
 
-homepage		http://pgpool.projects.postgresql.org/
-master_sites		http://pgfoundry.org/frs/download.php/3114/
-checksums           md5 dbb591a8aa3c3bd1e689f41a7638b9ee \
-                    sha1 6a6c972c5b01313bf6706e3ebf0db02f250f9890 \
-                    rmd160 d4c5774cb98ce09672ed014b7269f4a8a803b5e5
+homepage            https://www.pgpool.net/
+master_sites        ${homepage}mediawiki/images/
+checksums           rmd160  d6869fde4558a9e2edae311e59c9e37eda670482 \
+                    sha256  480ac23f01cd7d6c856b29386bf17a848712fb4b4057d4c8abd5c8bf819bdf06 \
+                    size    5188613
 
-configure.env		PATH=$env(PATH):${prefix}/lib/postgresql90/bin
-configure.args		--bindir=${prefix}/sbin/${name} \
-			--mandir=${prefix}/share/man/${name} \
-			--sysconfdir=${prefix}/etc/${name}
-depends_build		port:postgresql90
+depends_build        port:postgresql16
+
+configure.env       PGCONFIG=${prefix}/lib/postgresql16/bin/pg_config
 
 post-destroot {
-	xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
-	xinstall -m 644 -W ${worksrcpath} AUTHORS COPYING ChangeLog NEWS \
-		README README.euc_jp TODO ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} AUTHORS COPYING ChangeLog NEWS \
+        README TODO ${destroot}${prefix}/share/doc/${name}
 }
 
-livecheck.type	regex
-livecheck.url	http://pgfoundry.org/frs/?group_id=1000055
-livecheck.regex	pgpool-II-(\[0-9\\.\]+)\\.tar\\.gz
-
-variant postgresql84 description {uses postgresql84 installation} {
-	depends_build		port:postgresql84
-	configure.env		PATH=$env(PATH):${prefix}/lib/postgresql84/bin
-}
+livecheck.type      regex
+livecheck.url       https://pgpool.net/mediawiki/index.php/Downloads
+livecheck.regex     pgpool-II-(\[0-9\\.\]+)\\.tar\\.gz


### PR DESCRIPTION
#### Description

I can confirm this builds and links against postgresql, however, I am unable to test the program out. The changes from 3.x->4.x are mostly around [configuration](https://www.pgpool.net/docs/latest/en/html/release-4-0.html), I imagine that in the six years since release of 4.x users have had time to update their configurations.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
