### PR TITLE
ruff: Update to 0.6.2

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.6.1
+github.setup        astral-sh ruff 0.6.2
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  0c7382a2dc508503ec8f34a06afeac09d38c4d02 \
-                    sha256  230a4ca5b172ae0632afb310ee7792eec6913eefa790423790862f0d91889ad1 \
-                    size    5008090
+                    rmd160  c23c81c2302a7cdf8c2d3c89898b38489878a454 \
+                    sha256  5aa788770ad1e11dc11a5a3b7a75a3c5452ba4e2f812a03fb6a28536032b4853 \
+                    size    5028765
 
 cargo.offline_cmd
 
@@ -92,18 +92,19 @@ cargo.crates \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
-    camino                           1.1.7  e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239 \
+    camino                           1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     castaway                         0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
     cc                              1.0.95  d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.1.1  fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e \
+    cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chic                             1.2.2  a5b5db619f3556839cb2223ae86ff3f9a09da2c5013be42bc9af08c9589bf70c \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.15  11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc \
+    clap                            4.5.16  ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019 \
     clap_builder                    4.5.15  216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6 \
     clap_complete                    4.5.2  dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
@@ -131,7 +132,7 @@ cargo.crates \
     crossbeam-queue                 0.3.11  df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35 \
     crossbeam-utils                 0.8.19  248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345 \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
-    ctrlc                            3.4.4  672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345 \
+    ctrlc                            3.4.5  90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3 \
     darling                         0.20.8  54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391 \
     darling_core                    0.20.8  9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f \
     darling_macro                   0.20.8  a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f \
@@ -177,7 +178,7 @@ cargo.crates \
     ignore                          0.4.22  b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1 \
     imara-diff                       0.1.7  fc9da1a252bd44cd341657203722352efc9bc0c847d06ea6d2dc1cd1135e0a01 \
     imperative                       1.0.6  29a1f6526af721f9aec9ceed7ab8ebfca47f3399d08b80056c2acca3fcb694a9 \
-    indexmap                         2.3.0  de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0 \
+    indexmap                         2.4.0  93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inotify                          0.9.6  f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff \
@@ -194,11 +195,11 @@ cargo.crates \
     itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jod-thread                       0.1.2  8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae \
-    js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
+    js-sys                          0.3.70  1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a \
     kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
     kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.155  97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c \
+    libc                           0.2.157  374af5f94e54fa97cf75e945cce8a6b201e88a1a07e688b47dfd2a59c66dbd86 \
     libcst                           1.4.0  10293a04a48e8b0cb2cc825a93b83090e527bffd3c897a0255ad7bc96079e920 \
     libcst_derive                    1.4.0  a2ae40017ac09cd2c6a53504cb3c871c7f2b41466eac5bc66ba63f39073b467b \
     libmimalloc-sys                 0.1.39  23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44 \
@@ -213,12 +214,14 @@ cargo.crates \
     matchit                          0.8.4  47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3 \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     mimalloc                        0.1.43  68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633 \
+    minicov                          0.3.5  5c71e683cd655513b99affab7d317deb690528255a0d5f717f1024093c12b169 \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.7.2  9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7 \
     mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
     natord                           1.0.9  308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c \
     newtype-uuid                     1.1.0  3526cb7c660872e401beaf3297f95f548ce3b4b4bdd8121b7c0713771d7c4a6e \
     nix                             0.28.0  ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4 \
+    nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     notify                           6.1.1  6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d \
     nu-ansi-term                    0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
@@ -228,7 +231,7 @@ cargo.crates \
     once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
-    ordermap                         0.5.1  8c81974681ab4f0cc9fe49cad56f821d1cc67a08cd2caa9b5d58b0adaa5dd36d \
+    ordermap                         0.5.2  61d7d835be600a7ac71b24e39c92fe6fad9e818b3c71bfc379e3ba65e327d77f \
     os_str_bytes                     7.0.0  7ac44c994af577c799b1b4bd80dc214701e349873ad894d6cdf96f4f7526e0b9 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
@@ -288,11 +291,11 @@ cargo.crates \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
-    serde                          1.0.206  5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284 \
+    serde                          1.0.208  cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2 \
     serde-wasm-bindgen               0.6.5  8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b \
-    serde_derive                   1.0.206  fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97 \
+    serde_derive                   1.0.208  24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf \
     serde_derive_internals          0.29.0  330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3 \
-    serde_json                     1.0.124  66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d \
+    serde_json                     1.0.125  83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed \
     serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
     serde_spanned                    0.6.7  eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d \
     serde_test                     1.0.177  7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed \
@@ -311,7 +314,7 @@ cargo.crates \
     strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     subtle                           2.5.0  81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc \
-    syn                             2.0.74  1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7 \
+    syn                             2.0.75  f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     tempfile                        3.12.0  04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64 \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
@@ -364,14 +367,14 @@ cargo.crates \
     vte_generate_state_changes       0.1.1  d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.92  4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8 \
-    wasm-bindgen-backend            0.2.92  614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da \
-    wasm-bindgen-futures            0.4.42  76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0 \
-    wasm-bindgen-macro              0.2.92  a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726 \
-    wasm-bindgen-macro-support      0.2.92  e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7 \
-    wasm-bindgen-shared             0.2.92  af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96 \
-    wasm-bindgen-test               0.3.42  d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b \
-    wasm-bindgen-test-macro         0.3.42  b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0 \
+    wasm-bindgen                    0.2.93  a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5 \
+    wasm-bindgen-backend            0.2.93  9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b \
+    wasm-bindgen-futures            0.4.43  61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed \
+    wasm-bindgen-macro              0.2.93  585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf \
+    wasm-bindgen-macro-support      0.2.93  afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836 \
+    wasm-bindgen-shared             0.2.93  c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484 \
+    wasm-bindgen-test               0.3.43  68497a05fb21143a08a7d24fc81763384a3072ee43c44e86aad1744d6adef9d9 \
+    wasm-bindgen-test-macro         0.3.43  4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021 \
     web-sys                         0.3.69  77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                    0.26.1  b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009 \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.6.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
