### PR TITLE
neovim: include lua51 headers to build properly

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 
 github.setup            neovim neovim 0.10.1 v
-revision                0
+revision                1
 categories              editors
 maintainers             {raimue @raimue} \
                         {l2dy @l2dy} \
@@ -48,7 +48,12 @@ cmake.build_type        Release
 configure.args-append   -DLUA_PRG=${prefix}/bin/luajit
 
 # Building parsers is normally an extra step, see https://github.com/neovim/neovim/issues/29042
-patchfiles              embed-parsers-build.diff
+patchfiles              embed-parsers-build.diff \
+                        patch-lua51-includes.diff
+
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/CMakeLists.txt
+}
 
 subport neovim-devel {
     github.setup    neovim neovim 0c2860d9e5ec5417a94db6e3edd237578b76d418

--- a/editors/neovim/files/patch-lua51-includes.diff
+++ b/editors/neovim/files/patch-lua51-includes.diff
@@ -1,0 +1,21 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index 12e0d6e6a..538e6819e 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -23,6 +23,8 @@ if(XCODE)
+   message(FATAL_ERROR [[Xcode generator is not supported. Use "Ninja" or "Unix Makefiles" instead]])
+ endif()
+
++include_directories(BEFORE @PREFIX@/include/lua5.1)
++
+ # Point CMake at any custom modules we may ship
+ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+@@ -39,6 +41,7 @@ include(InstallHelpers)
+ include(PreventInTreeBuilds)
+ include(Util)
+
++
+ #-------------------------------------------------------------------------------
+ # User settings
+ #-------------------------------------------------------------------------------


### PR DESCRIPTION
#### Description
<!-- Note: it is best to make pull requests from a branch rather than from master -->

Fixes neovim builds. _See_ [#70420](https://trac.macports.org/ticket/70420#comment:9) for full description.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6 23G80 arm64
Xcode 15.4 15F31d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
