### PR TITLE
sheepshaver: switched repo, support newer OSes and arm

### DIFF
--- a/emulators/sheepshaver/Portfile
+++ b/emulators/sheepshaver/Portfile
@@ -2,134 +2,53 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
+PortGroup               xcode 1.0
 
-github.setup            cebix macemu 2e302d60a337daa252c6992335e6365a9beac83f
-version                 20180225
-checksums               rmd160  b7240735e8ca7ad7a263a4bb69935ad68b34a878 \
-                        sha256  dc4be91e7357b9f22343dba0de7d0d724d12031798fe7947a74074526a55b9e4 \
-                        size    2196035
+github.setup            kanjitalk755 macemu b63490dadb0b70bb83775283716754af0e1e290d
+version                 20240609
+checksums               rmd160  2783ef2b69123d18294af239f8a4f736151aa11a \
+                        sha256  1657c037ae3a888c879e5ebb9d8566d042da451eaea6e278848441e31b8774bf \
+                        size    3325858
+    
 epoch                   1
 # we need a name here as the github-supplied name is not correct for this port
 name                    sheepshaver
 
-# at present sheepshaver is best built as 32bit, so we we build the gtk2 gui
-# separately as a subport to avoid expensively rebuilding all of
-# gtk2 and all the dependencies as +universal
-subport                 sheepshaver-gui {}
-
 categories              emulators
 license                 GPL-2+
-platforms               darwin
-maintainers             nomaintainer
+maintainers             {@ZapDotZip gmail.com:zapdotzip} openmaintainer
 
 homepage                http://sheepshaver.cebix.net/
 
-worksrcdir              ${distname}/SheepShaver/src/Unix
-configure.cmd           ./autogen.sh
-configure.optflags      -O3
+worksrcdir              ${distname}/SheepShaver/src/MacOSX
 
-patchfiles-append       patch-001-sheepshaver-makefile-in-ditto-patch.diff
+xcode.project           "SheepShaver_Xcode8.xcodeproj"
+xcode.configuration     Release
 
-configure.cppflags-append -D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1
+# this allows SheepShaver to be built with MacPort's SDL2 port.
+patchfiles              xcode-sdl2.diff
 
-depends_build           port:autoconf \
-                        port:pkgconfig \
-                        port:automake
+depends_lib             port:libsdl
 
-# to fix an errant header owned by arpack that also provides debug.h (not a great name, arpack!)
-# force finding our includes first
-configure.cppflags-prepend -I${worksrcpath}/../include
+description             Open source PPC Mac emulator.
 
-set sheepshaver_dir     /SheepShaver
-universal_variant       no
-
-if {${subport} eq "sheepshaver"} {
-
-#    conflicts           sheepshaver-devel (to be added later)
-    description         Opensource PPC Mac emulator.
+long_description \
+    Longstanding PowerPC Macintosh emulator. Requires an appropriate Macintosh ROM image and a copy \
+    of Mac OS (7.5.2 through 9.0.4), and these are not supplied with this port. The emulator will \
+    be installed into your MacPorts Applications folder. This is the more frequently updated \
+    "kanjitalk755" fork of the original by cebix.
     
-    long_description \
-        Longstanding PowerPC Macintosh emulator. Requires an appropriate Macintosh ROM image and a copy \
-        of Mac OS (8.1 through 9.02), and \
-        these are not supplied with this port. The emulator will be installed into your \
-        MacPorts Applications folder.
 
-    variant SixtyFour description "Build 64 bit." {}
-
-    platform darwin i386 {
-        supported_archs   i386
-
-        # no need for gui to be same architecture as the emulator
-        depends_skip_archcheck-append \
-                          sheepshaver-gui
-
-        depends_lib       port:libsdl \
-                          port:sheepshaver-gui
-
-        configure.args    --disable-vosf \
-                          --without-esd  \
-                          --without-mon  \
-                          --enable-sdl-video \
-                          --enable-sdl-audio \
-                          --enable-jit-compiler \
-                          --enable-standalone-gui \
-                          --with-gtk=no
- 
-        configure.ldflags-append    \
-                          -Wl,-no_pie
-
-        if {[variant_isset SixtyFour]} {
-            supported_archs x86_64
-            }
+platform darwin powerpc {
+    # untested at present
+    supported_archs   ppc
+    pre-fetch {
+        ui_error "${name} is presently untested on PowerPC Mac systems."
+        return -code error "incompatible processor"
     }
+}
 
-    platform darwin powerpc {
-        # untested at present
-        supported_archs   ppc
-        pre-fetch {
-            ui_error "${name} is presently untested on PowerPC Mac systems."
-            return -code error "incompatible processor"
-        }
-    }
-
-    build.target            SheepShaver SheepShaver_app
-
-    post-destroot {
-        file mkdir ${destroot}${applications_dir}${sheepshaver_dir}
-        copy ${filespath}/SheepShaver_idiosyncracies.txt ${destroot}${applications_dir}${sheepshaver_dir}
-        copy ${worksrcpath}/SheepShaver.app ${destroot}${applications_dir}${sheepshaver_dir}
-        file delete ${destroot}${prefix}/bin/SheepShaver
-    }
-
-} elseif {${subport} eq "sheepshaver-gui"} {
-
-    name                sheepshaver-gui
-#    conflicts           sheepshaver-gui-devel (to be added later)
-
-    description         Graphical user interface to configure SheepShaver.
-    long_description    ${description}
-
-    depends_lib         path:lib/pkgconfig/gtk+-2.0.pc:gtk2
-
-    configure.args      --disable-vosf \
-                        --without-esd  \
-                        --without-mon \
-                        --enable-standalone-gui \
-                        --with-gtk=gtk2
-                        
-    build.target        SheepShaverGUI_app
-    
-    post-destroot {
-        file mkdir ${destroot}${applications_dir}${sheepshaver_dir}
-        copy ${worksrcpath}/SheepShaverGUI.app ${destroot}${applications_dir}${sheepshaver_dir}
-
-        # gui target insists on installing some of the SheepShaver files, which conflicts with SheepShaver subport
-        # so we manually delete these to avoid a conflict
-
-        file delete ${destroot}${prefix}/bin/SheepShaver
-        file delete ${destroot}${prefix}/share/SheepShaver/keycodes
-        file delete ${destroot}${prefix}/share/SheepShaver/tunconfig
-        file delete ${destroot}${prefix}/share/man/man1/SheepShaver.1.gz
-        file delete ${destroot}${prefix}/share/man/man1/SheepShaver.1
-    }
+# this is needed because at least on 10.13 the xcodebuild process produces a bad symlink and deletes SheepShaver.app.
+destroot {
+    copy [glob ${workpath}/macemu-*/SheepShaver/src/MacOSX/build/Release/SheepShaver.app] ${destroot}${applications_dir}
 }

--- a/emulators/sheepshaver/files/xcode-sdl2.diff
+++ b/emulators/sheepshaver/files/xcode-sdl2.diff
@@ -1,0 +1,177 @@
+--- SheepShaver_Xcode8.xcodeproj/project.pbxproj.orig	2024-07-09 17:46:36.000000000 -0700
++++ SheepShaver_Xcode8.xcodeproj/project.pbxproj	2024-08-12 20:43:38.000000000 -0700
+@@ -83,12 +83,10 @@
+ 		5DF4CB7F22B5BD5D00512A86 /* audio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5DF4CB7E22B5BD5D00512A86 /* audio.cpp */; };
+ 		A7B1921418C35D4700791D8D /* DiskType.m in Sources */ = {isa = PBXBuildFile; fileRef = A7B1921318C35D4700791D8D /* DiskType.m */; };
+ 		E413A40320CF7E6D00FBE967 /* video_sdl2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E413A40220CF7E6D00FBE967 /* video_sdl2.cpp */; };
+-		E4150D1220D557820077C51A /* SDL2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E4150D1120D557820077C51A /* SDL2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+ 		E41936C420CFE64D003A7654 /* SDLMain.m in Sources */ = {isa = PBXBuildFile; fileRef = E41936C320CFE64D003A7654 /* SDLMain.m */; };
+ 		E4202603241250EE000508DF /* runtool.c in Sources */ = {isa = PBXBuildFile; fileRef = E4202602241250EE000508DF /* runtool.c */; };
+ 		E420260524125182000508DF /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E420260424125182000508DF /* Security.framework */; };
+ 		E420260B24125442000508DF /* etherhelpertool in Resources */ = {isa = PBXBuildFile; fileRef = E420260A2412540D000508DF /* etherhelpertool */; };
+-		E420910120D0C4FA0094654F /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E420910020D0C4FA0094654F /* SDL2.framework */; };
+ 		E444DC1520C8F06700DD29C9 /* pict.c in Sources */ = {isa = PBXBuildFile; fileRef = E444DC1420C8F06700DD29C9 /* pict.c */; };
+ 		E447067025D904D500EA2C14 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E447066F25D904D500EA2C14 /* Metal.framework */; };
+ 		E44C460520D262B0000583AE /* tftp.c in Sources */ = {isa = PBXBuildFile; fileRef = E44C45DC20D262AD000583AE /* tftp.c */; };
+@@ -115,6 +113,7 @@
+ 		E4C9A03E1FD55CDC00CABBF9 /* basic-dyngen-ops-x86_64_macos.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E4C9A03D1FD55CDC00CABBF9 /* basic-dyngen-ops-x86_64_macos.hpp */; };
+ 		E4C9A0401FD55CE700CABBF9 /* ppc-dyngen-ops-x86_64_macos.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E4C9A03F1FD55CE700CABBF9 /* ppc-dyngen-ops-x86_64_macos.hpp */; };
+ 		E4CBF46120CFC451009F40CC /* video_sdl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4CBF46020CFC451009F40CC /* video_sdl.cpp */; };
++		EDE06E232C6AC704007BA478 /* libSDL2-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = EDE06E222C6AC704007BA478 /* libSDL2-2.0.0.dylib */; };
+ /* End PBXBuildFile section */
+ 
+ /* Begin PBXContainerItemProxy section */
+@@ -127,20 +126,6 @@
+ 		};
+ /* End PBXContainerItemProxy section */
+ 
+-/* Begin PBXCopyFilesBuildPhase section */
+-		E413A40820CF7EF800FBE967 /* Embed Frameworks */ = {
+-			isa = PBXCopyFilesBuildPhase;
+-			buildActionMask = 2147483647;
+-			dstPath = "";
+-			dstSubfolderSpec = 10;
+-			files = (
+-				E4150D1220D557820077C51A /* SDL2.framework in Embed Frameworks */,
+-			);
+-			name = "Embed Frameworks";
+-			runOnlyForDeploymentPostprocessing = 0;
+-		};
+-/* End PBXCopyFilesBuildPhase section */
+-
+ /* Begin PBXFileReference section */
+ 		08003F851E0624D100A3ADAB /* basic-dyngen-ops-x86_32.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = "basic-dyngen-ops-x86_32.hpp"; path = "dyngen_precompiled/basic-dyngen-ops-x86_32.hpp"; sourceTree = "<group>"; };
+ 		08003F871E0624D100A3ADAB /* basic-dyngen-ops.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = "basic-dyngen-ops.hpp"; path = "dyngen_precompiled/basic-dyngen-ops.hpp"; sourceTree = "<group>"; };
+@@ -339,14 +324,12 @@
+ 		A7B1921218C35D4700791D8D /* DiskType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DiskType.h; sourceTree = "<group>"; };
+ 		A7B1921318C35D4700791D8D /* DiskType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DiskType.m; sourceTree = "<group>"; };
+ 		E413A40220CF7E6D00FBE967 /* video_sdl2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_sdl2.cpp; path = ../../../BasiliskII/src/SDL/video_sdl2.cpp; sourceTree = "<group>"; };
+-		E4150D1120D557820077C51A /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = /Library/Frameworks/SDL2.framework; sourceTree = "<group>"; };
+ 		E41936C220CFE64D003A7654 /* SDLMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDLMain.h; path = ../../../BasiliskII/src/SDL/SDLMain.h; sourceTree = "<group>"; };
+ 		E41936C320CFE64D003A7654 /* SDLMain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLMain.m; path = ../../../BasiliskII/src/SDL/SDLMain.m; sourceTree = "<group>"; };
+ 		E4202600241250E2000508DF /* etherhelpertool.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = etherhelpertool.c; sourceTree = "<group>"; };
+ 		E4202602241250EE000508DF /* runtool.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = runtool.c; sourceTree = "<group>"; };
+ 		E420260424125182000508DF /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+ 		E420260A2412540D000508DF /* etherhelpertool */ = {isa = PBXFileReference; lastKnownFileType = text; path = etherhelpertool; sourceTree = BUILT_PRODUCTS_DIR; };
+-		E420910020D0C4FA0094654F /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = /Library/Frameworks/SDL2.framework; sourceTree = "<group>"; };
+ 		E4302EE21FBFE7FA00A5B500 /* lowmem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lowmem.c; path = Darwin/lowmem.c; sourceTree = "<group>"; };
+ 		E444DC1420C8F06700DD29C9 /* pict.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pict.c; path = ../pict.c; sourceTree = "<group>"; };
+ 		E447066F25D904D500EA2C14 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+@@ -396,6 +379,7 @@
+ 		E4C9A03D1FD55CDC00CABBF9 /* basic-dyngen-ops-x86_64_macos.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = "basic-dyngen-ops-x86_64_macos.hpp"; path = "dyngen_precompiled/basic-dyngen-ops-x86_64_macos.hpp"; sourceTree = "<group>"; };
+ 		E4C9A03F1FD55CE700CABBF9 /* ppc-dyngen-ops-x86_64_macos.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = "ppc-dyngen-ops-x86_64_macos.hpp"; path = "dyngen_precompiled/ppc-dyngen-ops-x86_64_macos.hpp"; sourceTree = "<group>"; };
+ 		E4CBF46020CFC451009F40CC /* video_sdl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_sdl.cpp; path = ../../../BasiliskII/src/SDL/video_sdl.cpp; sourceTree = "<group>"; };
++		EDE06E222C6AC704007BA478 /* libSDL2-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2-2.0.0.dylib"; path = "../../../../../../../opt/local/lib/libSDL2-2.0.0.dylib"; sourceTree = "<group>"; };
+ /* End PBXFileReference section */
+ 
+ /* Begin PBXFrameworksBuildPhase section */
+@@ -410,7 +394,7 @@
+ 			isa = PBXFrameworksBuildPhase;
+ 			buildActionMask = 2147483647;
+ 			files = (
+-				E420910120D0C4FA0094654F /* SDL2.framework in Frameworks */,
++				EDE06E232C6AC704007BA478 /* libSDL2-2.0.0.dylib in Frameworks */,
+ 				E420260524125182000508DF /* Security.framework in Frameworks */,
+ 				0856D21514A9A6C6000B1711 /* IOKit.framework in Frameworks */,
+ 				08CD42DC14B7B85B009CA2A2 /* Cocoa.framework in Frameworks */,
+@@ -447,7 +431,6 @@
+ 		0856CCAC14A99DE0000B1711 = {
+ 			isa = PBXGroup;
+ 			children = (
+-				E4150D1120D557820077C51A /* SDL2.framework */,
+ 				0856CCC814A99E30000B1711 /* Sources */,
+ 				08CD42DF14B7B865009CA2A2 /* Frameworks */,
+ 				0856CCC214A99E1C000B1711 /* Products */,
+@@ -895,9 +878,9 @@
+ 		08CD42DF14B7B865009CA2A2 /* Frameworks */ = {
+ 			isa = PBXGroup;
+ 			children = (
++				EDE06E222C6AC704007BA478 /* libSDL2-2.0.0.dylib */,
+ 				E447066F25D904D500EA2C14 /* Metal.framework */,
+ 				E420260424125182000508DF /* Security.framework */,
+-				E420910020D0C4FA0094654F /* SDL2.framework */,
+ 				08CD42E714B7B8AA009CA2A2 /* Carbon.framework */,
+ 				08CD42DB14B7B85B009CA2A2 /* Cocoa.framework */,
+ 				0856D21414A9A6C6000B1711 /* IOKit.framework */,
+@@ -959,7 +942,6 @@
+ 				0856CCBD14A99E1C000B1711 /* Resources */,
+ 				0856CCBE14A99E1C000B1711 /* Sources */,
+ 				0856CCBF14A99E1C000B1711 /* Frameworks */,
+-				E413A40820CF7EF800FBE967 /* Embed Frameworks */,
+ 				08CD3F3214B665E1009CA2A2 /* Preprocess Info.plist */,
+ 			);
+ 			buildRules = (
+@@ -1196,7 +1178,7 @@
+ 					_REENTRANT,
+ 				);
+ 				HEADER_SEARCH_PATHS = (
+-					/Library/Frameworks/SDL2.framework/Headers,
++					/opt/local/include/SDL2/,
+ 					./config/,
+ 					../Unix,
+ 					../MacOSX/Launcher,
+@@ -1235,7 +1217,7 @@
+ 					_REENTRANT,
+ 				);
+ 				HEADER_SEARCH_PATHS = (
+-					/Library/Frameworks/SDL2.framework/Headers,
++					/opt/local/include/SDL2/,
+ 					./config/,
+ 					../Unix,
+ 					../MacOSX/Launcher,
+@@ -1285,7 +1267,6 @@
+ 				CLANG_CXX_LIBRARY = "libc++";
+ 				CODE_SIGN_ENTITLEMENTS = SheepShaver.entitlements;
+ 				COPY_PHASE_STRIP = NO;
+-				FRAMEWORK_SEARCH_PATHS = /Library/Frameworks;
+ 				GCC_CW_ASM_SYNTAX = NO;
+ 				GCC_DYNAMIC_NO_PIC = NO;
+ 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
+@@ -1309,7 +1290,7 @@
+ 				GCC_WARN_UNUSED_FUNCTION = YES;
+ 				GCC_WARN_UNUSED_VARIABLE = YES;
+ 				HEADER_SEARCH_PATHS = (
+-					/Library/Frameworks/SDL2.framework/Headers,
++					/opt/local/include/SDL2/,
+ 					./config/,
+ 					../Unix,
+ 					../MacOSX/Launcher,
+@@ -1324,6 +1305,10 @@
+ 				INFOPLIST_PREPROCESS = NO;
+ 				INSTALL_PATH = "$(HOME)/Applications";
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
++				LIBRARY_SEARCH_PATHS = (
++					"$(inherited)",
++					/opt/local/lib,
++				);
+ 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				OTHER_CFLAGS = "";
+ 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+@@ -1351,7 +1336,6 @@
+ 				CODE_SIGN_ENTITLEMENTS = SheepShaver.entitlements;
+ 				COPY_PHASE_STRIP = NO;
+ 				DEAD_CODE_STRIPPING = NO;
+-				FRAMEWORK_SEARCH_PATHS = /Library/Frameworks;
+ 				GCC_CW_ASM_SYNTAX = NO;
+ 				GCC_DYNAMIC_NO_PIC = YES;
+ 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
+@@ -1375,7 +1359,7 @@
+ 				GCC_WARN_UNUSED_FUNCTION = YES;
+ 				GCC_WARN_UNUSED_VARIABLE = YES;
+ 				HEADER_SEARCH_PATHS = (
+-					/Library/Frameworks/SDL2.framework/Headers,
++					/opt/local/include/SDL2/,
+ 					./config/,
+ 					../Unix,
+ 					../MacOSX/Launcher,
+@@ -1391,6 +1375,10 @@
+ 				INFOPLIST_PREPROCESS = NO;
+ 				INSTALL_PATH = "$(HOME)/Applications";
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
++				LIBRARY_SEARCH_PATHS = (
++					"$(inherited)",
++					/opt/local/lib,
++				);
+ 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				OTHER_CFLAGS = "";
+ 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";


### PR DESCRIPTION
#### Description

I changed the repo from cebix's repo to the more frequently updated fork he recommends. I also changed the build system over to using Xcode, since in my testing the linux-based autogen build's Preferences window did not work correctly.

SheepShaver should now build correctly on newer OSes including ARM platforms.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 arm64
Xcode 14.2 14C18
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
