### PR TITLE
texinfo: do not build extra libs opportunistically

### DIFF
--- a/textproc/texinfo/Portfile
+++ b/textproc/texinfo/Portfile
@@ -12,7 +12,7 @@ if {[string match *gcc* ${configure.compiler}]} {
 
 name                texinfo
 version             7.1
-revision            0
+revision            1
 categories          textproc
 license             GPL-3+
 maintainers         nomaintainer
@@ -59,6 +59,10 @@ pre-configure {
         PERL_EXT_CFLAGS=[get_canonical_archflags cc] \
         PERL_EXT_LDFLAGS=[get_canonical_archflags ld]
 }
+
+# If not disabled, the port builds /opt/local/lib/texinfo/MiscXS.so and other libs,
+# which link to libunistring and leave the port broken if that is deactivated.
+configure.args-append   --disable-perl-xs
 
 destroot.target-append  install-tex
 destroot.args           TEXMF=${prefix}/share/texmf


### PR DESCRIPTION
#### Description

The port is supposed not to install libs, however it does, which brings in undeclared dependency on `libunistring`.
Avoid opportunistic building of libs and opportunistic linking.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
