### PR TITLE
aerc: update to 0.18.2

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile    1.0
 PortGroup           sourcehut   1.0
 
-sourcehut.setup     rjarry aerc 0.18.1
+sourcehut.setup     rjarry aerc 0.18.2
 revision            0
 
 homepage            https://aerc-mail.org
@@ -22,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  d177902250cd8c86e4ab387b0332e2885de4557a \
-                    sha256  f8a2923b1749b1b0eaa9ce221121536d13974297143b597f812b11ebbef0c1bf \
-                    size    447293
+checksums           rmd160  9d5516dd78f8880ce53bbe5b87859eccdf2995f0 \
+                    sha256  78408b3fe7a4991a6097c961c348fb7583af52dff80cbfcd99808415cf3d7586 \
+                    size    447348
 
 depends_build-append \
                     port:go \


### PR DESCRIPTION
#### Description
[Changelog](https://git.sr.ht/~rjarry/aerc/refs/0.18.2)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
