### PR TITLE
Meson 1.5.0 patch to solve destroot build error.

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                meson
 version             1.5.0
-revision            1
+revision            0
 
 license             Apache-2
 categories-prepend  devel

--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                meson
 version             1.5.0
-revision            0
+revision            1
 
 license             Apache-2
 categories-prepend  devel

--- a/python/py-meson/Portfile
+++ b/python/py-meson/Portfile
@@ -8,7 +8,7 @@ name                py-meson
 # update version and revision also in the meson port
 github.setup        mesonbuild meson 1.5.0
 github.tarball_from releases
-revision            0
+revision            1
 
 checksums           rmd160  a344eeb69d38eff4e54334caf1ca25941b08a6f4 \
                     sha256  45d7b8653c1e5139df35b33be2dd5b2d040c5b2c6129f9a7c890d507e33312b8 \
@@ -71,6 +71,15 @@ if {${subport} ne ${name}} {
 
     # add a search path for crossfiles in our prefix
     patchfiles-append   patch-meson-search-prefix-for-cross-files.diff
+    
+    # temporary fix for the destroot failure on a lot of packages using meson build
+    # Since version release 1.5.0 on darwin platform.
+    # This fix is poroposed to mesonbuild by :
+    # holymonson (Monson Shao)
+    # This patch will need to be removed by next meson release upgrade if 
+    # meson solved the problem upstream on next release.
+    patchfiles-append   duplicate-rpath-delete-darwin-fix.diff
+    
 
     platform darwin 8 {
         # this meson is modified for systems without @rpath support

--- a/python/py-meson/Portfile
+++ b/python/py-meson/Portfile
@@ -74,10 +74,7 @@ if {${subport} ne ${name}} {
     
     # temporary fix for the destroot failure on a lot of packages using meson build
     # Since version release 1.5.0 on darwin platform.
-    # This fix is poroposed to mesonbuild by :
-    # holymonson (Monson Shao)
-    # This patch will need to be removed by next meson release upgrade if 
-    # meson solved the problem upstream on next release.
+    # https://trac.macports.org/ticket/70394#comment:5
     patchfiles-append   duplicate-rpath-delete-darwin-fix.diff
     
 

--- a/python/py-meson/files/duplicate-rpath-delete-darwin-fix.diff
+++ b/python/py-meson/files/duplicate-rpath-delete-darwin-fix.diff
@@ -1,0 +1,28 @@
+--- mesonbuild/scripts/depfixer.py.orig	2024-07-01 17:31:21.000000000 +0200
++++ mesonbuild/scripts/depfixer.py	2024-07-24 12:56:26.000000000 +0200
+@@ -379,11 +379,14 @@
+             # note: e.get_rpath() and e.get_runpath() may be useful
+             e.fix_rpath(fname, rpath_dirs_to_remove, new_rpath)
+ 
+-def get_darwin_rpaths(fname: str) -> T.List[str]:
++def get_darwin_rpaths(fname: str) -> OrderedSet[str]:
+     p, out, _ = Popen_safe(['otool', '-l', fname], stderr=subprocess.DEVNULL)
+     if p.returncode != 0:
+         raise subprocess.CalledProcessError(p.returncode, p.args, out)
+-    result = []
++    # Need to deduplicate rpaths, as macOS's install_name_tool
++    # is *very* allergic to duplicate -delete_rpath arguments
++    # when calling depfixer on installation.
++    result = OrderedSet()
+     current_cmd = 'FOOBAR'
+     for line in out.split('\n'):
+         line = line.strip()
+@@ -394,7 +397,7 @@
+             current_cmd = value
+         if key == 'path' and current_cmd == 'LC_RPATH':
+             rp = value.split('(', 1)[0].strip()
+-            result.append(rp)
++            result.add(rp)
+     return result
+ 
+ def fix_darwin(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: str, final_path: str, install_name_mappings: T.Dict[str, str]) -> None:


### PR DESCRIPTION
 Since meson release 1.5.0 we do have a lot of packages using mesonbuild who do not build anymore
 Failure is during destroot install phase while excuting install_name_tool command.
 Tickets :
 https://trac.macports.org/ticket/70394
 https://trac.macports.org/ticket/69760#comment:3
 This patch is made by :
 holymonson (Monson Shao)
 Proposed to macports master by:
 christophecvr (christophecvr)

 Closes :  https://trac.macports.org/ticket/70394

 On branch master
 Changes to be committed:
	modified:   devel/meson/Portfile
	modified:   python/py-meson/Portfile
	new file:   python/py-meson/files/duplicate-rpath-delete-darwin-fix.diff

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6
Xcode 10.1 / Command Line Tools 10.1.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
