### PR TITLE
libqb: Use release tarball

### DIFF
--- a/devel/libqb/Portfile
+++ b/devel/libqb/Portfile
@@ -8,8 +8,10 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 github.setup        ClusterLabs libqb 2.0.8 v
-github.tarball_from archive
 revision            0
+checksums           rmd160  e5b9148564e2ff1d2097f73885ea997034436c42 \
+                    sha256  b42531fc20b8ac02f4c6d0a4dc49f7c4a1eef09bdb13af5f6927b7fc49522ee6 \
+                    size    521600
 
 homepage            https://clusterlabs.github.io/libqb/
 
@@ -19,21 +21,23 @@ description         \
 
 long_description    {*}${description}
 
-checksums           rmd160  eb698d03d6e13e7071b77b715a1a6d65ebd9d695 \
-                    sha256  c062048245c191b3585b43a93a39f9001c52bb60c2051867773a6f80b548dfbc \
-                    size    239568
-
 categories          devel
 license             LGPL-2.1
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
+github.tarball_from releases
+use_xz              yes
+
 patchfiles-append   patch-configure-remove-new-dtags-check.diff
 
 compiler.c_standard 1999
 
+# We are patching configure.ac.
 use_autoreconf      yes
 autoreconf.cmd      ./autogen.sh
+# https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
+configure.checks.implicit_function_declaration.whitelist-append strchr
 
 depends_build-append \
                     port:autoconf   \


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/70535

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18
