### PR TITLE
mise: Upgrade to 2024.8.8

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.8.7 v
+github.setup        jdx mise 2024.8.8 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  7ba4e61b82641c6b4f6ff79131fbf4b230f81d5b \
-                    sha256  f09cd3a09d58c318e02931cbfae263bb5aeda86cdb44fbd7ac3572c936dd49cc \
-                    size    3062620
+                    rmd160  cc4a34a27e65fd3f059e7499ea20d1a6497e62d0 \
+                    sha256  41dea6aeb96b9d6f24eb8cd5f256743980022857c5ecd3be7a8c4dd627365da4 \
+                    size    3062799
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -276,7 +276,7 @@ cargo.crates \
     os_pipe                          1.2.1  5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     owo-colors                       3.5.0  c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f \
-    papergrid                       0.11.0  9ad43c07024ef767f9160710b3a6773976194758c7919b17e63b863db0bdf7fb \
+    papergrid                       0.12.0  c7419ad52a7de9b60d33e11085a0fe3df1fbd5926aa3f93d3dd53afbc9e86725 \
     parse-zoneinfo                   0.3.1  1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24 \
     paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
     path-absolutize                  3.1.1  e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5 \
@@ -379,8 +379,8 @@ cargo.crates \
     syn                             2.0.74  1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7 \
     sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
-    tabled                          0.15.0  4c998b0c8b921495196a48aabaf1901ff28be0760136e31604f7967b0792050e \
-    tabled_derive                    0.7.0  4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17 \
+    tabled                          0.16.0  77c9303ee60b9bedf722012ea29ae3711ba13a67c9b9ae28993838b63057cb1b \
+    tabled_derive                    0.8.0  bf0fb8bfdc709786c154e24a66777493fb63ae97e3036d914c8666774c477069 \
     tar                             0.4.41  cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909 \
     tempfile                        3.12.0  04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64 \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
@@ -400,7 +400,7 @@ cargo.crates \
     time-macros                     0.2.18  3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf \
     tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.39.2  daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1 \
+    tokio                           1.39.3  9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5 \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                    0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
     tokio-util                      0.7.11  9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1 \
@@ -428,7 +428,7 @@ cargo.crates \
     unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
     unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
     unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
-    unicode-width                   0.1.13  0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d \
+    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \


### PR DESCRIPTION
#### Description

mise: Upgrade to 2024.8.8

##### Tested on

macOS 14.6.1 23G93 arm64 Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our
      [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and
      [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open
      [pull requests](https://github.com/macports/macports-ports/pulls) for the
      same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
