### PR TITLE
starship: update to 1.20.1

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo   1.0
 PortGroup           github  1.0
 PortGroup           openssl 1.0
 
-github.setup        starship starship 1.19.0 v
+github.setup        starship starship 1.20.1 v
 github.tarball_from archive
 revision            0
 
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  754167e6792e080c00b99f160950ddcd02299992 \
-                    sha256  cf789791b5c11d6d7a00628590696627bb8f980e3d7c7a0200026787b08aba37 \
-                    size    8414295
+                    rmd160  24e7dd6e8431fb43c4d6f4890f30a153f18612f1 \
+                    sha256  851d84be69f9171f10890e3b58b8c5ec6057dd873dc83bfe0bdf965f9844b5dc \
+                    size    9414001
 
 # crate:openssl-sys requires pkgconfig & libssl.dylib
 depends_build-append \
@@ -47,74 +47,76 @@ destroot {
 cargo.crates \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
     ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
-    aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
-    allocator-api2                  0.2.16  0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5 \
+    aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
+    allocator-api2                  0.2.18  5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anstream                         0.6.7  4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba \
-    anstyle                          1.0.4  7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87 \
-    anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
-    anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
-    anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
-    anyhow                          1.0.77  c9d19de80eff169429ac1e9f48fffb163916b448a44e8e046186232046d9e1f9 \
-    arc-swap                         1.6.0  bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6 \
+    anstream                        0.6.14  418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b \
+    anstyle                          1.0.7  038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b \
+    anstyle-parse                    0.2.4  c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4 \
+    anstyle-query                    1.1.0  ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391 \
+    anstyle-wincon                   3.0.3  61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19 \
+    anyhow                          1.0.86  b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da \
+    arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arraydeque                       0.5.1  7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236 \
     arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
-    async-broadcast                  0.7.0  258b52a1aa741b9f09783b2d86cf0aeeb617bbf847f6933340a39644227acbdb \
-    async-channel                    2.1.1  1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c \
-    async-executor                   1.8.0  17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c \
-    async-fs                         2.1.1  bc19683171f287921f2405677dd2ed2549c3b3bda697a563ebc3a121ace2aba1 \
-    async-io                         2.3.2  dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884 \
+    async-broadcast                  0.7.1  20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e \
+    async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
+    async-executor                  1.13.0  d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7 \
+    async-fs                         2.1.2  ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a \
+    async-io                         2.3.3  0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964 \
     async-lock                       2.8.0  287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b \
-    async-lock                       3.3.0  d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b \
-    async-process                    2.2.0  d999d925640d51b662b7b4e404224dd81de70f4aa4a199383c2c5e5b86885fa3 \
-    async-recursion                  1.0.5  5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0 \
-    async-signal                     0.2.5  9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5 \
-    async-task                       4.7.0  fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799 \
-    async-trait                     0.1.79  a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681 \
+    async-lock                       3.4.0  ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18 \
+    async-process                    2.2.3  f7eda79bbd84e29c2b308d1dc099d7de8dcc7035e48f4bf5dc4a531a44ff5e2a \
+    async-recursion                  1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
+    async-signal                     0.2.9  dfb3634b73397aa844481f814fad23bbf07fdb0eabec10f2eb95e58944b1ec32 \
+    async-task                       4.7.1  8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de \
+    async-trait                     0.1.81  6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    autocfg                          1.3.0  0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0 \
     base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
+    base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                         2.4.1  327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07 \
+    bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
     block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    blocking                         1.5.1  6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118 \
-    bstr                             1.9.0  c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc \
-    bumpalo                         3.14.0  7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec \
+    blocking                         1.6.1  703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea \
+    bstr                             1.9.1  05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706 \
+    bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytesize                         1.3.0  a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc \
-    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
+    cc                               1.1.6  2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    cfg_aliases                      0.1.1  fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e \
+    cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
-    clap                             4.5.4  90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0 \
-    clap_builder                     4.5.2  ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4 \
-    clap_complete                    4.5.2  dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e \
-    clap_derive                      4.5.4  528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64 \
-    clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
-    clru                             0.6.1  b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807 \
+    clap                            4.5.11  35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3 \
+    clap_builder                    4.5.11  49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa \
+    clap_complete                   4.5.11  c6ae69fbb0833c6fcd5a8d4b8609f108c7ad95fc11e248d853ff2c42a90df26a \
+    clap_derive                     4.5.11  5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e \
+    clap_lex                         0.7.1  4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70 \
+    clru                             0.6.2  cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59 \
     cmake                           0.1.50  a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130 \
-    colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
-    concurrent-queue                 2.4.0  d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363 \
-    const-random                    0.1.17  5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a \
+    colorchoice                      1.0.1  0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422 \
+    concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
+    const-random                    0.1.18  87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359 \
     const-random-macro              0.1.16  f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e \
     const_format                    0.2.32  e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673 \
     const_format_proc_macros        0.2.32  c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500 \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
     core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
-    cpufeatures                     0.2.11  ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0 \
-    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
-    crossbeam                        0.8.3  6eb9105919ca8e40d437fc9cbb8f1975d916f1bd28afe795a48aae32a2cc8920 \
-    crossbeam-channel               0.5.10  82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2 \
-    crossbeam-deque                  0.8.4  fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751 \
-    crossbeam-epoch                 0.9.17  0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d \
-    crossbeam-queue                 0.3.10  adc6598521bb5a83d491e8c1fe51db7296019d2ca3cb93cc6c2a20369a4d78a2 \
-    crossbeam-utils                 0.8.18  c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c \
+    cpufeatures                     0.2.12  53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504 \
+    crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
+    crossbeam                        0.8.4  1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8 \
+    crossbeam-channel               0.5.13  33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2 \
+    crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
+    crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-queue                 0.3.11  df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35 \
+    crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     deelevate                        0.2.0  1c7397f8c48906dd9b5afc75001368c979418e5dff5575998a831eb2319b424e \
-    deranged                        0.3.10  8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc \
+    deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
     digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
@@ -127,80 +129,81 @@ cargo.crates \
     dlv-list                         0.5.2  442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f \
     downcast                        0.11.0  1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1 \
     dunce                            1.0.4  56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b \
-    dyn-clone                       1.0.16  545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d \
-    either                           1.9.0  a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07 \
-    encoding_rs                     0.8.33  7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1 \
+    dyn-clone                       1.0.17  0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125 \
+    either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
+    encoding_rs                     0.8.34  b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59 \
     endi                             1.1.0  a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf \
-    enumflags2                       0.7.9  3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d \
-    enumflags2_derive                0.7.9  5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4 \
+    enumflags2                      0.7.10  d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d \
+    enumflags2_derive               0.7.10  de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8 \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                            0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
-    errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
+    errno                            0.3.9  534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba \
     errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
     event-listener                   2.5.3  0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0 \
     event-listener                   4.0.1  84f2cdcf274580f2d63697192d744727b3198894b1bf02923643bf59e2c26712 \
-    event-listener                   5.2.0  2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91 \
+    event-listener                   5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
     event-listener-strategy          0.4.0  958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3 \
-    event-listener-strategy          0.5.1  332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3 \
+    event-listener-strategy          0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
     faster-hex                       0.9.0  a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183 \
-    fastrand                         2.0.1  25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5 \
+    fastrand                         2.1.0  9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a \
     filedescriptor                   0.8.2  7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e \
     filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
-    flate2                          1.0.28  46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e \
+    flate2                          1.0.30  5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fragile                          2.0.0  6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa \
     futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
     futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
-    futures-lite                     2.1.0  aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143 \
+    futures-lite                     2.3.0  52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5 \
     futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
     futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
     futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
-    gethostname                      0.4.3  0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818 \
-    getrandom                       0.2.11  fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f \
-    gix                             0.62.0  5631c64fb4cd48eee767bf98a3cbc5c9318ef3bb71074d4c099a2371510282b6 \
-    gix-actor                       0.31.1  45c3a3bde455ad2ee8ba8a195745241ce0b770a8a26faae59fcf409d01b28c46 \
+    gethostname                      0.5.0  dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30 \
+    getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
+    gix                             0.64.0  d78414d29fcc82329080166077e0f7689f4016551fdb334d787c3d040fe2634f \
+    gix-actor                       0.31.5  a0e454357e34b833cc3a00b6efbbd3dd4d18b24b9fb0c023876ec2645e8aa3f2 \
     gix-bitmap                      0.2.11  a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae \
     gix-chunk                        0.4.8  45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52 \
-    gix-commitgraph                 0.24.2  f7b102311085da4af18823413b5176d7c500fb2272eaf391cfa8635d8bcb12c4 \
-    gix-config                      0.36.1  7580e05996e893347ad04e1eaceb92e1c0e6a3ffe517171af99bf6b6df0ca6e5 \
-    gix-config-value                0.14.6  fbd06203b1a9b33a78c88252a625031b094d9e1b647260070c25b09910c0a804 \
-    gix-date                         0.8.5  180b130a4a41870edfbd36ce4169c7090bca70e195da783dea088dd973daa59c \
-    gix-diff                        0.43.0  a5fbc24115b957346cd23fb0f47d830eb799c46c89cdcf2f5acc9bf2938c2d01 \
-    gix-discover                    0.31.0  64bab49087ed3710caf77e473dc0efc54ca33d8ccc6441359725f121211482b1 \
-    gix-features                    0.38.1  db4254037d20a247a0367aa79333750146a369719f0c6617fec4f5752cc62b37 \
-    gix-fs                          0.10.2  e2184c40e7910529677831c8b481acf788ffd92427ed21fad65b6aa637e631b8 \
-    gix-glob                        0.16.2  682bdc43cb3c00dbedfcc366de2a849b582efd8d886215dbad2ea662ec156bb5 \
+    gix-commitgraph                 0.24.3  133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78 \
+    gix-config                      0.38.0  28f53fd03d1bf09ebcc2c8654f08969439c4556e644ca925f27cf033bc43e658 \
+    gix-config-value                0.14.7  b328997d74dd15dc71b2773b162cb4af9a25c424105e4876e6d0686ab41c383e \
+    gix-date                         0.8.7  9eed6931f21491ee0aeb922751bd7ec97b4b2fe8fbfedcb678e2a2dce5f3b8c0 \
+    gix-diff                        0.44.1  1996d5c8a305b59709467d80617c9fde48d9d75fd1f4179ea970912630886c9d \
+    gix-discover                    0.33.0  67662731cec3cb31ba3ed2463809493f76d8e5d6c6d245de8b0560438c13450e \
+    gix-features                    0.38.2  ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69 \
+    gix-fs                          0.11.2  6adf99c27cdf17b1c4d77680c917e0d94d8783d4e1c73d3be0d1d63107163d7a \
+    gix-glob                        0.16.4  fa7df15afa265cc8abe92813cd354d522f1ac06b29ec6dfa163ad320575cb447 \
     gix-hash                        0.14.2  f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e \
     gix-hashtable                    0.5.2  7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242 \
-    gix-index                       0.32.0  3383122cf18655ef4c097c0b935bba5eb56983947959aaf3b0ceb1949d4dd371 \
-    gix-lock                        13.0.0  651e46174dc5e7d18b7b809d31937b6de3681b1debd78618c99162cc30fcf3e1 \
-    gix-macros                       0.1.4  1dff438f14e67e7713ab9332f5fd18c8f20eb7eb249494f6c2bf170522224032 \
-    gix-object                      0.42.1  3d4f8efae72030df1c4a81d02dbe2348e748d9b9a11e108ed6efbd846326e051 \
-    gix-odb                         0.60.0  e8bbb43d2fefdc4701ffdf9224844d05b136ae1b9a73c2f90710c8dd27a93503 \
-    gix-pack                        0.50.0  b58bad27c7677fa6b587aab3a1aca0b6c97373bd371a0a4290677c838c9bcaf1 \
-    gix-path                        0.10.7  23623cf0f475691a6d943f898c4d0b89f5c1a2a64d0f92bce0e0322ee6528783 \
+    gix-index                       0.33.1  9a9a44eb55bd84bb48f8a44980e951968ced21e171b22d115d1cdcef82a7d73f \
+    gix-lock                        14.0.0  e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d \
+    gix-macros                       0.1.5  999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17 \
+    gix-object                      0.42.3  25da2f46b4e7c2fa7b413ce4dffb87f69eaf89c2057e386491f4c55cadbfe386 \
+    gix-odb                         0.61.1  20d384fe541d93d8a3bb7d5d5ef210780d6df4f50c4e684ccba32665a5e3bc9b \
+    gix-pack                        0.51.1  3e0594491fffe55df94ba1c111a6566b7f56b3f8d2e1efc750e77d572f5f5229 \
+    gix-path                        0.10.9  8d23d5bbda31344d8abc8de7c075b3cf26e5873feba7c4a15d916bce67382bd9 \
     gix-quote                       0.4.12  cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff \
-    gix-ref                         0.43.0  fd4aba68b925101cb45d6df328979af0681364579db889098a0de75b36c77b65 \
-    gix-refspec                     0.23.0  dde848865834a54fe4d9b4573f15d0e9a68eaf3d061b42d3ed52b4b8acf880b2 \
-    gix-revision                    0.27.0  9e34196e1969bd5d36e2fbc4467d893999132219d503e23474a8ad2b221cb1e8 \
-    gix-revwalk                     0.13.0  e0a7d393ae814eeaae41a333c0ff684b243121cc61ccdc5bbe9897094588047d \
-    gix-sec                         0.10.6  fddc27984a643b20dd03e97790555804f98cf07404e0e552c0ad8133266a79a1 \
-    gix-tempfile                    13.0.0  2d337955b7af00fb87120d053d87cdfb422a80b9ff7a3aa4057a99c79422dc30 \
+    gix-ref                         0.45.0  636e96a0a5562715153fee098c217110c33a6f8218f08f4687ff99afde159bb5 \
+    gix-refspec                     0.23.1  6868f8cd2e62555d1f7c78b784bece43ace40dd2a462daf3b588d5416e603f37 \
+    gix-revision                    0.27.2  01b13e43c2118c4b0537ddac7d0821ae0dfa90b7b8dbf20c711e153fb749adce \
+    gix-revwalk                     0.13.2  1b030ccaab71af141f537e0225f19b9e74f25fefdba0372246b844491cab43e0 \
+    gix-sec                         0.10.7  1547d26fa5693a7f34f05b4a3b59a90890972922172653bcb891ab3f09f436df \
+    gix-tempfile                    14.0.1  006acf5a613e0b5cf095d8e4b3f48c12a60d9062aa2b2dd105afaf8344a5600c \
     gix-trace                        0.1.9  f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e \
-    gix-traverse                    0.39.0  f4029ec209b0cc480d209da3837a42c63801dd8548f09c1f4502c60accb62aeb \
-    gix-url                         0.27.3  0db829ebdca6180fbe32be7aed393591df6db4a72dbbc0b8369162390954d1cf \
+    gix-traverse                    0.39.2  e499a18c511e71cf4a20413b743b9f5bcf64b3d9e81e9c3c6cd399eae55a8840 \
+    gix-url                         0.27.4  e2eb9b35bba92ea8f0b5ab406fad3cf6b87f7929aa677ff10aa042c6da621156 \
     gix-utils                       0.1.12  35192df7fd0fa112263bad8021e2df7167df4cc2a6e6d15892e1e55621d3d4dc \
-    gix-validate                     0.8.4  e39fc6e06044985eac19dd34d474909e517307582e462b2eb4c8fa51b6241545 \
+    gix-validate                     0.8.5  82c27dd34a49b1addf193c92070bcbf3beaf6e10f16a78544de6372e146a0acf \
     guess_host_triple                0.1.3  b35a8ce923c7490629d84e12fa2f75e1733f1ec692a47c264f9b7fd632855afc \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
-    hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
+    hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashlink                         0.8.4  e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
+    hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
-    iana-time-zone                  0.1.58  8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20 \
+    iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
@@ -208,148 +211,152 @@ cargo.crates \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-wsl                           0.4.0  173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5 \
     is_debug                         1.0.1  06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89 \
-    itertools                       0.11.0  b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57 \
-    itertools                       0.12.0  25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0 \
-    itoa                            1.0.10  b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c \
-    js-sys                          0.3.66  cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca \
+    is_terminal_polyfill            1.70.0  f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800 \
+    itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
+    itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
+    js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
     jwalk                            0.8.1  2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56 \
-    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
-    libredox                         0.0.1  85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8 \
-    libz-ng-sys                     1.1.14  81157dde2fd4ad2b45ea3a4bb47b8193b52a6346b678840d91d80d3c2cd166c5 \
-    libz-sys                        1.1.14  295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050 \
-    linux-raw-sys                   0.4.12  c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456 \
-    lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
-    log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
+    libc                           0.2.155  97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c \
+    libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
+    libz-ng-sys                     1.1.15  c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5 \
+    libz-sys                        1.1.18  c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e \
+    linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
+    lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
+    log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
     mac-notification-sys             0.6.1  51fca4d74ff9dbaac16a01b924bc3693fa2bba0862c2c633abc73f9a8ea21f64 \
     mach2                            0.4.2  19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709 \
     malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
-    memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \
-    memmap2                          0.9.3  45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92 \
+    memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
+    memmap2                          0.9.4  fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322 \
     memmem                           0.1.1  a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15 \
-    memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
+    memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
-    miniz_oxide                      0.7.1  e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7 \
-    mockall                         0.12.1  43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48 \
-    mockall_derive                  0.12.1  af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2 \
-    nix                             0.28.0  ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4 \
+    miniz_oxide                      0.7.4  b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08 \
+    mockall                         0.13.0  d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a \
+    mockall_derive                  0.13.0  341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020 \
+    nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              5.1.3  08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     notify-rust                     4.11.0  5312f837191c317644f313f7b2b39f9cb1496570c74f7c17152dd3961219551f \
-    nu-ansi-term                    0.50.0  dd2800e1520bdc966782168a627aa5d1ad92e33b984bf7c7615d31280c83ff14 \
+    nu-ansi-term                    0.50.1  d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399 \
+    num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
     num-derive                       0.3.3  876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d \
-    num-traits                      0.2.17  39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c \
-    num_threads                      0.1.6  2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44 \
+    num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
+    num_threads                      0.1.7  5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
     objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
     objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
     objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
     once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
-    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
-    open                             5.1.2  449f0ff855d85ddbf1edd5b646d65249ead3f5e422aaa86b7d2d0b049b103e32 \
+    opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
+    open                             5.3.0  61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
-    ordered-multimap                 0.7.1  a4d6a8c22fc714f0c2373e6091bf6f5e9b37b1bc0b1184874b7e0a4e303d318f \
+    ordered-multimap                 0.7.3  49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79 \
     ordered-stream                   0.2.0  9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50 \
     os_info                          3.8.2  ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092 \
     parking                          2.2.0  bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae \
-    parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
-    parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
+    parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
+    parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     path-slash                       0.2.1  1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42 \
     pathdiff                         0.2.1  8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd \
     pathsearch                       0.2.0  da983bc5e582ab17179c190b4b66c7d76c5943a69c6d34df2a2b6bf8a2977b05 \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    pest                             2.7.9  311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95 \
-    pest_derive                      2.7.9  f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c \
-    pest_generator                   2.7.9  c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd \
-    pest_meta                        2.7.9  2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca \
+    pest                            2.7.11  cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95 \
+    pest_derive                     2.7.11  2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a \
+    pest_generator                  2.7.11  3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183 \
+    pest_meta                       2.7.11  a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f \
     phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
     phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
     phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
     phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
-    pin-project-lite                0.2.13  8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58 \
+    pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    piper                            0.2.1  668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4 \
-    pkg-config                      0.3.28  69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a \
-    polling                          3.3.1  cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e \
+    piper                            0.2.3  ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391 \
+    pkg-config                      0.3.30  d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec \
+    plist                            1.7.0  42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016 \
+    polling                          3.7.2  a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
-    predicates                       3.0.4  6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0 \
+    predicates                       3.1.0  68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8 \
     predicates-core                  1.0.6  b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174 \
     predicates-tree                  1.0.9  368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf \
     proc-macro-crate                 3.1.0  6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284 \
-    proc-macro2                     1.0.79  e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e \
+    proc-macro2                     1.0.86  5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77 \
     process_control                  4.1.0  4d18334c4a4b2770ee894e63cf466d5a9ea449cf29e321101b0b135a747afb6f \
     prodash                         28.0.0  744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79 \
-    quick-xml                       0.30.0  eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956 \
     quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
-    quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
+    quick-xml                       0.32.0  1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2 \
+    quick-xml                       0.36.1  96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc \
+    quote                           1.0.36  0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
-    redox_users                      0.4.4  a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4 \
-    regex                           1.10.4  c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c \
-    regex-automata                   0.4.4  3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a \
-    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    redox_syscall                    0.5.3  2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4 \
+    redox_users                      0.4.5  bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891 \
+    regex                           1.10.5  b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f \
+    regex-automata                   0.4.7  38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df \
+    regex-syntax                     0.8.4  7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b \
     rust-ini                        0.21.0  0d625ed57d8f49af6cfa514c42e1a71fadcff60eb0b1c517ff82fe41aa025b41 \
-    rustix                         0.38.31  6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949 \
-    ryu                             1.0.16  f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c \
+    rustix                         0.38.34  70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f \
+    ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    schemars                        0.8.19  fc6e7ed6919cb46507fb01ff1654309219f62b4d603822501b0b80d42f6f21ef \
-    schemars_derive                 0.8.19  185f2b7aa7e02d418e453790dde16890256bbd2bcd04b7dc5348811052b53f49 \
+    schemars                        0.8.21  09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92 \
+    schemars_derive                 0.8.21  b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     semver                          0.11.0  f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6 \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
     semver-parser                   0.10.2  00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7 \
-    serde                          1.0.201  780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c \
-    serde_derive                   1.0.201  c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865 \
-    serde_derive_internals          0.29.0  330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3 \
-    serde_json                     1.0.117  455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3 \
-    serde_repr                      0.1.18  0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb \
-    serde_spanned                    0.6.5  eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1 \
+    serde                          1.0.204  bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12 \
+    serde_derive                   1.0.204  e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222 \
+    serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
+    serde_json                     1.0.120  4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5 \
+    serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
+    serde_spanned                    0.6.7  eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
-    sha1-asm                         0.5.2  2ba6947745e7f86be3b8af00b7355857085dbdf8901393c89514510eb61f4e21 \
-    sha1_smol                        1.0.0  ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012 \
+    sha1-asm                         0.5.3  286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b \
+    sha1_smol                        1.0.1  bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d \
     sha2                             0.9.9  4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800 \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
-    shadow-rs                       0.27.1  7960cbd6ba74691bb15e7ebf97f7136bd02d1115f5695a58c1f31d5645750128 \
+    shadow-rs                       0.30.0  d253e54681d4be0161e965db57974ae642a0b6aaeb18a999424c4dab062be8c5 \
     shared_library                   0.1.9  5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11 \
     shell-words                      1.1.0  24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde \
     signal-hook                     0.1.17  7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729 \
     signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
-    signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
+    signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
     siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
-    smallvec                        1.11.2  4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970 \
-    starship-battery                 0.8.3  725bc1c7374f435ef65746eb1a5789cb7d02b8e997f9a3edf979bfb42da68311 \
+    smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
+    starship-battery                 0.9.1  da7915746794358b8f649d3032c8ce150f55b7a0cd41951f170162e82e6cf43f \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.53  7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032 \
+    syn                             2.0.72  dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af \
     systemstat                       0.2.3  a24aec24a9312c83999a28e3ef9db7e2afd5c64bf47725b758cdc1cafd5b0bd2 \
-    tauri-winrt-notification         0.2.0  2d59cba96cdbf291d74490ac477c66885ebdc87e28faca532ec1e00f4f3bd578 \
+    tauri-winrt-notification         0.2.1  f89f5fb70d6f62381f5d9b2ba9008196150b40b75f3068eb24faeddf1c686871 \
     tempfile                        3.10.1  85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1 \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
     terminfo                         0.7.5  da31aef70da0f6352dbcb462683eb4dd2bfad01cf3fc96cf204547b9a839a585 \
     termios                          0.3.3  411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b \
     termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
     termwiz                         0.15.0  31ef6892cc0348a9b3b8c377addba91e0f6365863d92354bf27559dca81ee8c5 \
-    thiserror                       1.0.52  83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d \
-    thiserror-impl                  1.0.52  e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3 \
-    time                            0.3.31  f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e \
+    thiserror                       1.0.63  c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724 \
+    thiserror-impl                  1.0.63  a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261 \
+    time                            0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
-    time-macros                     0.2.16  26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f \
+    time-macros                     0.2.18  3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf \
     tiny-keccak                      2.0.2  2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237 \
-    tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+    tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
-    toml                            0.8.12  e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3 \
-    toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
+    toml                            0.8.16  81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c \
+    toml_datetime                    0.6.7  f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db \
     toml_edit                       0.21.1  6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1 \
-    toml_edit                      0.22.12  d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef \
+    toml_edit                      0.22.17  8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16 \
     tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
     tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
     tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
@@ -357,74 +364,78 @@ cargo.crates \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
     ucd-trie                         0.1.6  ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9 \
     uds_windows                      1.1.0  89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9 \
-    uluru                            3.0.0  794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db \
+    uluru                            3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
     unicase                          2.7.0  f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89 \
-    unicode-bidi                    0.3.14  6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416 \
+    unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
     unicode-bom                      2.0.3  7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217 \
     unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
-    unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
+    unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
     unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
-    unicode-width                   0.1.12  68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6 \
+    unicode-width                   0.1.13  0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d \
     unicode-xid                      0.2.4  f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c \
     uom                             0.36.0  ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c \
-    url                              2.5.0  31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633 \
+    url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
+    utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
-    versions                         6.2.0  38a8931f8d167b6448076020e70b9de46dcf5ea1731212481a092d0071c4ac5b \
+    versions                         6.3.0  5fc28d1172a20e32754969ea1a873c2c6e68e36c449c6056aa3e2ee5fe69a794 \
     vtparse                          0.6.2  6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0 \
-    walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \
+    walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.89  0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e \
-    wasm-bindgen-backend            0.2.89  1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826 \
-    wasm-bindgen-macro              0.2.89  0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2 \
-    wasm-bindgen-macro-support      0.2.89  f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283 \
-    wasm-bindgen-shared             0.2.89  7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f \
+    wasm-bindgen                    0.2.92  4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8 \
+    wasm-bindgen-backend            0.2.92  614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da \
+    wasm-bindgen-macro              0.2.92  a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726 \
+    wasm-bindgen-macro-support      0.2.92  e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7 \
+    wasm-bindgen-shared             0.2.92  af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96 \
     which                            6.0.1  8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.6  f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596 \
+    winapi-util                      0.1.8  4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows                         0.54.0  9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49 \
     windows                         0.56.0  1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132 \
-    windows-core                    0.51.1  f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64 \
-    windows-core                    0.54.0  12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65 \
+    windows                         0.58.0  dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6 \
+    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
     windows-core                    0.56.0  4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6 \
+    windows-core                    0.58.0  6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99 \
     windows-implement               0.56.0  f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b \
+    windows-implement               0.58.0  2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b \
     windows-interface               0.56.0  08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc \
-    windows-result                   0.1.1  749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b \
+    windows-interface               0.58.0  053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515 \
+    windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
+    windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
+    windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
-    windows-targets                 0.52.5  6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb \
-    windows-version                  0.1.0  75aa004c988e080ad34aff5739c39d0312f4684699d6d71fc8a198d057b8b9b4 \
+    windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-version                  0.1.1  6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515 \
     windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
-    windows_aarch64_gnullvm         0.52.5  7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263 \
+    windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
     windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
-    windows_aarch64_msvc            0.52.5  9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6 \
+    windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
     windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
-    windows_i686_gnu                0.52.5  88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670 \
-    windows_i686_gnullvm            0.52.5  87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9 \
+    windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
     windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
-    windows_i686_msvc               0.52.5  db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf \
+    windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
     windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
-    windows_x86_64_gnu              0.52.5  4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9 \
+    windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
     windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
-    windows_x86_64_gnullvm          0.52.5  852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596 \
+    windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
-    windows_x86_64_msvc             0.52.5  bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0 \
+    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     winnow                          0.5.40  f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876 \
-    winnow                           0.6.5  dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8 \
+    winnow                          0.6.15  557404e450152cd6795bb558bca69e43c585055f4606e3bcae5894fc6dac9ba0 \
     winres                          0.1.12  b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
-    xdg-home                         1.1.0  21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e \
-    yaml-rust2                       0.8.0  498f4d102a79ea1c9d4dd27573c0fc96ad74c023e8da38484e47883076da25fb \
-    zbus                             4.1.2  c9ff46f2a25abd690ed072054733e0bc3157e3d4c45f41bd183dce09c2ff8ab9 \
-    zbus_macros                      4.1.2  4e0e3852c93dcdb49c9462afe67a2a468f7bd464150d866e861eaf06208633e0 \
+    xdg-home                         1.2.0  ca91dcf8f93db085f3a0a29358cd0b9d670915468f4290e8b85d118a34211ab8 \
+    yaml-rust2                       0.8.1  8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8 \
+    zbus                             4.4.0  bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725 \
+    zbus_macros                      4.4.0  267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e \
     zbus_names                       3.0.0  4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c \
-    zerocopy                        0.7.32  74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be \
-    zerocopy-derive                 0.7.32  9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6 \
-    zvariant                         4.0.2  2c1b3ca6db667bfada0f1ebfc94b2b1759ba25472ee5373d4551bb892616389a \
-    zvariant_derive                  4.0.2  b7a4b236063316163b69039f77ce3117accb41a09567fd24c168e43491e521bc \
-    zvariant_utils                   1.1.0  00bedb16a193cc12451873fee2a1bc6550225acece0e36f333e68326c73c8172
+    zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
+    zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
+    zvariant                         4.2.0  2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe \
+    zvariant_derive                  4.2.0  73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449 \
+    zvariant_utils                   2.1.0  c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340


### PR DESCRIPTION
#### Description

Update to Starship 1.20.1.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?