### PR TITLE
ircii: fix build on older systems and Sonoma

### DIFF
--- a/irc/ircii/Portfile
+++ b/irc/ircii/Portfile
@@ -33,6 +33,17 @@ configure.env       COPY_DIRECTORY=tar
 # uses TLS. Restore this when that gets fixed.
 #configure.args      --with-default-server=irc.libera.chat:6697
 
+# translat.h:24: error: redefinition of typedef ‘libiconv_t’
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
+
+# help.c:535:50: error: passing argument 3 of 'scandir'
+# from incompatible pointer type [-Wincompatible-pointer-types]
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.cflags-append \
+                    -Wno-error=incompatible-pointer-types
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}
 livecheck.regex     current release is ircII (\[0-9\]+)

--- a/irc/ircii/Portfile
+++ b/irc/ircii/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                ircii
 conflicts           ircii-classic
@@ -34,8 +35,10 @@ configure.env       COPY_DIRECTORY=tar
 #configure.args      --with-default-server=irc.libera.chat:6697
 
 # translat.h:24: error: redefinition of typedef ‘libiconv_t’
+# Both old Xcode gcc and the latest Xcode clang fail on this spot.
 compiler.blacklist-append \
-                    *gcc-4.0 *gcc-4.2
+                    *gcc-4.0 *gcc-4.2 \
+                    {clang > 1400}
 
 # help.c:535:50: error: passing argument 3 of 'scandir'
 # from incompatible pointer type [-Wincompatible-pointer-types]


### PR DESCRIPTION
#### Description

Fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
