### PR TITLE
pv: Update to 1.8.12

### DIFF
--- a/sysutils/pv/Portfile
+++ b/sysutils/pv/Portfile
@@ -8,7 +8,7 @@ PortGroup           codeberg 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-codeberg.setup      a-j-wood pv 1.8.10 v
+codeberg.setup      a-j-wood pv 1.8.12 v
 
 revision            0
 categories          sysutils
@@ -28,9 +28,9 @@ homepage            https://www.ivarch.com/programs/pv.shtml
 master_sites        ${codeberg.homepage}/releases/download/v${version}
 
 distname            ${name}-${version}
-checksums           rmd160  8ccce99b8079e11abbc973fd66594fe0fd3f1690 \
-                    sha256  d4c90c17cfcd44aa96b98237731e4f811e071d4c2052a689d2d81e6671f571b1 \
-                    size    328069
+checksums           rmd160  41f609bdbbf593203c2b98220dfeaad8a2477fef \
+                    sha256  9687f9deedb09d0dc00d80c30691f0c91282c0d5d8fa7d6a2a085c8742c2cd7c \
+                    size    328897
 
 patch.pre_args-replace  -p0 -p1
 patchfiles          fix-modifiers-direct-io-test.diff


### PR DESCRIPTION
#### Description

Update `pv` to its latest released version, 1.8.12

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
