### PR TITLE
neofetch: support MacPorts on non-Darwin systems

### DIFF
--- a/sysutils/neofetch/Portfile
+++ b/sysutils/neofetch/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dylanaraps neofetch 7.1.0
+revision            1
 platforms           any
 supported_archs     noarch
 license             MIT
@@ -19,6 +20,8 @@ long_description    Neofetch is a CLI system information tool written in \
 checksums           rmd160  c9db23b6959aa7d0b8b6de68c05994f80d1e846a \
                     sha256  c99d704d2f321d24a4655ce3fc052fd79539493dc75c025237ad78e93f9749bf \
                     size    95403
+
+patchfiles-append   0001-Support-MacPorts-on-non-Darwin-systems.patch
 
 use_configure       no
 destroot.post_args  ${destroot.destdir} PREFIX=${prefix}

--- a/sysutils/neofetch/files/0001-Support-MacPorts-on-non-Darwin-systems.patch
+++ b/sysutils/neofetch/files/0001-Support-MacPorts-on-non-Darwin-systems.patch
@@ -1,0 +1,21 @@
+From 6cb9041c463cea4df03fd52f736cadee959d3bef Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sun, 25 Aug 2024 08:33:46 +0800
+Subject: [PATCH] Support MacPorts on non-Darwin systems
+
+---
+ neofetch | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git neofetch neofetch
+index 48b96d21..b00bae27 100755
+--- neofetch
++++ neofetch
+@@ -1504,6 +1504,7 @@
+             has alps       && tot alps showinstalled
+             has butch      && tot butch list
+             has mine       && tot mine -q
++            has port       && pkgs_h=1 tot port installed && ((packages-=1))
+ 
+             # Counting files/dirs.
+             # Variables need to be unquoted here. Only Bedrock Linux is affected.


### PR DESCRIPTION
#### Description

Add support for MacPorts packages outside of MacOS.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
PinIx 2.1 / riscv64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
