### PR TITLE
x265: update to 3.6; revbump dependents

### DIFF
--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -51,7 +51,7 @@ universal_variant       no
 ##
 if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     version             2.2.8
-    revision            18
+    revision            19
     license             GPL-2+
 
     master_sites        https://download.videolan.org/pub/videolan/vlc/${version}/
@@ -64,7 +64,7 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
                         size    22137276
 
     depends_build-append \
-                        port:pkgconfig
+                        path:bin/pkg-config:pkgconfig
 
     depends_lib-append  port:a52dec \
                         port:avahi \
@@ -163,6 +163,14 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
                         no-sparkle.patch \
                         patch-vlc-no-O4.diff \
                         patch-soundfont-path.diff
+
+    # Cherry-picked from:
+    # https://github.com/videolan/vlc/commit/667c3a73b19d056821ba7a64420a4623aae40222
+    # https://github.com/videolan/vlc/commit/ab00e6c59d42e05ab08893091783d8b5febc0058
+    # https://github.com/videolan/vlc/commit/87724691c899a02d94fb64a3ef16868d65f3551b
+    # https://github.com/videolan/vlc/commit/77b86f4452be4dbe0d56a9cd1b66da61b116da60
+    # Needed at least to fix gcc14 build.
+    patchfiles-append   backport-fixes.patch
 
     if {[string match *clang* ${configure.compiler}]} {
         patchfiles-append \

--- a/multimedia/VLC2/files/backport-fixes.patch
+++ b/multimedia/VLC2/files/backport-fixes.patch
@@ -1,0 +1,128 @@
+--- modules/access/avio.c.orig	2015-10-22 00:58:47.000000000 +0800
++++ modules/access/avio.c	2024-09-30 04:06:06.000000000 +0800
+@@ -152,8 +152,8 @@
+     };
+     AVDictionary *options = NULL;
+     char *psz_opts = var_InheritString(access, "avio-options");
+-    if (psz_opts && *psz_opts) {
+-        options = vlc_av_get_options(psz_opts);
++    if (psz_opts) {
++        vlc_av_get_options(psz_opts, &options);
+         free(psz_opts);
+     }
+     ret = avio_open2(&sys->context, url, AVIO_FLAG_READ, &cb, &options);
+@@ -239,8 +239,8 @@
+     };
+     AVDictionary *options = NULL;
+     char *psz_opts = var_InheritString(access, "sout-avio-options");
+-    if (psz_opts && *psz_opts) {
+-        options = vlc_av_get_options(psz_opts);
++    if (psz_opts) {
++        vlc_av_get_options(psz_opts, &options);
+         free(psz_opts);
+     }
+     ret = avio_open2(&sys->context, access->psz_path, AVIO_FLAG_WRITE,
+
+--- modules/codec/avcodec/avcodec.c.orig	2015-04-14 03:54:35.000000000 +0800
++++ modules/codec/avcodec/avcodec.c	2024-09-30 04:08:05.000000000 +0800
+@@ -429,8 +429,8 @@
+     int ret;
+     char *psz_opts = var_InheritString( p_dec, "avcodec-options" );
+     AVDictionary *options = NULL;
+-    if (psz_opts && *psz_opts)
+-        options = vlc_av_get_options(psz_opts);
++    if (psz_opts)
++        vlc_av_get_options(psz_opts, &options);
+     free(psz_opts);
+ 
+     vlc_avcodec_lock();
+
+--- modules/codec/avcodec/subtitle.c.orig	2015-12-01 21:06:44.000000000 +0800
++++ modules/codec/avcodec/subtitle.c	2024-09-30 04:12:19.000000000 +0800
+@@ -90,8 +90,8 @@
+     int ret;
+     char *psz_opts = var_InheritString(dec, "avcodec-options");
+     AVDictionary *options = NULL;
+-    if (psz_opts && *psz_opts)
+-        options = vlc_av_get_options(psz_opts);
++    if (psz_opts)
++        vlc_av_get_options(psz_opts, &options);
+     free(psz_opts);
+ 
+     vlc_avcodec_lock();
+
+--- modules/demux/avformat/demux.c.orig	2016-01-17 01:44:23.000000000 +0800
++++ modules/demux/avformat/demux.c	2024-09-30 04:12:50.000000000 +0800
+@@ -333,8 +333,8 @@
+     unsigned int nb_streams = p_sys->ic->nb_streams;
+     for (unsigned i = 1; i < nb_streams; i++)
+         options[i] = NULL;
+-    if (psz_opts && *psz_opts) {
+-        options[0] = vlc_av_get_options(psz_opts);
++    if (psz_opts) {
++        vlc_av_get_options(psz_opts, &options[0]);
+         for (unsigned i = 1; i < nb_streams; i++) {
+             av_dict_copy(&options[i], options[0], 0);
+         }
+
+--- modules/demux/avformat/mux.c.orig	2015-10-22 01:11:03.000000000 +0800
++++ modules/demux/avformat/mux.c	2024-09-30 04:14:00.000000000 +0800
+@@ -374,8 +374,8 @@
+ 
+         char *psz_opts = var_GetNonEmptyString( p_mux, "sout-avformat-options" );
+         AVDictionary *options = NULL;
+-        if (psz_opts && *psz_opts)
+-            options = vlc_av_get_options(psz_opts);
++        if (psz_opts)
++            vlc_av_get_options(psz_opts, &options);
+         free(psz_opts);
+         error = avformat_write_header( p_sys->oc, options ? &options : NULL);
+         AVDictionaryEntry *t = NULL;
+
+--- modules/video_chroma/swscale.c
++++ modules/video_chroma/swscale.c
+@@ -589,8 +589,9 @@ static void Convert( filter_t *p_filter, struct SwsContext *ctx,
+ {
+     filter_sys_t *p_sys = p_filter->p_sys;
+     uint8_t palette[AVPALETTE_SIZE];
+-    uint8_t *src[4]; int src_stride[4];
+-    uint8_t *dst[4]; int dst_stride[4];
++    uint8_t *src[4], *dst[4];
++    const uint8_t *csrc[4];
++    int src_stride[4], dst_stride[4];
+ 
+     GetPixels( src, src_stride, p_sys->desc_in, &p_filter->fmt_in.video,
+                p_src, i_plane_count, b_swap_uvi );
+@@ -607,11 +608,14 @@ static void Convert( filter_t *p_filter, struct SwsContext *ctx,
+     GetPixels( dst, dst_stride, p_sys->desc_out, &p_filter->fmt_out.video,
+                p_dst, i_plane_count, b_swap_uvo );
+ 
++    for (size_t i = 0; i < ARRAY_SIZE(src); i++)
++        csrc[i] = src[i];
++
+ #if LIBSWSCALE_VERSION_INT  >= ((0<<16)+(5<<8)+0)
+-    sws_scale( ctx, src, src_stride, 0, i_height,
++    sws_scale( ctx, csrc, src_stride, 0, i_height,
+                dst, dst_stride );
+ #else
+-    sws_scale_ordered( ctx, src, src_stride, 0, i_height,
++    sws_scale_ordered( ctx, csrc, src_stride, 0, i_height,
+                        dst, dst_stride );
+ #endif
+ }
+
+--- modules/video_filter/deinterlace/yadif.h
++++ modules/video_filter/deinterlace/yadif.h
+@@ -139,7 +139,11 @@ static void yadif_filter_line_c(uint8_t *dst, uint8_t *prev, uint8_t *cur, uint8
+     FILTER
+ }
+ 
+-static void yadif_filter_line_c_16bit(uint16_t *dst, uint16_t *prev, uint16_t *cur, uint16_t *next, int w, int prefs, int mrefs, int parity, int mode) {
++static void yadif_filter_line_c_16bit(uint8_t *dst8, uint8_t *prev8, uint8_t *cur8, uint8_t *next8, int w, int prefs, int mrefs, int parity, int mode) {
++    uint16_t *dst = (uint16_t *)dst8;
++    uint16_t *prev = (uint16_t *)prev8;
++    uint16_t *cur = (uint16_t *)cur8;
++    uint16_t *next = (uint16_t *)next8;
+     int x;
+     uint16_t *prev2= parity ? prev : cur ;
+     uint16_t *next2= parity ? cur  : next;

--- a/multimedia/VLC2/files/patch-ffmpeg4-compat.diff
+++ b/multimedia/VLC2/files/patch-ffmpeg4-compat.diff
@@ -2,27 +2,30 @@ diff --git modules/codec/avcodec/avcommon.h modules/codec/avcodec/avcommon.h
 index f967473b472af234a740accdff5ac30a0ea91a81..e8f0a067f88655018214bba192e9fe9c4aefc167 100644
 --- modules/codec/avcodec/avcommon.h
 +++ modules/codec/avcodec/avcommon.h
-@@ -60,6 +60,20 @@ static inline AVDictionary *vlc_av_get_options(const char *psz_opts)
-     return options;
- }
+@@ -45,19 +45,18 @@
+ #define AV_OPTIONS_TEXT     "Advanced options"
+ #define AV_OPTIONS_LONGTEXT "Advanced options, in the form {opt=val,opt2=val2}."
  
-+static inline void vlc_av_get_options_ng(const char *psz_opts, AVDictionary** pp_dict)
-+{
-+    config_chain_t *cfg = NULL;
-+    config_ChainParseOptions(&cfg, psz_opts);
-+    while (cfg) {
-+        config_chain_t *next = cfg->p_next;
+-static inline AVDictionary *vlc_av_get_options(const char *psz_opts)
++static inline void vlc_av_get_options(const char *psz_opts, AVDictionary** pp_dict)
+ {
+-    AVDictionary *options = NULL;
+     config_chain_t *cfg = NULL;
+     config_ChainParseOptions(&cfg, psz_opts);
+     while (cfg) {
+         config_chain_t *next = cfg->p_next;
+-        av_dict_set(&options, cfg->psz_name, cfg->psz_value,
+-            AV_DICT_DONT_STRDUP_KEY | AV_DICT_DONT_STRDUP_VAL);
 +        av_dict_set(pp_dict, cfg->psz_name, cfg->psz_value, 0);
 +        free(cfg->psz_name);
 +        free(cfg->psz_value);
-+        free(cfg);
-+        cfg = next;
-+    }
-+}
-+
+         free(cfg);
+         cfg = next;
+     }
+-    return options;
+ }
+ 
  static inline void vlc_init_avutil(vlc_object_t *obj)
- {
-     int level = AV_LOG_QUIET;
 diff --git modules/codec/avcodec/avcommon_compat.h modules/codec/avcodec/avcommon_compat.h
 index 3c66a1e1b30a2ac742adbe40225cc363590c9b98..d3864448b7f059cfc72fc84262e8e728de8a6c0a 100644
 --- modules/codec/avcodec/avcommon_compat.h
@@ -700,7 +703,7 @@ index 9020576e0c0b3533c9d9760c3474941c43a6bd0c..d7d45e7183f1bf393df77cda972ee1fb
 -        options = vlc_av_get_options(psz_opts);
 -    free(psz_opts);
 +    if (psz_opts) {
-+        vlc_av_get_options_ng(psz_opts, options);
++        vlc_av_get_options(psz_opts, &options);
 +        free(psz_opts);
 +    }
  

--- a/multimedia/avidemux/Portfile
+++ b/multimedia/avidemux/Portfile
@@ -20,7 +20,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 
 name                        avidemux
 version                     2.8.1
-revision                    3
+revision                    4
 
 categories                  multimedia
 platforms                   macosx

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -68,7 +68,7 @@ checksums           rmd160  ac9916e0915cfe3952993644d0a26d9e7c70e1b7 \
 depends_build-append \
                     port:cctools \
                     port:gmake \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     port:texinfo
 
 depends_lib-append \

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -395,10 +395,12 @@ post-destroot {
 
 variant x11 {
     # enable x11grab_xcb input device
+    # Re libXv see: https://trac.macports.org/ticket/58617
     depends_lib-append \
                     port:xorg-libxcb \
                     port:xorg-libXext \
-                    port:xorg-libXfixes
+                    port:xorg-libXfixes \
+                    port:xorg-libXv
     configure.args-delete \
                     --disable-xlib \
                     --disable-libxcb \
@@ -406,10 +408,14 @@ variant x11 {
                     --disable-libxcb-xfixes
 }
 
-if {[variant_isset x11]} {
-    require_active_variants libsdl2 x11
-} else {
-    require_active_variants libsdl2 "" x11
+# On PowerPC libsdl2 is a stub for libsdl2-powerpc, which is always built
+# with X11 backend. It is meaningless to require it as a variant there.
+if {${configure.build_arch} ni [list ppc ppc64]} {
+    if {[variant_isset x11]} {
+        require_active_variants libsdl2 x11
+    } else {
+        require_active_variants libsdl2 "" x11
+    }
 }
 
 variant libdc1394 description {Enable IIDC-1394 frame grabbing using libdc1394 (experimental)} {

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -18,7 +18,7 @@ set my_name         ffmpeg
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            8
+revision            9
 epoch               1
 
 license             LGPL-2.1+

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -17,7 +17,7 @@ name                ffmpeg6
 set my_name         ffmpeg
 
 version             6.1.1
-revision            4
+revision            5
 epoch               0
 
 license             LGPL-2.1+

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -409,10 +409,12 @@ post-destroot {
 
 variant x11 {
     # enable x11grab_xcb input device
+    # Re libXv see: https://trac.macports.org/ticket/58617
     depends_lib-append \
                     port:xorg-libxcb \
                     port:xorg-libXext \
-                    port:xorg-libXfixes
+                    port:xorg-libXfixes \
+                    port:xorg-libXv
     configure.args-delete \
                     --disable-xlib \
                     --disable-libxcb \
@@ -420,10 +422,14 @@ variant x11 {
                     --disable-libxcb-xfixes
 }
 
-if {[variant_isset x11]} {
-    require_active_variants libsdl2 x11
-} else {
-    require_active_variants libsdl2 "" x11
+# On PowerPC libsdl2 is a stub for libsdl2-powerpc, which is always built
+# with X11 backend. It is meaningless to require it as a variant there.
+if {${configure.build_arch} ni [list ppc ppc64]} {
+    if {[variant_isset x11]} {
+        require_active_variants libsdl2 x11
+    } else {
+        require_active_variants libsdl2 "" x11
+    }
 }
 
 variant libdc1394 description {Enable IIDC-1394 frame grabbing using libdc1394 (experimental)} {

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -67,7 +67,7 @@ checksums           rmd160  75589206a87bb9fc9153119396d1f0a434561ea4 \
 depends_build-append \
                     port:cctools \
                     port:gmake \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     port:texinfo
 
 depends_lib-append \

--- a/multimedia/ffmpeg7/Portfile
+++ b/multimedia/ffmpeg7/Portfile
@@ -13,7 +13,7 @@ set my_name         ffmpeg
 conflicts           ffmpeg-devel
 
 version             7.0.2
-revision            0
+revision            1
 
 license             LGPL-2.1+
 categories          multimedia

--- a/multimedia/x265/Portfile
+++ b/multimedia/x265/Portfile
@@ -2,29 +2,27 @@
 
 PortSystem          1.0
 
-PortGroup           muniversal 1.0
+PortGroup           bitbucket 1.0
 PortGroup           cmake 1.1
+PortGroup           muniversal 1.0
 PortGroup           xcode_workaround 1.0
-PortGroup           github 1.0
 
 # https://trac.macports.org/ticket/59875
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 
 legacysupport.newest_darwin_requires_legacy 9
 
-github.setup        videolan x265 3.4
-revision            2
+name                x265
+bitbucket.setup     multicoreware x265_git 3.6
+revision            0
 
-checksums           rmd160  e614c4a03134a67e79efe8d3dd64d54c3990b99a \
-                    sha256  544d147bf146f8994a7bf8521ed878c93067ea1c7c6e93ab602389be3117eaaf \
-                    size    1530200
+checksums           rmd160  2295764f3de72c32454c6e54b51b8d7b4952297f \
+                    sha256  206329b9599c78d06969a1b7b7bb939f7c99a459ab283b2e93f76854bd34ca7b \
+                    size    1656575
 
 categories          multimedia
 license             GPL-2+
 maintainers         nomaintainer
-
-# exclude pre-release versions
-github.livecheck.regex  {([0-9.]+)}
 
 description         H.265 encoder
 long_description    x265 is a free software library and application for \
@@ -32,8 +30,9 @@ long_description    x265 is a free software library and application for \
                     compression format, and is released under the terms of the \
                     GNU GPL.
 homepage            https://www.videolan.org/developers/x265.html
-github.tarball_from archive
-worksrcdir          ${name}-${version}/source
+
+extract.rename      yes
+worksrcdir          ${worksrcpath}/source
 
 # allow overriding system processor detection
 patchfiles          patch-cmakelists-override-processor.diff
@@ -41,7 +40,8 @@ patchfiles          patch-cmakelists-override-processor.diff
 # Altivec uses instructions unsupported on Darwin: https://trac.macports.org/ticket/64781
 patchfiles-append   patch-ppc.diff
 
-depends_build-append port:gmake
+depends_build-append \
+                    port:gmake
 
 compiler.blacklist-append *llvm-gcc-4.2
 

--- a/multimedia/x265/files/patch-ppc.diff
+++ b/multimedia/x265/files/patch-ppc.diff
@@ -1,15 +1,15 @@
 --- CMakeLists.txt.orig	2020-05-29 23:24:35.000000000 +0545
-+++ CMakeLists.txt	2022-08-04 01:19:02.000000000 +0545
-@@ -43,7 +43,7 @@
- set(ARM_ALIASES armv6l armv7l aarch64)
++++ CMakeLists.txt	2024-08-10 17:47:07.000000000 +0800
+@@ -53,7 +53,7 @@
  list(FIND X86_ALIASES "${SYSPROC}" X86MATCH)
  list(FIND ARM_ALIASES "${SYSPROC}" ARMMATCH)
--set(POWER_ALIASES ppc64 ppc64le)
-+set(POWER_ALIASES ppc ppc64 ppc64le)
+ list(FIND ARM64_ALIASES "${SYSPROC}" ARM64MATCH)
+-set(POWER_ALIASES powerpc64 powerpc64le ppc64 ppc64le)
++set(POWER_ALIASES ppc powerpc64 powerpc64le ppc64 ppc64le)
  list(FIND POWER_ALIASES "${SYSPROC}" POWERMATCH)
- if("${SYSPROC}" STREQUAL "" OR X86MATCH GREATER "-1")
+ if(X86MATCH GREATER "-1")
      set(X86 1)
-@@ -469,7 +469,7 @@
+@@ -511,7 +511,7 @@
      endif(WINXP_SUPPORT)
  endif()
  


### PR DESCRIPTION
#### Description

1. Update x265, finally.
2. Revbump dependents.
3. Address a problem with FFMpeg which is pending for 5 years.

I do not revbump one completely broken port, it is pointless, and dropped `libheif` due to https://github.com/macports/macports-ports/pull/25265
I also do not include FFMpeg7 and -devel, since we rather merge https://github.com/macports/macports-ports/pull/25173 after this PR and avoid another rebuild.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
