### PR TITLE
ruff: Update to 0.5.6

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.5.5
+github.setup        astral-sh ruff 0.5.6
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  3b071b4ab55b1cd33c7f10c9a24d326e8df9faf8 \
-                    sha256  b0f710015cc27c58f3b7236d493f62d4141efaa37b49abdbd79f21c63d58ab41 \
-                    size    4830364
+                    rmd160  e4686408c42425a9238fd583bb02b02ee9610875 \
+                    sha256  f774651e684e21f155b43e6738336f2eb53b44cd42444e72a73ee6eb1f6ee079 \
+                    size    4870807
 
 cargo.offline_cmd
 
@@ -80,14 +80,15 @@ cargo.crates \
     anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
     anyhow                          1.0.86  b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
-    argfile                          0.2.0  b7c5c8e418080ef8aa932039d12eda7b6f5043baf48f1523c166fbc32d004534 \
+    argfile                          0.2.1  0a1cc0ba69de57db40674c66f7cf2caee3981ddef084388482c95c0e2133e5e8 \
     arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
     autocfg                          1.2.0  f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80 \
     base64                          0.22.0  9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51 \
     bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
-    bstr                             1.9.1  05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706 \
+    boomphf                          0.6.0  617e2d952880a00583ddb9237ac3965732e8df6a92a8e7bcc054100ec467ec3b \
+    bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
@@ -102,12 +103,12 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                             4.5.9  64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462 \
-    clap_builder                     4.5.9  6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942 \
+    clap                            4.5.11  35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3 \
+    clap_builder                    4.5.11  49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa \
     clap_complete                    4.5.2  dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.2  1accf1b463dee0d3ab2be72591dccdab8bef314958340447c882c4c72acfe2a3 \
-    clap_derive                      4.5.8  2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085 \
+    clap_derive                     4.5.11  5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e \
     clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
     clearscreen                      3.0.0  2f8c93eb5f77c9050c7750e14f13ef1033a40a0aac70c6371535b6763a01438c \
     codspeed                         2.6.0  3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089 \
@@ -146,7 +147,7 @@ cargo.crates \
     either                          1.11.0  a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2 \
     encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
     env_filter                       0.1.0  a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea \
-    env_logger                      0.11.3  38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9 \
+    env_logger                      0.11.5  e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
     etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
@@ -164,7 +165,7 @@ cargo.crates \
     globset                         0.4.14  57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1 \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashlink                         0.8.4  e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7 \
+    hashlink                         0.9.1  6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
@@ -174,8 +175,8 @@ cargo.crates \
     ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
     ignore                          0.4.22  b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1 \
-    imara-diff                       0.1.6  af13c8ceb376860ff0c6a66d83a8cdd4ecd9e464da24621bbffcd02b49619434 \
-    imperative                       1.0.5  8b70798296d538cdaa6d652941fcc795963f8b9878b9e300c9fab7a522bd2fc0 \
+    imara-diff                       0.1.7  fc9da1a252bd44cd341657203722352efc9bc0c847d06ea6d2dc1cd1135e0a01 \
+    imperative                       1.0.6  29a1f6526af721f9aec9ceed7ab8ebfca47f3399d08b80056c2acca3fcb694a9 \
     indexmap                         2.2.6  168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26 \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
@@ -228,7 +229,14 @@ cargo.crates \
     oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordermap                         0.5.0  ab5a8e22be64dfa1123429350872e7be33594dbf5ae5212c90c5890e71966d1d \
-    os_str_bytes                     6.6.1  e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1 \
+    orx-concurrent-ordered-bag       2.2.0  9aa866e2be4aa03927eddb481e7c479d5109fe3121324fb7db6d97f91adf9876 \
+    orx-concurrent-vec               2.2.0  c5912426ffb660f8b61e8f0812a1d07400803cd5513969d2c7af4d69602ba8a1 \
+    orx-fixed-vec                    3.2.0  7f69466c7c1fc2e1f00b58e39059b78c438b9fad144d1937ef177ecfc413e997 \
+    orx-pinned-concurrent-col        2.2.0  fdbcb1fa05dc1676f1c9cf19f443b3d2d2ca5835911477d22fa77cad8b79208d \
+    orx-pinned-vec                   3.2.0  c1071baf586de45722668234bddf56c52c1ece6a6153d16541bbb0505f0ac055 \
+    orx-pseudo-default               1.2.0  a2f627c439e723fa78e410a0faba89047a8a47d0dc013da5c0e05806e8a6cddb \
+    orx-split-vec                    3.2.0  52b9dbfa8c7069ae73a890870d3aa9097a897d616751d3d0278f2b42d5214730 \
+    os_str_bytes                     7.0.0  7ac44c994af577c799b1b4bd80dc214701e349873ad894d6cdf96f4f7526e0b9 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
@@ -290,9 +298,9 @@ cargo.crates \
     serde-wasm-bindgen               0.6.5  8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b \
     serde_derive                   1.0.204  e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222 \
     serde_derive_internals          0.29.0  330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3 \
-    serde_json                     1.0.120  4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5 \
+    serde_json                     1.0.121  4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609 \
     serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
-    serde_spanned                    0.6.6  79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0 \
+    serde_spanned                    0.6.7  eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d \
     serde_test                     1.0.176  5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab \
     serde_with                       3.9.0  69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857 \
     serde_with_macros                3.9.0  a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350 \
@@ -325,9 +333,9 @@ cargo.crates \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    toml                            0.8.15  ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28 \
-    toml_datetime                    0.6.6  4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf \
-    toml_edit                      0.22.16  278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788 \
+    toml                            0.8.16  81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c \
+    toml_datetime                    0.6.7  f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db \
+    toml_edit                      0.22.17  8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16 \
     tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
     tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
     tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
@@ -399,6 +407,7 @@ cargo.crates \
     windows_x86_64_msvc             0.52.5  bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0 \
     winnow                           0.6.6  f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352 \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
+    wyhash                           0.5.0  baf6e163c25e3fac820b4b453185ea2dea3b6a3e0a721d4d23d75bd33734c295 \
     yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec \
     yansi-term                       0.1.2  fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1 \
     zerocopy                        0.7.32  74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.5.6

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
