### PR TITLE
google-cloud-sdk: update to 487.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             486.0.0
+version             487.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  61ca19e1d59c5245b76f1fb2706b30dd80908a36 \
-                    sha256  e3b596ac95e36c375b694387666e6fd6323093303e5ecd5507d03b4cec262422 \
-                    size    51345361
+    checksums       rmd160  ec1a0900dfefd74cef180c5b35cbfb1c7fba5297 \
+                    sha256  c1391fb84a9a07475e570bf4c62d099dd029d88e3abdbc54b6dc864c7ee44d93 \
+                    size    51394284
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  e7b35a98fb8757d7fa5732d6cc99c52479d8e760 \
-                    sha256  bd69ef6e9176959737c2ac0731a428f0171cf117be0da46760ecaed205c10831 \
-                    size    52696879
+    checksums       rmd160  c7bb5f817271c50513979272327b531f4073c251 \
+                    sha256  376c6c8f2991c70d2a93b2cff1a6539dcb0377a15080b7349d4bf35850f1ea2d \
+                    size    52749882
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  e7a7eec9a17566dd175dbe2a577944be703c52c8 \
-                    sha256  3093a93dddece68f4ec2b60d591cafebd967316faea5fb2a3ad19bcd16559807 \
-                    size    52644566
+    checksums       rmd160  e64ba93ce2157449db52a686e3a44e2ae3e60639 \
+                    sha256  493d0f44b9838bbdee4a18c31034b3f17f18b675b77b78dadf8dd344dd4a65e5 \
+                    size    52698156
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 487.0.0.

###### Tested on

macOS 14.6 23G80 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?