### PR TITLE
mvnd: update to 1.0.2

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem      1.0
 
-version         1.0.1
+version         1.0.2
 revision        0
 name            mvnd
 categories      java
@@ -32,20 +32,20 @@ long_description mvnd aims at providing faster Maven builds using techniques kno
 homepage        https://github.com/apache/maven-mvnd
 supported_archs x86_64 arm64
 
-master_sites    https://archive.apache.org/dist/maven/mvnd/${version}/
+master_sites    https://downloads.apache.org/maven/mvnd/${version}/
 
 use_configure   no
 
 if {${configure.build_arch} eq "x86_64"} {
     distname        maven-mvnd-${version}-darwin-amd64
-    checksums       rmd160  c750ca87b6b495df16286b95cd522b92102cb427 \
-                    sha256  83c953218474ecefbcf829ff999a7d5ce717d4ed641bd8d7e9461368384a0c03 \
-                    size    23185002
+    checksums       rmd160  6d55549468ba215dcc239c0666f22e988c405a4d \
+                    sha256  926b0512ac3df2dd05770f61eeafbf97cfeafd14bb903fdea90b34bc8165ad21 \
+                    size    23228475
 } elseif {${configure.build_arch} eq "arm64"} {
     distname        maven-mvnd-${version}-darwin-aarch64
-    checksums       rmd160  eeea760a046fa32a8c11910aec748fe432d03c2b \
-                    sha256  685ee0017014ed413ca7aef9fc40759a15bddc64e9dbaaea152a1672ab9eaf5a \
-                    size    23316945
+    checksums       rmd160  9b3e1fe42a2b7e39d5e0080161ba1372fe74a7ea \
+                    sha256  a0f9fe345ca76726806fc17ef78caf73e3e1887921c8c156d53341564803e24b \
+                    size    23289264
 }
 
 build {}


### PR DESCRIPTION
#### Description

Update to Maven Daemon 1.0.2.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?