### PR TITLE
legacysupport-1.1 PG: Update default newest OS to Darwin 18

### DIFF
--- a/_resources/port1.0/group/legacysupport-1.1.tcl
+++ b/_resources/port1.0/group/legacysupport-1.1.tcl
@@ -21,8 +21,8 @@ namespace eval legacysupport {
 }
 
 # Newest Darwin version that requires legacy support.
-# Currently OS X 10.12 ( Sierra, Darwin 16) due to utimensat, fsgetpath, setattrlistat
-set ls_max_darwin_support 16
+# Currently OS X 10.14 ( Mojave, Darwin 18) due to timespec_get
+set ls_max_darwin_support 18
 options legacysupport.newest_darwin_requires_legacy
 default legacysupport.newest_darwin_requires_legacy ${ls_max_darwin_support}
 


### PR DESCRIPTION
Commit 9180c459eda overlooked the fact that there are two versions of the legacysupport PG, and only updated v1.0.  This makes the equivalent change to v1.1.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
