### PR TITLE
libfilezilla: fix for 10.15 and some other systems

### DIFF
--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -40,6 +40,9 @@ worksrcdir          ${name}-${version}
 
 patchfiles-append   patch-util.diff
 
+# unix/poller.cpp:45:11: error: use of undeclared identifier 'errno'
+patchfiles-append   patch-errno.diff
+
 depends_build-append \
                     port:gettext \
                     path:bin/perl:perl5 \

--- a/devel/libfilezilla/files/patch-errno.diff
+++ b/devel/libfilezilla/files/patch-errno.diff
@@ -1,0 +1,10 @@
+--- lib/unix/poller.cpp	2022-04-01 20:35:07.000000000 +0800
++++ lib/unix/poller.cpp	2024-07-25 09:56:56.000000000 +0800
+@@ -7,6 +7,7 @@
+ #include "../libfilezilla/glue/unix.hpp"
+ #endif
+ #include <unistd.h>
++#include <errno.h>
+ 
+ namespace fz {
+ 


### PR DESCRIPTION
#### Description

Fix build error. Revbump, since the port does build for a number of systems, but now a header is added.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15
Xcode 12.4

macOS 10.6.8 (to make sure adding header does not break gcc build)
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
