### PR TITLE
ruby-build: Update to 20240727

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20240722 v
+github.setup        rbenv ruby-build 20240727 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  85505a5d7f9dc1308d6315edcfedde394201a9b5 \
-                    sha256  e20be01cab3bafa924f33096e9ce9ed56ffeab47f6656d81049c2702114e9b55 \
-                    size    90442
+checksums           rmd160  0d5af7f4510e98c3f218c088df1abf7d2db3900a \
+                    sha256  c6359deb8694e19c00af37cadef239af7e3f00e63d89e9333870bbb0178d039c \
+                    size    90469
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20240727

##### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
