### PR TITLE
totp-cli:  Update dependencies

### DIFF
--- a/security/totp-cli/Portfile
+++ b/security/totp-cli/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 PortGroup           legacysupport 1.1
 
 go.setup            github.com/yitsushi/totp-cli 1.8.7 v
-revision            0
+revision            1
 
 categories          security
 maintainers         {gmail.com:smanojkarthick @manojkarthick} \
@@ -32,40 +32,40 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
                         size    91208 \
                     gopkg.in/check.v1 \
-                        lock    20d25e280405 \
-                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
-                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
-                        size    30360 \
+                        lock    10cb98267c6cb43ea9cd6793f29ff4089c306974 \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
                     golang.org/x/term \
-                        lock    v0.16.0 \
-                        rmd160  bd756f55b20d8afea67740e01a2cc13d9c03f2da \
-                        sha256  0619c31c8e802b7380b4bc4ed21dbadab3938e88861829deda723aded067f90f \
-                        size    14741 \
+                        lock    v0.23.0 \
+                        rmd160  131879e7d516e92f8c6dac47b5b750c18e7ab9bb \
+                        sha256  84a80901adbe8e647508a48d89e0c772c6aafd4b44bcc05271ca0a51a9e1d1a6 \
+                        size    14734 \
                     golang.org/x/sys \
-                        lock    v0.16.0 \
-                        rmd160  10e97b22e4ee6cb4210dc4a3939eff7029c76733 \
-                        sha256  1736d810e783163472b5653ec5eb4272b9f7d570f4e212c5d55d6491be694cf7 \
-                        size    1444408 \
+                        lock    v0.24.0 \
+                        rmd160  74fb804978246135d12ca76dbe1599abcdc5b29b \
+                        sha256  d794227ad7ad26a66b72121cfa6be48b4a8f340bac190b513044a714e8c9256c \
+                        size    1502103 \
                     golang.org/x/crypto \
-                        lock    v0.17.0 \
-                        rmd160  b42d588c4aa930e1d70d67b75a9a3f20a613536e \
-                        sha256  a559bc5b604090ff2ad6040e8207d79a969ff3017f9e61d2eb0df774ae3b47f4 \
-                        size    1809435 \
+                        lock    v0.26.0 \
+                        rmd160  437ca84bbed506eac15af824b0162f9bdd0008da \
+                        sha256  dd29f4e0dbf8eaffc8e8d97c7a94b81f59d86f8ff0e3b6e042b44a38f78845a7 \
+                        size    1799499 \
                     github.com/xrash/smetrics \
-                        lock    1d8dd44e695e \
-                        rmd160  1d4694c12438fe017b12295d85d9f48073115c84 \
-                        sha256  9b27416730ef4c8884569e4afb51afa20d95e79bed55d7d5e08ee7a9ca47fe6a \
-                        size    1823507 \
+                        lock    686a1a2994c11fac124829fadcb683a24ab8d25f \
+                        rmd160  6eeddadc807945dd735d28b8e19a239a242d5ae4 \
+                        sha256  ad89cc64ab0ee4f8c8364b85027e507ce99a8e1a5d0ccda24c623be30757d918 \
+                        size    1823558 \
                     github.com/urfave/cli \
-                        lock    v2.27.1 \
-                        rmd160  5ed423283f063a24972ad7ba2dec285e244a25fa \
-                        sha256  ca879821f57d546acad456afaee27cb3d49e68068e37005e777acf3712d9458d \
-                        size    3484663 \
+                        lock    v2.27.4 \
+                        rmd160  81fd03d63663a35fbd708ab09d9baae5db93c4cf \
+                        sha256  2f8294d5468a138610d4ffef827dc658b18b899c37e576d1ac1dcf34a1bbea0a \
+                        size    3485188 \
                     github.com/stretchr/testify \
-                        lock    v1.7.1 \
-                        rmd160  9e07f7d6890b8598706260ece5db26a7b12b5b2a \
-                        sha256  27cabaf81344157a188083266cf8ccc19d04c43d9a34b6276b760514b9c880a3 \
-                        size    94020 \
+                        lock    v1.9.0 \
+                        rmd160  59147e117812fdf8270ec79e46a229c472caf08d \
+                        sha256  e6fa4f530cad5bac94bf08af05ddd1f569aeac8db4017ab4330ab7fe2802a6a3 \
+                        size    108716 \
                     github.com/russross/blackfriday \
                         lock    v2.1.0 \
                         rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
@@ -82,16 +82,16 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/cpuguy83/go-md2man \
-                        lock    v2.0.3 \
-                        rmd160  f44cb99228e4f418c00979bf850d568837755b76 \
-                        sha256  712375b6a4472b6eff9225cdf3e01a4d33e1e0753f713874ecd67a0d0c74bfea \
-                        size    64980 \
+                        lock    v2.0.4 \
+                        rmd160  6ffe0c422d0b5730c8cf5a078fa9c7a67a1d2db8 \
+                        sha256  a9d98f865f053c7b569d0751ec9a80e93194f1ae9d49e0c6423e53e0d6cd5574 \
+                        size    9903 \
                     filippo.io/age \
                         repo    github.com/FiloSottile/age \
-                        lock    v1.1.1 \
-                        rmd160  5e09dc3b85d53c92b62c114355097f51a8f79690 \
-                        sha256  007f2a349124a61c8357a8d34703f420248a4cd9c0c00892efab8186310baa8c \
-                        size    204319
+                        lock    v1.2.0 \
+                        rmd160  60a3e0f7c2f398affebb00314376512e42c49d67 \
+                        sha256  39205e4fad8fe7b8885815277abe4048343d3d93ff22afb9ed4037f3e7f11faf \
+                        size    206743 \
 
 build.args-append   \
     -ldflags \"-X ${go.package}/internal/info.Version=${github.tag_prefix}${version}\"


### PR DESCRIPTION
totp-cli:  Update dependencies

* Bump revision number
* Update go dependencies to latest versions

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
