### PR TITLE
micronaut: update to 4.6.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.5.1 v
+github.setup    micronaut-projects micronaut-starter 4.6.0 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  942cf73fc1205c38d1820e87ce5cc780b9994ab5 \
-                 sha256  f6db0efc82fc0dfd92af09143ce26f76d4e7c8cee964959f9284e850cc4aaf45 \
-                 size    27174236
+    checksums    rmd160  bc423cf12e7c1c2d76f3a1b677f80253ab7f063b \
+                 sha256  99efc3e78a0a130b77ebf9cb1478b200db43f0f2f157a5fefc787ddbf4c3b4e1 \
+                 size    25491166
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  3562dbe4e62bee7b5448769730dda3cc12b4c8a7 \
-                 sha256  b6e4871f0c7e95f08fa44fe340dc4323b60e86d8aed06abd6d8fc09cacaebde6 \
-                 size    26877853
+    checksums    rmd160  04d306235a2799bfb2f6804c585afc02907e7673 \
+                 sha256  d67aa681b1b84d56e4affc182bcedc75caa6cdfe737dbd0820926f30b4091e75 \
+                 size    25299476
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.6.0.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?