### PR TITLE
zmqpp: needs C++11

### DIFF
--- a/devel/zmqpp/Portfile
+++ b/devel/zmqpp/Portfile
@@ -7,7 +7,6 @@ PortGroup           cmake 1.1
 github.setup        zeromq zmqpp 4.2.0
 revision            1
 categories          devel net
-platforms           darwin
 license             MPL-2
 maintainers         {@ierofant gmail.com:aw.kornilov} openmaintainer
 
@@ -17,7 +16,11 @@ long_description    This C++ binding for 0mq/zmq is a 'high-level' library \
                     It consists of a number of header and source files all residing in the zmq directory, \
                     these files are provided under the MPLv2 license (see LICENSE for details).
 
-depends_lib-append  port:zmq
+depends_lib-append  path:lib/libzmq.dylib:zmq
 
 checksums           sha256  8b434842eb806e020f189a08f77a9d571df15ecfff596067af5d74abe5267cdc \
-                    rmd160  4a1f05ea84a462fd9e079195bf36f6d995ce7aba
+                    rmd160  4a1f05ea84a462fd9e079195bf36f6d995ce7aba \
+                    size    102936
+
+# cc1plus: error: unrecognized command line option "-std=c++11"
+compiler.cxx_standard   2011


### PR DESCRIPTION
#### Description

Fix build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
