### PR TITLE
just-fast: fetch using macports_distfiles

### DIFF
--- a/sysutils/just-fast/Portfile
+++ b/sysutils/just-fast/Portfile
@@ -16,6 +16,7 @@ github.setup        GiuseppeCesarano just-fast 276b7b860a641cadd8ef2abec7a77b672
 version             2023.12.18
 revision            0
 categories          sysutils
+supported_archs     i386 ppc ppc64 x86_64
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Just Fast is CLI file manager
@@ -24,7 +25,10 @@ long_description    {*}${description} with focus on speed in both \
 checksums           rmd160  1c2616efb46df754fb87b803674ff2efe6f50e57 \
                     sha256  61090cbe086062e4fc1e09f6059e31094a34a456fadddcc9b51010d162e601de \
                     size    43091
-github.tarball_from archive
+#github.tarball_from archive
+# https://lists.macports.org/pipermail/macports-users/2024-July/052820.html
+# upstream repository has been deleted for an unknown reason
+master_sites        macports_distfiles
 
 depends_lib-append  port:cxxopts \
                     port:FTXUI


### PR DESCRIPTION
https://lists.macports.org/pipermail/macports-users/2024-July/052820.html

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
