### PR TITLE
qemu: Use libfdt from dtc

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
 version                 9.0.2
-revision                0
+revision                1
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -57,7 +57,8 @@ depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2 \
                         port:lzo2 \
                         port:snappy \
                         port:zlib \
-                        port:zstd
+                        port:zstd \
+                        port:dtc
 
 # "error: unknown type name 'fpunchhole_t'" pre-10.12.4
 patchfiles-append       patch-qemu-punchhole.diff
@@ -144,7 +145,8 @@ configure.args-append   --disable-cocoa \
                         --enable-parallels \
                         --enable-vdi \
                         --enable-virtfs \
-                        --enable-vvfat
+                        --enable-vvfat \
+                        --enable-fdt=system
 
 # Use 'smbd' installed by samba port, rather than macOS; latter does not work with qemu.
 configure.args-append   --smbd=${prefix}/sbin/smbd


### PR DESCRIPTION
#### Description

The libfdt included in qemu conflicts with the one in dtc. Configure qemu to depend on dtc and use that version of libfdt.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
