### PR TITLE
drupal7: use postgresql16 dependency

### DIFF
--- a/www/drupal7/Portfile
+++ b/www/drupal7/Portfile
@@ -33,18 +33,13 @@ depends_lib         port:apache2 \
                     port:php74-gd \
                     port:php74-mbstring
 
-variant sqlite conflicts postgresql postgresql83 description "use sqlite instead of mysql5" {
+variant sqlite conflicts postgresql description "use sqlite instead of mysql5" {
     depends_lib-append      port:php74-sqlite
     depends_lib-delete      path:bin/mysql_config5:mysql57
 }
 
-variant postgresql conflicts sqlite postgresql83 description "use postgresql as the drupal database" {
-    depends_lib-append      port:postgresql84
-    depends_lib-delete      path:bin/mysql_config5:mysql57
-}
-
-variant postgresql83 conflicts sqlite postgresql description "use postgresql83 as the drupal database" {
-    depends_lib-append      port:postgresql83
+variant postgresql conflicts sqlite description "use postgresql as the drupal database" {
+    depends_lib-append      port:postgresql16
     depends_lib-delete      path:bin/mysql_config5:mysql57
 }
 


### PR DESCRIPTION
#### Description

I did not attempt to build this although I suspect there are no users for the port. If there is a user they'll have to migrate their data between postgresql databases via pg_dump/pg_restore. In general the Portfile variants are not a great way to handle database dependencies for this package, I would suggest users instead just install their database of choice explicitly and separately.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
