### PR TITLE
libmspack: new port in archivers

### DIFF
--- a/archivers/libmspack/Portfile
+++ b/archivers/libmspack/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        kyz libmspack 1.11 v
+revision            0
+
+categories          archivers
+maintainers         nomaintainer
+license             LGPL
+
+description         Library supporting Microsoft compression formats
+long_description    The purpose of ${name} is to provide compressors and decompressors, \
+                    archivers and dearchivers for Microsoft compression formats.
+homepage            https://www.cabextract.org.uk/libmspack
+checksums           rmd160  5da46c6eff5059f954b22f41759c791d8c64faa2 \
+                    sha256  284e0e51fee991c40e8cbbc0f5e635f99722796a3642a14397989fc00b862f72 \
+                    size    408982
+github.tarball_from archive
+
+worksrcdir          ${worksrcpath}/${name}
+
+patchfiles          patch-xcode-gcc.diff
+
+use_autoreconf      yes

--- a/archivers/libmspack/files/patch-xcode-gcc.diff
+++ b/archivers/libmspack/files/patch-xcode-gcc.diff
@@ -1,0 +1,11 @@
+--- Makefile.am	2023-02-24 20:01:05.000000000 +0800
++++ Makefile.am	2024-07-28 22:20:05.000000000 +0800
+@@ -10,7 +10,7 @@
+ # default mspack_system and will fail without it -- any program with a call
+ # like "mspack_create_...(NULL)" expects a default mspack_system.
+ if GCC
+-AM_CFLAGS +=            -Wall -Wextra -Wno-unused-parameter -Wno-unused-result
++AM_CFLAGS +=            -Wall -Wextra -Wno-unused-parameter
+ endif
+ AM_CPPFLAGS =           -I$(srcdir)/mspack -I$(srcdir)/test
+ 


### PR DESCRIPTION
#### Description

New port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
