### PR TITLE
qrscan: fix build with Xcode gcc

### DIFF
--- a/graphics/qrscan/Portfile
+++ b/graphics/qrscan/Portfile
@@ -28,6 +28,9 @@ depends_lib-append  path:lib/pkgconfig/libjpeg.pc:libjpeg-turbo \
                     port:libpng \
                     port:libquirc
 
+# options.c: error: ‘for’ loop initial declaration used outside C99 mode
+compiler.c_standard 1999
+
 use_parallel_build  no
 
 patchfiles-append   patch-Makefile.diff

--- a/graphics/qrscan/files/patch-Makefile.diff
+++ b/graphics/qrscan/files/patch-Makefile.diff
@@ -20,7 +20,7 @@ Patch Makefile to use existing installation of libquirc
  
 -CFLAGS += -I$(QUIRC) $(shell $(PKG_CONFIG) --cflags --static libpng libjpeg)
 -LDFLAGS += -lz -lm
-+CFLAGS += $(shell $(PKG_CONFIG) --cflags --static libpng libjpeg)
++CFLAGS += -std=c99 $(shell $(PKG_CONFIG) --cflags --static libpng libjpeg)
 +LDFLAGS += -lz -lm -lquirc
  ifeq ($(shell uname -s),Darwin)
  	GROUP = staff


### PR DESCRIPTION
#### Description

Simple fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
