### PR TITLE
ffmpeg7: fix compilation for OS X 10.7 through 10.12

### DIFF
--- a/multimedia/ffmpeg7/Portfile
+++ b/multimedia/ffmpeg7/Portfile
@@ -107,6 +107,14 @@ patchfiles-append   patch-libavcodec-profvidworkflow.diff
 # TODO: Raise the issue to upstream
 patchfiles-append   patch-libavcodec-librsvgdec.diff
 
+platform darwin {
+    # Typedef AVMediaType to NSString* on older systems
+    # Patch submitted to upstream, remove once upstream has included it
+    if {${os.major} < 17} {
+        patchfiles-append   patch-libavdevice-avfoundation.diff
+    }
+}
+
 # https://trac.macports.org/ticket/68720
 # Remove once upstream has included these in the next release
 # patchfiles-append   patch-issue-10695.diff

--- a/multimedia/ffmpeg7/files/patch-libavdevice-avfoundation.diff
+++ b/multimedia/ffmpeg7/files/patch-libavdevice-avfoundation.diff
@@ -1,0 +1,14 @@
+--- libavdevice/avfoundation.m
++++ libavdevice/avfoundation.m
+@@ -763,6 +763,11 @@ static int get_audio_config(AVFormatContext *s)
+     return 0;
+ }
+
++#if (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED < 110000) || \
++    ((!defined(TARGET_OS_OSX) || TARGET_OS_OSX) && __MAC_OS_X_VERSION_MAX_ALLOWED < 101300)
++typedef NSString* AVMediaType;
++#endif
++
+ static NSArray* getDevicesWithMediaType(AVMediaType mediaType) {
+ #if ((TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500))
+     NSMutableArray *deviceTypes = nil;


### PR DESCRIPTION
#### Description

Add patch that adds a type alias for OS X <= 10.12 from `AVMediaType` to `NSString*` (introduced in the 10.13 SDK, but with an extra specifier). I have submitted the same patch to ffmpeg. Before 10.13 these constants were declared directly as `NSString*`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
