### PR TITLE
uv: Update to 0.2.35

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,12 +4,12 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.2.34
+github.setup            astral-sh uv 0.2.35
 github.tarball_from     archive
 revision                0
 categories              devel python
 license                 {Apache-2 MIT}
-platforms               {darwin >= 16}
+platforms               {darwin >= 17}
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
 description             Extremely fast Python package installer and resolver
@@ -17,9 +17,9 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for common pip and pip-tools workflows.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  2d50efce5e6041a983031ead1a039b547ebe7299 \
-                        sha256  b111d5f6c4958bab14a6c4e3c4a77dc576a900aa3ce48caf0c2269901df64652 \
-                        size    1680027
+                        rmd160  f170e5567acee35d67c185a54f83c18370b15356 \
+                        sha256  75233b4fe20715ac2da9e14e35379ed67f025e267fbe63abcb5d607033572c41 \
+                        size    1724476
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -65,16 +65,16 @@ cargo.crates \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
     anstream                        0.6.15  64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526 \
-    anstyle                          1.0.7  038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b \
-    anstyle-parse                    0.2.4  c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4 \
-    anstyle-query                    1.1.0  ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391 \
-    anstyle-wincon                   3.0.3  61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19 \
+    anstyle                          1.0.8  1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1 \
+    anstyle-parse                    0.2.5  eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb \
+    anstyle-query                    1.1.1  6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a \
+    anstyle-wincon                   3.0.4  5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8 \
     anyhow                          1.0.86  b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arrayref                         0.3.8  9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a \
     arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
-    assert_cmd                      2.0.15  bc65048dd435533bb1baf2ed9956b9a278fbfdcf90301b39ee117f06c0199d37 \
+    assert_cmd                      2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     assert_fs                        1.1.2  7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674 \
     async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
     async-compression               0.4.12  fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa \
@@ -96,23 +96,24 @@ cargo.crates \
     bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     bitvec                           1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    boxcar                           0.2.5  510a90332002c1af3317ef6b712f0dab697f30bbe809b86965eac2923c0bca8e \
     brotli                           6.0.0  74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b \
     brotli-decompressor              4.0.1  9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362 \
-    bstr                             1.9.1  05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706 \
+    bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytecheck                       0.6.12  23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2 \
     bytecheck_derive                0.6.12  3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659 \
-    bytemuck                        1.16.1  b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e \
+    bytemuck                        1.16.3  102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83 \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     byteorder-lite                   0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
-    bytes                            1.6.1  a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952 \
+    bytes                            1.7.1  8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50 \
     bzip2                            0.4.4  bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8 \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
     camino                           1.1.7  e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239 \
     cargo-util                      0.2.13  14104698cb1694d43c2ff73492468ccf2bb0b047071a9838d999eeba9e984ffa \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
-    cc                               1.1.6  2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f \
+    cc                               1.1.8  504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.1.1  fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e \
     charset                          0.1.5  f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e \
@@ -120,18 +121,18 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.13  0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc \
-    clap_builder                    4.5.13  64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99 \
-    clap_complete                    4.5.9  faa2032320fd6f50d22af510d204b2994eef49600dfbd0e771a166213844e4cd \
+    clap                            4.5.14  c937d4061031a6d0c8da4b9a4f98a172fc2976dfb1c19213a9cf7d0d3c837e36 \
+    clap_builder                    4.5.14  85379ba512b21a328adf887e85f7742d12e96eb31f3ef077df4ffc26b506ffed \
+    clap_complete                   4.5.13  aa3c596da3cf0983427b0df0dba359df9182c13bd5b519b585a482b0c351f4e8 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
-    clap_complete_nushell            4.5.2  1accf1b463dee0d3ab2be72591dccdab8bef314958340447c882c4c72acfe2a3 \
+    clap_complete_nushell            4.5.3  5fe32110e006bccf720f8c9af3fee1ba7db290c724eab61544e1d3295be3a40e \
     clap_derive                     4.5.13  501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0 \
-    clap_lex                         0.7.1  4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70 \
+    clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
     cmake                           0.1.50  a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130 \
     codspeed                         2.6.0  3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089 \
     codspeed-criterion-compat        2.6.0  722c36bdc62d9436d027256ce2627af81ac7a596dfc7d13d849d0d212448d7fe \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
-    colorchoice                      1.0.1  0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422 \
+    colorchoice                      1.0.2  d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0 \
     colored                          2.1.0  cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8 \
     concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     configparser                     3.1.0  e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b \
@@ -174,12 +175,12 @@ cargo.crates \
     event-listener-strategy          0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
     fastrand                         2.1.0  9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a \
     fdeflate                         0.3.4  4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645 \
-    filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
+    filetime                        0.2.24  bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550 \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
     flate2                          1.0.31  7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920 \
     float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    fontconfig-parser                0.5.6  6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d \
+    fontconfig-parser                0.5.7  c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7 \
     fontdb                          0.12.0  ff20bef7942a72af07104346154a70a70b089c572e454b41bef6eb6cb10e9c06 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fs-err                          2.11.0  88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41 \
@@ -221,7 +222,7 @@ cargo.crates \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     hyper                            1.4.1  50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05 \
     hyper-rustls                    0.27.2  5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155 \
-    hyper-util                       0.1.6  3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956 \
+    hyper-util                       0.1.7  cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9 \
     iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
@@ -236,7 +237,7 @@ cargo.crates \
     ipnet                            2.9.0  8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3 \
     is-terminal                     0.4.12  f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b \
     is_ci                            1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
-    is_terminal_polyfill            1.70.0  f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800 \
+    is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
     itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
@@ -282,7 +283,7 @@ cargo.crates \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
-    object                          0.36.2  3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e \
+    object                          0.36.3  27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9 \
     once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     oorandom                        11.1.4  b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
@@ -316,10 +317,10 @@ cargo.crates \
     png                            0.17.13  06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1 \
     poloto                          19.1.2  164dbd541c9832e92fa34452e9c2e98b515a548a3f8549fb2402fe1cd5e46b96 \
     portable-atomic                  1.7.0  da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265 \
-    ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
+    ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
     predicates                       3.1.2  7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97 \
-    predicates-core                  1.0.6  b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174 \
-    predicates-tree                  1.0.9  368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf \
+    predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
+    predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
     pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
     priority-queue                   2.0.3  70c501afe3a2e25c9bd219aa56ec1e04cdb3fcdd763055be268778c13fa82c1f \
     proc-macro2                     1.0.86  5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77 \
@@ -331,8 +332,8 @@ cargo.crates \
     pyo3-log                        0.10.0  2af49834b8d2ecd555177e63b273b708dea75150abc6f5341d0a6e1a9623976c \
     pyo3-macros                     0.21.2  77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c \
     pyo3-macros-backend             0.21.2  08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c \
-    quinn                           0.11.2  e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad \
-    quinn-proto                     0.11.3  ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe \
+    quinn                           0.11.3  b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156 \
+    quinn-proto                     0.11.6  ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd \
     quinn-udp                        0.5.4  8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285 \
     quote                           1.0.36  0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7 \
     quoted_printable                 0.5.1  640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73 \
@@ -345,7 +346,6 @@ cargo.crates \
     rctree                           0.5.0  3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f \
     redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
     redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
-    redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
     redox_syscall                    0.5.3  2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4 \
     redox_users                      0.4.5  bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891 \
     reflink-copy                    0.1.19  dc31414597d1cd7fdd2422798b7652a6329dda0fe0219e6335a13d5bcaa9aeb6 \
@@ -358,7 +358,7 @@ cargo.crates \
     reqwest                         0.12.5  c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37 \
     resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
     retry-policies                   0.4.0  5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c \
-    rgb                             0.8.45  ade4539f42266ded9e755c605bdddf546242b2c961b03b06a7375260788a0523 \
+    rgb                             0.8.48  0f86ae463694029097b846d8f99fd5536740602ae00022c0c50c5600720b2f71 \
     ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
     rkyv                            0.7.44  5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0 \
     rkyv_derive                     0.7.44  a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65 \
@@ -366,7 +366,7 @@ cargo.crates \
     rmp-serde                        1.3.0  52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db \
     rosvgtree                        0.1.0  bdc23d1ace03d6b8153c7d16f0708cd80b61ee8e80304954803354e67e40d150 \
     roxmltree                       0.18.1  862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302 \
-    roxmltree                       0.19.0  3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f \
+    roxmltree                       0.20.0  6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97 \
     rust-netrc                       0.1.1  32662f97cbfdbad9d5f78f1338116f06871e7dae4fd37e9f59a0f57cf2044868 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
@@ -374,8 +374,8 @@ cargo.crates \
     rustix                         0.38.34  70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f \
     rustls                         0.23.12  c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044 \
     rustls-native-certs              0.7.1  a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba \
-    rustls-pemfile                   2.1.2  29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d \
-    rustls-pki-types                 1.7.0  976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d \
+    rustls-pemfile                   2.1.3  196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425 \
+    rustls-pki-types                 1.8.0  fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0 \
     rustls-webpki                  0.102.6  8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e \
     rustybuzz                        0.7.0  162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
@@ -388,8 +388,8 @@ cargo.crates \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework-sys          2.11.1  75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
-    serde                          1.0.204  bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12 \
-    serde_derive                   1.0.204  e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222 \
+    serde                          1.0.205  e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150 \
+    serde_derive                   1.0.205  692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1 \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
     serde_json                     1.0.122  784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da \
     serde_spanned                    0.6.7  eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d \
@@ -426,7 +426,7 @@ cargo.crates \
     tap                              1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
     target-lexicon                 0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
     temp-env                         0.3.6  96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050 \
-    tempfile                        3.11.0  b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53 \
+    tempfile                        3.12.0  04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64 \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
     termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
     test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
@@ -492,7 +492,7 @@ cargo.crates \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     uuid                            1.10.0  81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314 \
     valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
-    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
@@ -512,7 +512,7 @@ cargo.crates \
     widestring                       1.1.0  7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.8  4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b \
+    winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     windows                         0.52.0  e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be \
     windows                         0.58.0  dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6 \
@@ -526,6 +526,7 @@ cargo.crates \
     windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
     windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
@@ -554,8 +555,10 @@ cargo.crates \
     xmlparser                       0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec \
+    zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
+    zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
     zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
     zstd                            0.13.2  fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9 \
-    zstd-safe                        7.2.0  fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa \
-    zstd-sys             2.0.12+zstd.1.5.6  0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13
+    zstd-safe                        7.2.1  54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059 \
+    zstd-sys             2.0.13+zstd.1.5.6  38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.2.35

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
