### PR TITLE
osxphotos: update to 0.68.5

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.68.4
+version                 0.68.5
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  49738496a3ff5d9d9c5992611c02118b8f06c8cd \
-                        sha256  ef4625f785fb2dfb79d6ffe6cfa020ed8e64797e8eb5657b01ad9ea955a65127 \
-                        size    2184175
+checksums               rmd160  97eb477d3ce5544e6f12d2c591a2e6af64d2592f \
+                        sha256  505eb5f2ef162b3edfd2373b7ba8388cece9a6a6f23c5eb382246934f075ef06 \
+                        size    2169009
 
 python.default_version  312
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.68.5.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?