### PR TITLE
minify: new port

### DIFF
--- a/devel/minify/Portfile
+++ b/devel/minify/Portfile
@@ -1,0 +1,106 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang   1.0
+
+go.setup            github.com/tdewolff/minify 2.20.37 v
+revision            0
+
+description         Go minifier for web formats.
+
+long_description    \
+    Minify is a minifier CLI written in Go. It can minify HTML5, CSS3, JS, JSON, SVG and XML.
+
+categories          devel
+installs_libs       no
+license             MIT
+maintainers         {@ZapDotZip gmail.com:zapdotzip} openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  4c0d307f9bb313b66ce9ae8922450b89ee3de02d \
+                        sha256  101c3e43dd3dd80318a3bc2fc9f27038d07d027dc33a109b1f2f6714f9e0614c \
+                        size    7747838
+
+go.vendors          golang.org/x/sys \
+                        lock    v0.16.0 \
+                        rmd160  10e97b22e4ee6cb4210dc4a3939eff7029c76733 \
+                        sha256  1736d810e783163472b5653ec5eb4272b9f7d570f4e212c5d55d6491be694cf7 \
+                        size    1444408 \
+                    github.com/tdewolff/test \
+                        lock    7de5f7df4739 \
+                        rmd160  4cbe095642b04e477eeddbe435c4083190baafc0 \
+                        sha256  71b183acdc8ac70986afd458b90bb9a612ff5de385713675ee1e826fa313a1ac \
+                        size    3427 \
+                    github.com/tdewolff/parse \
+                        lock    v2.7.15 \
+                        rmd160  8040e8b25f6d8d32d783fc6422f704a1c6a63bfc \
+                        sha256  e02af9bfcf25a08b3d97abb40955d6ef300df9f8475af7a93d529111ec353fbe \
+                        size    109766 \
+                    github.com/tdewolff/argp \
+                        lock    960de61a6aa8 \
+                        rmd160  9c6fb8f0bbad6b525b52bf62ddb536eb2d75605c \
+                        sha256  2d3f57638a02a58adc953a66a50614068ce0d5fcdbb53a2d80c6e5c17caaa1ba \
+                        size    17459 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.9.5 \
+                        rmd160  82b54e63618f66f791ce83a86ec04b85b24daf96 \
+                        sha256  335d53529bfead717c2c44454e05a2396918bba311e3262b8bcb295b7c8772fd \
+                        size    106961 \
+                    github.com/mattn/go-sqlite3 \
+                        lock    v1.14.22 \
+                        rmd160  51cca4f09f23a404613e3eb48b77a44f4d98814e \
+                        sha256  02c8bc2780ff6f0b845e01efe0cfa006d8f85e48a06cd6c8566c21c3b88a644e \
+                        size    2602371 \
+                    github.com/matryer/try \
+                        lock    9ac251b645a2 \
+                        rmd160  2287e4c6eddec05c64ee6b94fe43dcbf43004d27 \
+                        sha256  4bc980959de0953a21fa0d561ea76036166bfaa2d2bd12725f334081f34d2fbd \
+                        size    3042 \
+                    github.com/lib/pq \
+                        lock    v1.10.9 \
+                        rmd160  beb0e233773f49d8d08ee991abf23bc8febf69d0 \
+                        sha256  08610bf0370b202bee369b7303c3085e02c7f6fdfd42a3f58e8f033088151eea \
+                        size    114528 \
+                    github.com/jmoiron/sqlx \
+                        lock    v1.4.0 \
+                        rmd160  31cbbd492d0ff6b9910a91eb03ffac4c7a095206 \
+                        sha256  13391150ebd301bf2c3f97424273943499ec8d362c0fe7316430c255b6de198f \
+                        size    54560 \
+                    github.com/go-sql-driver/mysql \
+                        lock    v1.8.1 \
+                        rmd160  f32a15ddd5c0a9e628bf1d6fa236f0865b1f1697 \
+                        sha256  a3d9fcb9479ffb100441dee59ebcefeb6306f6dd3549f7c429b91c5e9399a80d \
+                        size    105661 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.7.0 \
+                        rmd160  9198dec094f5008a8b24a2e51542ce4ec3453162 \
+                        sha256  d7cd46fbc8e25bfd37edb1b86851dcccc18c5180f09e533c6a35e4dcf2693d22 \
+                        size    57508 \
+                    github.com/djherbis/atime \
+                        lock    v1.1.0 \
+                        rmd160  895c7d4dd8841c7dde34e2842715d75022fdce08 \
+                        sha256  65d7b3933a59b2dc7ff25ee141e66680dd2a6142bdd84048b0430955296ef08d \
+                        size    3142 \
+                    github.com/cheekybits/is \
+                        lock    68e9c0620927 \
+                        rmd160  99c622c934775726009db52929520b60aa2848f1 \
+                        sha256  004f572ac22a2525009d1390dfd53632cdb25efc180a501e91bb81cfa62b8e30 \
+                        size    5850 \
+                    filippo.io/edwards25519 \
+                        repo    github.com/FiloSottile/edwards25519 \
+                        lock    v1.1.0 \
+                        rmd160  32e76862168e566190f9be95e5a88dcb10b3a6a2 \
+                        sha256  a68a54423370e136bf03e4217d2fba807b4d041f873f6ebbcfc8ad4ba9925f5d \
+                        size    47132
+
+build.pre_args-append \
+    -ldflags \"-s -w -X 'main.Version=${version}' \" -trimpath
+
+build.args          -o ${worksrcpath}/cmd/${name}/${name} ./cmd/minify
+
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/cmd/${name}/${name} ${destroot}${prefix}/bin/
+    xinstall -d -m 0755 ${destroot}${prefix}/etc/bash_completion.d
+    copy ${worksrcpath}/cmd/${name}/bash_completion ${destroot}${prefix}/etc/bash_completion.d/${name}
+}


### PR DESCRIPTION
#### Description

Added port "minify"

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 arm64
Xcode 14.2 14C18
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
