### PR TITLE
qt4-mac-postgresql16-plugin: new port

### DIFF
--- a/aqua/qt4-mac-postgresql16-plugin/Portfile
+++ b/aqua/qt4-mac-postgresql16-plugin/Portfile
@@ -7,7 +7,7 @@ PortSystem          1.0
 set building_qt4    1
 PortGroup           qmake 1.0
 
-name                qt4-mac-postgresql91-plugin
+name                qt4-mac-postgresql16-plugin
 version             4.8.7
 revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -46,7 +46,7 @@ configure.dir       ${worksrcpath}/${PLUGIN}
 configure.env-append \
                     QMAKESPEC=${qt_mkspecs_dir}/macx-g++
 
-set mp.ports        {postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92}
+set mp.ports        {postgresql15 postgresql16}
 foreach mp.port ${mp.ports} {
 
     lappend mp.names "qt4-mac-${mp.port}-plugin"


### PR DESCRIPTION
This also adds qt4-mac-postgresql15-plugin and removes ports for PostgreSQL 8.2 through 9.2.

#### Description

I confirmed the new package is building a libqsqlpsql.dylib that links against the right PostgreSQL and libqt but am unable to test its functionality. This also blows away the old ports without notice but presumably they have no users given how old and unsupported the versions are.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
