### PR TITLE
papilo: switch to boost 1.81, fix build with gcc

### DIFF
--- a/math/papilo/Portfile
+++ b/math/papilo/Portfile
@@ -7,9 +7,13 @@ PortGroup               github 1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               compilers 1.0
 
+# Boost 1.76 has a bug in multiprecision library,
+# which leads to including x86 header on powerpc.
+boost.version           1.81
+
 # NOTE: PaPILO is a header-based library, please bump all dependent ports on update
 github.setup            scipopt papilo 2.1.4 v
-revision                1
+revision                2
 categories              math
 license                 {LGPL-3 GPL-3}
 
@@ -57,5 +61,11 @@ if {${name} eq ${subport}} {
 # PAPILO may be linked against libquadmath, prevent that by using GMP.
 configure.args-append   -DGMP=ON \
                         -DQUADMATH=OFF
+
+if {[string match *gcc* ${configure.compiler}]} {
+    # ___atomic_fetch_add_8
+    configure.ldflags-append \
+                        -latomic
+}
 
 test.run                yes


### PR DESCRIPTION
#### Description

Fix build with gcc, use boost 1.81

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
