### PR TITLE
netcalc: fix build where it fails

### DIFF
--- a/net/netcalc/Portfile
+++ b/net/netcalc/Portfile
@@ -25,3 +25,6 @@ checksums           rmd160  2121ba2768624540da37a7d8e711b0bbba29e64f \
                     size    126109
 
 conflicts           ipcalc
+
+# https://github.com/troglobit/netcalc/pull/25
+patchfiles-append   0001-netcalc.h-add-missing-include-for-macOS.patch

--- a/net/netcalc/files/0001-netcalc.h-add-missing-include-for-macOS.patch
+++ b/net/netcalc/files/0001-netcalc.h-add-missing-include-for-macOS.patch
@@ -1,0 +1,23 @@
+From f8f37546e9b4447d5490e507441dbee88052061a Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Fri, 26 Jul 2024 05:13:25 +0800
+Subject: [PATCH] netcalc.h: add missing include for macOS
+
+---
+ src/netcalc.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git src/netcalc.h src/netcalc.h
+index b31d669..0e5c30b 100644
+--- src/netcalc.h
++++ src/netcalc.h
+@@ -32,6 +32,9 @@
+ #include <config.h>
+ #include <stdint.h>
+ #include <err.h>		/* warnx() et al */
++#ifdef __APPLE__
++#include <sys/socket.h> /* Has to be included before net/if.h */
++#endif
+ #include <net/if.h>		/* IFNAMSIZ */
+ 
+ #define V4ADDR_VAL "0123456789."


### PR DESCRIPTION
#### Description

Fix build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
