### PR TITLE
zlib-ng: new port (v2.2.1)

### DIFF
--- a/archivers/zlib-ng/Portfile
+++ b/archivers/zlib-ng/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake   1.1
+PortGroup           github  1.0
+
+github.setup        zlib-ng zlib-ng 2.2.1
+github.tarball_from archive
+revision            0
+
+description         \
+    zlib replacement with optimizations for \"next generation\" systems.
+
+long_description    \
+    {*}${description} \
+    Features: \
+    - Zlib compatible API with support for dual-linking \
+    - Modernized native API based on zlib API for ease of porting \
+    - Modern C11 syntax and a clean code layout \
+    - Deflate medium and quick algorithms based on Intel\’s zlib fork \
+    - Support for CPU intrinsics when available \
+    - Unaligned memory read/writes and large bit buffer improvements \
+    - Includes improvements from Cloudflare and Intel forks \
+    - Configure, CMake, and NMake build system support \
+    - Comprehensive set of CMake unit tests \
+    - Code sanitizers, fuzzing, and coverage \
+    - GitHub Actions continuous integration on Windows, macOS, and Linux \
+    - Emulated CI for ARM, AARCH64, PPC, PPC64, RISCV, SPARC64, S390x using \
+      qemu
+
+categories          archivers
+license             Zlib
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  1f359e2a9cc81fd95fcef7480eadb3a95ebbc533 \
+                    sha256  ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf \
+                    size    2412427


### PR DESCRIPTION
https://github.com/zlib-ng/zlib-ng

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
