### PR TITLE
oberon-risc: New port, version 20200818

### DIFF
--- a/emulators/oberon-risc/Portfile
+++ b/emulators/oberon-risc/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        pdewacht oberon-risc-emu 26c8ac5
+
+name                oberon-risc
+version             20200818
+categories          emulators
+platforms           darwin
+license             BSD
+description         Project Oberon RISC system emulator
+long_description    Project Oberon 2013 by Niklaus Wirth and Jürg Gutknecht \
+    is a lean and easily understandable desktop computer. This emulation \
+    by Peter De Wachter includes a disk image of the latest full system \
+    (note: make a scratch, writable copy)
+homepage            https://www.projectoberon.net/
+maintainers         {@jflude hotmail.com:justin_flude} openmaintainer
+
+checksums           rmd160 205aba103984e4606633f39cdb3d9b5a829e650c \
+                    sha256 43ca13736b0e5618a18d95efaeb57d529d71cb4f1fd43950103d25f24dfa05c9 \
+                    size 1073579
+
+depends_lib         port:libsdl2
+
+patch.pre_args-replace  -p0 -p1
+patchfiles          patch-rename-program.diff
+
+use_configure       no
+build.args-append   CC=${configure.cc}
+build.target        risc
+
+destroot {
+    xinstall ${worksrcpath}/risc ${destroot}${prefix}/bin/${name}
+    xinstall -d ${destroot}${prefix}/share/${name}
+    xinstall -m 644 -W ${worksrcpath} DiskImage/Oberon-2020-08-18.dsk \
+        README.md po2013.png ${destroot}${prefix}/share/${name}
+    xinstall -W ${worksrcpath} pcsend.sh pcreceive.sh \
+        ${destroot}${prefix}/share/${name}
+}

--- a/emulators/oberon-risc/files/patch-rename-program.diff
+++ b/emulators/oberon-risc/files/patch-rename-program.diff
@@ -1,0 +1,22 @@
+--- a/src/sdl-main.c
++++ b/src/sdl-main.c
+@@ -83,7 +83,7 @@ static void fail(int code, const char *fmt, ...) {
+ }
+ 
+ static void usage() {
+-  puts("Usage: risc [OPTIONS...] DISK-IMAGE\n"
++  printf("Usage: %s [OPTIONS...] DISK-IMAGE\n"
+        "\n"
+        "Options:\n"
+        "  --fullscreen          Start the emulator in full screen mode\n"
+@@ -93,8 +93,8 @@ static void usage() {
+        "  --size WIDTHxHEIGHT   Set framebuffer size\n"
+        "  --boot-from-serial    Boot from serial line (disk image not required)\n"
+        "  --serial-in FILE      Read serial input from FILE\n"
+-       "  --serial-out FILE     Write serial output to FILE\n"
+-       );
++       "  --serial-out FILE     Write serial output to FILE\n",
++       getprogname());
+   exit(1);
+ }
+ 


### PR DESCRIPTION
#### Description

Emulator for Wirth & Gutknecht's Project Oberon 2013 desktop system.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
