### PR TITLE
xpdf: enable building with qt4 for old systems, fix compiler choice to support atomics

### DIFF
--- a/graphics/xpdf/Portfile
+++ b/graphics/xpdf/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 name                xpdf
 version             4.05
@@ -23,28 +24,44 @@ checksums           rmd160  0c2d6533dd117aab8df935b89c3225531c5468c6 \
                     sha256  92707ed5acb6584fbd73f34091fda91365654ded1f31ba72f0970022cf2a5cea \
                     size    986596
 
+compiler.cxx_standard   2011
 
-variant qt6 conflicts qt5 description {Use Qt 6} {
+patchfiles-append   patch-fix-qt4.diff
+
+# PDFCore.h: error: atomic: No such file or directory
+compiler.blacklist-append \
+                    {clang < 601}
+
+variant qt6 conflicts qt4 qt5 description {Use Qt 6} {
     PortGroup   qt6 1.0
 
     qt6.find_method module_path
 }
 
-variant qt5 conflicts qt6 description {Use Qt 5} {
+variant qt5 conflicts qt4 qt6 description {Use Qt 5} {
     PortGroup   qt5 1.0
 
 }
 
-if {![variant_isset qt5]} {
-    # https://doc.qt.io/qt-6/macos.html
-    if {${os.major} >= 21 || ${os.platform} ne "darwin"} {
-        # icons are missing when using Qt6
-        # default_variants-append +qt6
-    }
+variant qt4 conflicts qt5 qt6 description {Use Qt 4} {
+    PortGroup   qt4 1.0
+
 }
 
-if {![variant_isset qt6]} {
-    default_variants-append +qt5
+if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    default_variants-append +qt4
+} else {
+    if {![variant_isset qt5]} {
+        # https://doc.qt.io/qt-6/macos.html
+        if {${os.major} >= 21 || ${os.platform} ne "darwin"} {
+            # icons are missing when using Qt6
+            # default_variants-append +qt6
+        }
+    }
+
+    if {![variant_isset qt6]} {
+        default_variants-append +qt5
+    }
 }
 
 variant no_mangle_names description {do not mangle the CLI tool names, conflicts with poppler} {

--- a/graphics/xpdf/files/patch-fix-qt4.diff
+++ b/graphics/xpdf/files/patch-fix-qt4.diff
@@ -1,0 +1,175 @@
+--- xpdf-qt/XpdfViewer.cc.orig	2024-02-08 04:32:41.000000000 +0800
++++ xpdf-qt/XpdfViewer.cc	2024-07-28 11:58:15.000000000 +0800
+@@ -49,6 +49,9 @@
+ #include <QToolBar>
+ #include <QTreeView>
+ #include <QVBoxLayout>
++#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
++#include <QDesktopWidget>
++#endif
+ #include "GString.h"
+ #include "GList.h"
+ #include "GlobalParams.h"
+@@ -883,7 +886,11 @@
+   }
+ 
+   QSize hint = sizeHint();
++#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+   QRect screen = QGuiApplication::primaryScreen()->availableGeometry();
++#else
++  QRect screen = QApplication::desktop()->availableGeometry();
++#endif
+   int w = hint.width();
+   int h = hint.height();
+   if (w > screen.width() - 60) {
+@@ -2794,6 +2801,7 @@
+ 
+   // for historical reasons xpdf uses X11 button numbering for mouse
+   // wheel events
++#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+   QPoint delta = e->angleDelta();
+   if (delta.y() > 0) {
+     keyCode = xpdfKeyCodeMousePress4;
+@@ -2804,8 +2812,12 @@
+   } else if (delta.x() < 0) {
+     keyCode = xpdfKeyCodeMousePress7;
+   } else {
++#endif
+     return;
++#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+   }
++#endif
++
+   if ((cmds = globalParams->getKeyBinding(keyCode,
+ 					  getModifiers(e->modifiers()),
+ 					  getContext(e->modifiers())))) {
+
+--- xpdf-qt/XpdfWidget.cc.orig	2024-02-08 04:32:41.000000000 +0800
++++ xpdf-qt/XpdfWidget.cc	2024-07-28 11:56:14.000000000 +0800
+@@ -1282,7 +1282,7 @@
+     } else if (color == pdfImageColorGray) {
+       mode = splashModeMono8;
+       paperColor[0] = 0xff;
+-      format = QImage::Format_Grayscale8;
++      format = QImage::Format_Indexed8;
+     } else {
+       mode = splashModeRGB8;
+       paperColor[0] = paperColor[1] = paperColor[2] = 0xff;
+@@ -1388,7 +1388,7 @@
+     } else if (color == pdfImageColorGray) {
+       mode = splashModeMono8;
+       paperColor[0] = 0xff;
+-      format = QImage::Format_Grayscale8;
++      format = QImage::Format_Indexed8;
+     } else {
+       mode = splashModeRGB8;
+       paperColor[0] = paperColor[1] = paperColor[2] = 0xff;
+@@ -2163,7 +2163,9 @@
+   lastMousePressTime[1] = lastMousePressTime[2];
+   lastMousePressX[2] = e->pos().x();
+   lastMousePressY[2] = e->pos().y();
++#if QT_VERSION >= 0x050000
+   lastMousePressTime[2] = e->timestamp();
++#endif
+   lastMouseEventWasPress = true;
+   if (!mousePassthrough) {
+     x = (int)(e->pos().x() * scaleFactor);
+@@ -2202,6 +2204,7 @@
+   // single clicks just have to be "nearby"
+   ulong maxTime = (ulong)QApplication::doubleClickInterval();
+   int maxDistance = QApplication::startDragDistance();
++#if QT_VERSION >= 0x050000
+   if (e->timestamp() - lastMousePressTime[0] < 2 * maxTime &&
+       abs(e->pos().x() - lastMousePressX[0])
+         + abs(e->pos().y() - lastMousePressY[0]) <= maxDistance) {
+@@ -2220,6 +2223,12 @@
+ 	       + abs(e->pos().y() - lastMousePressY[2]) <= maxDistance) {
+     emit mouseClick(e);
+   }
++#else
++    if (abs(e->pos().x() - lastMousePressX[2])
++	       + abs(e->pos().y() - lastMousePressY[2]) <= maxDistance) {
++    emit mouseClick(e);
++  }
++#endif
+ }
+ 
+ void XpdfWidget::mouseMoveEvent(QMouseEvent *e) {
+
+--- xpdf-qt/QtPDFCore.cc.orig	2024-02-08 04:32:41.000000000 +0800
++++ xpdf-qt/QtPDFCore.cc	2024-07-28 11:59:05.000000000 +0800
+@@ -24,6 +24,9 @@
+ #include <QStyle>
+ #include <QUrl>
+ #include <QWidget>
++#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
++#include <QDesktopWidget>
++#endif
+ #include "gmem.h"
+ #include "gmempp.h"
+ #include "gfile.h"
+@@ -98,10 +101,10 @@
+ }
+ 
+ double QtPDFCore::computeScaleFactor() {
++#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+   // get Qt's HiDPI scale factor
+   QGuiApplication *app = (QGuiApplication *)QGuiApplication::instance();
+   QScreen *screen = app->primaryScreen();
+-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+   return screen->devicePixelRatio();
+ #else
+   return 1;
+@@ -109,9 +112,13 @@
+ }
+ 
+ int QtPDFCore::computeDisplayDpi() {
++#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+   QGuiApplication *app = (QGuiApplication *)QGuiApplication::instance();
+   QScreen *screen = app->primaryScreen();
+   return (int)(screen->logicalDotsPerInch() * computeScaleFactor());
++#else
++  return (int)(qApp->desktop()->logicalDpiX() * computeScaleFactor());
++#endif
+ }
+ 
+ //------------------------------------------------------------------------
+
+--- xpdf-qt/XpdfWidgetPrint.cc.orig	2024-02-08 04:32:41.000000000 +0800
++++ xpdf-qt/XpdfWidgetPrint.cc	2024-07-28 11:54:37.000000000 +0800
+@@ -62,7 +62,11 @@
+   QPrinter::ColorMode colorMode;
+   QSize paperSize;
+   QPrinter::PaperSource paperSource;
++#if QT_VERSION >= 0x050000
+   QPageLayout::Orientation pageOrientation;
++#else
++  QPrinter::Orientation pageOrientation;
++#endif
+   FILE *f;
+   GBool deletePDFFile;
+   int startPage, endPage, pg, i;
+@@ -117,9 +121,14 @@
+   //--- get other parameters
+ 
+   colorMode = prt->colorMode();
++#if QT_VERSION >= 0x050000
+   paperSize = prt->pageLayout().pageSize().sizePoints();
+   paperSource = prt->paperSource();
+   pageOrientation = prt->pageLayout().orientation();
++#else
++  paperSource = prt->paperSource();
++  pageOrientation = prt->orientation();
++#endif
+ 
+   //--- create the Session and PrintSettings
+ 
+@@ -232,7 +241,7 @@
+   //--- set page orientation
+ 
+   PMGetAdjustedPaperRect(pageFormat, &paperRect);
+-  if (pageOrientation == QPageLayout::Landscape) {
++  if (pageOrientation == QPrinter::Landscape) {
+     PMSetOrientation(pageFormat, kPMLandscape, kPMUnlocked);
+     paperRect2 = CGRectMake(paperRect.top,
+ 			    paperRect.left,


### PR DESCRIPTION
#### Description

1. Support on systems where Qt5 fails to install (see logs in port details) via Qt4 variant.
2. Hopefully fix for other legacy OS by amending compiler choice for atomics support (cannot test, but should work).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

P. S. As far as I can tell, Qt4-based app is functional, though has minor glitches. Specifically, pulling sliders does not work and wheel scrolling works only if the cursor is placed above sliders, but not randomly over a page; single-page view mode literally displays a single page instead of displaying document per-page; changing pages via clicking on arrows in the tab bar does not work correctly.
Notice, neither of these makes the app unusable, since other methods of scrolling and changing pages work normally.
Also zoom works, text search works, saving documents and printing dialogue work.