### PR TITLE
magic-wormhole: update to 0.15.0

### DIFF
--- a/net/magic-wormhole/Portfile
+++ b/net/magic-wormhole/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                magic-wormhole
-version             0.13.0
-revision            1
+version             0.15.0
+revision            0
 
 homepage            https://magic-wormhole.readthedocs.io
 
@@ -28,9 +28,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  0f01edf2ff481fa9f773b7470cd7e9f115952f0f \
-                    sha256  ac3bd68286270e7f149c06149a8e409e5fa34d7feb0e88844a26d29eed2d1516 \
-                    size    274564
+checksums           rmd160  c3443ae6be5eef95336b374fc387d8c1cb0a36f6 \
+                    sha256  be2563b5c5547ba333bc6608f048004c8f36d556139bf2ffe3d9f41da2797006 \
+                    size    283096
 
 python.default_version  311
 


### PR DESCRIPTION
#### Description

magic-wormhole: update to 0.15.0

fixes: https://trac.macports.org/ticket/69937

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
