### PR TITLE
vala{,-devel}: add missing lib dep for graphviz

### DIFF
--- a/lang/vala-devel/Portfile
+++ b/lang/vala-devel/Portfile
@@ -6,7 +6,7 @@ name                vala-devel
 conflicts           vala
 set my_name         vala
 version             0.56.17
-revision            1
+revision            2
 
 categories          lang
 license             LGPL-2.1+
@@ -58,7 +58,8 @@ configure.args-append \
                     --disable-valadoc
 
 variant valadoc description {Install valadoc and documentation} {
-    depends_build-append \
+    # valadoc links aaginst libraries installed by graphviz
+    depends_lib-append \
                     path:bin/dot:graphviz
 
     configure.args-delete \

--- a/lang/vala/Portfile
+++ b/lang/vala/Portfile
@@ -6,7 +6,7 @@ name                vala
 conflicts           vala-devel
 set my_name         vala
 version             0.56.17
-revision            1
+revision            2
 
 categories          lang
 license             LGPL-2.1+
@@ -58,7 +58,8 @@ configure.args-append \
                     --disable-valadoc
 
 variant valadoc description {Install valadoc and documentation} {
-    depends_build-append \
+    # valadoc links aaginst libraries installed by graphviz
+    depends_lib-append \
                     path:bin/dot:graphviz
 
     configure.args-delete \


### PR DESCRIPTION
#### Description
```
:) cllang@gallumbits:~$ sudo port -vy rev-upgrade
--->  Scanning binaries for linking errors
Could not open /opt/local/lib/libcdt.5.dylib: Error opening or reading file (referenced from /opt/local/bin/valadoc-0.56)
Could not open /opt/local/lib/libcgraph.6.dylib: Error opening or reading file (referenced from /opt/local/bin/valadoc-0.56)
Could not open /opt/local/lib/libgvc.6.dylib: Error opening or reading file (referenced from /opt/local/bin/valadoc-0.56)
--->  Found 6 broken files, matching files to ports
--->  Found 1 broken port, determining rebuild order
You can always run 'port rev-upgrade' again to fix errors.
The following ports will be rebuilt: vala @0.56.17+valadoc
```

This has probably been broken for a while, but
7352fd2fee713ea5d9b89024a9df92af326d3640 made valadoc a default variant.

See: https://trac.macports.org/ticket/68895
See: https://trac.macports.org/ticket/70417

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.6 23G80 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
