### PR TITLE
mise: Upgrade to 2024.8.6

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.8.5 v
+github.setup        jdx mise 2024.8.6 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  64ef8871305fdbfc86ab47cd446dbf01c4f2396b \
-                    sha256  38a7d5da54b8089202c7fc576a0310cc06a422e4ee2e3c5980439eb2e602495a \
-                    size    3061466
+                    rmd160  ebdf4a1ddd208547374044ffb3d57e7f8c947108 \
+                    sha256  890a461c56f151ee997513fd024e86bfd15469a1949a480a64348d8fdf4116b1 \
+                    size    3062428
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -95,7 +95,7 @@ cargo.crates \
     anstyle-wincon                   3.0.4  5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8 \
     arbitrary                        1.3.2  7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110 \
     arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
-    assert_cmd                      2.0.15  bc65048dd435533bb1baf2ed9956b9a278fbfdcf90301b39ee117f06c0199d37 \
+    assert_cmd                      2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     async-compression               0.4.12  fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa \
     autocfg                          1.3.0  0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0 \
     backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
@@ -112,14 +112,14 @@ cargo.crates \
     bytes                            1.7.1  8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50 \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                               1.1.7  26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc \
+    cc                              1.1.10  e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
     chrono-tz                        0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
-    clap                            4.5.13  0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc \
-    clap_builder                    4.5.13  64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99 \
+    clap                            4.5.15  11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc \
+    clap_builder                    4.5.15  216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6 \
     clap_derive                     4.5.13  501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0 \
     clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
     clap_mangen                     0.2.23  f17415fd4dfbea46e3274fcd8d368284519b358654772afb700dc2e8d2b24eeb \
@@ -134,7 +134,7 @@ cargo.crates \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     contracts                        0.6.3  f1d1429e3bd78171c65aa010eabcdf8f863ba3254728dbfb0ad4b1545beac15c \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
-    core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
+    core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     cpufeatures                     0.2.12  53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
     crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
@@ -156,7 +156,7 @@ cargo.crates \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
     dotenvy                         0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
     duct                            0.13.7  e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c \
-    dunce                            1.0.4  56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b \
+    dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                    2.1.1  4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871 \
     either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
@@ -173,7 +173,7 @@ cargo.crates \
     fastrand                         1.9.0  e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be \
     fastrand                         2.1.0  9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a \
     fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
-    filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
+    filetime                        0.2.24  bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550 \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
     flate2                          1.0.31  7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920 \
     float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
@@ -216,7 +216,7 @@ cargo.crates \
     hyper                            1.4.1  50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05 \
     hyper-rustls                    0.27.2  5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155 \
     hyper-tls                        0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
-    hyper-util                       0.1.6  3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956 \
+    hyper-util                       0.1.7  cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9 \
     iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
@@ -239,6 +239,7 @@ cargo.crates \
     libc                           0.2.155  97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c \
     libgit2-sys               0.17.0+1.8.1  10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224 \
     libm                             0.2.8  4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058 \
+    libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
     libz-sys                        1.1.18  c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
@@ -305,8 +306,8 @@ cargo.crates \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro2                     1.0.86  5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77 \
     quick-xml                       0.23.1  11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea \
-    quinn                           0.11.2  e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad \
-    quinn-proto                     0.11.3  ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe \
+    quinn                           0.11.3  b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156 \
+    quinn-proto                     0.11.6  ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd \
     quinn-udp                        0.5.4  8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285 \
     quote                           1.0.36  0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
@@ -314,7 +315,7 @@ cargo.crates \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
-    redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
+    redox_syscall                    0.5.3  2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4 \
     regex                           1.10.6  4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                   0.4.7  38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df \
@@ -326,13 +327,13 @@ cargo.crates \
     rmp-serde                        1.3.0  52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
-    rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
+    rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
     rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
     rustix                         0.38.34  70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f \
     rustls                         0.23.12  c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044 \
     rustls-native-certs              0.7.1  a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba \
     rustls-pemfile                   2.1.3  196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425 \
-    rustls-pki-types                 1.7.0  976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d \
+    rustls-pki-types                 1.8.0  fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0 \
     rustls-webpki                  0.102.6  8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e \
     rustversion                     1.0.17  955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6 \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
@@ -343,9 +344,9 @@ cargo.crates \
     self-replace                     1.4.0  f7828a58998685d8bf5a3c5e7a3379a5867289c20828c3ee436280b44b598515 \
     self_update                     0.41.0  469a3970061380c19852269f393e74c0fe607a4e23d85267382cf25486aa8de5 \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
-    serde                          1.0.204  bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12 \
-    serde_derive                   1.0.204  e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222 \
-    serde_json                     1.0.122  784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da \
+    serde                          1.0.206  5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284 \
+    serde_derive                   1.0.206  fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97 \
+    serde_json                     1.0.124  66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d \
     serde_spanned                    0.6.7  eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
@@ -372,13 +373,13 @@ cargo.crates \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.72  dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af \
+    syn                             2.0.74  1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7 \
     sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     tabled                          0.15.0  4c998b0c8b921495196a48aabaf1901ff28be0760136e31604f7967b0792050e \
     tabled_derive                    0.7.0  4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17 \
     tar                             0.4.41  cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909 \
-    tempfile                        3.11.0  b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53 \
+    tempfile                        3.12.0  04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64 \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
@@ -407,7 +408,6 @@ cargo.crates \
     tower-layer                      0.3.2  c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0 \
     tower-service                    0.3.2  b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52 \
     tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
-    tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
     tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
     tracing-error                    0.2.0  d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
@@ -434,7 +434,7 @@ cargo.crates \
     valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
-    versions                         6.3.0  5fc28d1172a20e32754969ea1a873c2c6e68e36c449c6056aa3e2ee5fe69a794 \
+    versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
     vte                             0.10.1  6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983 \
     vte_generate_state_changes       0.1.2  2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \


### PR DESCRIPTION
#### Description

mise: Upgrade to 2024.8.6

##### Tested on

macOS 14.6.1 23G93 arm64 Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our
      [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and
      [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open
      [pull requests](https://github.com/macports/macports-ports/pulls) for the
      same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
