### PR TITLE
py-meson: unbreak linking on < 10.7

### DIFF
--- a/python/py-meson/Portfile
+++ b/python/py-meson/Portfile
@@ -8,7 +8,7 @@ name                py-meson
 # update version and revision also in the meson port
 github.setup        mesonbuild meson 1.5.1
 github.tarball_from releases
-revision            0
+revision            1
 
 checksums           rmd160  9d8c02bf13789368f7af53c0cc66fe0ccc88c476 \
                     sha256  567e533adf255de73a2de35049b99923caf872a455af9ce03e01077e0d384bed \
@@ -47,6 +47,10 @@ if {${subport} ne ${name}} {
     if {${os.platform} eq "darwin" && ${os.major} <= 10} {
         patchfiles-append \
                         patch-meson-remove-Wl,-no_weak_imports.diff
+
+        # See: https://github.com/mesonbuild/meson/pull/13291
+        patchfiles-append \
+                        patch-unbreak-linking.diff
     }
 
     # https://github.com/mesonbuild/meson/issues/6187

--- a/python/py-meson/files/patch-unbreak-linking.diff
+++ b/python/py-meson/files/patch-unbreak-linking.diff
@@ -1,0 +1,48 @@
+From 446fd2a2bf04154b10e03638bd448bdba2bb732f Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Sat, 10 Aug 2024 02:52:23 +0800
+Subject: [PATCH] Revert "Add -export_dynamic flag for AppleDynamicLinker"
+
+This reverts commit dfd22db4be6bfc0e64272479b51bbf314db04ac2.
+---
+ mesonbuild/linkers/linkers.py |  3 ---
+ unittests/darwintests.py      | 12 ------------
+ 2 files changed, 15 deletions(-)
+
+diff --git mesonbuild/linkers/linkers.py mesonbuild/linkers/linkers.py
+index 0b8927359..103d368db 100644
+--- mesonbuild/linkers/linkers.py
++++ mesonbuild/linkers/linkers.py
+@@ -839,9 +839,6 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
+         return ["-Wl,-cache_path_lto," + path]
+ 
+-    def export_dynamic_args(self, env: 'Environment') -> T.List[str]:
+-        return self._apply_prefix('-export_dynamic')
+-
+ 
+ class LLVMLD64DynamicLinker(AppleDynamicLinker):
+ 
+diff --git unittests/darwintests.py unittests/darwintests.py
+index afc663a57..5739beca5 100644
+--- unittests/darwintests.py
++++ unittests/darwintests.py
+@@ -81,18 +81,6 @@ class DarwinTests(BasePlatformTests):
+         self.build()
+         self.run_tests()
+ 
+-    def test_apple_lto_export_dynamic(self):
+-        '''
+-        Tests that -Wl,-export_dynamic is correctly added, when export_dynamic: true is set.
+-        On macOS, this is relevant for LTO builds only.
+-        '''
+-        testdir = os.path.join(self.common_test_dir, '148 shared module resolving symbol in executable')
+-        # Ensure that it builds even with LTO enabled
+-        env = {'CFLAGS': '-flto'}
+-        self.init(testdir, override_envvars=env)
+-        self.build()
+-        self.run_tests()
+-
+     def _get_darwin_versions(self, fname):
+         fname = os.path.join(self.builddir, fname)
+         out = subprocess.check_output(['otool', '-L', fname], universal_newlines=True)


### PR DESCRIPTION
See:
https://trac.macports.org/ticket/70386
https://trac.macports.org/ticket/70496

#### Description

This should be fixed ASAP

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
