### PR TITLE
Submission: py-dmgbuild (and py-ds-store, which the former depends on)

### DIFF
--- a/python/py-dmgbuild/Portfile
+++ b/python/py-dmgbuild/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-dmgbuild
+version             1.6.2
+
+categories-append   devel
+license             {MIT PSF}
+platforms           {darwin any}
+supported_archs     noarch
+maintainers         nomaintainer
+description         macOS command line utility to build disk images
+long_description \
+    dmgbuild is a command line tool to create macOS disk images (aka .dmg files). While it is possible to create disk images easily enough from the command line using the hdiutil program that ships with macOS, there is no easy way to configure the appearance of the resulting disk image when the user opens it.
+
+homepage            https://dmgbuild.readthedocs.io/en/latest/
+
+checksums           rmd160  0a9436e0a4f98d95c031db32a5323f547533b4da \
+                    sha256  dba01d29f10c6804f2d72301600ddd03724daa41cd21a95409c44a3e199b19aa \
+                    size    36893
+
+patchfiles-append   patch-pyproject.patch
+
+python.versions     39 310 311 312
+
+if {$subport ne $name} {
+    depends_lib-append     port:py${python.version}-mac-alias \
+                           port:py${python.version}-ds-store
+
+    post-destroot {
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport} \
+        ${destroot}${prefix}/share/examples/${subport}
+        xinstall -m 644 -W ${worksrcpath} LICENSE README.rst \
+        ${destroot}${prefix}/share/doc/${subport}
+    }
+}

--- a/python/py-dmgbuild/files/patch-pyproject.patch
+++ b/python/py-dmgbuild/files/patch-pyproject.patch
@@ -1,0 +1,12 @@
+diff --git pyproject.toml pyproject.toml
+index 3dadef1..d1c8c48 100644
+--- pyproject.toml
++++ pyproject.toml
+@@ -1,6 +1,6 @@
+ [build-system]
+ requires = [
+-    "setuptools==70.3.0",
++    "setuptools>=70.3.0",
+ ]
+ build-backend = "setuptools.build_meta"
+ 

--- a/python/py-ds-store/Portfile
+++ b/python/py-ds-store/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-ds-store
+version             1.3.1
+distname            ds_store-${version}
+
+categories-append   devel
+license             {MIT PSF}
+platforms           {darwin any}
+supported_archs     noarch
+maintainers         nomaintainer
+description         Manipulate Finder .DS_Store files from Python
+long_description    ds_store lets you examine and modify .DS_Store files from Python code\; since it is written in pure Python, it is portable and will run on any platform, not just Mac OS X.
+
+homepage            https://ds-store.readthedocs.io/en/latest/
+
+checksums           rmd160  a5a3a5ca0f221c43a8feddc66a864e080588e1c0 \
+                    sha256  c27d413caf13c19acb85d75da4752673f1f38267f9eb6ba81b3b5aa99c2d207c \
+                    size    27052
+
+python.versions     39 310 311 312
+
+if {$subport ne $name} {
+    depends_lib-append     port:py${python.version}-mac-alias
+
+    post-destroot {
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport} \
+        ${destroot}${prefix}/share/examples/${subport}
+        xinstall -m 644 -W ${worksrcpath} LICENSE README.rst \
+        ${destroot}${prefix}/share/doc/${subport}
+    }
+}

--- a/python/py-mac-alias/Portfile
+++ b/python/py-mac-alias/Portfile
@@ -25,4 +25,4 @@ checksums           rmd160  8d46ee63eb8cd89e6ac896a988f62f4d1ed70b03 \
                     sha256  c99c728eb512e955c11f1a6203a0ffa8883b26549e8afe68804031aa5da856b7 \
                     size    34073
 
-python.versions     312
+python.versions     39 310 311 312


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.9
Xcode 15.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

I have not included the dmgbuild tests as they do not work, but this is because the source archive appears to be missing files necessary for the tests to work properly.
