### PR TITLE
ruby30,32,33: Remove inappropriate -std=c99.

### DIFF
--- a/lang/ruby30/Portfile
+++ b/lang/ruby30/Portfile
@@ -7,13 +7,12 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                ruby30
 version             3.0.7
-revision            0
+revision            1
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} \
                     {fwright.net:fw @fhgwright} \
                     openmaintainer
-platforms           darwin
 
 description         Powerful and clean object-oriented scripting language
 long_description    Ruby is the interpreted scripting language for quick \
@@ -213,7 +212,6 @@ platform darwin {
         depends_build-append    port:gmake
         build.cmd               ${prefix}/bin/gmake
         configure.args-append   --disable-dtrace
-        configure.cflags-append -std=c99
     }
 
     if {${os.major} == 8} {

--- a/lang/ruby32/Portfile
+++ b/lang/ruby32/Portfile
@@ -14,13 +14,12 @@ set ruby_patch      5
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
-revision            0
+revision            1
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} \
                     {fwright.net:fw @fhgwright} \
                     openmaintainer
-platforms           darwin
 
 description         Powerful and clean object-oriented scripting language
 long_description    Ruby is the interpreted scripting language for quick \
@@ -179,7 +178,6 @@ platform darwin {
         depends_build-append    port:gmake
         build.cmd               ${prefix}/bin/gmake
         configure.args-append   --disable-dtrace
-        configure.cflags-append -std=c99
     }
 
     if {${os.major} == 8} {

--- a/lang/ruby33/Portfile
+++ b/lang/ruby33/Portfile
@@ -21,13 +21,12 @@ set ruby_patch      4
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
-revision            2
+revision            3
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} \
                     {fwright.net:fw @fhgwright} \
                     openmaintainer
-platforms           darwin
 
 description         Powerful and clean object-oriented scripting language
 long_description    Ruby is the interpreted scripting language for quick \
@@ -186,7 +185,6 @@ platform darwin {
         depends_build-append    port:gmake
         build.cmd               ${prefix}/bin/gmake
         configure.args-append   --disable-dtrace
-        configure.cflags-append -std=c99
     }
 
     if {${os.major} == 8} {


### PR DESCRIPTION
The Portfile has been carrying the -std=c99 setting (for OS <10.7) forward through many versions, but that has been inappropriate since ruby30, when the compiler selection was switched by the thread-local storage requirement.  Since the compiler now defaults to C11, specifying C99 is a step backward.  This removes that inappropriate setting.

Since this is not known not to impact the installed content, it includes a revbump.

Also, since the latest legacy-support includes fgetattrlist(), builds of ruby32-33 for <10.6 no longer include the private fallback, making the installed content different on those platforms.  The revbump covers that as well.

Also removes unnecessary "platforms darwin", making lint happy.

TESTED:
Minimally tested on unaffected 10.7+.
Built successfully with no variants on 10.4-10.5 ppc, 10.4-10.6 i386, and 10.5-10.6 x86_64.
Built with all variants except jemalloc and yjit on 10.4-10.5, and all variants except yjit on 10.6.
Universal included for ruby30 on 10.6.
Tests not run due to test framework issues.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - The test framework has issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
