### PR TITLE
tio: replace post-patch with upstream fix, revbump to pick changes

### DIFF
--- a/comms/tio/Portfile
+++ b/comms/tio/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 github.setup            tio tio 3.6 v
 github.tarball_from     releases
-revision                0
+revision                1
 
 categories              comms
 installs_libs           no
@@ -31,14 +31,9 @@ checksums               rmd160  d403f8d5d371a8d6020a85c1ce5c7ecc729c5f27 \
                         sha256  04a91686f8a19f157b885a7c146a138b4cff6a3fb8dba48723d1fdad15c61167 \
                         size    3458048
 
-# https://lists.apple.com/archives/macnetworkprog/2002/Dec/msg00091.html
-# After (!) 18 years, it has only been implemented in macOS Big Sur
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    post-patch {
-        reinplace "s|MSG_NOSIGNAL|SO_NOSIGPIPE|" \
-        ${worksrcpath}/src/socket.c
-    }
-}
+# https://github.com/tio/tio/issues/265
+# remove this patch in the next release
+patchfiles-append       patch-socket.diff
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 

--- a/comms/tio/files/patch-socket.diff
+++ b/comms/tio/files/patch-socket.diff
@@ -1,0 +1,34 @@
+From 6163bc392bd353c2157d3e5a29bf914ada541100 Mon Sep 17 00:00:00 2001
+From: Martin Lund <martin.lund@keep-it-simple.com>
+Date: Sat, 20 Jul 2024 08:23:59 +0200
+Subject: [PATCH] Fix socket send call on platforms without MSG_NOSIGNAL
+
+To fix build issue encountered on MacOS Catalina but may apply to other
+platforms.
+--- src/socket.c
++++ src/socket.c
+@@ -226,7 +226,11 @@ void socket_configure(void)
+         exit(EXIT_FAILURE);
+     }
+ 
++#if defined(SO_NOSIGPIPE) && !defined(MSG_NOSIGNAL)
++    if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR | SO_NOSIGPIPE, &optval, sizeof(optval)))
++#else
+     if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)))
++#endif
+     {
+         tio_error_printf("Failed to set socket options (%s)", strerror(errno));
+         exit(EXIT_FAILURE);
+@@ -270,7 +274,12 @@ void socket_write(char input_char)
+     {
+         if (clientfds[i] != -1)
+         {
++
++#if defined(SO_NOSIGPIPE) && !defined(MSG_NOSIGNAL)
++            if (send(clientfds[i], &input_char, 1, 0) <= 0)
++#else
+             if (send(clientfds[i], &input_char, 1, MSG_NOSIGNAL) <= 0)
++#endif
+             {
+                 tio_error_printf_silent("Failed to write to socket (%s)", strerror(errno));
+                 close(clientfds[i]);


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
