### PR TITLE
urlscan: update to 1.0.3

### DIFF
--- a/mail/urlscan/Portfile
+++ b/mail/urlscan/Portfile
@@ -4,11 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        firecat53 urlscan 0.9.5
+github.setup        firecat53 urlscan 1.0.3
 categories          mail python
-platforms           darwin
+platforms           {darwin any}
+supported_archs     noarch
 license             GPL-2
 maintainers         {@ryanakca debian.org:rak} \
+                    {@exprez135 ijams.me:nate} \
                     openmaintainer
 description         extract and browse the URLs in an email
 long_description    ${name} lets you easily browse URLs contained in an email\
@@ -17,13 +19,14 @@ long_description    ${name} lets you easily browse URLs contained in an email\
 
 github.tarball_from archive
 
-python.default_version 39
+python.default_version 312
+python.pep517_backend hatch
 
-checksums           rmd160  439e24ccb82619affe45c22bbca2272d466b875a \
-                    sha256  db76f61966431a8938adc998aaa2b30be54f9b1ff2a4c0064e9915df2fb6b996 \
-                    size    32010
+checksums           rmd160  d8842153eacd06a2085f2e44c1c5e85b5af4b1d2 \
+                    sha256  f9c0b6067b1327059bf6298bd6f4834148a3a71bb9864943c0cb1d6872de5c6c \
+                    size    35837
 
 depends_build-append \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-hatch-vcs
 
 depends_lib-append  port:py${python.version}-urwid


### PR DESCRIPTION
Update urlscan to 1.0.3

– Add new build dependencies: hatchling and hatch-vcs
– Use Python 3.12 by default
– Add compatible Python versions
– Remove unnecessary 

**This should not be merged without review from project's maintainer (@ryanakca), since the package is being updated from a prerelease version to a stable version.**

#### Description

The urlscan package is quite outdated. Here, I've updated it to the newest version, which includes the addition of two new build dependencies. I've also set the compatible Python versions and defaulted to 3.12 (previously 3.9). This also removes the unnecessary `darwin` setting.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
