### PR TITLE
c2t: allow build with Xcode gcc

### DIFF
--- a/devel/c2t/Portfile
+++ b/devel/c2t/Portfile
@@ -11,7 +11,6 @@ checksums           rmd160  92d58a9f2dd9b534dc0f90a52c5021d3140462ca \
                     size    2458969
 
 categories          devel
-platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             Permissive
 
@@ -26,6 +25,7 @@ long_description    ${name} is a command line tool that can convert \
 
 github.tarball_from archive
 
+# cc1: error: unrecognized command line option "-Wno-misleading-indentation"
 patchfiles          Makefile.patch
 
 # Don't extract the pre-compiled binaries; we'll compile them ourselves.

--- a/devel/c2t/files/Makefile.patch
+++ b/devel/c2t/files/Makefile.patch
@@ -14,11 +14,11 @@
  
  bin/c2t: c2t.c c2t.h
 -	gcc -Wall -Wno-strict-aliasing -Wno-misleading-indentation -Wno-unused-value -Wno-unused-function -I. -O3 -o bin/c2t c2t.c -lm
-+	$(CC) -Wall -Wno-strict-aliasing -Wno-misleading-indentation -Wno-unused-value -Wno-unused-function -I. $(CFLAGS) $(LDFLAGS) -o bin/c2t c2t.c -lm
++	$(CC) -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. $(CFLAGS) $(LDFLAGS) -o bin/c2t c2t.c -lm
  
  bin/c2t-96h: c2t-96h.c c2t.h
 -	gcc -Wall -Wno-strict-aliasing -Wno-misleading-indentation -Wno-unused-value -Wno-unused-function -I. -O3 -o bin/c2t-96h c2t-96h.c -lm
-+	$(CC) -Wall -Wno-strict-aliasing -Wno-misleading-indentation -Wno-unused-value -Wno-unused-function -I. $(CFLAGS) $(LDFLAGS) -o bin/c2t-96h c2t-96h.c -lm
++	$(CC) -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. $(CFLAGS) $(LDFLAGS) -o bin/c2t-96h c2t-96h.c -lm
  
  bin/c2t.exe: c2t.c c2t.h
 -	$(WIN32GCC) -Wall -Wno-strict-aliasing -Wno-unused-value -Wno-unused-function -I. -O3 -o bin/c2t.exe c2t.c


### PR DESCRIPTION
#### Description

Drop a warning flag which breaks the build with Xcode gcc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
