### PR TITLE
jitsi-meet-electron: update to 2024.6.0

### DIFF
--- a/net/jitsi-meet-electron/Portfile
+++ b/net/jitsi-meet-electron/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jitsi jitsi-meet-electron 2023.10.0 v
+github.setup        jitsi jitsi-meet-electron 2024.6.0 v
 github.tarball_from archive
 revision            0
 
@@ -14,9 +14,9 @@ maintainers         {@takikawa simplyrobot.org:agile.ice1123} openmaintainer
 description         Jitsi Meet Electron
 long_description    Jistsi Meet Electron is a client for the open-source Jitsi Meet teleconferencing system
 
-checksums           rmd160  e228a568fd78c6679594e765e2948db1fd16dab3 \
-                    sha256  1d7f996d4119f1ef6fb70530c60ea0240fcf046f1631ee43a5ce9d883b73b180 \
-                    size    827902
+checksums           rmd160  86a95c4ee05049932a9f2f1fb06df81b6d4dc3d5 \
+                    sha256  10cce8a14c8cf8df220b339ee30131e0a90565c6eeea108e909e7e9b7ddb711c \
+                    size    794929
 
 depends_build       port:yarn
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update jitsi-meet-electron. 
This port is marked as openmaintainer and has been outdated for quite some time.
I've checked the changelog, there haven't been any mayor changes and it still builds and works.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
