### PR TITLE
openjdk21-openj9: update to 21.0.4

### DIFF
--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      21.0.3
+version      21.0.4
 revision     0
 
-set build    9
-set openj9_version 0.44.0
+set build    7
+set openj9_version 0.46.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 21
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru21-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  def35b5be32a3811f5fa49d2649d8647030f13be \
-                 sha256  95640346ef677fbdbf40efa0298cc61314cffed0c43d1b3bd329b84d445db869 \
-                 size    224552939
+    checksums    rmd160  2172f491f85239b65276ba48c3cedeab7ad22189 \
+                 sha256  b36371d5844ed7d56ae03a8287fe724199b1b047c22eb175f20247f605be6e9c \
+                 size    225669765
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  52da307addc619f3139edfa2d68aecb3029da0f5 \
-                 sha256  a95896a4ca7b69050a25b1557520f430abc66d098e9fd15cd394e20c4c93e5cf \
-                 size    217767190
+    checksums    rmd160  20c89ec891001833c44f5c11ac54565bc403bb59 \
+                 sha256  3f13030a8c36d02110145874ebdb71b5a526e053a2a2cbfdcbf45eb123b96dae \
+                 size    218850739
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 21.0.4.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?