### PR TITLE
libpqxx: update to 7.9.2

### DIFF
--- a/databases/libpqxx/Portfile
+++ b/databases/libpqxx/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       compiler_blacklist_versions 1.0
 PortGroup       github 1.0
 
-github.setup    jtv libpqxx 7.8.1
+github.setup    jtv libpqxx 7.9.2
 
 categories      databases devel
 license         BSD
@@ -30,13 +30,12 @@ database interfaces.
 
 homepage        https://pqxx.org/development/libpqxx
 
-checksums       rmd160  130f4ee924b34b618392fb91463d160ef28608c8 \
-                sha256  0f4c0762de45a415c9fd7357ce508666fa88b9a4a463f5fb76c235bc80dd6a84 \
-                size    776338
+checksums       rmd160  b94fb8de426e732ec8423cd0022d7c1c48cda7b7 \
+                sha256  e37d5774c39f6c802e32d7f418e88b8e530404fb54758516e884fc0ebdee6da4 \
+                size    774422
 github.tarball_from archive
 
-set pg_ports [list postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
-              postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 postgresql16]
+set pg_ports [list postgresql13 postgresql14 postgresql15 postgresql16]
 
 set any_variant_set no
 foreach pg_port $pg_ports {


### PR DESCRIPTION
#### Description

The test suite passes but the lints fail. I assume that upstream gets the lints to pass before making a release anyway. I opened https://github.com/jtv/libpqxx/issues/885 to track the lint issue upstream.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
