### PR TITLE
gng: update to 1.0.5

### DIFF
--- a/java/gng/Portfile
+++ b/java/gng/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    gdubw gng 1.0.4 v
+github.setup    gdubw gng 1.0.5 v
 revision        0
 
 categories      java devel
@@ -23,9 +23,9 @@ long_description GNG (Gradle is Not Gradle) is a script that automatically searc
 
 homepage        https://gng.dsun.org
 
-checksums       rmd160  5d15c5245b4c97970e9fbf35f607721a4e467168 \
-                sha256  2721a96ad79557b6fedecb20bfd89e4120e6f381e490487283ba677a9723e5f3 \
-                size    71341
+checksums       rmd160  134a4303287c11ad36df371ba09143ce938269f7 \
+                sha256  2f4526b04a1e589ae05d4d333044245f8f725774865edf69e4ee8a306514ab1b \
+                size    71137
 
 depends_run     port:bash
 


### PR DESCRIPTION
#### Description

Update to gng 1.0.5.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?