### PR TITLE
emacs{,-app}-devel: update to 20240804

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -122,16 +122,16 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs 9688fd6eb1d05e97c556cd53c53dd92220d9efaa
+    github.setup    emacs-mirror emacs f70a6ea0ea86ef461e40d20664a75a92d02679ea
     epoch           5
-    version         20240623
-    revision        1
+    version         20240804
+    revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  de2e1912e8b8a8e09c2b1bd243c26af06f8a2118 \
-                    sha256  6778dd5f8af6d69cc6b4e77c4e873093ebee8a2c6c043c815a3754e2d74279a2 \
-                    size    50586899
+    checksums       rmd160  12a45be4572b1ab5bb4cd7983673742f984ca52b \
+                    sha256  de8ab5f6bd3f9a269626f3d5110da1a10db71bfade08b8e043643ee9d66e4986 \
+                    size    50643953
 
     patchfiles-append \
                     patch-allow-powerpc-devel.diff


### PR DESCRIPTION
#### Description

Includes some nice NS improvements:

- https://github.com/emacs-mirror/emacs/commit/ceb5a1522270c41d0c9f5e6b52d61e3173f72f1d
- https://github.com/emacs-mirror/emacs/commit/9f7c1ace9f86e4b657030a6e94c5d6aadc586878

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
