### PR TITLE
libmusicbrainz3: build-time conflict with cppunit

### DIFF
--- a/audio/libmusicbrainz3/Portfile
+++ b/audio/libmusicbrainz3/Portfile
@@ -1,8 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-
 PortGroup           cmake 1.0
+PortGroup           conflicts_build 1.0
 
 name                libmusicbrainz3
 set my_name         libmusicbrainz
@@ -23,6 +23,11 @@ checksums           md5     f4824d0a75bdeeef1e45cc88de7bb58a \
                     rmd160  5eba6458a5b3ac28747b743787948ec781d2a998
 depends_lib-append  port:libdiscid \
                     port:neon
+
+# If cppunit is found, build system includes tests, which pull in
+# a requirement of C++11. Just avoid it.
+conflicts_build     cppunit
+
 livecheck.type      regex
 livecheck.url       ${master_sites}
 livecheck.regex     "${my_name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
#### Description

Avoid requiring C++11 unnecessarily.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
