### PR TITLE
Bun: Upgrade to 1.1.25

### DIFF
--- a/devel/bun/Portfile
+++ b/devel/bun/Portfile
@@ -6,7 +6,7 @@ PortGroup           npm 1.0
 npm.nodejs_version  22
 
 name                bun
-version             1.1.24
+version             1.1.25
 maintainers         {johnlindop.com:git @JLindop} openmaintainer
 revision            0
 
@@ -20,6 +20,6 @@ categories          devel
 homepage            https://bun.sh
 license             MIT
 
-checksums           rmd160  12fc33de730e1eee209c93409493e151ccd108cc \
-                    sha256  231e88e5ddcdb2fdbca22072d8815e6ff0ffc8195e7bfde0f96b4898bd50619e \
-                    size    5394
+checksums           rmd160  fc40275c6ac18d1b5ab8018a5821418880bcf2fd \
+                    sha256  352190454577562ce85f0c189202e44651ac9292bc9af0ecc60a7c3153553d71 \
+                    size    5395


### PR DESCRIPTION
#### Description

Upgrade Bun to 1.1.25

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
