### PR TITLE
felix & fx have mutual conflicts

### DIFF
--- a/sysutils/felix/Portfile
+++ b/sysutils/felix/Portfile
@@ -6,11 +6,13 @@ PortGroup           github  1.0
 
 github.setup        kyoheiu felix 2.13.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         tui file manager with vim-like key mapping
 
 long_description    {*}${description}
+
+conflicts           fx
 
 categories          sysutils
 installs_libs       no

--- a/sysutils/fx/Portfile
+++ b/sysutils/fx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/antonmedv/fx 35.0.0
-revision            0
+revision            1
 
 homepage            https://fx.wtf
 
@@ -17,6 +17,8 @@ maintainers         {@sikmir disroot.org:sikmir} \
 
 description         Terminal JSON viewer & processor
 long_description    {*}${description}
+
+conflicts           felix
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

- **felix: conflicts with sysutils/fx**
- **fx: conflicts with sysutils/felix**

###### Type(s)

- [x] bugfix

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?

Mutual installs now properly fail early when the conflicting port is active.

```console
Error: Can't install felix because conflicting ports are active: fx
```

Should we consider having a `felix+felix` variant that installs felix as `felix` instead of `fx`?
