### PR TITLE
infisical: new submission

### DIFF
--- a/security/infisical/Portfile
+++ b/security/infisical/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/infisical/infisical 0.28.4 infisical-cli/v
+github.tarball_from archive
+revision            0
+
+categories          security devel
+maintainers         nomaintainer
+license             MIT
+
+description         Official CLI for Infisical, an open source secrets platform
+long_description    ${description}
+homepage            https://infisical.com/
+
+# Allow Go to fetch deps at build time
+go.offline_build    no
+
+build.dir           ${worksrcpath}/cli
+build.args          -o ${name} -ldflags=\"-X 'github.com/Infisical/infisical-merge/packages/util.CLI_VERSION=${go.version}'\"
+
+checksums           rmd160  8a1aef35240d7691eaa04ca2980ca37b4b608ddb \
+                    sha256  868b27d8222b67d3d52ec67b225ffde8fcd90a1ece0b90f1dab15081ffb8dd3a \
+                    size    309604849
+
+destroot {
+     xinstall -m 0755 ${worksrcpath}/cli/${name} ${destroot}${prefix}/bin/
+}
+
+test.run            yes
+test.cmd            ${prefix}/bin/infisical
+test.target         --version


### PR DESCRIPTION
#### Description

Support the [Infisical](https://github.com/Infisical/infisical/) secret manager.

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
