### PR TITLE
google-cloud-sdk: update to 489.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             488.0.0
+version             489.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  584ad976599600d3dad86e99b152018baad638a6 \
-                    sha256  aefa999026ba69f16d09a9e7dba005422715642b6bafa13a22849ee9757f3f00 \
-                    size    51450926
+    checksums       rmd160  d0ba7a06f38f3f20c8848940e229d3e26a1720b3 \
+                    sha256  bb1634998f332176283a7f2824697f6b04dbe986f204937d16e6035586eba6bb \
+                    size    51518986
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  35d07fd89118c40d0f828603e6cccdb3691ee694 \
-                    sha256  fd3af8763384cc07443216684f139fe2c2d07c3b58743972c4bdb6dacd77da35 \
-                    size    52800121
+    checksums       rmd160  3ed9f274afd0622fcb0505c2d5c90554905296db \
+                    sha256  39968a0ca540ee26ed07b0e998d9dbdda19f98ce71a6690f7025aed1e03c9628 \
+                    size    52869501
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  06c103a778a1100a63a823cbc1e8e615059aaaec \
-                    sha256  e71cd8651966b09145703f968a0bca88133b41a8329ab6f4c07bb32d3e48e5e4 \
-                    size    52748463
+    checksums       rmd160  28ab7167d259b3c6873ef4c05192124e90961596 \
+                    sha256  5266fd5830eb72e1e3b41ce2fc184456dd7a64ed4331d622644c58a362fc79a0 \
+                    size    52817636
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 489.0.0.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?