### PR TITLE
pounce: fix build on macOS <10.9

### DIFF
--- a/irc/pounce/Portfile
+++ b/irc/pounce/Portfile
@@ -1,10 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
+PortGroup           makefile 1.0
+
+# getline
+legacysupport.newest_darwin_requires_legacy 10
 
 name                pounce
 version             3.1
-revision            1
+revision            2
 
 set domain          https://git.causal.agency/${name}
 
@@ -35,6 +40,13 @@ checksums           rmd160  1ae7f9fe9239352992c2ad67107e13a44d4ef5b2 \
                     sha256  97f245556b1cc940553fca18f4d7d82692e6c11a30f612415e5e391e5d96604e \
                     size    50801
 
+# Modern explicit_bzero uses memset_s(), which is not
+# available on macOS <10.9, so emulate it with
+# volatile memset().
+if {${os.platform} eq "darwin" && ${os.major} < 13} {
+    patchfiles          patch-explicit-bzero.diff
+}
+
 depends_build-append \
                     port:pkgconfig
 
@@ -42,11 +54,9 @@ depends_lib-append  port:curl \
                     port:libretls \
                     port:sqlite3
 
-build.pre_args-append \
-                    MANDIR=${prefix}/share/man
+compiler.c_standard 2011
 
-destroot.pre_args-append \
-                    MANDIR=${prefix}/share/man
+use_configure       yes
 
 livecheck.type      regex
 livecheck.url       ${domain}/refs/

--- a/irc/pounce/files/patch-explicit-bzero.diff
+++ b/irc/pounce/files/patch-explicit-bzero.diff
@@ -1,0 +1,23 @@
+Copied from https://github.com/ansemjo/tinyssh-convert/blob/9028c16d99c6ab36aa3e51ac4f3c0b505ebfdff5/utilities.h
+--- bounce.h
++++ bounce.h
+@@ -292,3 +292,7 @@ static inline void base64(char *dst, const byte *src, size_t len) {
+ 	}
+ 	dst[i] = '\0';
+ }
++
++/* volatile memset to try & avoid optmising it away */
++static void * (* const volatile volatile_memset)(void *, int, size_t) = memset;
++#define memzero(ptr, size) volatile_memset(ptr, 0, size)
+--- configure
++++ configure
+@@ -51,8 +51,7 @@ case "$(uname)" in
+ 		defvar OPENSSL_BIN openssl exec_prefix /bin/openssl
+ 		;;
+ 	(Darwin)
+-		cflags -D__STDC_WANT_LIB_EXT1__=1
+-		cflags "-D'explicit_bzero(b,l)=memset_s((b),(l),0,(l))'"
++		cflags "-D'explicit_bzero(b,l)=memzero((b),(l))'"
+ 		ldadd crypt ''
+ 		config libtls
+ 		defvar OPENSSL_BIN openssl exec_prefix /bin/openssl


### PR DESCRIPTION
* respect MacPorts flags via enabling use_configure

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
