### PR TITLE
stylua: Enable more Lua version formatting

### DIFF
--- a/lua/stylua/Portfile
+++ b/lua/stylua/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        johnnymorganz stylua 0.20.0 v
-revision            0
+revision            1
 categories          lua
 platforms           darwin
 maintainers         {judaew @judaew} \
@@ -13,7 +13,7 @@ maintainers         {judaew @judaew} \
 license             MPL-2
 
 description         An opinionated Lua code formatter
-long_description    An opinionated code formatter for Lua 5.1, Lua 5.2 and Luau. \
+long_description    An opinionated code formatter for Lua 5.1-5.4 and Luau. \
                     StyLua is inspired by the likes of prettier, it parses your \
                     Lua codebase, and prints it back out from scratch, enforcing \
                     a consistent code style.
@@ -22,6 +22,9 @@ checksums           ${distname}${extract.suffix} \
                     rmd160  c712aa18d8a2c1a9cc9db81d155c50cadfa173fb \
                     sha256  34235d51602229e8ad95b4099c6f7a36fde8eef699b998e17f3d00c61e6151ad \
                     size    412909
+
+build.pre_args-append \
+                    --features editorconfig,wasm-bindgen,luau,lua54
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

By default, stylua is built with support for Lua 5.1 only, but can be built to support Lua 5.1 through Lua 5.4 and Luau. This only requires adding `luau` and `lua54` to the default features, `editorconfig` and `wasm-bindgen`. `lua54` implies `lua52` and `lua53`.

I was able to format a Lua 5.4 file that was not previously formattable with the existing feature set.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 14.6.1 23G93 arm64 Xcode 15.4 15F31d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?