### PR TITLE
google-cloud-sdk: update to 485.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             484.0.0
+version             485.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  cbd7125d90b4d03d03f888cdb55fdc4cbeebf959 \
-                    sha256  367bea1c994dc14e187b74efedabe6d8825ee8065aec77311b70ccfe8c16eaed \
-                    size    51160326
+    checksums       rmd160  0f66fad0b58234ac7c095f87739b57bd2e00ed22 \
+                    sha256  c754495321a5cf07913480bb3268ae3501dfecf744a54a762c99a283fdfd2f6c \
+                    size    51253501
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  6cfb174e0a53d817952f9be6aa63689273b62e64 \
-                    sha256  fd1f9bd53f5cdc07bfe72bda042d1c94218e5d05535e5ab00446fb0d03504f5b \
-                    size    52513502
+    checksums       rmd160  8a58eb8068881469652d2f8b80f5f0e879bf60c1 \
+                    sha256  11aa7c62ae7c571c80546b8efbfbb189f7f33a11e757147b39cad4764cf9067e \
+                    size    52604404
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  0340b709991160ea7da42d546c8d089c324dd4aa \
-                    sha256  e9f37781b052b3cda731bb0b729554f73b482dbeb40727f89faf3050fee31d11 \
-                    size    52460879
+    checksums       rmd160  6423548797b50b4e250184d34b03ab3161be084e \
+                    sha256  c33c1d2baa5fc4ee952869b41658f78d064120260701a74efc3534158328daf4 \
+                    size    52552059
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 485.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?