### PR TITLE
google-cloud-sdk: update to 488.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             487.0.0
+version             488.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  ec1a0900dfefd74cef180c5b35cbfb1c7fba5297 \
-                    sha256  c1391fb84a9a07475e570bf4c62d099dd029d88e3abdbc54b6dc864c7ee44d93 \
-                    size    51394284
+    checksums       rmd160  584ad976599600d3dad86e99b152018baad638a6 \
+                    sha256  aefa999026ba69f16d09a9e7dba005422715642b6bafa13a22849ee9757f3f00 \
+                    size    51450926
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  c7bb5f817271c50513979272327b531f4073c251 \
-                    sha256  376c6c8f2991c70d2a93b2cff1a6539dcb0377a15080b7349d4bf35850f1ea2d \
-                    size    52749882
+    checksums       rmd160  35d07fd89118c40d0f828603e6cccdb3691ee694 \
+                    sha256  fd3af8763384cc07443216684f139fe2c2d07c3b58743972c4bdb6dacd77da35 \
+                    size    52800121
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  e64ba93ce2157449db52a686e3a44e2ae3e60639 \
-                    sha256  493d0f44b9838bbdee4a18c31034b3f17f18b675b77b78dadf8dd344dd4a65e5 \
-                    size    52698156
+    checksums       rmd160  06c103a778a1100a63a823cbc1e8e615059aaaec \
+                    sha256  e71cd8651966b09145703f968a0bca88133b41a8329ab6f4c07bb32d3e48e5e4 \
+                    size    52748463
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 488.0.0.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?