### PR TITLE
darktable-devel: update to 4.8.1

### DIFF
--- a/graphics/darktable-devel/Portfile
+++ b/graphics/darktable-devel/Portfile
@@ -10,7 +10,7 @@ PortGroup               perl5 1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               conflicts_build 1.0
 
-github.setup            darktable-org darktable 4.6.1 release-
+github.setup            darktable-org darktable 4.8.1 release-
 name                    darktable-devel
 conflicts               darktable
 set my_name             darktable
@@ -34,9 +34,9 @@ github.tarball_from     releases
 dist_subdir             ${my_name}
 use_xz                  yes
 
-checksums               rmd160  e45bd69300537e6d261140abc1628f9c4ddb6cfe \
-                        sha256  16edc0a070293e2d3cda4ea10e49bda9bde932e23f9e62e2fa2e7ac74acf7afd \
-                        size    6240188
+checksums               rmd160  8c4f84242041cdc8797333237b4c5645610a9479 \
+                        sha256  901b0e2caed36fb8619fdf4c60edfb8d31134b947d3054b5c66fd55c38af5991 \
+                        size    6258312
 
 # If lua installed, those headers are found first, rather than lua54
 conflicts_build-append  lua
@@ -240,4 +240,4 @@ if {[variant_isset openmp]} {
 }
 
 livecheck.url       https://github.com/darktable-org/darktable/releases
-livecheck.regex     {darktable (\d+(?:\.\d+)*) released}
+livecheck.regex     {release (\d+(?:\.\d+)*)}


### PR DESCRIPTION
#### Description

Update `darktable-devel` port to latest version released by upstream (4.8.1).
Also adapted livecheck regex to new convention used in upstream releases page.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 21H1320 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
