### PR TITLE
torsocks: Update to 2.4.0

### DIFF
--- a/net/torsocks/Portfile
+++ b/net/torsocks/Portfile
@@ -1,10 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem        1.0
+PortGroup           gitlab 1.0
 
-name              torsocks
-version           2.3.0
+gitlab.instance     https://gitlab.torproject.org/tpo
+gitlab.setup        core torsocks 2.4.0 v
 revision            0
+checksums           rmd160  667813c86c1309281aae37a11e12101e760cbc12 \
+                    sha256  f428cacf231ca9d11706ad2c701effc2b5fb71e9bdbdce1bbe294e0679a6fb17 \
+                    size    96854
+
 categories        net security
 license           GPL-2+
 maintainers       yopmail.com:sami.laine
@@ -12,26 +17,29 @@ maintainers       yopmail.com:sami.laine
 description       A transparent socks proxy for use with tor
 
 long_description  Torsocks is an application for Linux, BSD and \
-                  OS X that allows you to use network applications \
+                  macOS that allows you to use network applications \
                   such as ssh and irssi with Tor. Torsocks allows you \
                   to use most socks-friendly applications in a safe \
                   way with Tor. It ensures that DNS requests are \
                   handled safely and explicitly rejects UDP traffic \
                   from the application you are using.
 
-homepage          https://git.torproject.org/torsocks.git
-master_sites      https://people.torproject.org/~dgoulet/torsocks/
-use_xz            yes
-
 # See https://trac.torproject.org/projects/tor/ticket/28538
+# and https://gitlab.torproject.org/tpo/core/torsocks/-/issues/28538
 # This same patch is being used by the Homebrew torsocks formula
 patchfiles          0001-Fix-macros-for-accept4-2.patch
-
-checksums           rmd160  f8ca8158424b0befd272a136cd3f97416dff76dd \
-                    sha256  b9f1b981d6b3fd4e1820de1eee325f8a7038c84765d5a6cd9af12571d5cc3622 \
-                    size    313072
+patchfiles-append   implicit.patch gethostbyaddr_r.patch version.patch
 
 depends_build       path:libexec/coreutils/libstdbuf.so:coreutils
+
+# No configure script in tarball.
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+autoreconf.args
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
 
 configure.args      --disable-silent-rules
 

--- a/net/torsocks/files/gethostbyaddr_r.patch
+++ b/net/torsocks/files/gethostbyaddr_r.patch
@@ -1,0 +1,20 @@
+Fix:
+
+error: implicit declaration of function 'gethostbyaddr_r' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+https://gitlab.torproject.org/tpo/core/torsocks/-/issues/40005#note_2720242
+
+Just declaring the function prototype like this without providing an
+implementation should not work because macOS does not have this function,
+and yet the test suite passes.
+--- tests/test_dns.c.orig	2022-05-25 09:36:05.000000000 -0500
++++ tests/test_dns.c	2024-08-02 20:40:40.000000000 -0500
+@@ -26,6 +26,8 @@
+ #include <tap/tap.h>
+ #include "helpers.h"
+ 
++int gethostbyaddr_r();
++
+ #define NUM_TESTS 6
+ 
+ struct test_host {

--- a/net/torsocks/files/implicit.patch
+++ b/net/torsocks/files/implicit.patch
@@ -1,0 +1,14 @@
+Fix:
+
+error: implicit declaration of function 'conf_file_set_enable_ipv6' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+https://gitlab.torproject.org/tpo/core/torsocks/-/commit/969d782ad3b560448325ff6e9aa29801d6276a3e
+--- src/common/config-file.h
++++ src/common/config-file.h
+@@ -109,6 +109,7 @@ int conf_file_set_allow_inbound(const char *val, struct configuration *config);
+ int conf_file_set_allow_outbound_localhost(const char *val, struct
+ 		configuration *config);
+ int conf_file_set_isolate_pid(const char *val, struct configuration *config);
++int conf_file_set_enable_ipv6(const char *val, struct configuration *config);
+ 
+ int conf_apply_socks_auth(struct configuration *config);

--- a/net/torsocks/files/version.patch
+++ b/net/torsocks/files/version.patch
@@ -1,0 +1,13 @@
+Fix version
+https://gitlab.torproject.org/tpo/core/torsocks/-/commit/47cf8b2caea0d9b42c1839eee9e09c92d1ce5f31
+--- configure.ac
++++ configure.ac
+@@ -3,7 +3,7 @@
+ ##############################################################################
+ 
+ # Process this file with autoconf to produce a configure script.
+-AC_INIT([torsocks], [2.3.0],[dgoulet@torproject.org],[],[https://torproject.org])
++AC_INIT([torsocks], [2.4.0],[dgoulet@torproject.org],[],[https://torproject.org])
+ AC_CONFIG_AUX_DIR([config])
+ AC_CANONICAL_TARGET
+ # Get hostname and other information.


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/61631

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
