### PR TITLE
findutils: update to 4.10.0

### DIFF
--- a/sysutils/findutils/Portfile
+++ b/sysutils/findutils/Portfile
@@ -8,7 +8,7 @@ name            findutils
 conflicts       findutils-devel
 set my_name     findutils
 
-version         4.9.0
+version         4.10.0
 revision        0
 
 categories      sysutils
@@ -27,9 +27,9 @@ use_xz          yes
 
 installs_libs   no
 
-checksums       rmd160  afb19ac8a7d457827bc548aa904660b5ddec00ea \
-                sha256  a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe \
-                size    2046252
+checksums       rmd160  623fffe9e2331a2a11b52bd212790480d3c7a8c4 \
+                sha256  1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5 \
+                size    2240712
 
 depends_build-append \
                 port:gettext


### PR DESCRIPTION
#### Description

I see a series of tickets about gnulib-related failures on old versions of MacOS X. I imagine this release has the latest gnulib and any fixes, however, I don't have any of these old machines to see if findutils is building better on them. So I will not close any of those tickets in this PR.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
