### PR TITLE
ruby-devel: update to 2024.08.11, drop now unneeded fix for gcc14

### DIFF
--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -15,13 +15,13 @@ legacysupport.newest_darwin_requires_legacy 14
 # ruby/openssl since ruby-3.2 supports openssl-3
 openssl.branch      3
 
-github.setup        ruby ruby b708661313246bb17e349f8f90c663c5e286a1c8
+github.setup        ruby ruby ca5b7276c668f595b8348822fc61a90cd5b9710f
 
 set ruby_ver        3.4
 set ruby_patch      0
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby-devel
-version             2024.08.03
+version             2024.08.11
 revision            0
 
 categories          lang ruby
@@ -37,9 +37,9 @@ long_description    Ruby is the interpreted scripting language \
 homepage            https://www.ruby-lang.org
 license             {Ruby BSD}
 
-checksums           rmd160  2ea064ad5d43d832f6d6dbf28cd098292b744d24 \
-                    sha256  c319434b47135ff4c9567c6cfbd738814b0a6dd65eccf19022f20629b49d84eb \
-                    size    16504316
+checksums           rmd160  c15161253b38c0a1acc2c1aed4b607062a02a6eb \
+                    sha256  579b6c5c0f5a8edbcb426c73671f2116e7e393142f2f207dd1f5deaccc762fff \
+                    size    16508679
 github.tarball_from archive
 
 universal_variant   no
@@ -138,11 +138,6 @@ platform darwin {
             return -code error "incompatible macOS version"
         }
     }
-}
-
-if {[string match *gcc* ${configure.compiler}]} {
-    configure.cflags-append \
-            -Wno-error=incompatible-pointer-types
 }
 
 # https://github.com/ruby/ruby/pull/5975#issuecomment-1279751636


### PR DESCRIPTION
#### Description

Upstream fixes the bug, no need to add a special flag anymore.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
