### PR TITLE
tippecanoe: update to 2.58.0

### DIFF
--- a/gis/tippecanoe/Portfile
+++ b/gis/tippecanoe/Portfile
@@ -6,7 +6,7 @@ PortGroup               makefile 1.0
 PortGroup               legacysupport 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            felt tippecanoe 2.57.0
+github.setup            felt tippecanoe 2.58.0
 github.tarball_from     archive
 revision                0
 categories              gis
@@ -15,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             Build vector tilesets from large collections of GeoJSON features
 long_description        {*}${description}
 
-checksums               rmd160  8ce137232b3f5725242ee5383527597e043bfa5b \
-                        sha256  34d77da8d71b27db4d3ac7ae014f70f0105b8af96b570dee1b9278640b1203ed \
-                        size    22887670
+checksums               rmd160  256a5b62e95e7989d1d1c97bb96141450c59e2fc \
+                        sha256  bfa8e2ad4bfd552c42d324765c9684efa72a1750807ffb9f03a8b9b7b01ca866 \
+                        size    23762738
 
 depends_lib-append      port:sqlite3 \
                         port:zlib


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/felt/tippecanoe/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
