### PR TITLE
uv: Update to 0.3.2

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.3.1
+github.setup            astral-sh uv 0.3.2
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -17,9 +17,9 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for common pip and pip-tools workflows.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  0c111f954067df825efeee09ddbf14c29186e1ba \
-                        sha256  6436b8ba15e74be0ca27ebf9a75b1d6b0ea60b9405bc2575c1bca40795c1abeb \
-                        size    2400493
+                        rmd160  669e629f425dc7a79f2842df6f89f156baceff74 \
+                        sha256  f81ecd38dbaad3664084549a7f2152b6042a1984e2cee3b0d5f90751a8dc9ad3 \
+                        size    2414989
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.3.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
