### PR TITLE
asprint: Fetch from GitHub tarball instead of git rep

### DIFF
--- a/sysutils/asprint/Portfile
+++ b/sysutils/asprint/Portfile
@@ -1,12 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                asprint
+# No tags in repository. No source code release download available.
+# https://github.com/ali-rantakari/asprint/issues/2
+github.setup        ali-rantakari asprint 89398c852a26fca0fb8696b9bfc0c61a3caeb16e
 version             0.5.0
 revision            1
+checksums           rmd160  914656c1c6da46468773c7f1d00230ddabdf3010 \
+                    sha256  61ac7ac47c42aabd9ada171b80c10a49e2910ab851401a6f2d8b51e917d8623b \
+                    size    14245
+
 categories          sysutils
-platforms           darwin
+platforms           {darwin >= 9}
 maintainers         perlhacker.org:sepp
 license             Apache-2
 
@@ -17,16 +24,7 @@ long_description    ${name} is a command-line program that pretty-prints the \
                     ANSI escape sequences.
 
 homepage            http://hasseg.org/asprint/
-fetch.type          git
-git.url             http://hasseg.org/git-public/asprint.git
-git.branch          89398c852a26fca0fb8696b9bfc0c61a3caeb16e
-
-platform darwin 8 {
-    pre-fetch {
-        ui_error "${name} requires Mac OS X 10.5 or greater."
-        return -code error "incompatible Mac OS X version"
-    }
-}
+github.tarball_from archive
 
 patchfiles          patch-Makefile.diff \
                     patch-asprint.pod.diff
@@ -46,5 +44,7 @@ destroot {
     xinstall -m 644 -W ${worksrcpath}/deployment-files readme.txt ${docdir}
 }
 
+livecheck.version   ${version}
+livecheck.url       ${homepage}
 livecheck.type      regex
 livecheck.regex     ${name}-v(\[0-9.\]+)\\.


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/70576

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
