### PR TITLE
libsoup, -devel: drop now unneeded special case for ppc

### DIFF
--- a/gnome/libsoup-devel/Portfile
+++ b/gnome/libsoup-devel/Portfile
@@ -8,7 +8,7 @@ name                libsoup-devel
 conflicts           libsoup
 set my_name         libsoup
 version             3.5.1
-revision            0
+revision            1
 
 categories          gnome net
 license             LGPL-2+
@@ -41,7 +41,7 @@ set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build-append \
                     port:python${py_ver_nodot} \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     port:curl \
                     path:bin/vala:vala
 
@@ -102,13 +102,6 @@ variant docs description {Enable doc generation} {
     configure.args-replace \
                     -Ddocs=disabled \
                     -Ddocs=enabled
-}
-
-platform darwin {
-    # vapigen is broken on PPC at the moment
-    if { ${build_arch} eq "ppc" } {
-        configure.args-append -Dvapi=disabled
-    }
 }
 
 livecheck.type      gnome

--- a/gnome/libsoup/Portfile
+++ b/gnome/libsoup/Portfile
@@ -8,7 +8,7 @@ name                libsoup
 conflicts           libsoup-devel
 set my_name         libsoup
 version             3.5.1
-revision            0
+revision            1
 
 categories          gnome net
 license             LGPL-2+
@@ -41,7 +41,7 @@ set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build-append \
                     port:python${py_ver_nodot} \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     port:curl \
                     path:bin/vala:vala
 
@@ -106,13 +106,6 @@ variant docs description {Enable doc generation} {
     configure.args-replace \
                     -Ddocs=disabled \
                     -Ddocs=enabled
-}
-
-platform darwin {
-    # vapigen is broken on PPC at the moment
-    if { ${build_arch} eq "ppc" } {
-        configure.args-append -Dvapi=disabled
-    }
 }
 
 livecheck.type      gnome


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/70479

#### Description

There is no problem with `vapigen` anymore, drop a special case. Fixes build of `gnome-calculator`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
