### PR TITLE
openssh: Add legacy_dsa variant.

### DIFF
--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -162,6 +162,11 @@ if {${name} eq ${subport}} {
         }
     }
 
+    pre-test {
+        ui_msg "Tests require a cooperating server named 'somehost'."
+        ui_msg "Failure to connect to it results in a hang."
+    }
+
     variant xauth description {Build with support for xauth} {
         configure.args-replace  --without-xauth \
                                 --with-xauth=${prefix}/bin/xauth
@@ -201,6 +206,12 @@ if {${name} eq ${subport}} {
         depends_lib-append      port:libfido2
     }
 
+    variant legacy_dsa description "Enable legacy DSA support (until 2025)" {
+        configure.args-append  --enable-dsa-keys
+        notes-append "DSA support is scheduled to be removed in early 2025."
+        notes-append "DSA-based keys will need to be replaced by then."
+        notes-append "See: https://www.openbsd.org/openssh/releasenotes.html"
+    }
 
     platform darwin {
         # create link to /usr/include/pam because 'security' was renamed to 'pam'
@@ -251,7 +262,6 @@ if {${name} eq ${subport}} {
 
 subport ssh-copy-id {
     revision            0
-    platforms           any
     supported_archs     noarch
     maintainers         {l2dy @l2dy} openmaintainer
     description         Shell script to install your public key(s) on a remote machine


### PR DESCRIPTION
Also adds message regarding test requirements.

Closes: https://trac.macports.org/ticket/70319

TESTED:
With +legacy_dsa, accepts "+ssh-rsa,ssh-dss" config options. Built successfully on OSX 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-14.x arm64.  Included all variants compatible with available dependencies on the respective platforms, except that testing of +universal was limited to avoid the need to install +universal versions of many dependencies.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.6.8 22G820, arm64, Xcode 15.2 15C500b
macOS 14.6 23G80, arm64, Xcode 15.4 15F31d
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - Tests require an appropriate cooperating server.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
