### PR TITLE
quotatool: Update to 1.6.5

### DIFF
--- a/sysutils/quotatool/Portfile
+++ b/sysutils/quotatool/Portfile
@@ -1,17 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                quotatool
-version             1.6.2
+github.setup        ekenberg quotatool 1.6.5 v
+revision            0
+checksums           rmd160  57d261c868111cae1d3619b1572864013dd89ea2 \
+                    sha256  24de7e879e851def11d2057fd086102c0db4de452c1d96cffb73ccb4652f4835 \
+                    size    108551
+
 categories          sysutils
-platforms           darwin
 license             GPL-2
-maintainers         gmail.com:johan.ekenberg
+maintainers         {gmail.com:johan.ekenberg @ekenberg}
 description         A command line utility for filesystem disk quotas.
 long_description    A command line utility for filesystem disk quotas.
 homepage            http://quotatool.ekenberg.se/
-master_sites        http://quotatool.ekenberg.se/
+github.tarball_from archive
 
-checksums           rmd160 6202d7ec898de8f799e1ac1830fb8c1005d15f8e \
-                    sha256 e53adc480d54ae873d160dc0e88d78095f95d9131e528749fd982245513ea090
+patchfiles-append   install.patch
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${subport}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        AUTHORS \
+        ChangeLog \
+        COPYING \
+        README.md \
+        ${destroot}${docdir}
+}

--- a/sysutils/quotatool/files/install.patch
+++ b/sysutils/quotatool/files/install.patch
@@ -1,0 +1,19 @@
+Fix:
+
+/usr/bin/install: illegal option -- D
+
+https://github.com/ekenberg/quotatool/issues/30
+Reverts https://github.com/ekenberg/quotatool/commit/5529c8084a06d4d95905f76e47d2621564876081
+--- Makefile.orig	2024-07-24 04:23:51.000000000 -0500
++++ Makefile	2024-08-15 04:51:31.000000000 -0500
+@@ -65,8 +65,8 @@
+ men   :=   $(wildcard $(srcdir)/man/*)
+ install: $(prog)
+ 	$(NORMAL_INSTALL)
+-	$(INSTALL_PROGRAM) -D $(srcdir)/$(prog) $(DESTDIR)$(sbindir)/$(prog)
+-	$(foreach man,$(men),$(INSTALL_DATA) -D $(man) $(DESTDIR)$(mandir)/man$(subst .,,$(suffix $(man)))/$(notdir $(man)))
++	$(INSTALL_PROGRAM) $(srcdir)/$(prog) $(DESTDIR)$(sbindir)/$(prog)
++	$(foreach man,$(men),$(INSTALL_DATA) $(man) $(DESTDIR)$(mandir)/man$(subst .,,$(suffix $(man)))/$(notdir $(man)))
+ 
+ uninstall:
+ 	$(NORMAL_UNINSTALL)


### PR DESCRIPTION
#### Description

quotatool: Update to 1.6.5

Fixes implicit function declaration build failure with Xcode 12 and later.

Also adds maintainer GitHub handle.

Also switches to GitHub hosting.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
