### PR TITLE
pngloss: patch Makefile to respect CFLAGS & LDFLAGS

### DIFF
--- a/graphics/pngloss/Portfile
+++ b/graphics/pngloss/Portfile
@@ -6,7 +6,7 @@ PortGroup           makefile    1.0
 
 github.setup        foobaz pngloss 1.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Lossy compression of PNG images
 
@@ -30,10 +30,10 @@ checksums           rmd160  e87c09329c8eeb702e05381368e1c59b8eb29d55 \
                     sha256  24c5c3d176b299a3787fb019f668808ff54a75f236fb5e65ad87ecf499e26f77 \
                     size    3108037
 
-depends_build-append \
-                    port:autoconf   \
-                    port:automake   \
-                    port:libtool    \
-                    port:pkgconfig
+patchfiles-append   patch-Makefile.diff
 
 depends_lib-append  port:libpng
+
+build.target        ${name}
+
+compiler.c_standard 1999

--- a/graphics/pngloss/files/patch-Makefile.diff
+++ b/graphics/pngloss/files/patch-Makefile.diff
@@ -1,0 +1,27 @@
+--- ./Makefile	2024-08-25 23:22:11
++++ ./Makefile	2024-08-25 23:23:26
+@@ -1,9 +1,12 @@
+ -include config.mk
+ 
++PREFIX ?= /opt/local
++
+ CC ?= /usr/bin/cc
+-CFLAGS = -O3 -Wall -Wextra -I/usr/local/include
+-LDFLAGS = -L/usr/local/lib -lpng
+-VERSION = 1.0
++CFLAGS ?= -O3 -Wall -Wextra -I$(PREFIX)/include
++LDFLAGS ?= -L$(PREFIX)/lib
++DEFAULT_LDFLAGS = -lpng
++VERSION ?= 1.0
+ 
+ BIN ?= pngloss
+ DESTDIR ?= /usr/local
+@@ -19,7 +22,7 @@
+ all: $(BIN)
+ 
+ $(BIN): $(OBJS)
+-	$(CC) $(OBJS) $(CFLAGS) $(LDFLAGS) -o $@
++	$(CC) $(OBJS) $(CFLAGS) $(DEFAULT_LDFLAGS) $(LDFLAGS) -o $@
+ 
+ dist: $(TARFILE)
+ 


### PR DESCRIPTION
- set C compiler standard to C99

See: https://trac.macports.org/ticket/70456

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
