### PR TITLE
p5-ifeffit: fix build on old systems

### DIFF
--- a/perl/p5-ifeffit/Portfile
+++ b/perl/p5-ifeffit/Portfile
@@ -10,7 +10,6 @@ epoch               1
 version             1.2.13
 revision            2
 
-platforms           darwin
 license             Permissive
 maintainers         nomaintainer
 
@@ -43,6 +42,9 @@ if {${perl5.major} != ""} {
 
     compilers.choose    f77
     compilers.setup     require_fortran
+    # Undefined symbols: "restGPRx", "__gfortran_transfer_real_write", "__gfortran_transfer_integer_write"
+    compiler.blacklist-append \
+                        *gcc-4.0 *gcc-4.2
 
     compilers.enforce_fortran  ifeffit
     # this shows up in the contents of Makefile.PL, as the gcc/gfortran library


### PR DESCRIPTION
#### Description

Avoid Xcode gcc, it cannot link this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
