### PR TITLE
lima: Upgrade to 0.23.1

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 0.22.0 v
+go.setup            github.com/lima-vm/lima 0.23.1 v
 go.offline_build    no
 github.tarball_from archive
-revision            1
+revision            0
 
 homepage            https://lima-vm.io
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 depends_run         port:qemu
 
-checksums           rmd160  a24c3a0a5623b2b759dec8dbe7ef5a0d2892af7b \
-                    sha256  9ea5b439cf71bb8fc4d831c3a71540baaa4c4420152addf1e32de57a4dc8af96 \
-                    size    6103965
+checksums           rmd160  59c1fcdc58ea99e939f31f8858fb4f1906dcb9ad \
+                    sha256  90485789d02071106864a3003b62975bc213dcedbcc96e53c07adc4c2a91c38d \
+                    size    6116493
 
 build.cmd           make
 

--- a/sysutils/lima/files/patch-Makefile.diff
+++ b/sysutils/lima/files/patch-Makefile.diff
@@ -1,5 +1,5 @@
---- Makefile.orig	2023-11-12 11:56:29
-+++ Makefile	2023-11-12 11:56:33
+--- Makefile.orig	2024-08-18 14:29:29
++++ Makefile	2024-08-18 14:33:54
 @@ -40,7 +40,7 @@
  
  PACKAGE := github.com/lima-vm/lima
@@ -9,12 +9,3 @@
  VERSION_TRIMMED := $(VERSION:v%=%)
  
  GO_BUILD := $(GO) build -ldflags="-s -w -X $(PACKAGE)/pkg/version.Version=$(VERSION)" -tags "$(GO_BUILDTAGS)"
-@@ -209,7 +209,7 @@
- install: uninstall
- 	mkdir -p "$(DEST)"
- 	# Use tar rather than cp, for better symlink handling
--	( cd _output && tar c * | tar Cxv "$(DEST)" )
-+	( cd _output && $(TAR) c * | $(TAR) -xv --no-same-owner -C "$(DEST)" )
- 	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/nerdctl" ]; then ln -sf nerdctl.lima "$(DEST)/bin/nerdctl"; fi
- 	if [ "$(shell uname -s )" != "Linux" -a ! -e "$(DEST)/bin/apptainer" ]; then ln -sf apptainer.lima "$(DEST)/bin/apptainer"; fi
- 


### PR DESCRIPTION
#### Description

lima: Upgrade to 0.23.1

##### Tested on

macOS 14.6.1 23G93 arm64 Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our
      [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and
      [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open
      [pull requests](https://github.com/macports/macports-ports/pulls) for the
      same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
