### PR TITLE
bash: update to 5.2.32

### DIFF
--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                bash
 set bash_version    5.2
-set bash_patchlevel 26
+set bash_patchlevel 32
 subport bash50 {
     # used by bashdb port
     set bash_version    5.0
@@ -30,6 +30,12 @@ if {${subport} eq ${name}} {
    conflicts        bash50
 } elseif {${subport} eq "bash50"} {
    conflicts        bash
+}
+
+if {${subport} eq "bash50"} {
+    # https://www.mail-archive.com/bug-bash@gnu.org/msg25109.html
+    # bash 5.0 lacks fixes needed to build on arm
+    supported_archs     x86_64
 }
 
 master_sites        gnu
@@ -151,7 +157,31 @@ if {${subport} eq ${name}} {
                         bash52-026 \
                         rmd160  9a4710c808def2c4d1337c81bd761936be0d9bc5 \
                         sha256  96ee1f549aa0b530521e36bdc0ba7661602cfaee409f7023cac744dd42852eac \
-                        size    1372
+                        size    1372 \
+                        bash52-027 \
+                        rmd160  fa30b5e39ac2c6bd310ba77b1817aa2243ce8367 \
+                        sha256  e12a890a2e4f0d9c6ec1ce65b73da4fe116c8e4209bac8ac9dc4cd96f486ab39 \
+                        size    1881 \
+                        bash52-028 \
+                        rmd160  d63afa9945c1ffae75151e688cd756d2dbee758f \
+                        sha256  6042780ba2893daca4a3f0f9b65728592cd7bb6d4cebe073855a6aad4d63aac1 \
+                        size    1571 \
+                        bash52-029 \
+                        rmd160  e7d5b1f14eef4c1b7d55d2f1d17610957e5d02c7 \
+                        sha256  125cacb37e625471924b3ee06c54cb1bf21b3b7fe0e569d24a681b0ec4a29987 \
+                        size    3619 \
+                        bash52-030 \
+                        rmd160  afe33531734a9b157c5d15eb62590f80c012a2cd \
+                        sha256  c3ff73230e123acdb5ac216921a386df8f74340459533d776d02811a1f76698f \
+                        size    4111 \
+                        bash52-031 \
+                        rmd160  66dbb9443510b7bc2752c5916ef57e9a129fe4da \
+                        sha256  c2d1b7be2df771126105020af7fafa00fffd4deff4a4e45d60fc6a235bcba795 \
+                        size    1159 \
+                        bash52-032 \
+                        rmd160  2ec870b706258160f24334b82faf264dbcd2633a \
+                        sha256  7b9c77daeca93ff711781d7537234166e83ed9835ce1ee7dcd5742319c372a16 \
+                        size    1529
 } elseif {${subport} eq "bash50"} {
    checksums           ${distname}${extract.suffix} \
                        rmd160  a081428a896d617855499376b670eca3433a27c1 \


### PR DESCRIPTION
#### Description

Just very minor bugfixes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
