### PR TITLE
edid-decode: update to version 20240731

### DIFF
--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           meson 1.0
 
 name                edid-decode
-version             20240703
+version             20240731
 categories          sysutils
 maintainers         @wwalexander openmaintainer
 license             MIT
@@ -14,7 +14,7 @@ set domain          linuxtv.org
 homepage            https://git.${domain}/${name}.git
 fetch.type          git
 git.url             git://${domain}/${name}.git
-git.branch          6f117a8
+git.branch          303b033
 
 compiler.cxx_standard \
                     2011


### PR DESCRIPTION
#### Description

Update to version 20240731

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 15.0 24A5298h arm64
Xcode 16.0 16A5171c

###### Verification 
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?