### PR TITLE
gdal, py-gdal: Update to version 3.9.2

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -8,12 +8,12 @@ PortGroup           legacysupport 1.1
 PortGroup           muniversal 1.0
 
 name                gdal
-version             3.9.1
-revision            1
+version             3.9.2
+revision            0
 
-checksums           rmd160  8dd9e368cfacc39dfad3b5f42b713b61e23bab15 \
-                    sha256  aff3086fee75f5773e33a5598df98d8a4d10be411f777d3ce23584b21d8171ca \
-                    size    9098844
+checksums           rmd160  8755fd65d478d0d796775452a96ea6daaece8ca1 \
+                    sha256  bfbcc9f087f012c36151c20c79f8eac9529e1e5298fbded79cd5a1365f0b113a \
+                    size    9102740
 
 categories          gis
 license             MIT BSD

--- a/python/py-gdal/Portfile
+++ b/python/py-gdal/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 name                py-gdal
 # keep version in sync with gdal; rebuilt after gdal update
-version             3.9.1
+version             3.9.2
 revision            0
 
 categories-append   gis
@@ -19,9 +19,9 @@ long_description    This Python package and extensions are a number of tools for
 
 homepage            https://www.gdal.org
 
-checksums           rmd160  8065bda72fc555809d5a1c3cf3be18d6d7fab68d \
-                    sha256  6d8a8f162ed32c5cb58839fa9198def477c68b670eed4cbce9eeef387ac3c8da \
-                    size    840332
+checksums           rmd160  e8e29d19f6e6d320f7f6337d6b9c3080e783f3c0 \
+                    sha256  cf9c1add09ce152975c94d48a1a89dd300c292e0761fd3d22a8071a98852e129 \
+                    size    840643
 
 python.versions     38 39 310 311 312
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update `gdal` and `py-gdal` to version 3.9.2.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
