### PR TITLE
imposm: update to 0.14.0

### DIFF
--- a/gis/imposm/Portfile
+++ b/gis/imposm/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/omniscale/imposm3 0.13.2 v
+go.setup            github.com/omniscale/imposm3 0.14.0 v
 go.offline_build    no
 github.tarball_from archive
 name                imposm
@@ -16,9 +16,9 @@ description         Imposm imports OpenStreetMap data into PostGIS
 long_description    {*}${description}
 homepage            https://imposm.org/
 
-checksums           rmd160  8ef9d81817ac8df05c746e9ce54c83ff8cae1fc3 \
-                    sha256  a4edb7626d929919224c3778af5a2f2d11539a5d5c30fec00bacacbc39dfb7a0 \
-                    size    2284495
+checksums           rmd160  c38438da85916336a7b7c3bb33a4a3fb8aaab01b \
+                    sha256  d6b012497eff1b8faa25d125ce0becb97f68c95a68dd2c35cf65a0bf3c34b833 \
+                    size    2350908
 
 depends_lib-append  port:geos \
                     port:leveldb


### PR DESCRIPTION
#### Description
https://github.com/omniscale/imposm3/releases/tag/v0.14.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
