### PR TITLE
ipsw: Update to 3.1.533

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/blacktop/ipsw 3.1.532 v
+go.setup                github.com/blacktop/ipsw 3.1.533 v
 github.tarball_from     archive
 revision                0
 categories              security devel
@@ -18,9 +18,9 @@ long_description        {*}${description}. Everything you need to start \
 
 homepage                https://blacktop.github.io/ipsw
 
-checksums               rmd160  ffa1d8f02bbc5a3ed4cb2d5d2a48a550d41ad9de \
-                        sha256  3e2c313c82615f7c3a2014572c136ef710b807d288a76d56dae794d17f4ee096 \
-                        size    10354428
+checksums               rmd160  25b8a15b9ac029e8cbfbca9c46d995c0684bda7c \
+                        sha256  3b9fb2156ef24cf9cf0ac3def47137419ab5b6d63edec72f8ebb9151a83b6a6e \
+                        size    10357171
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, [3.1.533](https://github.com/blacktop/ipsw/releases/tag/v3.1.533)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
