### PR TITLE
openjdk17-openj9: update to 17.0.12

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      17.0.11
+version      17.0.12
 revision     0
 
-set build    9
-set openj9_version 0.44.0
+set build    7
+set openj9_version 0.46.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 17
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru17-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  326a8158ebd83a44be8ddf00ed858d6aac2542d4 \
-                 sha256  adfd6dee2634345e37503f763ecdd7c17ee1d8cb99d746698c5d4275ede92662 \
-                 size    212134087
+    checksums    rmd160  d3a0f50e3f9eea412f40ea76b5cec7fc155a6a8e \
+                 sha256  7deda0966edee2d9af447f848bd28d8889149d3fc2e534627136c029edd25689 \
+                 size    213139862
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  231d7cebdfac203aef49f4bb46c8f5efc6727f14 \
-                 sha256  ad8d92148d1720172484f918565657324007f589d1229da8c7d25c886f270549 \
-                 size    205386483
+    checksums    rmd160  fa0becace070bf8a9085148ef4252b93ca4f45ac \
+                 sha256  cd17c6adc0e4c2da99c74dfd19d9c7745a2d0ee8277b16a83f5cf124711bef78 \
+                 size    206381295
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.12.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?