### PR TITLE
bloaty: fix the port, revbump

### DIFF
--- a/devel/bloaty/Portfile
+++ b/devel/bloaty/Portfile
@@ -3,10 +3,17 @@
 PortSystem          1.0
 PortGroup           cmake   1.1
 PortGroup           github  1.0
+PortGroup           legacysupport 1.1
 
-github.setup        google bloaty 1.1 v
-github.tarball_from releases
-revision            0
+# strnlen
+legacysupport.newest_darwin_requires_legacy 10
+
+# Commit-based until next release, since old release
+# fails to build against current versions of re2 etc.
+# https://github.com/google/bloaty/issues/380
+github.setup        google bloaty 34f4a66559ad4938c1e629e9b5f54630b2b4d7b0
+version             1.1
+revision            1
 
 description         A size profiler for binaries
 
@@ -17,8 +24,22 @@ categories          devel
 license             Apache-2
 maintainers         nomaintainer
 
-checksums           rmd160  4a6e827d34b86775b6871ea0c117caba89cd9e9b \
-                    sha256  a308d8369d5812aba45982e55e7c3db2ea4780b7496a5455792fb3dcba9abd6f \
-                    size    5363836
+fetch.type          git
 
-use_bzip2           yes
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+depends_lib-append  port:capstone \
+                    port:protobuf3-cpp \
+                    port:re2 \
+                    port:zlib
+
+compiler.cxx_standard   2017
+
+configure.args-append \
+                    -DBLOATY_ENABLE_RE2=ON \
+                    -DBLOATY_PREFER_SYSTEM_CAPSTONE=ON \
+                    -DBUILD_TESTING=OFF


### PR DESCRIPTION
#### Description

1. Current portfile ignores that the source prefers external libs. This is not seen on buildbots, since bundled duplicates will be built in absence of external ones. But we do not want this.
2. Set required C++ standard.
3. Fix for < 10.7.
4. Use commit-based build until next release, since 2020 release fails to link against current `re2` etc., which use C++17, not C++11.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
