### PR TITLE
py-xraylarch, py-pyqtgraph: update versions, add Python 3.11-3.12

### DIFF
--- a/python/py-pyqtgraph/Portfile
+++ b/python/py-pyqtgraph/Portfile
@@ -20,15 +20,15 @@ long_description    PyQtGraph is a pure-python graphics and GUI library \
                     for number crunching and Qt’s GraphicsView framework \
                     for fast display.
 
-version             0.13.1
-checksums           rmd160  684e82952133c5ed6d4b0b1a08658135eab55253 \
-                    sha256  698f87f59db965727b33602a0b29058de21291d8b143dea878b50578aec0dc08 \
-                    size    1364064
+version             0.13.7
+checksums           rmd160  dcc61a485d23320e58c7ff5a9b5a15035d0381fc \
+                    sha256  64f84f1935c6996d0e09b1ee66fe478a7771e3ca6f3aaa05f00f6e068321d9e3 \
+                    size    2343380
 revision            0
 
 homepage            https://pyqtgraph.org/
 
-python.versions     38 39 310
+python.versions     38 39 310 311 312
 
 if {${subport} ne ${name}} {
     if {[variant_isset pyqt4] || [variant_isset pyside]} {
@@ -36,6 +36,11 @@ if {${subport} ne ${name}} {
         checksums   rmd160  dd120edb7b6199222713dd67d01387edc52277b0 \
                     sha256  7d1417f36b5b92d1365671633a91711513e5afbcc82f32475d0690317607714e \
                     size    789229
+    } elseif {${python.version} < 310} {
+        version     0.13.1
+        checksums   rmd160  684e82952133c5ed6d4b0b1a08658135eab55253 \
+                    sha256  698f87f59db965727b33602a0b29058de21291d8b143dea878b50578aec0dc08 \
+                    size    1364064
     }
 
     depends_lib-append      port:py${python.version}-scipy

--- a/python/py-xraylarch/Portfile
+++ b/python/py-xraylarch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-xraylarch
-version             0.9.62
+version             0.9.80
 revision            0
 
 categories-append   science
@@ -26,61 +26,54 @@ long_description    Larch is a open-source library and set of applications for p
 
 homepage            https://xraypy.github.io/xraylarch
 
-# Find the latest at https://pypi.org/project/xraylarch/#files
-master_sites        https://files.pythonhosted.org/packages/ff/4a/cf7f494aaa3ea1ba15adf5806cef0ac5136affc7e8f7c2048999fa4e28d9/
-distname            xraylarch-${version}-py3-none-any
+checksums           rmd160  1bedf6d4522e3b325a0f818d42f865989b99ae45 \
+                    sha256  716c9f64e85a12ef4c37a56098a73eda9269d91f24e9bdf15ba124eb9306873a \
+                    size    21463230
 
-checksums           rmd160  0736ee2e7d6ba40c8c55dc7111cb3c3067454fd2 \
-                    sha256  92d558df4c8302a277ead4ad597920285abf3b7e69ca9ab13873e8dc319e452a \
-                    size    21056444
-
-python.versions     38 39 310
-python.pep517       yes
-python.pep517_backend
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
-
-    # Must build from wheel file, because PyPi distributes only that and no tarballs
-    # (starting with version 0.9.61 in May 2022).
-    # See discussion at https://github.com/xraypy/xraylarch/issues/380
-
-    extract.suffix  .whl
-    extract.only
-
-    build { }
 
     depends_lib-append \
                     port:py${python.version}-numpy
 
+    # The following list copies the order in upstream setup.cfg, so it's easier to cross-check.
+
     depends_run-append \
                     port:py${python.version}-asteval \
-                    port:py${python.version}-h5py \
-                    port:py${python.version}-fabio \
-                    port:py${python.version}-importlib-metadata \
+                    port:py${python.version}-scipy \
+                    port:py${python.version}-uncertainties \
                     port:py${python.version}-lmfit \
+                    port:py${python.version}-pyshortcuts \
+                    port:py${python.version}-xraydb \
+                    port:py${python.version}-silx \
                     port:py${python.version}-matplotlib \
-                    port:py${python.version}-numdifftools \
+                    port:py${python.version}-sqlalchemy \
+                    port:py${python.version}-h5py \
+                    port:py${python.version}-hdf5plugin \
                     port:py${python.version}-Pillow \
-                    port:py${python.version}-peakutils \
-                    port:py${python.version}-psutil \
-                    port:py${python.version}-pyqt5 \
-                    port:py${python.version}-pyqtgraph \
-                    port:py${python.version}-pyqt5-webengine \
+                    port:py${python.version}-numdifftools \
+                    port:py${python.version}-pandas \
+                    port:py${python.version}-packaging \
+                    port:py${python.version}-yaml \
+                    port:py${python.version}-toml \
+                    port:py${python.version}-termcolor \
+                    port:py${python.version}-dill \
+                    port:py${python.version}-imageio \
+                    port:py${python.version}-charset-normalizer \
                     port:py${python.version}-requests \
-                    port:py${python.version}-ruamel-yaml-clib \
                     port:py${python.version}-scikit-image \
                     port:py${python.version}-scikit-learn \
-                    port:py${python.version}-scipy \
-                    port:py${python.version}-silx \
-                    port:py${python.version}-sqlalchemy \
-                    port:py${python.version}-termcolor \
-                    port:py${python.version}-toml \
-                    port:py${python.version}-uncertainties \
-                    port:py${python.version}-xraydb \
+                    port:py${python.version}-psutil \
+                    port:py${python.version}-pymatgen \
+                    port:py${python.version}-fabio \
+                    port:py${python.version}-pyFAI \
+                    port:py${python.version}-tabulate \
+                    port:py${python.version}-numexpr \
                     port:py${python.version}-wxmplot \
                     port:py${python.version}-wxpython-4.0 \
                     port:py${python.version}-wxutils \
-                    port:py${python.version}-yaml
-
-    destroot.target ${distpath}/${distfiles}
+                    port:py${python.version}-pyqt5 \
+                    port:py${python.version}-pyqt5-webengine \
+                    port:py${python.version}-pyqtgraph
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

See closed PR #21146, where we tried to update the version before. That failed because I could not get the tarball build to work, and I still cannot. PyPi does offer a tarball now, but building from it leads to a `File is not a zip file` error. So even though we don't love to install from a wheel, I cannot make the tarball approach work.