### PR TITLE
pragtical: new port

### DIFF
--- a/editors/pragtical/Portfile
+++ b/editors/pragtical/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+PortGroup           meson   1.0
+
+github.setup        pragtical pragtical 3.4.2 v
+github.tarball_from archive
+revision            0
+
+homepage            https://pragtical.dev
+
+description         The practical and pragmatic code editor.
+
+long_description    \
+    Pragtical is a code editor which was forked from Lite XL \(also a fork of \
+    lite\) written mostly in Lua with a focus on being practical rather than \
+    minimalist.
+
+categories          editors
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  0eda7bc5d8ce45a549ffa05b6ec4f32220a81150 \
+                    sha256  81f8f3b2b22185786905ebcb613b65ea020ddf1ab1efe89d772c6e2951d44f9a \
+                    size    1160808
+
+set lua_version     54
+
+configure.env-append \
+                    PATH=$env(PATH):${prefix}/libexec/lua${lua_version}/bin
+build.env-append    PATH=$env(PATH):${prefix}/libexec/lua${lua_version}/bin
+
+depends_build-append \
+                    path:bin/git:git \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  port:freetype \
+                    port:libgit2 \
+                    port:libsdl2 \
+                    port:libzip \
+                    port:lua${lua_version} \
+                    port:mbedtls \
+                    port:pcre2 \
+                    port:uchardet \
+                    port:zlib
+
+configure.args-append \
+                    -Duse_system_lua=false


### PR DESCRIPTION
https://pragtical.dev/

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
