### PR TITLE
spdlog0: backport upstream fix for old systems

### DIFF
--- a/devel/spdlog0/Portfile
+++ b/devel/spdlog0/Portfile
@@ -26,4 +26,7 @@ github.tarball_from archive
 supported_archs     noarch
 compiler.cxx_standard   2011
 
+# Backport of https://github.com/gabime/spdlog/commit/c65aa4e4889939c1afa82001db349cac237a13f8
+patchfiles          patch-pthread.diff
+
 livecheck.type      none

--- a/devel/spdlog0/files/patch-pthread.diff
+++ b/devel/spdlog0/files/patch-pthread.diff
@@ -1,0 +1,32 @@
+--- include/spdlog/details/os.h	2018-05-22 01:38:13.000000000 +0800
++++ include/spdlog/details/os.h	2024-08-25 09:14:56.000000000 +0800
+@@ -49,6 +49,10 @@
+ 
+ #endif // unix
+ 
++#if defined __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ #ifndef __has_feature      // Clang - feature checking macros.
+ #define __has_feature(x) 0 // Compatibility with non-clang compilers.
+ #endif
+@@ -337,7 +341,17 @@
+     return static_cast<size_t>(tid);
+ #elif __APPLE__
+     uint64_t tid;
+-    pthread_threadid_np(nullptr, &tid);
++#if (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || defined(__POWERPC__)
++        tid = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++        if (&pthread_threadid_np) {
++            pthread_threadid_np(nullptr, &tid);
++        } else {
++            tid = pthread_mach_thread_np(pthread_self());
++        }
++#else
++        pthread_threadid_np(nullptr, &tid);
++#endif
+     return static_cast<size_t>(tid);
+ #else // Default to standard C++11 (other Unix)
+     return static_cast<size_t>(std::hash<std::thread::id>()(std::this_thread::get_id()));


### PR DESCRIPTION
#### Description

Backport a patch

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
