### PR TITLE
cpp-argparse-dev: update to v1.9.3

### DIFF
--- a/devel/cpp-argparse-dev/Portfile
+++ b/devel/cpp-argparse-dev/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            rue-ryuzaki argparse 1.9.2 v
+github.setup            rue-ryuzaki argparse 1.9.3 v
 github.tarball_from     archive
 revision                0
 name                    cpp-argparse-dev
@@ -18,9 +18,9 @@ maintainers             {gmail.com:golubchikov.mihail @rue-ryuzaki} \
 description             C++ argument parser.
 long_description        Python-like header-only argument parser for C++ projects.
 
-checksums               rmd160  85c2f04711e5fec2776f99096abda8318fff13e4 \
-                        sha256  3afdc4f83be5c26258fe86b74605528c8f253131e165c2727f695086999a1f00 \
-                        size    436918
+checksums               rmd160  9b9c184ca0d4b5319897b21f05b808438289c1c5 \
+                        sha256  9128f043e43593c09c4089ce17d9644bc19f4afe9d306a066445715f4085949c \
+                        size    444466
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description

  * Fix: (C++11) build with gcc 4.8.1-5.4, 6.1-6.3
  * Add: Argument::choice\<T>(...) functions
  * Update: self_test checks
  * Remove: function keyword from bash_completion output

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.5 22G621 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
