### PR TITLE
openjdk21: update to 21.0.4

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 
 name                openjdk21
 # See https://openjdk-sources.osci.io/openjdk21/ for the version and build number that matches the latest '-ga' version
-version             21.0.3
-set build 9
-revision            1
+version             21.0.4
+set build 7
+revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -20,9 +20,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  0c3c2fc6f9460460c6804c914b916f8d67fdc8e9 \
-                    sha256  1a73d369c125ca45240a02f8b5c4b01b113d5fa7041145bb6492807d123d4da7 \
-                    size    69593116
+checksums           rmd160  54dd5afc18c2b631b7d70e51d69cb69c8456d551 \
+                    sha256  d171ebc9bf386b597e5fbcc41729d64bfb4b309670e4dc22fc05ef7b56d45152 \
+                    size    69647724
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.4.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?