### PR TITLE
resticprofile: new port

### DIFF
--- a/sysutils/resticprofile/Portfile
+++ b/sysutils/resticprofile/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/creativeprojects/resticprofile 0.27.1 v
+go.offline_build    no
+github.tarball_from archive
+revision            0
+
+homepage            https://creativeprojects.github.io/resticprofile/
+
+description         Configuration profiles manager and scheduler for restic
+
+long_description    resticprofile is one of many automation tools for restic, \
+                    also called a wrapper. In a nutshell, resticprofile \
+                    provides a configuration file and a runner that will \
+                    generate all the necessary calls to restic. \
+                    Additionally, it can schedule a profile via a user agent or \
+                    a daemon in launchd
+
+categories          sysutils
+installs_libs       no
+license             GPL-3
+maintainers         {fsoj.de:lheise @lucaheise} \
+                    openmaintainer
+
+checksums           rmd160  b4a704c4d88e6f3f795d62768a16ea325eebf726 \
+                    sha256  9c9b5b5e56c633ab4969355fff139b3c36979f88b815bdd02ff8d1dd14e69765 \
+                    size    3195445
+
+depends_run         port:restic
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+


### PR DESCRIPTION
#### Description

add resticprofile, a configuration profiles manager and scheduler for restic 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6 23G80 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
