### PR TITLE
mvnd: restore master_sites URL

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -32,7 +32,7 @@ long_description mvnd aims at providing faster Maven builds using techniques kno
 homepage        https://github.com/apache/maven-mvnd
 supported_archs x86_64 arm64
 
-master_sites    https://downloads.apache.org/maven/mvnd/${version}/
+master_sites    https://archive.apache.org/dist/maven/mvnd/${version}/
 
 use_configure   no
 


### PR DESCRIPTION
#### Description

Restore master_sites URL.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?