### PR TITLE
ruby32: update to 3.2.5

### DIFF
--- a/lang/ruby32/Portfile
+++ b/lang/ruby32/Portfile
@@ -10,7 +10,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 14
 
 set ruby_ver        3.2
-set ruby_patch      4
+set ruby_patch      5
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
@@ -36,9 +36,9 @@ master_sites        ruby:${ruby_ver}
 distname            ruby-${version}
 dist_subdir         ruby${ruby_ver_nodot}
 
-checksums           rmd160  d7e5420af382751846b8a0c3013a913042372dad \
-                    sha256  c72b3c5c30482dca18b0f868c9075f3f47d8168eaf626d4e682ce5b59c858692 \
-                    size    20581711
+checksums           rmd160  9e01fbc8b7c48576c27b6b0a24c97950b4cf32fb \
+                    sha256  ef0610b498f60fb5cfd77b51adb3c10f4ca8ed9a17cb87c61e5bea314ac34a16 \
+                    size    20619047
 
 # Universal builds don't currently work, including via the approach used
 # in ruby30.
@@ -65,7 +65,7 @@ select.file         ${filespath}/ruby${ruby_ver_nodot}
 # patch-sources.diff: fixes for various issues.
 # This includes the 'gem' versioning fix formerly handled via reinplace.
 #
-# This diff is from v3_2_4 vs. macports-3_2_4.
+# This diff is from v3_2_5 vs. macports-3_2_5.
 #
 patchfiles-append   patch-sources.diff
 

--- a/lang/ruby32/files/patch-sources.diff
+++ b/lang/ruby32/files/patch-sources.diff
@@ -1,5 +1,5 @@
---- .gdbinit.orig	2024-04-23 03:20:09.000000000 -0700
-+++ .gdbinit	2024-04-27 17:32:33.000000000 -0700
+--- .gdbinit.orig	2024-07-26 04:54:27.000000000 -0700
++++ .gdbinit	2024-07-26 20:56:01.000000000 -0700
 @@ -1,4 +1,5 @@
 -set startup-with-shell off
 +# Move this to end, so failure on older gdbs doesn't blow the rest
@@ -14,8 +14,8 @@
 +
 +# Moved from beginning, since it fails on older gdbs
 +set startup-with-shell off
---- ext/digest/md5/md5cc.h.orig	2024-04-23 03:20:09.000000000 -0700
-+++ ext/digest/md5/md5cc.h	2024-04-27 17:32:33.000000000 -0700
+--- ext/digest/md5/md5cc.h.orig	2024-07-26 04:54:27.000000000 -0700
++++ ext/digest/md5/md5cc.h	2024-07-26 20:56:01.000000000 -0700
 @@ -17,3 +17,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(MD5
  #undef MD5_Finish
  #define MD5_Update rb_digest_MD5_update
@@ -28,8 +28,8 @@
 + */
 +#undef MD5_Init
 +#define MD5_Init CC_MD5_Init
---- ext/digest/sha1/sha1cc.h.orig	2024-04-23 03:20:09.000000000 -0700
-+++ ext/digest/sha1/sha1cc.h	2024-04-27 17:32:33.000000000 -0700
+--- ext/digest/sha1/sha1cc.h.orig	2024-07-26 04:54:27.000000000 -0700
++++ ext/digest/sha1/sha1cc.h	2024-07-26 20:56:01.000000000 -0700
 @@ -12,3 +12,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(SHA
  #undef SHA1_Finish
  #define SHA1_Update rb_digest_SHA1_update
@@ -42,8 +42,8 @@
 + */
 +#undef SHA1_Init
 +#define SHA1_Init CC_SHA1_Init
---- ext/digest/sha2/sha2cc.h.orig	2024-04-23 03:20:09.000000000 -0700
-+++ ext/digest/sha2/sha2cc.h	2024-04-27 17:32:33.000000000 -0700
+--- ext/digest/sha2/sha2cc.h.orig	2024-07-26 04:54:27.000000000 -0700
++++ ext/digest/sha2/sha2cc.h	2024-07-26 20:56:01.000000000 -0700
 @@ -1,6 +1,33 @@
  #define COMMON_DIGEST_FOR_OPENSSL 1
  #include <CommonCrypto/CommonDigest.h>
@@ -94,8 +94,8 @@
 +#define SHA384_Init CC_SHA384_Init
 +#undef SHA512_Init
 +#define SHA512_Init CC_SHA512_Init
---- lib/bundler/gem_helper.rb.orig	2024-04-23 03:20:09.000000000 -0700
-+++ lib/bundler/gem_helper.rb	2024-04-27 17:32:33.000000000 -0700
+--- lib/bundler/gem_helper.rb.orig	2024-07-26 04:54:27.000000000 -0700
++++ lib/bundler/gem_helper.rb	2024-07-26 20:56:01.000000000 -0700
 @@ -231,7 +231,7 @@ module Bundler
      end
  
@@ -105,8 +105,8 @@
      end
    end
  end
---- signal.c.orig	2024-04-23 03:20:09.000000000 -0700
-+++ signal.c	2024-04-27 17:32:33.000000000 -0700
+--- signal.c.orig	2024-07-26 04:54:27.000000000 -0700
++++ signal.c	2024-07-26 20:56:01.000000000 -0700
 @@ -841,7 +841,8 @@ check_stack_overflow(int sig, const uint
      const greg_t bp = mctx->gregs[REG_EBP];
  #   endif
@@ -117,8 +117,8 @@
  #     define MCTX_SS_REG(reg) __ss.__##reg
  #   else
  #     define MCTX_SS_REG(reg) ss.reg
---- tool/transform_mjit_header.rb.orig	2024-04-23 03:20:09.000000000 -0700
-+++ tool/transform_mjit_header.rb	2024-04-27 17:32:33.000000000 -0700
+--- tool/transform_mjit_header.rb.orig	2024-07-26 04:54:27.000000000 -0700
++++ tool/transform_mjit_header.rb	2024-07-26 20:56:01.000000000 -0700
 @@ -181,7 +181,9 @@ module MJITHeader
    def self.conflicting_types?(code, cc, cflags)
      with_code(code) do |path|
@@ -130,8 +130,8 @@
        !$?.success? &&
          (out.match?(/error: conflicting types for '[^']+'/) ||
           out.match?(/error: redefinition of parameter '[^']+'/))
---- vm_dump.c.orig	2024-04-23 03:20:09.000000000 -0700
-+++ vm_dump.c	2024-04-27 17:32:33.000000000 -0700
+--- vm_dump.c.orig	2024-07-26 04:54:27.000000000 -0700
++++ vm_dump.c	2024-07-26 20:56:01.000000000 -0700
 @@ -470,7 +470,8 @@ rb_vmdebug_thread_dump_state(VALUE self)
  }
  


### PR DESCRIPTION
See:
https://www.ruby-lang.org/en/news/2024/07/26/ruby-3-2-5-released/

The upstream code includes both the change that broke 3.2.4 and the fix for it as patched in 3.2.4_2.

TESTED:
Built successfully on OSX 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-14.x arm64.  Included all variants compatible with available dependencies on the respective platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.5 21H1222, x86_64, Xcode 14.2 14C18
macOS 12.7.5 21H1222, arm64, Xcode 14.2 14C18
macOS 13.6.7 22G720, arm64, Xcode 15.2 15C500b
macOS 14.5 23F79, arm64, Xcode 15.4 15F31d
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` The test framework has issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
