### PR TITLE
google-cloud-sdk: update to 486.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             485.0.0
+version             486.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  0f66fad0b58234ac7c095f87739b57bd2e00ed22 \
-                    sha256  c754495321a5cf07913480bb3268ae3501dfecf744a54a762c99a283fdfd2f6c \
-                    size    51253501
+    checksums       rmd160  61ca19e1d59c5245b76f1fb2706b30dd80908a36 \
+                    sha256  e3b596ac95e36c375b694387666e6fd6323093303e5ecd5507d03b4cec262422 \
+                    size    51345361
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  8a58eb8068881469652d2f8b80f5f0e879bf60c1 \
-                    sha256  11aa7c62ae7c571c80546b8efbfbb189f7f33a11e757147b39cad4764cf9067e \
-                    size    52604404
+    checksums       rmd160  e7b35a98fb8757d7fa5732d6cc99c52479d8e760 \
+                    sha256  bd69ef6e9176959737c2ac0731a428f0171cf117be0da46760ecaed205c10831 \
+                    size    52696879
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  6423548797b50b4e250184d34b03ab3161be084e \
-                    sha256  c33c1d2baa5fc4ee952869b41658f78d064120260701a74efc3534158328daf4 \
-                    size    52552059
+    checksums       rmd160  e7a7eec9a17566dd175dbe2a577944be703c52c8 \
+                    sha256  3093a93dddece68f4ec2b60d591cafebd967316faea5fb2a3ad19bcd16559807 \
+                    size    52644566
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 486.0.0.

###### Tested on

macOS 14.6 23G80 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?