### PR TITLE
libsdl2_*: backport fixes from upstream, allow build with gcc

### DIFF
--- a/audio/libsdl2_mixer/Portfile
+++ b/audio/libsdl2_mixer/Portfile
@@ -25,6 +25,9 @@ depends_lib     port:libsdl2 \
                 port:opusfile \
                 port:wavpack
 
+# https://github.com/libsdl-org/SDL_mixer/commit/a2c6c892aae6b28bbb03adc1bb5ffe32f1eea17e
+patchfiles      a2c6c892aae6b28bbb03adc1bb5ffe32f1eea17e.patch
+
 configure.args  --disable-sdltest \
                 --disable-music-gme \
                 --disable-music-midi-fluidsynth \
@@ -32,7 +35,7 @@ configure.args  --disable-sdltest \
                 --disable-music-opus-shared \
                 --disable-music-wavpack-shared
 
-compiler.blacklist *gcc* { clang < 211 }
+compiler.blacklist *gcc-4.* { clang < 211 }
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}

--- a/audio/libsdl2_mixer/files/a2c6c892aae6b28bbb03adc1bb5ffe32f1eea17e.patch
+++ b/audio/libsdl2_mixer/files/a2c6c892aae6b28bbb03adc1bb5ffe32f1eea17e.patch
@@ -1,0 +1,62 @@
+From a2c6c892aae6b28bbb03adc1bb5ffe32f1eea17e Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 14 Aug 2024 03:47:43 +0800
+Subject: [PATCH] Unbreak build with gcc on macOS
+
+---
+ src/codecs/music_opus.c    | 2 +-
+ src/codecs/music_wavpack.c | 2 +-
+ src/codecs/music_xmp.c     | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/codecs/music_opus.c b/src/codecs/music_opus.c
+index ce394445..58ae3308 100644
+--- src/codecs/music_opus.c
++++ src/codecs/music_opus.c
+@@ -60,11 +60,11 @@ static opus_loader opus;
+     if (opus.FUNC == NULL) { Mix_SetError("Missing opus.framework"); return -1; }
+ #endif
+ 
+-static int OPUS_Load(void)
+ #ifdef __APPLE__
+     /* Need to turn off optimizations so weak framework load check works */
+     __attribute__ ((optnone))
+ #endif
++static int OPUS_Load(void)
+ {
+     if (opus.loaded == 0) {
+ #ifdef OPUS_DYNAMIC
+diff --git a/src/codecs/music_wavpack.c b/src/codecs/music_wavpack.c
+index fc9a1042..60d6f8c2 100644
+--- src/codecs/music_wavpack.c
++++ src/codecs/music_wavpack.c
+@@ -96,11 +96,11 @@ static wavpack_loader wvpk;
+     if (wvpk.FUNC == NULL) { Mix_SetError("Missing wavpack.framework"); return -1; }
+ #endif
+ 
+-static int WAVPACK_Load(void)
+ #ifdef __APPLE__
+     /* Need to turn off optimizations so weak framework load check works */
+     __attribute__ ((optnone))
+ #endif
++static int WAVPACK_Load(void)
+ {
+     if (wvpk.loaded == 0) {
+ #ifdef WAVPACK_DYNAMIC
+diff --git a/src/codecs/music_xmp.c b/src/codecs/music_xmp.c
+index 3aeaf9c2..93a8632a 100644
+--- src/codecs/music_xmp.c
++++ src/codecs/music_xmp.c
+@@ -76,11 +76,11 @@ static xmp_loader libxmp;
+     if (libxmp.FUNC == NULL) { Mix_SetError("Missing xmp.framework"); return -1; }
+ #endif
+ 
+-static int XMP_Load(void)
+ #ifdef __APPLE__
+     /* Need to turn off optimizations so weak framework load check works */
+     __attribute__ ((optnone))
+ #endif
++static int XMP_Load(void)
+ {
+     if (libxmp.loaded == 0) {
+ #ifdef XMP_DYNAMIC

--- a/devel/libsdl2_image/Portfile
+++ b/devel/libsdl2_image/Portfile
@@ -25,6 +25,9 @@ depends_lib     port:libsdl2 \
                 port:tiff \
                 port:webp
 
+# https://github.com/libsdl-org/SDL_image/commit/30b30dfa804602423db7450483b973d62d144bb3
+patchfiles      30b30dfa804602423db7450483b973d62d144bb3.patch
+
 configure.args  --disable-avif \
                 --disable-imageio \
                 --disable-jxl \
@@ -32,7 +35,7 @@ configure.args  --disable-avif \
                 --disable-tif-shared \
                 --disable-webp-shared
 
-compiler.blacklist *gcc* { clang < 211 }
+compiler.blacklist *gcc-4.* { clang < 211 }
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}

--- a/devel/libsdl2_image/files/30b30dfa804602423db7450483b973d62d144bb3.patch
+++ b/devel/libsdl2_image/files/30b30dfa804602423db7450483b973d62d144bb3.patch
@@ -1,0 +1,27 @@
+From 30b30dfa804602423db7450483b973d62d144bb3 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 14 Aug 2024 03:35:52 +0800
+Subject: [PATCH] Unbreak build with gcc on macOS
+
+Closes: https://github.com/libsdl-org/SDL_image/issues/462
+---
+ src/IMG_webp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/IMG_webp.c b/src/IMG_webp.c
+index 6152916e..77d8de31 100644
+--- src/IMG_webp.c
++++ src/IMG_webp.c
+@@ -71,11 +71,11 @@
+     if (lib.FUNC == NULL) { IMG_SetError("Missing webpdemux.framework"); return -1; }
+ #endif
+ 
+-int IMG_InitWEBP()
+ #ifdef __APPLE__
+     /* Need to turn off optimizations so weak framework load check works */
+     __attribute__ ((optnone))
+ #endif
++int IMG_InitWEBP()
+ {
+     if (lib.loaded == 0) {
+ #if defined(LOAD_WEBP_DYNAMIC) && defined(LOAD_WEBPDEMUX_DYNAMIC)

--- a/devel/libsdl2_net/Portfile
+++ b/devel/libsdl2_net/Portfile
@@ -24,7 +24,7 @@ depends_lib     port:libsdl2
 
 configure.args  --disable-sdltest
 
-compiler.blacklist *gcc* { clang < 211 }
+compiler.blacklist *gcc-4.* { clang < 211 }
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name}

--- a/devel/libsdl2_ttf/Portfile
+++ b/devel/libsdl2_ttf/Portfile
@@ -26,7 +26,7 @@ configure.args  --disable-sdltest \
                 --disable-freetype-builtin \
                 --disable-harfbuzz
 
-compiler.blacklist *gcc* { clang < 211 }
+compiler.blacklist *gcc-4.* { clang < 211 }
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

@jmroot @reneeotten These are the minimal patches to fix the build. Upstream got every instance of this error fixed, but we skip some components, so I only include what is required.

Refs:
https://github.com/libsdl-org/SDL_image/commit/30b30dfa804602423db7450483b973d62d144bb3
https://github.com/libsdl-org/SDL_image/commit/5c5051cb3e594cf301e76f6e6b55df1c6b54c04b
https://github.com/libsdl-org/SDL_mixer/commit/a2c6c892aae6b28bbb03adc1bb5ffe32f1eea17e
https://github.com/libsdl-org/SDL_mixer/commit/518311a7e473c9fc3f1314b486db1c899823020f


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
