### PR TITLE
gdal: cleanup after 0659a06

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -323,10 +323,10 @@ if {$subport eq $name} {
     # Register plugins
     configure.args-append  \
                         -DGDAL_REGISTER_DRIVER_PDF_FOR_LATER_PLUGIN=ON \
-                        -DGDAL_DRIVER_PDF_PLUGIN_INSTALLATION_MESSAGE="Install the PDF driver with 'sudo port gdal-pdf'." \
+                        -DGDAL_DRIVER_PDF_PLUGIN_INSTALLATION_MESSAGE="Install the PDF driver with 'sudo port install gdal-pdf'." \
                         -DGDAL_USE_POPPLER=ON \
                         -DOGR_REGISTER_DRIVER_LIBKML_FOR_LATER_PLUGIN=ON \
-                        -DOGR_DRIVER_LIBKML_PLUGIN_INSTALLATION_MESSAGE="Install the LIBKML driver with 'sudo port gdal-libkml'." \
+                        -DOGR_DRIVER_LIBKML_PLUGIN_INSTALLATION_MESSAGE="Install the LIBKML driver with 'sudo port install gdal-libkml'." \
                         -DGDAL_USE_LIBKML=OFF
 
     depends_build-append \
@@ -456,8 +456,10 @@ if {$subport eq $name} {
     }
 
     variant libkml description {Enable libkml} {
-        ui_error "The '+libkml' variant is removed. It is replaced by 'grass-libkml' subport."
-        return -code error "unsupported variant"
+        pre-fetch {
+            ui_error "The '+libkml' variant has been removed and replaced by the 'gdal-libkml' subport."
+            return -code error "unsupported variant"
+        }
     }
 
     variant lto description {Enable Link Time Optimization} {
@@ -550,8 +552,10 @@ if {$subport eq $name} {
     }
 
     variant poppler description {Enable Poppler support} {
-        ui_error "The '+poppler' variant is removed. It is replaced by 'grass-pdf' subport."
-        return -code error "unsupported variant"
+        pre-fetch {
+            ui_error "The '+poppler' variant has been removed and replaced by the 'gdal-pdf' subport."
+            return -code error "unsupported variant"
+        }
     }
 
     variant tiledb description {Enable TileDB support} {


### PR DESCRIPTION
#### Description
0659a06 left gdal's variants in a broken state. Thus, this PR:
- corrects the subport installation messages
- moves variant error messages to pre-fetch blocks
- refers to the new sub-ports correctly

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
