### PR TITLE
gtk3: Add missing build dependency on mesa

### DIFF
--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -46,9 +46,18 @@ minimum_xcodeversions {9 3.1}
 
 set port_ver_major  [lindex [split ${version} .] 0]
 
+# libexpoxy installs epoxy.pc, which contains `Requires.private: gl`, which is
+# provided by mesa. Attempting to configure gtk3 without mesa installed causes:
+# | Package gl was not found in the pkg-config search path.
+# | Perhaps you should add the directory containing `gl.pc'
+# | to the PKG_CONFIG_PATH environment variable
+# | Package 'gl', required by 'epoxy', not found
+# This is also true for libexpoxy +quartz. Do not remove the mesa build
+# dependency without testing a gtk3 +quartz build.
 depends_build-append \
                     port:gtk-doc \
-                    path:bin/pkg-config:pkgconfig
+                    path:bin/pkg-config:pkgconfig \
+                    port:mesa
 
 depends_lib-append \
                     port:atk \

--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -46,9 +46,18 @@ minimum_xcodeversions {9 3.1}
 
 set port_ver_major  [lindex [split ${version} .] 0]
 
+# libexpoxy installs epoxy.pc, which contains `Requires.private: gl`, which is
+# provided by mesa. Attempting to configure gtk3 without mesa installed causes:
+# | Package gl was not found in the pkg-config search path.
+# | Perhaps you should add the directory containing `gl.pc'
+# | to the PKG_CONFIG_PATH environment variable
+# | Package 'gl', required by 'epoxy', not found
+# This is also true for libexpoxy +quartz. Do not remove the mesa build
+# dependency without testing a gtk3 +quartz build.
 depends_build-append \
                     port:gtk-doc \
-                    path:bin/pkg-config:pkgconfig
+                    path:bin/pkg-config:pkgconfig \
+                    port:mesa
 
 depends_lib-append \
                     port:atk \


### PR DESCRIPTION
#### Description

Partially reverts 4fb8088b2838539db152705c8ec612d71aa4d237.

According to [1], this only is a problem when epoxy was configured with mesa present, but until somebody fixes epoxy to never add `Requires.private: gl` to its pkg-config file when built with +quartz, we must assume user systems out there have it and value build stability over minimal dependencies.

[1]: https://github.com/macports/macports-ports/commit/4fb8088b2838539db152705c8ec612d71aa4d237#commitcomment-142476278

See: https://lists.macports.org/pipermail/macports-users/2024-August/052836.html
Closes: https://trac.macports.org/ticket/70184

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?