### PR TITLE
Packwiz: New Port

### DIFF
--- a/games/packwiz/Portfile
+++ b/games/packwiz/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/packwiz/packwiz 7b4be47578151c36e784306b36d251ec2590e50c
+go.offline_build    no
+
+version             20240527
+maintainers         {johnlindop.com:git @JLindop} openmaintainer
+revision            0
+
+description         Command line tool for creating Minecraft modpacks
+
+long_description    packwiz is a command line tool for creating Minecraft modpacks. \
+                    Instead of managing JAR files directly, packwiz creates TOML files \
+                    that can be easily version-controlled and shared with git. You can then \
+                    export to a CurseForge or Modrinth modpack.
+
+categories          games
+license             MIT
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  5a078e939c80ae50e81d577ac8f72e516961d1a3 \
+                        sha256  d1c93be6926bdd24c9679851b79a0c130b3de27ff2a7f110a126db42ff3adf69 \
+                        size    86147
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

Packwiz is a command line tool for creating Minecraft modpacks. `go.offline_build no` is used because it depends on a package that is in a sub-folder of a GitHub repository, which the portgroup has trouble downloading by itself.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
