### PR TITLE
oski: avoid archaic Xcode gcc

### DIFF
--- a/devel/oski/Portfile
+++ b/devel/oski/Portfile
@@ -12,7 +12,6 @@ categories              devel
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 homepage                https://bebop.cs.berkeley.edu/oski/
 master_sites            sourceforge
-platforms               darwin
 use_bzip2               yes
 license                 BSD
 
@@ -27,6 +26,10 @@ long_description        The Optimized Sparse Kernel Interface (OSKI) Library is 
 checksums               rmd160  5fef952d604334194df467712a053f60969d7695 \
                         sha256  9748a7e69067efb7d4132adc790a6d0659c7eda1cf948aa3f5fe586d0bdeb65b \
                         size    2538789
+
+# https://trac.macports.org/ticket/70543
+compiler.blacklist-append \
+                        *gcc-4.0 *gcc-4.2
 
 compilers.setup         require_fortran
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/70543

#### Description

Avoid Xcode gcc which fails to link this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
