### PR TITLE
checkssl: update to 0.6.0

### DIFF
--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/szazeski/checkssl 0.5.1 v
+go.setup            github.com/szazeski/checkssl 0.6.0 v
 revision            0
 
 homepage            https://www.checkssl.org
@@ -19,9 +19,9 @@ installs_libs       no
 maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 
-checksums           rmd160  bec45146c382baafeb41426c6c95e39c1f92fe2a \
-                    sha256  9dc89404b70cb9dd26702daafee0f8214ab036f595fde794db41f767d8ee0237 \
-                    size    13049
+checksums           rmd160  38150b170472a02463f5ba45dbd86728d2aa8261 \
+                    sha256  bb3d15ab940670f86fc142705de2c4047252a020f960ec8b1b391f21328a3b84 \
+                    size    14592
 
 destroot {
     set doc_dir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update to checkssl 0.6.0.

###### Tested on

macOS 14.6 23G80 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?