### PR TITLE
openjdk8-openj9: update to 8u422

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
-version      8u412
+version      8u422
 revision     0
 
-set build    08
-set openj9_version 0.44.0
+set build    05
+set openj9_version 0.46.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 8
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -29,9 +29,9 @@ master_sites https://github.com/ibmruntimes/semeru8-binaries/releases/download/j
 distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  67c3fa451cec32114957f08eb73c59601eda62fa \
-             sha256  4e8a34442fc0c1c1288ca4d251ecfe744c201ec6494103d8dafa52e785d3f8ae \
-             size    130528416
+checksums    rmd160  1b4648d1dc961debac32ffb29a91451a0a8f836c \
+             sha256  3cb422d24fb258b8c3b4c1daa0269f0664e1ddf3d4fd6e366c96dff7eed1d26a \
+             size    130899491
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8u422.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?