### PR TITLE
kotlin: update to 2.0.20

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 2.0.10 v
+github.setup        JetBrains kotlin 2.0.20 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  8ae7ec6d9004f633f862f9cbaebb81c2435d4c8a \
-                    sha256  88d7d8bad362ae4e114a8b9668c6887b8c85f48e340883db0e317e47c8dc2f4f \
-                    size    83745882
+checksums           rmd160  c04b391aec043642557574efb69f7439b49b7388 \
+                    sha256  5f5d2a8ad6a718a002acd0775b67a9e27035872fdbd4b0791e3cb3ea00095931 \
+                    size    86110157
 
 java.version        1.8+
 java.fallback       openjdk21


### PR DESCRIPTION
#### Description

Update to Kotlin 2.0.20.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?