### PR TITLE
tea: update to 63.1.0

### DIFF
--- a/editors/tea/Portfile
+++ b/editors/tea/Portfile
@@ -3,11 +3,11 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            psemiletov tea-qt 62.1.2
+github.setup            psemiletov tea-qt 63.1.0
 revision                0
-checksums               rmd160  76b783e22cfa22a1666f1505ac0e60e7e27cd6ad \
-                        sha256  c1bf26c179bf80d1992e59bfdf17bfe7e7d2063197fdf1259e964a6676630eba \
-                        size    676295
+checksums               rmd160  87acec8cf51a3a78b4cb8fd03a268ae61fdf782e \
+                        sha256  15eba879907e31c1d2d061fae38fb5e43e1084689cbc057b5421cc3fb0a6a38d \
+                        size    715890
 
 name                    tea
 description             TEA is the powerful text editor for GNU/Linux and *BSD.
@@ -28,10 +28,22 @@ depends_lib-append      port:aspell \
 
 patchfiles-append       tea-qmake.pro.patch
 
+# Backport from upstream, drop on next update:
+patchfiles-append       7126a9aef1f8313a2e97b7e3b1b8280f8f088935.patch
+
 if {[string match *clang* ${configure.cxx}]} {
     configure.ldflags-append \
                         -stdlib=${configure.cxx_stdlib}
 }
+
+# https://github.com/psemiletov/tea-qt/issues/68
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.cxxflags-append \
+                        -fpermissive
+}
+
+# atypes.hxx: error: ‘nullptr’ was not declared in this scope
+compiler.cxx_standard   2011
 
 destroot {
     copy ${worksrcpath}/bin/tea.app ${destroot}${applications_dir}
@@ -61,8 +73,10 @@ variant qt5 conflicts qt4 description {Use Qt 5} {}
 
 if {[variant_isset qt4]} {
     PortGroup           qmake 1.0
+
 }
 
 if {[variant_isset qt5]} {
     PortGroup           qmake5 1.0
+
 }

--- a/editors/tea/files/7126a9aef1f8313a2e97b7e3b1b8280f8f088935.patch
+++ b/editors/tea/files/7126a9aef1f8313a2e97b7e3b1b8280f8f088935.patch
@@ -1,0 +1,62 @@
+From 7126a9aef1f8313a2e97b7e3b1b8280f8f088935 Mon Sep 17 00:00:00 2001
+From: Petr Semiletov <peter.semiletov@gmail.com>
+Date: Fri, 16 Aug 2024 19:17:11 +0300
+Subject: [PATCH] possible MACOS 12 fix
+
+---
+ CMakeLists.txt     | 6 ++++--
+ src/spellchecker.h | 9 +++++++++
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7ae72b1..5a2a0e3 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -8,6 +8,10 @@ set(CMAKE_AUTOMOC ON)
+ set(CMAKE_AUTOUIC ON)
+ set(CMAKE_AUTORCC ON)
+ 
++set(PROJECT "tea-qt")
++project ($PROJECT VERSION 63.1.0 LANGUAGES CXX C)
++
++
+ enable_language(CXX)
+ enable_language(C)
+ 
+@@ -32,8 +36,6 @@ set(CMAKE_AUTORCC ON)
+ set(CMAKE_AUTOUIC ON)
+ 
+ 
+-set(PROJECT "tea-qt")
+-project ($PROJECT VERSION 63.1.0 LANGUAGES CXX C)
+ qt_add_resources(QT_RESOURCES resources.qrc)
+ 
+ add_definitions(-DVERSION_NUMBER="\\"${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}\\"")
+diff --git a/src/spellchecker.h b/src/spellchecker.h
+index feb4a47..81c9d9f 100644
+--- src/spellchecker.h
++++ src/spellchecker.h
+@@ -33,7 +33,12 @@
+ 
+ //#include <iostream>
+ 
++#ifdef __APPLE__
+ 
++#include <stdint.h>
++#define UTF16TEXT char16_t
++
++#else
+ #if QT_VERSION >= 0x050000
+ #include <uchar.h>
+ #define UTF16TEXT char16_t
+@@ -41,6 +46,10 @@
+ #define UTF16TEXT ushort
+ #endif
+ 
++#endif
++
++
++
+ #ifdef HUNSPELL_ENABLE
+ #include <hunspell/hunspell.hxx>
+ #endif


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
