### PR TITLE
skaffold: update to 2.13.2

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.13.1 v
+github.setup        GoogleContainerTools skaffold 2.13.2 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  8efa585a550929302e3b117179fc3dea6b53161d \
-                    sha256  f483c357c4c2a9dd0a80a01c0d232927b6cf06bc2c419a6c59fe81aabe24d4c6 \
-                    size    61152854
+checksums           rmd160  eccca8bd14070ca56d361aa5fd54405ab2865593 \
+                    sha256  6c89d3da48a586d241d49f96aad5d8e71e6b47f5faa53ab4a583df82ad0bf9ef \
+                    size    61153005
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.13.2.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?