### PR TITLE
ipsw: Update to 3.1.535

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/blacktop/ipsw 3.1.534 v
+go.setup                github.com/blacktop/ipsw 3.1.535 v
 github.tarball_from     archive
 revision                0
 categories              security devel
@@ -18,9 +18,9 @@ long_description        {*}${description}. Everything you need to start \
 
 homepage                https://blacktop.github.io/ipsw
 
-checksums               rmd160  a6b419f00f9fca884d20977971d288e1ee7a682c \
-                        sha256  e0b5a4145d9e952593fdc6b008ef3a7e3295f5cc4d4053746a81a952864ee890 \
-                        size    10356845
+checksums               rmd160  59009ed832ab4d3328a1bb9b5cf346fb4b592459 \
+                        sha256  0d915fca4fb46033ea90aa3a473b6142e8a0e04d6dc1440274e460df1417eb40 \
+                        size    10369476
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -32,7 +32,7 @@ go.offline_build        no
 
 build.args-append       -tags libusb,unicorn \
                         -ldflags \"-X ${go.package}/cmd/ipsw/cmd.AppVersion=${version} \
-                                   -X ${go.package}/cmd/ipsw/cmd.AppBuildCommit=unknown\"
+                                   -X ${go.package}/cmd/ipsw/cmd.AppBuildCommit=MacPorts\"
 
 build.post_args-append  ./cmd/${name}
 


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, 3.1.535

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
