### PR TITLE
LucenePlusPlus: fix on 10.7–10.11

### DIFF
--- a/devel/LucenePlusPlus/Portfile
+++ b/devel/LucenePlusPlus/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           boost 1.0
 PortGroup           cmake 1.1
 PortGroup           conflicts_build 1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 boost.version       1.78
@@ -34,6 +35,16 @@ conflicts_build     gtest
 
 compiler.cxx_standard   2011
 compiler.c_standard     2011
+
+# error: unknown argument: '-fno-pch-timestamp'
+# https://github.com/luceneplusplus/LucenePlusPlus/issues/205
+# error: use of undeclared identifier 'max_align_t'
+# std::size_t size, std::size_t align = BOOST_ASIO_DEFAULT_ALIGN)
+# error: default initialization of an object of const type 'void *const'
+# void* const pointer = aligned_new(align, chunks * chunk_size + 1);
+# https://github.com/luceneplusplus/LucenePlusPlus/issues/206
+compiler.blacklist-append \
+                    {clang < 900}
 
 configure.pre_args-replace \
                     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \


### PR DESCRIPTION
#### Description

Fix builds

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5
Xcode 5.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
