### PR TITLE
php-postgres: update postgresql versions

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -2047,120 +2047,36 @@ subport ${php}-postgresql {
 
     long_description        ${description}
 
-    variant postgresql82 conflicts postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 8.2 libraries} {
-        depends_lib-append      port:postgresql82
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql82/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql82/bin
-    }
-
-    variant postgresql83 conflicts postgresql82 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 8.3 libraries} {
-        depends_lib-append      port:postgresql83
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql83/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql83/bin
-    }
-
-    variant postgresql84 conflicts postgresql82 postgresql83 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 8.4 libraries} {
-        depends_lib-append      port:postgresql84
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql84/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql84/bin
-    }
-
-    variant postgresql90 conflicts postgresql82 postgresql83 postgresql84 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 9.0 libraries} {
-        depends_lib-append      port:postgresql90
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql90/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql90/bin
-    }
-
-    variant postgresql91 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 9.1 libraries} {
-        depends_lib-append      port:postgresql91
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql91/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql91/bin
-    }
-
-    variant postgresql92 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 9.2 libraries} {
-        depends_lib-append      port:postgresql92
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql92/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql92/bin
-    }
-
-    variant postgresql93 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 9.3 libraries} {
-        depends_lib-append      port:postgresql93
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql93/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql93/bin
-    }
-
-    variant postgresql94 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 9.4 libraries} {
-        depends_lib-append      port:postgresql94
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql94/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql94/bin
-    }
-
-    variant postgresql95 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 9.5 libraries} {
-        depends_lib-append      port:postgresql95
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql95/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql95/bin
-    }
-
-    variant postgresql96 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 9.6 libraries} {
-        depends_lib-append      port:postgresql96
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql96/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql96/bin
-    }
-
-    variant postgresql10 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 10 libraries} {
-        depends_lib-append      port:postgresql10
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql10/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql10/bin
-    }
-
-    variant postgresql11 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql12 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 11 libraries} {
-        depends_lib-append      port:postgresql11
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql11/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql11/bin
-    }
-
-    variant postgresql12 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 12 libraries} {
-        depends_lib-append      port:postgresql12
-
-        configure.args-append   --with-pgsql=${prefix}/lib/postgresql12/bin \
-                                --with-pdo-pgsql=${prefix}/lib/postgresql12/bin
-    }
-
-    variant postgresql13 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql14 postgresql15 description {Use PostgreSQL 13 libraries} {
+    variant postgresql13 conflicts postgresql14 postgresql15 postgresql16 description {Use PostgreSQL 13 libraries} {
         depends_lib-append      port:postgresql13
 
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql13/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql13/bin
     }
 
-    variant postgresql14 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql15 description {Use PostgreSQL 14 libraries} {
+    variant postgresql14 conflicts postgresql13 postgresql15 postgresql16 description {Use PostgreSQL 14 libraries} {
         depends_lib-append      port:postgresql14
 
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql14/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql14/bin
     }
 
-    variant postgresql15 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 description {Use PostgreSQL 15 libraries} {
+    variant postgresql15 conflicts postgresql13 postgresql14 postgresql16 description {Use PostgreSQL 15 libraries} {
         depends_lib-append      port:postgresql15
 
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql15/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql15/bin
     }
 
-    if {![variant_isset postgresql82] && ![variant_isset postgresql83] && ![variant_isset postgresql84] && ![variant_isset postgresql90] && ![variant_isset postgresql91] && ![variant_isset postgresql92] && ![variant_isset postgresql93] && ![variant_isset postgresql94] && ![variant_isset postgresql95] && ![variant_isset postgresql96] && ![variant_isset postgresql10] && ![variant_isset postgresql11] && ![variant_isset postgresql12] && ![variant_isset postgresql13] && ![variant_isset postgresql14] && ![variant_isset postgresql15]} {
-        default_variants +postgresql15
+    variant postgresql16 conflicts postgresql13 postgresql14 postgresql15 description {Use PostgreSQL 16 libraries} {
+        depends_lib-append      port:postgresql16
+
+        configure.args-append   --with-pgsql=${prefix}/lib/postgresql16/bin \
+                                --with-pdo-pgsql=${prefix}/lib/postgresql16/bin
+    }
+
+    if {![variant_isset postgresql13] && ![variant_isset postgresql14] && ![variant_isset postgresql15] && ![variant_isset postgresql16]} {
+        default_variants +postgresql16
     }
 }
 


### PR DESCRIPTION
#### Description

I was able to succesfully build php82-postgresql and confirmed pdo_pgsql.so and pgsql.so both linked against the right postgresql16 libpq. However, I did not test the functionality of the libraries.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
