### PR TITLE
cdo: update to 2.4.3

### DIFF
--- a/.github/workflows/bootstrap.sh
+++ b/.github/workflows/bootstrap.sh
@@ -111,7 +111,7 @@ begingroup "Configuring MacPorts"
 # Set PATH for portindex
 source /opt/local/share/macports/setupenv.bash
 # Set ports tree to $PWD/ports
-sudo sed -i "" "s|rsync://rsync.macports.org/macports/release/tarballs/ports.tar|file://${PWD}/ports|; /^file:/s/default/nosync,default/" /opt/local/etc/macports/sources.conf
+echo "file://${PWD}/ports [default,nosync]" | sudo tee /opt/local/etc/macports/sources.conf >/dev/null
 # CI is not interactive
 echo "ui_interactive no" | sudo tee -a /opt/local/etc/macports/macports.conf >/dev/null
 # Only download from the CDN, not the mirrors

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -162,6 +162,11 @@ if {${name} eq ${subport}} {
         }
     }
 
+    pre-test {
+        ui_msg "Tests require a cooperating server named 'somehost'."
+        ui_msg "Failure to connect to it results in a hang."
+    }
+
     variant xauth description {Build with support for xauth} {
         configure.args-replace  --without-xauth \
                                 --with-xauth=${prefix}/bin/xauth
@@ -201,6 +206,12 @@ if {${name} eq ${subport}} {
         depends_lib-append      port:libfido2
     }
 
+    variant legacy_dsa description "Enable legacy DSA support (until 2025)" {
+        configure.args-append  --enable-dsa-keys
+        notes-append "DSA support is scheduled to be removed in early 2025."
+        notes-append "DSA-based keys will need to be replaced by then."
+        notes-append "See: https://www.openbsd.org/openssh/releasenotes.html"
+    }
 
     platform darwin {
         # create link to /usr/include/pam because 'security' was renamed to 'pam'
@@ -251,7 +262,6 @@ if {${name} eq ${subport}} {
 
 subport ssh-copy-id {
     revision            0
-    platforms           any
     supported_archs     noarch
     maintainers         {l2dy @l2dy} openmaintainer
     description         Shell script to install your public key(s) on a remote machine

--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,7 +5,7 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.0
 
 name                        cdo
-version                     2.4.2
+version                     2.4.3
 revision                    0
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} \
@@ -15,11 +15,11 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/29481
+master_sites                https://code.mpimet.mpg.de/attachments/download/29616
 
-checksums           rmd160  71a6fb8cacf47e84e2d42e875b57f54ddcbad8f7 \
-                    sha256  4df1fe2b8f92f54c27eb9f399edfab40d9322005a6732ca1524ef5c1627ac4e7 \
-                    size    13519106
+checksums           rmd160  8956c5978cb35f98fc37601b95ffd3ac491210bf \
+                    sha256  4a608b70ee1907b45e149ad44033bb47d35b7da96096553193bd362ca9d445eb \
+                    size    13550871
 
 long_description \
     CDO is a collection of command line Operators               \


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.4.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
