### PR TITLE
qrcp: Update to 0.11.2

### DIFF
--- a/sysutils/qrcp/Portfile
+++ b/sysutils/qrcp/Portfile
@@ -3,190 +3,231 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/claudiodangelis/qrcp 0.10.1
+go.setup            github.com/claudiodangelis/qrcp 0.11.2
 categories          sysutils net
 maintainers         {cal @neverpanic} openmaintainer
 
 license             MIT MPL-2 BSD LGPL-3 Apache-2
-homepage            https://claudiodangelis.com/qrcp/
 description         Transfer files over wifi from your computer to your mobile device by scanning a QR code without leaving the terminal.
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  15076964700f5dc6b9f7329d0534754edf985eee \
-                        sha256  7e5687a5d44732219762b592e7ae558efe67fbf309949eb9a90dd64f0ecf4e2c \
-                        size    26510141
+                        rmd160  cdc90d43a1eb328d7d2d9c8bc7fcb4b2281c714e \
+                        sha256  c7182adc97dcd9f7efccf103fef37b497744c10172a00be1f43d5e9f11ad8e71 \
+                        size    13295556
 
 go.vendors          gopkg.in/yaml.v3 \
-                        lock    9f266ea9e77c \
-                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
-                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
-                        size    86890 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
                     gopkg.in/yaml.v2 \
-                        lock    v2.2.2 \
-                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
-                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
-                        size    70676 \
+                        lock    v2.4.0 \
+                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
+                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
+                        size    73231 \
+                    gopkg.in/ini.v1 \
+                        lock    v1.67.0 \
+                        rmd160  4aa285a6719b0bb909b12bb70cb08cdf66ffeff3 \
+                        sha256  596cc2f7a771b35a1d308449ee2e3f96a79f834dd6d8d3c863c0fff321f70777 \
+                        size    53538 \
                     gopkg.in/cheggaaa/pb.v1 \
                         lock    v1.0.28 \
                         rmd160  d344c349278a6ba83ab17a1854523493632762a3 \
                         sha256  2a6cdb7d2c7984ad3f1d06cee4bef99453fe09720a79024083270b312845cdb0 \
                         size    11796 \
                     gopkg.in/check.v1 \
-                        lock    788fd7840127 \
-                        rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
-                        sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
-                        size    31597 \
+                        lock    41f04d3bba15 \
+                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
+                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
+                        size    31612 \
                     golang.org/x/text \
-                        lock    v0.3.0 \
-                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
-                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
-                        size    6102563 \
+                        lock    v0.14.0 \
+                        rmd160  e26a72d542901d19f6dde4e07746f72206fb8701 \
+                        sha256  ef54709caaafdd8b27ce3d5f7c53408f11bc5fd1688c1c4f328de8ed268b3188 \
+                        size    8972503 \
                     golang.org/x/sys \
-                        lock    v0.7.0 \
-                        rmd160  06b7e1f7f518376deaad92ca77d2d54b8a6807ec \
-                        sha256  82e99ca5ba1b5fddecc2dfef4b08e6cc1137ffe5eb41d0e0232fbdd8124e1ebf \
-                        size    1435346 \
+                        lock    v0.15.0 \
+                        rmd160  84270c5ffe3cd1540ccf8b8f19120cbdb117f848 \
+                        sha256  183f3870369e62e0ecaf378b5ef3d335e7fcebfd3ebfb81a0576b424a941476f \
+                        size    1443915 \
+                    golang.org/x/exp \
+                        lock    921286631fa9 \
+                        rmd160  4414b620e7dd0d4e95ec541192afa11081f8746d \
+                        sha256  a4e2ce5a0ff86e2141f5e23aeed5c21dc1821301156b88992efc11fc40d18c02 \
+                        size    1634450 \
+                    go.uber.org/multierr \
+                        repo    github.com/uber-go/multierr \
+                        lock    v1.9.0 \
+                        rmd160  a62e8085169740d9dcb002f9a360466b90a90afb \
+                        sha256  7bebee5c3b9c61eb805071deeb0857d992f177f8450083d42785aa51b9ab8b11 \
+                        size    15674 \
+                    go.uber.org/atomic \
+                        repo    github.com/uber-go/atomic \
+                        lock    v1.9.0 \
+                        rmd160  7705959c7053aa8e405560f5ffef3fbca414ee69 \
+                        sha256  8baccde94a6ecaea185ef40b9bdecbd3dd8d8df7cbc50c89856b58c5cd897e40 \
+                        size    21353 \
+                    github.com/subosito/gotenv \
+                        lock    v1.6.0 \
+                        rmd160  d99c048eeaed43103fbf28a86902dc5a2311f980 \
+                        sha256  b5890171316a97614d5a45363350e9c575dfc61ec8249742e68ae97ca21a444c \
+                        size    11487 \
                     github.com/stretchr/testify \
-                        lock    v1.6.1 \
-                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
-                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
-                        size    84248 \
+                        lock    v1.8.4 \
+                        rmd160  8e1645055c9b1d8e117df7974034e74b7f600d27 \
+                        sha256  6d0a77075bbe0f8f1c0cbed51dd4d174579db976fef39d9ae6b500aab8917d6a \
+                        size    104469 \
                     github.com/spf13/viper \
-                        lock    v1.4.0 \
-                        rmd160  a89f447feafc87e3b18f304634f122e0a81c9c15 \
-                        sha256  42f30be9b1797160ace166dc959e34c32f171b7d7b1b48d734fd23b3e2490d48 \
-                        size    44191 \
+                        lock    v1.18.2 \
+                        rmd160  8837f225975918742dd7f67abd3ece9919d4814e \
+                        sha256  49fcf5245d42b70b2d9651a325bc0580bd2f344ad5c52a0c262843a1bc1cd26a \
+                        size    118513 \
                     github.com/spf13/pflag \
-                        lock    v1.0.3 \
-                        rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
-                        sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
-                        size    46029 \
-                    github.com/spf13/jwalterweatherman \
-                        lock    v1.0.0 \
-                        rmd160  364fd0d61e94bd3651b5506d61f0e9652d6e33a3 \
-                        sha256  e70eb4dbab0603ad35c32bf89cefd595b2d6d56d66695866bfad2350db939404 \
-                        size    6405 \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
                     github.com/spf13/cobra \
-                        lock    v1.0.0 \
-                        rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
-                        sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
-                        size    128931 \
+                        lock    v1.8.0 \
+                        rmd160  d506ddb57519970c8227ded6411adb8153fc8278 \
+                        sha256  f35c4dd06645b4bca315c7d7f9a245f9d8851bb5fd43331fcb2aadbd585149e9 \
+                        size    189731 \
                     github.com/spf13/cast \
-                        lock    v1.3.0 \
-                        rmd160  26b82e9734f643bc70be8c73742d4a4f514b6dd2 \
-                        sha256  f2913fc10731a578c016701bd10e6a267c299b94e69d8362d258ce8482d14faf \
-                        size    11086 \
+                        lock    v1.6.0 \
+                        rmd160  c7d5bf6b598bcc91b9d56ada428f3bf8ef33e9c4 \
+                        sha256  cd5a5e7af2e781c1fe837d31d0abad184a2858d40c702df8ba5955d86959e047 \
+                        size    15629 \
                     github.com/spf13/afero \
-                        lock    v1.1.2 \
-                        rmd160  dc2ff3aa582c3dc782e3c062e35b65564bfc44e5 \
-                        sha256  08dca858dce5a4336ca385028ff38e0fa6a9f064f5c874fdabe2096a34b6fc91 \
-                        size    45324 \
+                        lock    v1.11.0 \
+                        rmd160  a986da1741dfe513ea0a0edaed3b2961e7a06069 \
+                        sha256  f8c35597e31410563e80730100f8bb615e359ad931a9214787feefa4085d48b6 \
+                        size    89254 \
+                    github.com/sourcegraph/conc \
+                        lock    v0.3.0 \
+                        rmd160  79458f4b5d9aca51fc58e3b3d31b54971169040b \
+                        sha256  a35f688a3ff3dc8c86889947febcedf7af0517cd910d1057cba5a0a5c2386451 \
+                        size    23025 \
                     github.com/skip2/go-qrcode \
                         lock    9434209cb086 \
                         rmd160  30a042f8d9e6d8a3d4f44bfb8107d53dd440a9be \
                         sha256  14df66c360abe69e729592ce94654a86492595adcfaf485f655aaa9ada90222d \
                         size    36086 \
+                    github.com/sagikazarmark/slog-shim \
+                        lock    v0.1.0 \
+                        rmd160  b83db4c4f465c978a6239aeee1afe2d8ecf97353 \
+                        sha256  53509e3267df1338fad356fa43949af957d12ba2267ec1410f498569a1866cd8 \
+                        size    10882 \
+                    github.com/sagikazarmark/locafero \
+                        lock    v0.4.0 \
+                        rmd160  61bc7c899fa9b193d92e2dade0894e25cd1c1d41 \
+                        sha256  7056ea0cdb195b98b9f26d4f6aba77c73a6f7882a4f1e40c3926460a605814cb \
+                        size    9698 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.9.0 \
+                        rmd160  acb8f644e5634bdae632cdb61ea736422aeb88f0 \
+                        sha256  65b0852e5c78fa920fef2176fa17180bf1f7f32a1163baacb44c2aa480845a16 \
+                        size    133682 \
                     github.com/pmezard/go-difflib \
-                        lock    v1.0.0 \
-                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
-                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
-                        size    11409 \
+                        lock    5d4384ee4fb2 \
+                        rmd160  18b381fb63f46047dcc373a07a40e026b1ce1732 \
+                        sha256  64935467335b4dff1a510bc726473b9f97124ca6be3fe74c9c2382b0ff6675aa \
+                        size    11401 \
                     github.com/pelletier/go-toml \
-                        lock    v1.2.0 \
-                        rmd160  8d91b6485f373ccaa894abcb3bd53839e55b9057 \
-                        sha256  0a9503f2b53444e0c3ea960d18febe14d472c16279844f231994c5ccb81dbdff \
-                        size    57515 \
+                        lock    v2.1.0 \
+                        rmd160  8333f1e37c354b98998a2793c1dd290482838c9e \
+                        sha256  cd68736aa89935e4c00384e1c04a3dc0a2f548fa91dd0921a4137be46c090b03 \
+                        size    899447 \
                     github.com/mitchellh/mapstructure \
-                        lock    v1.1.2 \
-                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
-                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
-                        size    20992 \
+                        lock    v1.5.0 \
+                        rmd160  c838fb22a642081963c8e6f236cdd4c6000bfaf4 \
+                        sha256  bd695f63e58f35f07aac6883ac5dc53d44db6cf24caa53efaadcf0842d03d762 \
+                        size    30135 \
                     github.com/mattn/go-runewidth \
                         lock    v0.0.9 \
                         rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
                         sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
                         size    16716 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.12 \
-                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
-                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
-                        size    4549 \
+                        lock    v0.0.17 \
+                        rmd160  8a79d7ac1ac5311cb4892f75b7a439fd07cccc17 \
+                        sha256  e75610c71dfca6ab7f671d1372f7b603b98338b7cbf1098d5a418d5a6760fb52 \
+                        size    4700 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.6 \
-                        rmd160  3c6531ff68909aacc83a16f92149722803b465a7 \
-                        sha256  3f3b5a79ae9511dd610d288768d782faffa27bf92ad1d6c8be3f37aa9d3bc975 \
-                        size    9477 \
+                        lock    v0.1.13 \
+                        rmd160  c9e8ab9d0773c0984f36235e3c9f8c033552ac1a \
+                        sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
+                        size    9778 \
                     github.com/manifoldco/promptui \
-                        lock    v0.7.0 \
-                        rmd160  9dc391ee449f2d9c535ab79b19b2ae54c8340d23 \
-                        sha256  fed2ddd7c8e15bb66c2679dba0b948cda9e752a4aed5149fb1e65fa9c5331445 \
-                        size    26673 \
+                        lock    v0.9.0 \
+                        rmd160  0557a766a57005f08f096935e894bfb34a7b0e03 \
+                        sha256  bb66c3deb1709d13f67a00ec2421185792f7a1efc5836e7a1607639a46ce1178 \
+                        size    25927 \
                     github.com/magiconair/properties \
-                        lock    v1.8.0 \
-                        rmd160  327cf3e96df60025444491a413aba0145ef448f3 \
-                        sha256  1a51357a88b298284fa48607836e7d05bee5fc58e00c87ba943a8d719d2ece2c \
-                        size    29500 \
-                    github.com/lunixbochs/vtclean \
-                        lock    2d01aacdc34a \
-                        rmd160  a378a8e18f9fc0f242d5d25bfe8f3a321f2cfd25 \
-                        sha256  7dcc634f0e50b918bddfdd88f7cfa99e35e885c1e53cf61854e8f638a3a90727 \
-                        size    4185 \
+                        lock    v1.8.7 \
+                        rmd160  df6e5639d11fcd7db0638153e247235b1cf17eb8 \
+                        sha256  494b9c870a97ffc3b9377280412ab0c5afff549d109b28d484b02ced07713656 \
+                        size    31419 \
                     github.com/kr/text \
-                        lock    v0.1.0 \
-                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
-                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
-                        size    8691 \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
                     github.com/kr/pretty \
-                        lock    v0.1.0 \
-                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
-                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
-                        size    8553 \
-                    github.com/juju/ansiterm \
-                        lock    720a0952cc2a \
-                        rmd160  c3c15da3b3d62f7caa467b66f45b251e2e868626 \
-                        sha256  a0efc9542e6fe50c97cdd999685ddda6069ab44754a6b3c87c6b18b21899e05b \
-                        size    15418 \
+                        lock    v0.3.1 \
+                        rmd160  8c08579b4c56cdc958794e77afe3413e80aa67c3 \
+                        sha256  7fcea475d6280976cf4a838e75d2b3a4105827316e588a80e49e8063d950c999 \
+                        size    10232 \
                     github.com/jhoonb/archivex \
                         lock    0488e4ce1681 \
                         rmd160  f3f52a7b98d1623eb37c90e9137e27c3c7c8c461 \
                         sha256  cde011a4d4ff9312645893d8a0a49f3e0ff3fdea8a33fba6056afb3e23087a8d \
                         size    5178 \
                     github.com/inconshreveable/mousetrap \
-                        lock    v1.0.0 \
-                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
-                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
-                        size    2291 \
+                        lock    v1.1.0 \
+                        rmd160  88f9577df93ac0f8801d8960adc7f28e38867f3e \
+                        sha256  f69af10ff08c0e87f92dac3ee5172d8ed02463725b74edfc8943ef018a1a632d \
+                        size    5343 \
                     github.com/hashicorp/hcl \
                         lock    v1.0.0 \
                         rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
                         sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
                         size    70636 \
-                    github.com/glendc/go-external-ip \
-                        lock    139229dcdddd \
-                        rmd160  c0f7a7447c6025c8d2f4c14d9092cd1a4bb155fe \
-                        sha256  9f0bf3945d0ff2e41278137ec7204f7b8a52c84d3eb876e12d4bd6f825cee724 \
-                        size    5659 \
+                    github.com/google/go-cmp \
+                        lock    v0.5.9 \
+                        rmd160  9832ae80123461baed8aa20e830199c0e21e337b \
+                        sha256  3058d20d61f03aa05fca0fc07acb8c50850c68086998c542857aec7ad1529482 \
+                        size    104431 \
+                    github.com/GlenDC/go-external-ip \
+                        lock    v0.1.0 \
+                        rmd160  e2da7f2b6e9bbb8c7e02bf1de18fdf98779b52e6 \
+                        sha256  12fc539e893f62e9fa45ac02d89fd09285499bd754686417e4146c1a1e95b979 \
+                        size    6995 \
                     github.com/fsnotify/fsnotify \
-                        lock    v1.4.7 \
-                        rmd160  24712e412814020224e2779186e634610e2f6926 \
-                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
-                        size    31147 \
+                        lock    v1.7.0 \
+                        rmd160  9198dec094f5008a8b24a2e51542ce4ec3453162 \
+                        sha256  d7cd46fbc8e25bfd37edb1b86851dcccc18c5180f09e533c6a35e4dcf2693d22 \
+                        size    57508 \
+                    github.com/frankban/quicktest \
+                        lock    v1.14.6 \
+                        rmd160  d517a6cb2f6acc7f969c9ed49f464014a717bf98 \
+                        sha256  0142a3dd40b949b4d7e86768020e5f3c08fe026447458fd975b1b4c1f18b0745 \
+                        size    40112 \
                     github.com/fatih/color \
-                        lock    v1.9.0 \
-                        rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
-                        sha256  577c8e778833fec90d76918f138cee9f7765435757b7c92a669e5b34933e0b4f \
-                        size    1231337 \
+                        lock    v1.14.1 \
+                        rmd160  84b28475fc7b807de85c16c1d0a44221b4752482 \
+                        sha256  b386d1a4f60d24494ab4f01dbde6fb33700bda87ae54b2c2a5f9a26b0d3b29f3 \
+                        size    11020 \
                     github.com/eiannone/keyboard \
                         lock    caf4b762e807 \
                         rmd160  3bc7409fda500b63dee7372dc9f49e7f03ee33d9 \
                         sha256  79087c296ad6a4c8dc60e862a19d094ef63ff89e432497dd6012b23023a54be3 \
                         size    8564 \
                     github.com/davecgh/go-spew \
-                        lock    v1.1.1 \
-                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
-                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
-                        size    42171 \
+                        lock    d8f796af33cc \
+                        rmd160  412da847dd485c586e0557e0e511bbdab6c7e929 \
+                        sha256  989c527fb1568e2bfd9d4bec811d67ababa346d20fa2ffcc0760fad258241c26 \
+                        size    42174 \
                     github.com/chzyer/test \
                         lock    a1ea475d72b1 \
                         rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
@@ -208,15 +249,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  b5b2683d6b0bb1e516dcba00393f10c198496309575d299a4a996a61207e839d \
                         size    57033 \
                     github.com/adrg/xdg \
-                        lock    v0.3.2 \
-                        rmd160  c54789954a6a2f1f919215273459b6927021a0ad \
-                        sha256  61988f4f3ebb2ea0bdb594f94fa7d5894a561bfff47a53dc06200dee0454fc80 \
-                        size    16126 \
-                    github.com/BurntSushi/toml \
-                        lock    v0.3.1 \
-                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
-                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
-                        size    42087
+                        lock    v0.4.0 \
+                        rmd160  9a5eabbef937e0482168febd9fc3fc63ad61d6fd \
+                        sha256  1a1276ed8071b21d00f417eff83dc3a77d4a7878e3064f117bc22421902e0cfe \
+                        size    20032
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

qrcp: Update to 0.11.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
