### PR TITLE
msp430-elf-gcc: fix version bug

### DIFF
--- a/cross/msp430-elf-gcc/Portfile
+++ b/cross/msp430-elf-gcc/Portfile
@@ -3,11 +3,17 @@
 PortSystem          1.0
 PortGroup           crossgcc 1.0
 
+# This post-extract block must be declared before the one created by crossgcc.setup.
+post-extract {
+    ln -s gcc-${crossgcc.version} ${workpath}/gcc-${version}
+}
+
 crossgcc.setup      msp430-elf 9.3.0
 crossgcc.setup_libc newlib 2.4.0
 
-# Align with TI's versioning
 version             9.3.1.2
+revision            1
+
 set vers_patch      9.3.1.11
 set name_patch      msp430-gcc-${vers_patch}-source-patches
 set file_patch      ${name_patch}.tar.bz2
@@ -25,22 +31,18 @@ checksums-append    ${file_patch} \
                     sha256  ec6472b034e11e8cfdeb3934b218e5bafbb7a03f3afc0e76536bd9c42653525b \
                     size    283677
 
-# Bump back version so that newlib will compile correctly.
-pre-extract {
-    version         9.3.0
-}
-
 depends_run         port:msp430-gcc-support-files
 
 depends_extract-append \
                     port:bzip2
 
 post-extract {
-    system -W ${workpath} "${prefix}/bin/bzip2 -dc ${distpath}/${file_patch} | /usr/bin/tar xf -"
+    system -W ${workpath} "${prefix}/bin/bzip2 -dc [shellescape ${distpath}/${file_patch}] | /usr/bin/tar xf -"
 }
+
 pre-patch {
-    system -W ${worksrcpath} "/usr/bin/patch -p0 < ${workpath}/${name_patch}/gcc-${version}.patch"
-    system -W ${workpath}/newlib-2.4.0 "/usr/bin/patch -p0 < ${workpath}/${name_patch}/newlib-2_4_0.patch"
+    system -W ${worksrcpath} "/usr/bin/patch -p0 < [shellescape ${workpath}/${name_patch}/gcc-9.3.0.patch]"
+    system -W ${workpath}/newlib-2.4.0 "/usr/bin/patch -p0 < [shellescape ${workpath}/${name_patch}/newlib-2_4_0.patch]"
 }
 
 # gcc_system.diff: See https://gcc.gnu.org/bugzilla/show_bug.cgi?format=multiple&id=111632


### PR DESCRIPTION
#### Description

Fix bug #70411 reported on https://trac.macports.org/ticket/70411.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
