### PR TITLE
QMPlay2: fix installation on new systems after switch to Ninja

### DIFF
--- a/multimedia/QMPlay2/Portfile
+++ b/multimedia/QMPlay2/Portfile
@@ -77,7 +77,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 15} {
                         1001-Fix-Qt-paths.patch
      } else {
         github.setup    zaps166 QMPlay2 24.06.16
-        revision        0
+        revision        1
         checksums       rmd160  b1851ab0fc52849471cc4f3a2d19a01d068fa864 \
                         sha256  7b06be4b95cb15064015934b24e76e583b85398136fc28b622dc1118d07c55b4 \
                         size    2042180
@@ -117,10 +117,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 15} {
     post-destroot {
         system "install_name_tool -id ${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib \
                     ${destroot}${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib"
-        system "install_name_tool -change ${prefix}/lib/libqmplay2.dylib \
+        if {${os.platform} eq "darwin" && ${os.major} < 15} {
+            system "install_name_tool -change ${prefix}/lib/libqmplay2.dylib \
                     ${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib \
                     ${destroot}${applications_dir}/${name}.app/Contents/MacOS/QMPlay2"
-        if {${os.platform} eq "darwin" && ${os.major} < 15} {
             foreach dylib [ exec find ${destroot}${applications_dir}/${name}.app/Contents/MacOS/modules -name "\*.dylib" ] {
                 regsub ":$" ${dylib} "" destroot_dylib_path
                 regsub ${destroot} ${destroot_dylib_path} "" dylib_path
@@ -129,11 +129,14 @@ if {${os.platform} eq "darwin" && ${os.major} < 15} {
                     ${destroot_dylib_path}"
             }
         } else {
+            system "install_name_tool -change @rpath/libqmplay2.dylib \
+                    ${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib \
+                    ${destroot}${applications_dir}/${name}.app/Contents/MacOS/QMPlay2"
             foreach so [ exec find ${destroot}${applications_dir}/${name}.app/Contents/MacOS/modules -name "\*.so" ] {
                 regsub ":$" ${so} "" destroot_so_path
                 regsub ${destroot} ${destroot_so_path} "" so_path
                 system "install_name_tool -id ${so_path} ${destroot_so_path}"
-                system "install_name_tool -change ${prefix}/lib/libqmplay2.dylib ${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib \
+                system "install_name_tool -change @rpath/libqmplay2.dylib ${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib \
                     ${destroot_so_path}"
             }
         }


### PR DESCRIPTION
#### Description

Some of the recent updates from upstream has broken the port due to `@rpath` being baked into libraries and app, which was not the case earlier, so our destroot fixup code did not work anymore. Perhaps this commit https://github.com/zaps166/QMPlay2/commit/7f9c183cf54d0a71893f46c986dfe3e0c13d9282 has broken it.

Fix the fix, revbump. Only newer systems affected, nothing changes for the earlier.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5
Xcode 15.4

macOS 10.15
Xcode 12.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
