### PR TITLE
libdeflate: update to 1.21

### DIFF
--- a/archivers/libdeflate/Portfile
+++ b/archivers/libdeflate/Portfile
@@ -6,13 +6,13 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github          1.0
 PortGroup           legacysupport   1.1
 
-github.setup        ebiggers libdeflate 1.20 v
+github.setup        ebiggers libdeflate 1.21 v
 github.tarball_from releases
 revision            0
 
-checksums           rmd160  2be9896fef678064d9c34e64e0d0cb584466addb \
-                    sha256  c52cf0239fd644d71c9e88613dd7431a5306ebee1280c5791c71ca264869250a \
-                    size    183481
+checksums           rmd160  f14d93bb78143d5cde99c7c42880a94e94bdaa77 \
+                    sha256  7f05b533dd1d95e48a9f7d633beab67d8c6f502c01a2a5f46b204c16d1e748ad \
+                    size    184767
 
 description         Heavily optimized library for DEFLATE/zlib/gzip \
                     compression and decompression


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
