### PR TITLE
fix: add setuptools as dep of vitables

### DIFF
--- a/python/vitables/Portfile
+++ b/python/vitables/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                vitables
 version             3.0.3
-revision            0
+revision            1
 
 categories-append   science
 platforms           {darwin any}
@@ -26,5 +26,6 @@ checksums           sha256  24570963c1a2fc8df3ecb39a736256a5384aff114b56540c6bda
 python.default_version  312
 python.pep517_backend   hatch
 
-depends_lib-append  port:py${python.version}-tables \
+depends_lib-append  port:py${python.version}-setuptools \
+                    port:py${python.version}-tables \
                     port:py${python.version}-qtpy


### PR DESCRIPTION
#### Description

https://github.com/macports/macports-ports/pull/25001#issuecomment-2252917174

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
