### PR TITLE
libheif: build with kvazaar instead of x265

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -6,7 +6,7 @@ PortGroup                   cmake 1.1
 PortGroup                   compiler_blacklist_versions 1.0
 
 github.setup                strukturag libheif 1.18.2 v
-revision                    0
+revision                    1
 
 checksums                   rmd160  fb41f7c4d109883a214b8db5db1039809a3fb8eb \
                             sha256  c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf \
@@ -31,10 +31,11 @@ depends_lib-append \
                             path:include/turbojpeg.h:libjpeg-turbo \
                             port:libpng \
                             port:svt-av1 \
-                            port:webp \
-                            port:x265
+                            port:webp
 
 configure.args-append \
+                            -DWITH_X265:BOOL=OFF \
+                            -DWITH_KVAZAAR:BOOL=OFF \
                             -DWITH_RAV1E:BOOL=OFF
 
 # Disable dynamic plugin loading, due to upstream issue:
@@ -70,6 +71,18 @@ platform darwin {
     }
 }
 
+variant kvazaar conflicts x265 description {Use kvazaar for HEIC encoding} {
+    depends_lib-append      port:kvazaar
+    configure.args-replace  -DWITH_KVAZAAR:BOOL=OFF \
+                            -DWITH_KVAZAAR:BOOL=ON
+}
+
+variant x265 conflicts kvazaar description {Use x265 for HEIC encoding} {
+    depends_lib-append      port:x265
+    configure.args-replace  -DWITH_X265:BOOL=OFF \
+                            -DWITH_X265:BOOL=ON
+}
+
 variant rav1e description {Enable codec rav1e} {
     depends_lib-append \
                             port:rav1e
@@ -84,6 +97,10 @@ variant tests description {Enable tests} {
                             -DBUILD_TESTING:BOOL=ON \
                             -DWITH_REDUCED_VISIBILITY:BOOL=OFF
     test.run                yes
+}
+
+if {![variant_isset x265]} {
+    default_variants-append +kvazaar
 }
 
 if {![variant_isset rav1e]} {


### PR DESCRIPTION
x265 has a GPL license which makes redistribution difficult.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?