### PR TITLE
libical: update to 3.0.18

### DIFF
--- a/devel/libical/Portfile
+++ b/devel/libical/Portfile
@@ -4,11 +4,12 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        libical libical 3.0.17 v
-revision            1
-checksums           rmd160  25683e028bf50cd5812ac9fd062ed33dca6e8782 \
-                    sha256  0d15191fbb43c414855aec49b1824b3d2b5b25cf8a5d1fbae5e7173485608072 \
-                    size    909122
+github.setup        libical libical 3.0.18 v
+revision            0
+checksums           rmd160  3169ffbee16545db4b73f0168b8a1845bbb3278c \
+                    sha256  72b7dc1a5937533aee5a2baefc990983b66b141dd80d43b51f80aced4aae219c \
+                    size    908948
+github.tarball_from archive
 
 categories          devel
 maintainers         nomaintainer
@@ -21,7 +22,7 @@ depends_build-append \
                     port:gtk-doc \
                     port:libxml2 \
                     path:bin/perl:perl5 \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     path:bin/vala:vala
 
 depends_lib-append  path:lib/pkgconfig/glib-2.0.pc:glib2 \
@@ -32,13 +33,7 @@ configure.args      -DGOBJECT_INTROSPECTION=ON \
                     -DICAL_GLIB_VAPI=ON \
                     -DICAL_BUILD_DOCS=OFF
 
-platform darwin 10 {
-    # on Rosetta linkage stage fails with gcc-4.2
-    if {${build_arch} eq "ppc"} {
-        compiler.blacklist-append *gcc-4.* *clang*
-    }
-}
+compiler.cxx_standard   2011
 
-if {[string match *gcc-4.* ${configure.compiler}]} {
-    patchfiles-append patch-gcc42.diff
-}
+# https://github.com/libical/libical/issues/723
+use_parallel_build  no


### PR DESCRIPTION
#### Description

Requires C++11 now (in fact already in 3.0.17, but that was missed), so drop a patch for gcc-4.2.
```
:info:configure   Target "ical_cxx" requires the language dialect "CXX11" (with compiler
:info:configure   extensions).  But the current compiler "GNU" does not support this, or
:info:configure   CMake does not know the flags to enable it.
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
