### PR TITLE
openjdk22-openj9-: update to 22.0.2

### DIFF
--- a/java/openjdk22-openj9/Portfile
+++ b/java/openjdk22-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      22.0.1
+version      22.0.2
 revision     0
 
-set build    8
-set openj9_version 0.45.0
+set build    9
+set openj9_version 0.46.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 22
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru22-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  1a286bcb9ad605a0ba38868823b4117ac012afe4 \
-                 sha256  f0e459df70b5a3c8fc0abc099d5c06a596da40b95f8226d76474516a646a3861 \
-                 size    222418946
+    checksums    rmd160  6323bfa47b2622e73e48ca38f125dfc8d20bd384 \
+                 sha256  24b49444a11f3e6a91e6f5dd2f298ea64da0f7953016b99e53cdb86e86d392eb \
+                 size    223473891
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  bc9b02fcb348782b3d0af1f0734f97ebf6e6fa98 \
-                 sha256  623cc15daa3b4c7f21d47f225c94a163e2261074cc3c11f30d2938fc249b9355 \
-                 size    215747283
+    checksums    rmd160  c4f0ea39e7098ded7c79ac19ffae8eb37ad343bc \
+                 sha256  b2018fd12ba90c0e030b4f499b0126360ebcac62042257df8c49b3fedf5979f9 \
+                 size    216744793
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 22.0.2.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?