### PR TITLE
openjdk21-microsoft: update to 21.0.4

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      21.0.3
-set build    9
+version      21.0.4
+set build    7
 revision     0
 
 description  Microsoft Build of OpenJDK 21 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  dd2ced70234146bd64b39ee8da5a1e5ae3a92b3c \
-                 sha256  cf7d2c967088ac71b29cf28ad791a071bbf2c1dab333dd73dc0e791cb974c1f6 \
-                 size    202947464
+    checksums    rmd160  5ee1a5eb33847e69b0860044d9fa9306fd565886 \
+                 sha256  8bf2a7b24746af5a802bafd29adee6dccd1337a03d508776fa847c0b2d998bf3 \
+                 size    203051213
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  eb3e320efb4635dbe4c89fee5c0d3ea5ca035e82 \
-                 sha256  489c96c8a4d3592811d1907346c05b75c12642729f83576982b9f62d0aafc672 \
-                 size    200438427
+    checksums    rmd160  40e7529f7bc2b2094301bbdddae7409428f40454 \
+                 sha256  65c7585a1bd2dd9cba99a43efd51d830b2714dfade80591b883ce9ef3300d50c \
+                 size    200536590
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 21.0.4.

###### Tested on

macOS 14.6 23G80 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?