### PR TITLE
shellcheck: add manpage

### DIFF
--- a/devel/shellcheck/Portfile
+++ b/devel/shellcheck/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        koalaman shellcheck 0.10.0 v
-revision            5
+revision            6
 categories          devel haskell
 
 license             GPL-3+
@@ -31,6 +31,8 @@ checksums           rmd160  ad6d0032a391181418af0e3b367ee8d24b439281 \
 livecheck.url       https://hackage.haskell.org/package/ShellCheck
 
 installs_libs       no
+depends_build-append \
+                    port:pandoc
 
 variant stack \
     description {Use stack to build.} {}
@@ -39,4 +41,13 @@ if { [variant_isset "stack"] } {
     PortGroup       haskell_stack 1.0
 } else {
     PortGroup       haskell_cabal 1.0
+}
+
+post-build {
+    system -W ${worksrcpath} "./manpage"
+}
+
+post-destroot {
+    xinstall -m 0644 ${worksrcpath}/${name}.1 \
+        ${destroot}${prefix}/share/man/man1/
 }


### PR DESCRIPTION
#### Description

Add man.1 for shellcheck

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.7.2 21G1974 x86_64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
