### PR TITLE
openjdk11-openj9: update to 11.0.24

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      11.0.23
+version      11.0.24
 revision     0
 
-set build    9
-set openj9_version 0.44.0
+set build    8
+set openj9_version 0.46.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 11
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  121a9b15ab7fc5b743e19df9434b0acb9f71f041 \
-                 sha256  6a225f3024d1919528107ece20256e8a8594523ea2204d93a041c012cbf1e2d2 \
-                 size    207093767
+    checksums    rmd160  c7cc0a2c59f88053ac8fd7cb50748a74049679aa \
+                 sha256  3fee7c12ebb89eebff89ae401f793237f5ebf4064b063d2a5adc208f69f71e7a \
+                 size    208047776
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  5ebc036ebf2343e687d4734807beeadfe9048a25 \
-                 sha256  451336700a8b219d219e2e3b26b60154c44e8ab209056cc3466b0fcd4b15e53d \
-                 size    201360201
+    checksums    rmd160  a55cc8862f640bdac7820fbf0add1843991c3389 \
+                 sha256  6688e7bb5a385f245c28b077094f4625270c696a92aab5a261f6c75f7310215b \
+                 size    202290319
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.24.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?