### PR TITLE
py-pulp: update to 2.9.0; migrate to PyPi

### DIFF
--- a/python/py-pulp/Portfile
+++ b/python/py-pulp/Portfile
@@ -1,13 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        coin-or pulp 2.8.0
+name                py-pulp
+
+version             2.9.0
 revision            0
-name                py-${github.project}
-github.tarball_from tarball
 
 categories-append   science math
 
@@ -23,9 +22,9 @@ long_description    PuLP is an LP modeler written in Python. PuLP can generate M
 
 homepage            https://coin-or.github.io/pulp/
 
-checksums           rmd160  a378276a676bd186ac77b8de363f5e389092cb9c \
-                    sha256  0235b020862e14e8419c9a4e904a8b9f0f2e379cdb15cd17c694c8c9e609bf57 \
-                    size    31433659
+checksums           rmd160  857aada4c9882f918f1e608660d16e4474e43290 \
+                    sha256  2e30e6c0ef2c0edac185220e3e53faca62eb786a9bd68465208f05bc63e850f3 \
+                    size    17610175
 
 python.versions     39 310 311 312
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update`py-pulp` to 2.9.0; migrate to PyPi.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
