### PR TITLE
openjdk17-microsoft: update to 17.0.12

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      17.0.11
-set build    9
+version      17.0.12
+set build    7
 revision     0
 
 description  Microsoft Build of OpenJDK 17 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  a8a1c413ec08e40d4589deb587f6d3d298b42a31 \
-                 sha256  be78392de3b8eafca233048ad54fa8a63cb7e92d5a97cd2b4c079f97327cc718 \
-                 size    188135698
+    checksums    rmd160  957821bf76b3ddea6d8f80198c16ad7aab1ee209 \
+                 sha256  c4a44fbbf4c17282662856c44e97ec0ff0ebff44a7fc90a857204ccb8528d30c \
+                 size    188291485
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  c4d6e819cefde70393bae4a115515619036acb7e \
-                 sha256  af06d9e5fa6686b8d293992b11d6b923590104da1400f591a155f725124609c3 \
-                 size    185989362
+    checksums    rmd160  c3502d2928a3a24233081a58211c4129b851fc65 \
+                 sha256  070aafe1b417a95f70daa5ac3c9febff223fb71192b7359dc7c4667e2dd57904 \
+                 size    186047485
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.12.

###### Tested on

macOS 14.6 23G80 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?