### PR TITLE
libmed: use legacysupport for strndup

### DIFF
--- a/science/libmed/Portfile
+++ b/science/libmed/Portfile
@@ -3,10 +3,14 @@
 PortSystem              1.0
 PortGroup               mpi       1.0
 PortGroup               cmake     1.1
+PortGroup               legacysupport 1.1
+
+# MEDfileExist.c: error: implicit declaration of function 'strndup' [-Wimplicit-function-declaration]
+legacysupport.newest_darwin_requires_legacy 10
 
 name                    libmed
 version                 4.1.1
-revision                3
+revision                4
 categories              science devel
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 license                 GPL-3+ LGPL-3+
@@ -26,6 +30,9 @@ checksums               rmd160  2e0a189cb4b5d72ae88c8e8fb26a61821e4e60be \
 
 patchfiles              patch-hdf5-1.12.diff \
                         patch-test10.diff
+
+# error: cinttypes: No such file or directory
+compiler.c_standard     2011
 
 mpi.setup               require_fortran
 if {[mpi_variant_isset]} {


### PR DESCRIPTION
#### Description

Revbump needed, because it was building before, despite undefined `strndup`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
