### PR TITLE
colima: Upgrade to 0.7.0

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.6.10 v
+go.setup            github.com/abiosoft/colima 0.7.0 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  65431f9b2b95b022ec4a14367d344b2d3ea3faa7 \
-                    sha256  619b87083826e97291d29254562c50bbc8c945099fa1d0b582896669c0338b1d \
-                    size    608988
+checksums           rmd160  f995373e1b83b28cf46ffedf333383373d7163a1 \
+                    sha256  ea02a8749659728dbc6e7f2d4bda0e0b85655722d6464a0fbb3308a19084f1fe \
+                    size    611334
 
 depends_run         port:lima
 
@@ -55,8 +55,8 @@ notes {
     If upgrading from Colima 0.5.6 or earlier, both colima instances and
     profiles must be deleted and recreated.
 
-    Colima 0.6.8 addresses several CVEs. Newly created colima instances
-    are automatically patched. Existing instances should upgrade manually:
+    If upgrading from Colima 0.6.7 or earlier, several instance CVEs were
+    resolved and existing instances should be replaced or upgraded manually:
 
       colima ssh -- \
         sh -c "sudo apt update && sudo apt install -y containerd.io"


### PR DESCRIPTION
#### Description

colima: Upgrade to 0.7.0

##### Tested on

macOS 14.6 23G80 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
