### PR TITLE
edid-decode: update to version 20240811

### DIFF
--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           meson 1.0
 
 name                edid-decode
-version             20240731
+version             20240811
 categories          sysutils
 maintainers         @wwalexander openmaintainer
 license             MIT
@@ -14,10 +14,11 @@ set domain          linuxtv.org
 homepage            https://git.${domain}/${name}.git
 fetch.type          git
 git.url             git://${domain}/${name}.git
-git.branch          303b033
+git.branch          c370882
 
 compiler.cxx_standard \
                     2011
 
 configure.cxxflags-append \
                     -std=c++11
+


### PR DESCRIPTION
#### Description

Update to version 20240811

* translate cp437 and ISO 8859-1 to UTF-8
* document new --utf8 option
* enable UTF-8 for the emscripten version
* document the two supported InfoFrame variants


###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 15.0 24A5309e arm64
Xcode 16.0 16A5171c

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
