### PR TITLE
yt-dlp: update to 2024.08.01

### DIFF
--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -37,11 +37,11 @@ if {${subport} eq ${name}} {
 }
 
 subport yt-dlp {
-    github.setup    yt-dlp ${subport} 2024.07.25
+    github.setup    yt-dlp ${subport} 2024.08.01
     revision        0
-    checksums       rmd160  2f35b4f134dd4580b01709fb7c37c4377a0d68fb \
-                    sha256  f34f396cd100f9a68ad6ffbb0d09932011e8f6896d01a177f3c6610b39b53488 \
-                    size    5695273
+    checksums       rmd160  0916acd4be5693d07bbfe10e48953f0e9a725bd2 \
+                    sha256  9ddf1082359431dadb8cc78c91b04bfd8308a2c2fc2c51573a7936e558dca327 \
+                    size    5708569
 
     dist_subdir     ${subport}/${version}
     distname        ${subport}


### PR DESCRIPTION
#### Description

yt-dlp: update to 2024.08.01

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.6 23G80 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
