### PR TITLE
audacious: set correct compiler standards, fix build with gcc and for powerpc

### DIFF
--- a/multimedia/audacious-core/Portfile
+++ b/multimedia/audacious-core/Portfile
@@ -44,7 +44,8 @@ depends_lib         port:libiconv \
                     path:lib/pkgconfig/dbus-1.pc:dbus \
                     path:lib/pkgconfig/glib-2.0.pc:glib2
 
-compiler.cxx_standard   2011
+compiler.c_standard     1999
+compiler.cxx_standard   2017
 
 configure.args      -Ddbus=true \
                     -Dqt=false \

--- a/multimedia/audacious-core/Portfile
+++ b/multimedia/audacious-core/Portfile
@@ -52,7 +52,8 @@ configure.args      -Ddbus=true \
                     -Dgtk=false \
                     -Dvalgrind=false
 
-depends_build       port:pkgconfig
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
 
 post-destroot {
     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${real_name}

--- a/multimedia/audacious-core/Portfile
+++ b/multimedia/audacious-core/Portfile
@@ -85,9 +85,14 @@ variant gtk3 conflicts gtk2 description {Add GTK3 support} {
     configure.args-append   -Dgtk3=true
 }
 
-# Need either one of gtk2, gtk3 or Qt5 to have a GUI. Default to qt5, which is preferred by upstream.
+# Need either one of gtk2, gtk3 or Qt5 to have a GUI.
+# On 10.7+ default to qt5, which is preferred by upstream.
 if {![variant_isset gtk2] && ![variant_isset gtk3] && ![variant_isset qt5]} {
-    default_variants-append +qt5
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        default_variants-append +gtk3
+    } else {
+        default_variants-append +qt5
+    }
 }
 
 livecheck.type      regex

--- a/multimedia/audacious-plugins/Portfile
+++ b/multimedia/audacious-plugins/Portfile
@@ -125,6 +125,22 @@ configure.args-append \
 configure.args-append \
                     -Dmoonstone=false
 
+# https://github.com/audacious-media-player/audacious-plugins/pull/166
+patchfiles-append   0001-xsf-desmume-types.h-ensure-LOCAL_BE-gets-defined-on-.patch
+
+# SPInvocationGrabbing.m: error: '-fobjc-exceptions' is required to enable Objective-C exception syntax
+# SPInvocationGrabbing.m: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
+# SPInvocationGrabbing.m: note: use option '-std=c99', '-std=gnu99', '-std=c11' or '-std=gnu11' to compile your code
+patchfiles-append   0002-mac-media-keys-use-correct-objc-flags.patch
+
+# Even if we disable blocks to make it build with GCC, it is broken
+# and outputs only hiss. Use SDL audio out instead, until fixed.
+# FIXME: https://github.com/audacious-media-player/audacious/issues/1440
+platform darwin powerpc {
+    configure.args-replace \
+                    -Dcoreaudio=true -Dcoreaudio=false
+}
+
 default_variants    +full
 
 depends_build-append \

--- a/multimedia/audacious-plugins/Portfile
+++ b/multimedia/audacious-plugins/Portfile
@@ -40,7 +40,8 @@ depends_lib         port:audacious-core \
 
 depends_run         port:unzip
 
-compiler.cxx_standard   2011
+compiler.c_standard     1999
+compiler.cxx_standard   2017
 
 # Options order per meson_options.txt
 # gui

--- a/multimedia/audacious-plugins/Portfile
+++ b/multimedia/audacious-plugins/Portfile
@@ -410,9 +410,13 @@ if {![variant_isset sdl1]} {
 }
 
 # Need either one of gtk2, gtk3 or Qt5 to have a GUI.
-# Default to qt5, which is preferred by upstream.
-if {![variant_isset gtk2] && ![variant_isset gtk3]} {
-    default_variants-append +qt5
+# On 10.7+ default to qt5, which is preferred by upstream.
+if {![variant_isset gtk2] && ![variant_isset gtk3] && ![variant_isset qt5]} {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        default_variants-append +gtk3
+    } else {
+        default_variants-append +qt5
+    }
 }
 
 # UI required variants

--- a/multimedia/audacious-plugins/Portfile
+++ b/multimedia/audacious-plugins/Portfile
@@ -127,7 +127,8 @@ configure.args-append \
 
 default_variants    +full
 
-depends_build       port:pkgconfig
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
 
 post-destroot {
     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}

--- a/multimedia/audacious-plugins/files/0001-xsf-desmume-types.h-ensure-LOCAL_BE-gets-defined-on-.patch
+++ b/multimedia/audacious-plugins/files/0001-xsf-desmume-types.h-ensure-LOCAL_BE-gets-defined-on-.patch
@@ -1,0 +1,23 @@
+From 343d20c6ece2d48dba06a8ba4f474499a8a3a1f0 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Thu, 25 Jul 2024 23:33:55 +0800
+Subject: [PATCH] xsf/desmume/types.h: ensure LOCAL_BE gets defined on
+ Big-endian platforms
+
+---
+ src/xsf/desmume/types.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git src/xsf/desmume/types.h src/xsf/desmume/types.h
+index 61d858cec..d3113fccd 100644
+--- src/xsf/desmume/types.h
++++ src/xsf/desmume/types.h
+@@ -96,7 +96,7 @@ using s8 = int8_t;
+ 
+ /*----------------------*/
+ 
+-#ifdef __BIG_ENDIAN__
++#if defined(__BIG_ENDIAN__) || (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+ # ifndef WORDS_BIGENDIAN
+ #  define WORDS_BIGENDIAN
+ # endif

--- a/multimedia/audacious-plugins/files/0002-mac-media-keys-use-correct-objc-flags.patch
+++ b/multimedia/audacious-plugins/files/0002-mac-media-keys-use-correct-objc-flags.patch
@@ -1,0 +1,21 @@
+From f850f8be295d0765b17f6a4612ecea7c6a6d59e6 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Thu, 25 Jul 2024 23:36:09 +0800
+Subject: [PATCH] mac-media-keys: use correct objc flags
+
+---
+ src/mac-media-keys/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git src/mac-media-keys/meson.build src/mac-media-keys/meson.build
+index 72663781d..c647a2f98 100644
+--- src/mac-media-keys/meson.build
++++ src/mac-media-keys/meson.build
+@@ -9,6 +9,7 @@ shared_module('mac-media-keys',
+   mac_media_keys_sources,
+   dependencies: [audacious_dep],
+   name_prefix: '',
++  objc_args: ['-std=c99', '-fobjc-exceptions'],
+   objcpp_args: '-std=c++11',
+   link_args: ['-framework', 'AppKit', '-framework', 'Carbon'],
+   install: true,


### PR DESCRIPTION
#### Description

Ports are broken on older systems due to a wrong C++ standard in the portfile. Fix that.
```
# meson.build:119:7: ERROR: C++ Compiler does not support -std=gnu++17
```
Source: https://github.com/audacious-media-player/audacious/blob/005eae06671dab4331bd0d8316072e98601bf254/meson.build#L5-L6

Switch < 10.7 to GTK3 by default, since Qt5 is broken there on all archs.

Fix build with gcc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5
Xcode 5.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
