### PR TITLE
neovim, -devel: update to 0.10.1 and 20240805

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -4,8 +4,8 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            neovim neovim 0.10.0 v
-revision                1
+github.setup            neovim neovim 0.10.1 v
+revision                0
 categories              editors
 maintainers             {raimue @raimue} \
                         {l2dy @l2dy} \
@@ -24,9 +24,9 @@ long_description \
 homepage                https://neovim.io
 
 github.tarball_from     archive
-checksums               rmd160  a573b99de81e23f37ba6114a7cd669d6e62a4c1a \
-                        sha256  372ea2584b0ea2a5a765844d95206bda9e4a57eaa1a2412a9a0726bab750f828 \
-                        size    12792034
+checksums               rmd160  a49cf46d56f8c01362c349ac0d524d36f13d8d51 \
+                        sha256  edce96e79903adfcb3c41e9a8238511946325ea9568fde177a70a614501af689 \
+                        size    12796966
 
 depends_build-append    port:pkgconfig
 
@@ -51,16 +51,19 @@ configure.args-append   -DLUA_PRG=${prefix}/bin/luajit
 patchfiles              embed-parsers-build.diff
 
 subport neovim-devel {
-    github.setup    neovim neovim efaf37a2b9450d56acbf48a44c3c791d00d70199
-    version         20240501-[string range ${github.version} 0 6]
-    revision        1
+    github.setup    neovim neovim 0c2860d9e5ec5417a94db6e3edd237578b76d418
+    version         20240805-[string range ${github.version} 0 6]
+    revision        0
 
     github.tarball_from tarball
-    checksums       rmd160  1e4dce0c64f3d793120c64555a60050daed5e504 \
-                    sha256  fa4babe9705a246c5d0db4acb41d816225b562cac3edf9953bf1f9ad8009bf17 \
-                    size    12774557
+    checksums       rmd160  ba12caf9471df0abf6aa229e19ddf9761fefe17c \
+                    sha256  2cce952d8a08276687f9188f1f19ed3de4a6a337abb6769098556872c50114ac \
+                    size    12906200
 
     conflicts       neovim
+
+    depends_lib-append \
+                    port:libutf8proc
 
     livecheck.url   ${github.homepage}/commits/nightly.atom
 }

--- a/editors/neovim/files/embed-parsers-build.diff
+++ b/editors/neovim/files/embed-parsers-build.diff
@@ -1,9 +1,8 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index 5ad99cbf0..3828ee192 100644
+index 12e0d6e6a..27fe5c50d 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -98,8 +98,21 @@ else()
- endif()
+@@ -102,6 +102,19 @@ endif()
  
  list(INSERT CMAKE_PREFIX_PATH 0 ${DEPS_PREFIX})
  
@@ -23,13 +22,11 @@ index 5ad99cbf0..3828ee192 100644
  if(APPLE)
    # If the macOS deployment target is not set manually (via $MACOSX_DEPLOYMENT_TARGET),
    # fall back to local system version. Needs to be done both here and in cmake.deps.
-   if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
 diff --git cmake.deps/cmake/BuildTreesitterParsers.cmake cmake.deps/cmake/BuildTreesitterParsers.cmake
-index 837d075d2..6dbd69554 100644
+index 060447e6f..9c3f7165e 100644
 --- cmake.deps/cmake/BuildTreesitterParsers.cmake
 +++ cmake.deps/cmake/BuildTreesitterParsers.cmake
-@@ -20,15 +20,17 @@ function(BuildTSParser)
-   get_externalproject_options(${NAME} ${DEPS_IGNORE_SHA})
+@@ -21,13 +21,15 @@ function(BuildTSParser)
    ExternalProject_Add(${NAME}
      DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/${NAME}
      PATCH_COMMAND ${CMAKE_COMMAND} -E copy
@@ -41,18 +38,16 @@ index 837d075d2..6dbd69554 100644
      ${EXTERNALPROJECT_OPTIONS})
  endfunction()
  
-+set(ALL_BUNDLED_TS_PARSER_TARGETS c lua vim vimdoc query python bash markdown) # All parsers built in the lines directly below.
++set(ALL_BUNDLED_TS_PARSER_TARGETS c lua vim vimdoc query markdown) # All parsers built in the lines directly below.
 +list(TRANSFORM ALL_BUNDLED_TS_PARSER_TARGETS PREPEND treesitter_)
- foreach(lang c lua vim vimdoc query python bash)
+ foreach(lang c lua vim vimdoc query)
    BuildTSParser(LANG ${lang})
  endforeach()
- BuildTSParser(LANG markdown CMAKE_FILE MarkdownParserCMakeLists.txt)
 diff --git src/nvim/CMakeLists.txt src/nvim/CMakeLists.txt
-index d9cc695c5..53bf044ba 100644
+index a100e733d..6e05f66cf 100644
 --- src/nvim/CMakeLists.txt
 +++ src/nvim/CMakeLists.txt
-@@ -767,12 +767,10 @@ if(WIN32)
- endif()
+@@ -770,10 +770,8 @@ endif()
  
  file(MAKE_DIRECTORY ${BINARY_LIB_DIR})
  
@@ -65,4 +60,3 @@ index d9cc695c5..53bf044ba 100644
  
  install(DIRECTORY ${BINARY_LIB_DIR}
    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-   USE_SOURCE_PERMISSIONS)


### PR DESCRIPTION
#### Description

- neovim: update to 0.10.1
- neovim-devel: update to 20240803

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
