### PR TITLE
tippecanoe: update to 2.60.0

### DIFF
--- a/gis/tippecanoe/Portfile
+++ b/gis/tippecanoe/Portfile
@@ -6,7 +6,7 @@ PortGroup               makefile 1.0
 PortGroup               legacysupport 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            felt tippecanoe 2.58.0
+github.setup            felt tippecanoe 2.60.0
 github.tarball_from     archive
 revision                0
 categories              gis
@@ -15,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             Build vector tilesets from large collections of GeoJSON features
 long_description        {*}${description}
 
-checksums               rmd160  256a5b62e95e7989d1d1c97bb96141450c59e2fc \
-                        sha256  bfa8e2ad4bfd552c42d324765c9684efa72a1750807ffb9f03a8b9b7b01ca866 \
-                        size    23762738
+checksums               rmd160  c86df3551b7932f4eff75e67928b22b314d72420 \
+                        sha256  ed5722674ba90e5e7fecdeabb671dac0ee81fc89c5f3da35cef6b50300f4ba4b \
+                        size    23773277
 
 depends_lib-append      port:sqlite3 \
                         port:zlib


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/felt/tippecanoe/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
