### PR TITLE
mtxclient, nheko: revbump for spdlog ABI change

### DIFF
--- a/net/mtxclient/Portfile
+++ b/net/mtxclient/Portfile
@@ -8,7 +8,7 @@ PortGroup           boost 1.0
 
 github.setup        Nheko-Reborn mtxclient 0.9.2 v
 epoch               2
-revision            11
+revision            12
 
 checksums           rmd160  4584fdcd4d6632a531343f235ec2258f7ba38204 \
                     sha256  14df722738830510edf8768b24648568d46f392953c9b2f8d1bf749f0c12435d \

--- a/net/nheko/Portfile
+++ b/net/nheko/Portfile
@@ -7,7 +7,7 @@ PortGroup           qt5 1.0
 PortGroup           boost 1.0
 
 github.setup        nheko-reborn nheko 0.11.3 v
-revision            3
+revision            4
 checksums           rmd160  a25950b5483becc488ccc42b32bb9c6913a64ff8 \
                     sha256  f285156884a3a0c6870f3fba89c13d1fd70c8727bd179d8310b13819f8a63a37 \
                     size    1780179


### PR DESCRIPTION
#### Description

44d5472e3a5ab532ac23ecb98d6345f8799eb5bf changed the ABI of spdlog, but did not revbump its dependents.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
