### PR TITLE
whisper: submission of port (whisper.cpp)

### DIFF
--- a/audio/whisper/Portfile
+++ b/audio/whisper/Portfile
@@ -1,0 +1,120 @@
+#-*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+name                whisper
+categories          audio
+github.setup        ggerganov whisper.cpp 1.6.2 v
+github.tarball_from archive
+license             MIT
+maintainers         {ijams.me:nate @exprez135} \
+                    openmaintainer
+description         Port of OpenAI's Whisper model in C/C++
+long_description    High-performance inference of OpenAI's Whisper automatic speech recognition \
+                    (ASR) model
+notes               "
+Install this port's variants to include models, or download
+your own and use the built-in `-m` feature.
+
+Remember that whisper.cpp only functions on 16-bit WAV
+files. You can use `ffmpeg -i input.mp3 -ar 16000
+output.wav` to convert the file first.
+"
+
+checksums           whisper.cpp-${version}.tar.gz \
+                    rmd160  26b0b29e46c990b13c9d10d95c11aa429fc8d56d \
+                    sha256  da7988072022acc3cfa61b370b3c51baad017f1900c3dc4e68cb276499f66894 \
+                    size    5088298
+
+build.target        main
+makefile.has_destdir    no
+patchfiles          whisper-add-models.diff \
+                    ggml-hard-coded.diff \
+                    add-metal-path.diff
+
+post-patch {
+    reinplace "s|__PREFIX__|${prefix}|" \
+        whisper.cpp \
+        ggml-metal.metal \
+        ggml-metal.m
+}
+
+post-build {
+    move ${worksrcpath}/main ${worksrcpath}/whisper
+}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/bin
+    xinstall -m 755 ${worksrcpath}/whisper ${destroot}${prefix}/bin/whisper
+}
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/share/whisper/ggml
+    xinstall ${worksrcpath}/ggml-metal.metal ${destroot}${prefix}/share/whisper/ggml
+    xinstall ${worksrcpath}/ggml-common.h ${destroot}${prefix}/share/whisper/ggml
+}
+
+
+# Define model variants
+
+variant tiny description {Install tiny model} {
+    distfiles-append        ggml-tiny.bin:tiny
+    master_sites-append     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/
+    checksums-append        ggml-tiny.bin \
+                            sha256  be07e048e1e599ad46341c8d2a135645097a538221678b7acdd1b1919c6e1b21 \
+                            size    77691713
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/whisper/models
+        xinstall ${distpath}/ggml-tiny.bin ${destroot}${prefix}/share/whisper/models/tiny.bin
+    }
+}
+
+variant base description {Install base model} {
+    distfiles-append        ggml-base.bin:base
+    master_sites-append     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/
+    checksums-append        ggml-base.bin \
+                            sha256  60ed5bc3dd14eea856493d334349b405782ddcaf0028d4b5df4088345fba2efe \
+                            size    147951465
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/whisper/models
+        xinstall ${distpath}/ggml-base.bin ${destroot}${prefix}/share/whisper/models/base.bin
+    }
+}
+
+variant small description {Install small model} {
+    distfiles-append        ggml-small.bin:small
+    master_sites-append     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/
+    checksums-append        ggml-small.bin \
+                            sha256  1be3a9b2063867b937e64e2ec7483364a79917e157fa98c5d94b5c1fffea987b \
+                            size    487601967
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/whisper/models
+        xinstall ${distpath}/ggml-small.bin ${destroot}${prefix}/share/whisper/models/small.bin
+    }
+}
+
+variant medium description {Install medium model} {
+    distfiles-append        ggml-medium.bin:medium
+    master_sites-append     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/
+    checksums-append        ggml-medium.bin \
+                            sha256  6c14d5adee5f86394037b4e4e8b59f1673b6cee10e3cf0b11bbdbee79c156208 \
+                            size    1533763059
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/whisper/models
+        xinstall ${distpath}/ggml-medium.bin ${destroot}${prefix}/share/whisper/models/medium.bin
+    }
+}
+
+variant large description {Install large model} {
+    distfiles-append        ggml-large-v3.bin:large
+    master_sites-append     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/
+    checksums-append        ggml-large.bin
+                            sha256  64d182b440b98d5203c4f9bd541544d84c605196c4f7b845dfa11fb23594d1e2 \
+                            size    3095033483
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/whisper/models
+        xinstall ${distpath}/ggml-large-v3.bin ${destroot}${prefix}/share/whisper/models/large.bin
+    }
+}

--- a/audio/whisper/files/add-metal-path.diff
+++ b/audio/whisper/files/add-metal-path.diff
@@ -1,0 +1,14 @@
+--- ggml-metal.m	2024-05-27 02:35:09
++++ CHANGED-ggml-metal.m	2024-08-09 10:44:38
+@@ -360,7 +360,10 @@
+             if (path_resource) {
+                 path_source = [path_resource stringByAppendingPathComponent:@"ggml-metal.metal"];
+             } else {
+-                path_source = [bundle pathForResource:@"ggml-metal" ofType:@"metal"];
++		path_resource = @"__PREFIX__/share/whisper/ggml";
++		GGML_METAL_LOG_INFO("%s: GGML_METAL_PATH_RESOURCES = %s\n", __func__, path_resource ? [path_resource UTF8String] : "nil");
++		path_source = [path_resource stringByAppendingPathComponent:@"ggml-metal.metal"];
++		/* path_source = [bundle pathForResource:@"ggml-metal" ofType:@"metal"];*/
+             }
+ 
+             if (path_source == nil) {

--- a/audio/whisper/files/ggml-hard-coded.diff
+++ b/audio/whisper/files/ggml-hard-coded.diff
@@ -1,0 +1,10 @@
+--- ggml-metal.metal	2024-05-27 02:35:09
++++ CHANGED-ggml-metal.metal	2024-08-09 10:44:53
+@@ -1,6 +1,6 @@
+ #define GGML_COMMON_DECL_METAL
+ #define GGML_COMMON_IMPL_METAL
+-#include "ggml-common.h"
++#include "__PREFIX__/share/whisper/ggml/ggml-common.h"
+ 
+ #include <metal_stdlib>
+ 

--- a/audio/whisper/files/whisper-add-models.diff
+++ b/audio/whisper/files/whisper-add-models.diff
@@ -1,0 +1,64 @@
+--- whisper.cpp	2024-07-31 09:14:56
++++ CHANGED.cpp	2024-08-09 10:45:42
+@@ -53,6 +53,8 @@
+ #include <random>
+ #include <functional>
+ #include <codecvt>
++#include <dirent.h>
++#include <sys/types.h>
+ 
+ #if defined(_MSC_VER)
+ #pragma warning(disable: 4244 4267) // possible loss of data
+@@ -3621,17 +3623,50 @@
+ 
+ struct whisper_context * whisper_init_from_file_with_params_no_state(const char * path_model, struct whisper_context_params params) {
+     WHISPER_LOG_INFO("%s: loading model from '%s'\n", __func__, path_model);
++
+ #ifdef _MSC_VER
+-    // Convert UTF-8 path to wide string (UTF-16) for Windows, resolving character encoding issues.
+     std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+     std::wstring path_model_wide = converter.from_bytes(path_model);
+     auto fin = std::ifstream(path_model_wide, std::ios::binary);
+ #else
+     auto fin = std::ifstream(path_model, std::ios::binary);
+ #endif
++
+     if (!fin) {
+         WHISPER_LOG_ERROR("%s: failed to open '%s'\n", __func__, path_model);
+-        return nullptr;
++
++        const std::string fallback_dir = "__PREFIX__/share/whisper/models";
++        std::string fallback_path;
++
++        DIR *dir = opendir(fallback_dir.c_str());
++        if (dir) {
++            struct dirent *entry;
++            while ((entry = readdir(dir)) != nullptr) {
++                std::string filename = entry->d_name;
++                if (filename.size() > 4 && filename.substr(filename.size() - 4) == ".bin") {
++                    fallback_path = fallback_dir + "/" + filename;
++                    break;
++                }
++            }
++            closedir(dir);
++        }
++
++        if (fallback_path.empty()) {
++            WHISPER_LOG_ERROR("%s: no .bin files found in fallback directory '%s'\n", __func__, fallback_dir.c_str());
++            return nullptr;
++        }
++
++#ifdef _MSC_VER
++        std::wstring fallback_path_wide = converter.from_bytes(fallback_path);
++        fin.open(fallback_path_wide, std::ios::binary);
++#else
++        fin.open(fallback_path, std::ios::binary);
++#endif
++
++        if (!fin) {
++            WHISPER_LOG_ERROR("%s: failed to open fallback file '%s'\n", __func__, fallback_path.c_str());
++            return nullptr;
++        }
+     }
+ 
+     whisper_model_loader loader = {};


### PR DESCRIPTION
#### Description

Adds the whisper.cpp project to MacPorts (a port of OpenAI's whisper in C/C++). Note: this is my first contribution to MacPorts, so forgive any mistakes or bad practices. I named the project "whisper," but maybe it needs to be whisper-cpp or something like that, though whisper is easier as a name and executable. Its variants also allow users to download the models that are necessary for using the program and store them in /opt/local/share/whisper.
Replaces #25270 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.3 15E204a


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
