### PR TITLE
fastfetch: update to 2.22.0 for legacy systems

### DIFF
--- a/sysutils/fastfetch/Portfile
+++ b/sysutils/fastfetch/Portfile
@@ -46,16 +46,25 @@ configure.args-append \
 compiler.c_standard     2011
 compiler.cxx_standard   2017
 
+patch.pre_args-replace  -p0 -p1
+
+# https://trac.macports.org/ticket/70616
+if {${os.platform} eq "darwin" \
+    && (${os.major} > 10 && ${os.major} < 15)} {
+    patchfiles-append \
+                    1001-CMakeLists-disable-bluetooth-modules.patch
+}
+
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # As of now, it is intended to get updated,
     # but since rebasing may be non-trivial,
     # we keep a dedicated case for older OS
     # to avoid potential breakages on every update.
-    github.setup    fastfetch-cli fastfetch 2.21.3
+    github.setup    fastfetch-cli fastfetch 2.22.0
     revision        0
-    checksums       rmd160  db69b939835aeb5a2ff0caf1548495f903a1d16d \
-                    sha256  cec1f126ade7a5ef971901b1cdbe79f5864523d7a0a92732991619485d13e2e7 \
-                    size    1093534
+    checksums       rmd160  d1638ac541828b1c626778978c7037ff4d42d2c9 \
+                    sha256  ada2d56e14ce2eadaa88573dada5881684ceeaaa11df23017631b91dfa745d00 \
+                    size    1099230
 
     maintainers-append \
                     {@barracuda156 gmail.com:vital.had}
@@ -66,7 +75,6 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # https://github.com/fastfetch-cli/fastfetch/issues/943
     # https://github.com/fastfetch-cli/fastfetch/issues/944
     # https://github.com/fastfetch-cli/fastfetch/issues/1148
-    patch.pre_args-replace -p0 -p1
     patchfiles-append \
                     0001-Support-hostinfo-for-PowerPC-Macs.patch \
                     0002-version.c-add-a-missing-macro-for-powerpc.patch \
@@ -84,9 +92,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
                     0014-yyjson-PowerPC-macros.patch \
                     0015-monitor_apple.m-no-HDR-before-10.11.patch \
                     0016-Fix-autorelease-pools.patch \
-                    0017-CMakeLists-adjust-for-legacy-macOS.patch \
-                    0018-Fix-compatibility-with-10.4.patch \
-                    0019-Revert-some-breakages.patch
+                    0017-Fix-compatibility-with-10.4.patch \
+                    0018-Revert-some-breakages.patch \
+                    0019-CMakeLists-adjust-for-legacy-macOS.patch \
+                    0020-swap_fat_arch_64-does-not-exist-in-10.6.patch
 
     # Leopard needs this at least due to physicaldisk_apple module,
     # which uses definitions from storage/IOStorageDeviceCharacteristics.h (IOKit framework);
@@ -94,7 +103,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # that SDK version, or otherwise disable physicaldisk_apple (see the patch).
     if {${os.major} < 10} {
         patchfiles-append \
-                    0020-Tiger-specific-adjustments-to-CMakeLists.patch
+                    0021-Tiger-specific-adjustments-to-CMakeLists.patch
     }
 
     # To make sure OpenCL is not accidentally enabled.

--- a/sysutils/fastfetch/files/0001-Support-hostinfo-for-PowerPC-Macs.patch
+++ b/sysutils/fastfetch/files/0001-Support-hostinfo-for-PowerPC-Macs.patch
@@ -1,4 +1,4 @@
-From b861e7a46b54fda9af20f7d9661cda551c50824b Mon Sep 17 00:00:00 2001
+From c8d52df37ba41829f3040c03f14cd1a75fec2b4a Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <vital.had@gmail.com>
 Date: Tue, 6 Aug 2024 01:28:18 +0800
 Subject: [PATCH 01/19] Support hostinfo for PowerPC Macs

--- a/sysutils/fastfetch/files/0002-version.c-add-a-missing-macro-for-powerpc.patch
+++ b/sysutils/fastfetch/files/0002-version.c-add-a-missing-macro-for-powerpc.patch
@@ -1,4 +1,4 @@
-From 9a5cf92cda83165b69493290b941e829ace74cb6 Mon Sep 17 00:00:00 2001
+From 7a24689e4e6283f564fc0f726b645d9e13d3bad3 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Tue, 6 Aug 2024 09:31:41 +0800
 Subject: [PATCH 02/19] version.c: add a missing macro for powerpc
@@ -8,7 +8,7 @@ Subject: [PATCH 02/19] version.c: add a missing macro for powerpc
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/detection/version/version.c b/src/detection/version/version.c
-index 5c1fb0ae..b745b45d 100644
+index fe87e2e7..9f4b238c 100644
 --- a/src/detection/version/version.c
 +++ b/src/detection/version/version.c
 @@ -10,7 +10,7 @@

--- a/sysutils/fastfetch/files/0003-Support-PowerPC-CPU-detection.patch
+++ b/sysutils/fastfetch/files/0003-Support-PowerPC-CPU-detection.patch
@@ -1,19 +1,19 @@
-From b50bb19f3ad6bc9b315b0229404b21d959b7e6f4 Mon Sep 17 00:00:00 2001
+From 0e5b27becf205847a52d27548ddc88e72a7e9833 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
-Date: Sun, 4 Aug 2024 21:05:10 +0800
+Date: Tue, 27 Aug 2024 15:01:43 +0800
 Subject: [PATCH 03/19] Support PowerPC CPU detection
 
 ---
  src/detection/cpu/cpu.c       | 11 +++++++++++
- src/detection/cpu/cpu.h       |  1 +
- src/detection/cpu/cpu_apple.c | 11 +++++++++++
- 3 files changed, 23 insertions(+)
+ src/detection/cpu/cpu.h       |  2 +-
+ src/detection/cpu/cpu_apple.c | 12 +++++++++++-
+ 3 files changed, 23 insertions(+), 2 deletions(-)
 
 diff --git a/src/detection/cpu/cpu.c b/src/detection/cpu/cpu.c
-index 68d23ac8..e9590344 100644
+index dc27da24..13e97f5b 100644
 --- a/src/detection/cpu/cpu.c
 +++ b/src/detection/cpu/cpu.c
-@@ -39,3 +39,14 @@ const char* ffCPUAppleCodeToName(uint32_t code)
+@@ -40,3 +40,14 @@ const char* ffCPUAppleCodeToName(uint32_t code)
          default: return "Apple Silicon";
      }
  }
@@ -29,19 +29,23 @@ index 68d23ac8..e9590344 100644
 +    }
 +}
 diff --git a/src/detection/cpu/cpu.h b/src/detection/cpu/cpu.h
-index e27a437a..753d5294 100644
+index dd2d178e..bb99c424 100644
 --- a/src/detection/cpu/cpu.h
 +++ b/src/detection/cpu/cpu.h
-@@ -30,3 +30,4 @@ typedef struct FFCPUResult
+@@ -30,7 +30,7 @@ typedef struct FFCPUResult
  
  const char* ffDetectCPU(const FFCPUOptions* options, FFCPUResult* cpu);
  const char* ffCPUAppleCodeToName(uint32_t code);
+-
 +const char* ffCPUApplePPCCodeToName(int cpuSubType);
+ 
+ #if defined(__x86_64__) || defined(__i386__)
+ 
 diff --git a/src/detection/cpu/cpu_apple.c b/src/detection/cpu/cpu_apple.c
-index efdad950..6608c11b 100644
+index efdad950..cd2cf8ce 100644
 --- a/src/detection/cpu/cpu_apple.c
 +++ b/src/detection/cpu/cpu_apple.c
-@@ -100,12 +100,23 @@ static const char* detectCoreCount(FFCPUResult* cpu)
+@@ -100,13 +100,23 @@ static const char* detectCoreCount(FFCPUResult* cpu)
  
  const char* ffDetectCPUImpl(const FFCPUOptions* options, FFCPUResult* cpu)
  {
@@ -61,10 +65,11 @@ index efdad950..6608c11b 100644
      ffSysctlGetString("machdep.cpu.vendor", &cpu->vendor);
      if (cpu->vendor.length == 0 && ffStrbufStartsWithS(&cpu->name, "Apple "))
          ffStrbufAppendS(&cpu->vendor, "Apple");
+-
 +#endif
- 
      cpu->coresPhysical = (uint16_t) ffSysctlGetInt("hw.physicalcpu_max", 1);
      if(cpu->coresPhysical == 1)
+         cpu->coresPhysical = (uint16_t) ffSysctlGetInt("hw.physicalcpu", 1);
 -- 
 2.46.0
 

--- a/sysutils/fastfetch/files/0004-gpu_apple.m-unbreak-for-10.11.patch
+++ b/sysutils/fastfetch/files/0004-gpu_apple.m-unbreak-for-10.11.patch
@@ -1,4 +1,4 @@
-From b193ad96b5bfd18c8207c2f120a9b185a50bcd64 Mon Sep 17 00:00:00 2001
+From fd0c0ffe50dbfa34e36ca4be64e6ebfb42788d47 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 00:54:02 +0800
 Subject: [PATCH 04/19] gpu_apple.m: unbreak for < 10.11

--- a/sysutils/fastfetch/files/0005-memory_apple-fix-for-32-bit.patch
+++ b/sysutils/fastfetch/files/0005-memory_apple-fix-for-32-bit.patch
@@ -1,4 +1,4 @@
-From c6d2b4351450a5deabe86716fcf2fb62fd9bd628 Mon Sep 17 00:00:00 2001
+From 7114ef3b2fbe18049c28af92a00d666f67aef3c5 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 00:58:05 +0800
 Subject: [PATCH 05/19] memory_apple: fix for 32-bit

--- a/sysutils/fastfetch/files/0006-opengl_apple.c-fix-for-10.7.patch
+++ b/sysutils/fastfetch/files/0006-opengl_apple.c-fix-for-10.7.patch
@@ -1,4 +1,4 @@
-From 4847acc6347c77802a8a6728557f2746b450d307 Mon Sep 17 00:00:00 2001
+From ccdf551ebfe9733f3e6c675c029aa3d1594687bf Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 01:01:30 +0800
 Subject: [PATCH 06/19] opengl_apple.c: fix for < 10.7

--- a/sysutils/fastfetch/files/0007-sound_apple.c-fix-for-10.8.patch
+++ b/sysutils/fastfetch/files/0007-sound_apple.c-fix-for-10.8.patch
@@ -1,4 +1,4 @@
-From b346305ac72841c4c71dc5ba574e981538e4576b Mon Sep 17 00:00:00 2001
+From 28e7f3e61629f6242b96afe89c0f0987d8ffbcce Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 01:03:05 +0800
 Subject: [PATCH 07/19] sound_apple.c: fix for < 10.8

--- a/sysutils/fastfetch/files/0008-gpu_apple.c-fix-for-old-systems.patch
+++ b/sysutils/fastfetch/files/0008-gpu_apple.c-fix-for-old-systems.patch
@@ -1,4 +1,4 @@
-From 7588bdb60d3e014bd2d591cf93f46c43fabf72b2 Mon Sep 17 00:00:00 2001
+From ef56f002f6ea96f5b942912b285c11ad63c26f6c Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 01:09:46 +0800
 Subject: [PATCH 08/19] gpu_apple.c: fix for old systems

--- a/sysutils/fastfetch/files/0009-camera_apple.m-unbreak-for-10.7.patch
+++ b/sysutils/fastfetch/files/0009-camera_apple.m-unbreak-for-10.7.patch
@@ -1,4 +1,4 @@
-From e1fc41a094b5755b457e54494a8616c070ce5b8b Mon Sep 17 00:00:00 2001
+From 1bc11125ef4fddd4a7c0a87a8666755cf8877b0c Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 01:11:58 +0800
 Subject: [PATCH 09/19] camera_apple.m: unbreak for < 10.7

--- a/sysutils/fastfetch/files/0010-brightness_apple.c-add-a-missing-include.patch
+++ b/sysutils/fastfetch/files/0010-brightness_apple.c-add-a-missing-include.patch
@@ -1,4 +1,4 @@
-From c0c5bec2ff12cee50d24757503240e41be45ddb7 Mon Sep 17 00:00:00 2001
+From 9d47faf725df10720b0174f3870565952752ecb1 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 01:24:23 +0800
 Subject: [PATCH 10/19] brightness_apple.c: add a missing include

--- a/sysutils/fastfetch/files/0011-os_apple.m-etc.-fix-syntax-for-plists.patch
+++ b/sysutils/fastfetch/files/0011-os_apple.m-etc.-fix-syntax-for-plists.patch
@@ -1,4 +1,4 @@
-From 93eda631525d26392d6e86a19886724c45d935e7 Mon Sep 17 00:00:00 2001
+From 1fb64e94a8220bd3f2813557a3c15f49ce2833a8 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 01:39:51 +0800
 Subject: [PATCH 11/19] os_apple.m etc.: fix syntax for plists
@@ -12,10 +12,10 @@ Subject: [PATCH 11/19] os_apple.m etc.: fix syntax for plists
  5 files changed, 18 insertions(+), 54 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e403b237..38cbb216 100644
+index 1abe943d..37013992 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -641,7 +641,7 @@ elseif(APPLE)
+@@ -643,7 +643,7 @@ elseif(APPLE)
          src/detection/cpu/cpu_apple.c
          src/detection/cpucache/cpucache_apple.c
          src/detection/cpuusage/cpuusage_apple.c

--- a/sysutils/fastfetch/files/0012-osascript.m-fix-syntax.patch
+++ b/sysutils/fastfetch/files/0012-osascript.m-fix-syntax.patch
@@ -1,4 +1,4 @@
-From 7f04a76faf643a7ffd06325c6b9f21718113db31 Mon Sep 17 00:00:00 2001
+From e42506ec282f89d10b15d5f4430c2001f0e1dfc5 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 01:38:18 +0800
 Subject: [PATCH 12/19] osascript.m: fix syntax

--- a/sysutils/fastfetch/files/0013-disk_bsd-no-support-for-creation-time.patch
+++ b/sysutils/fastfetch/files/0013-disk_bsd-no-support-for-creation-time.patch
@@ -1,4 +1,4 @@
-From ac9f83ff7700436f1f7e30511da0584199fa2063 Mon Sep 17 00:00:00 2001
+From ba6071276ef71b1d4f02c68c89813183523aac20 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Sun, 4 Aug 2024 19:58:34 +0800
 Subject: [PATCH 13/19] disk_bsd: no support for creation time

--- a/sysutils/fastfetch/files/0014-yyjson-PowerPC-macros.patch
+++ b/sysutils/fastfetch/files/0014-yyjson-PowerPC-macros.patch
@@ -1,4 +1,4 @@
-From 222160322993ce0ee4498e3692531027a90571c5 Mon Sep 17 00:00:00 2001
+From 7bb957418770816db84fa0ebe5263d7e9e9b40b6 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Thu, 15 Aug 2024 22:15:15 +0800
 Subject: [PATCH 14/19] yyjson: PowerPC macros

--- a/sysutils/fastfetch/files/0015-monitor_apple.m-no-HDR-before-10.11.patch
+++ b/sysutils/fastfetch/files/0015-monitor_apple.m-no-HDR-before-10.11.patch
@@ -1,4 +1,4 @@
-From ba129af0b281149f5a211e46ca0a294aaa1c7229 Mon Sep 17 00:00:00 2001
+From 41ca98e98e8a099c6144f48f87f374f4f259723a Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Thu, 15 Aug 2024 22:19:23 +0800
 Subject: [PATCH 15/19] monitor_apple.m: no HDR before 10.11

--- a/sysutils/fastfetch/files/0016-Fix-autorelease-pools.patch
+++ b/sysutils/fastfetch/files/0016-Fix-autorelease-pools.patch
@@ -1,4 +1,4 @@
-From 0f8dce5a9b69a92148404d8619ccfc0cd0ea93f2 Mon Sep 17 00:00:00 2001
+From 46cdebf1d95b992c677b234e1b63cd1ac703d1ca Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Thu, 15 Aug 2024 22:41:23 +0800
 Subject: [PATCH 16/19] Fix autorelease pools

--- a/sysutils/fastfetch/files/0017-Fix-compatibility-with-10.4.patch
+++ b/sysutils/fastfetch/files/0017-Fix-compatibility-with-10.4.patch
@@ -1,7 +1,7 @@
-From 8a48b63538dc759ca2cf06f295e3733599d484d2 Mon Sep 17 00:00:00 2001
+From fad2a4dba82d239f2c060b2b3cddb89ccf04ed0b Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
 Date: Tue, 6 Aug 2024 03:52:56 +0800
-Subject: [PATCH 18/19] Fix compatibility with 10.4
+Subject: [PATCH 17/19] Fix compatibility with 10.4
 
 ---
  src/common/processing_linux.c                   | 8 ++++++--

--- a/sysutils/fastfetch/files/0018-Revert-some-breakages.patch
+++ b/sysutils/fastfetch/files/0018-Revert-some-breakages.patch
@@ -1,18 +1,18 @@
-From 9da42dd266dbdcc32c92c59354455521935a9513 Mon Sep 17 00:00:00 2001
+From 33e8c1d7a6574c8e2a0e892f659e84647c2f0b80 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
-Date: Thu, 15 Aug 2024 23:00:10 +0800
-Subject: [PATCH 19/19] Revert some breakages
+Date: Tue, 27 Aug 2024 16:03:55 +0800
+Subject: [PATCH 18/19] Revert some breakages
 
 ---
  src/detection/displayserver/displayserver.c   |  35 +++--
  src/detection/displayserver/displayserver.h   |  14 +-
- .../displayserver/displayserver_apple.c       | 136 +++++++-----------
+ .../displayserver/displayserver_apple.c       | 138 +++++++-----------
  src/detection/font/font_apple.m               |   3 +-
  src/detection/monitor/monitor.h               |   1 -
  src/detection/monitor/monitor_apple.m         |  19 +--
  src/modules/display/display.c                 |  60 ++------
  src/modules/monitor/monitor.c                 |   8 +-
- 8 files changed, 98 insertions(+), 178 deletions(-)
+ 8 files changed, 98 insertions(+), 180 deletions(-)
 
 diff --git a/src/detection/displayserver/displayserver.c b/src/detection/displayserver/displayserver.c
 index ddc97396..20a36623 100644
@@ -115,10 +115,10 @@ index 127dbc5f..ffe46466 100644
 -    uint32_t physicalHeight);
 +    uint64_t id);
 diff --git a/src/detection/displayserver/displayserver_apple.c b/src/detection/displayserver/displayserver_apple.c
-index d05eb8b1..4b6b6fe4 100644
+index ab2abe5e..4b6b6fe4 100644
 --- a/src/detection/displayserver/displayserver_apple.c
 +++ b/src/detection/displayserver/displayserver_apple.c
-@@ -1,109 +1,77 @@
+@@ -1,111 +1,77 @@
  #include "displayserver.h"
  #include "util/apple/cf_helpers.h"
 -#include "util/stringUtils.h"
@@ -244,10 +244,12 @@ index d05eb8b1..4b6b6fe4 100644
 -                    display->bitDepth = (uint8_t) bitDepth;
 -                }
 -
+-                #ifdef MAC_OS_X_VERSION_10_15
 -                if (CoreDisplay_Display_IsHDRModeEnabled)
 -                {
 -                    display->hdrEnabled = CoreDisplay_Display_IsHDRModeEnabled(screen);
 -                }
+-                #endif
 -            }
 -            CGDisplayModeRelease(mode);
 -        }
@@ -337,7 +339,7 @@ index c72c7f55..5c6cdb0d 100644
              monitor->manufactureYear = (uint16_t) year;
          if (ffCfDictGetInt64(displayInfo, CFSTR("DisplayWeekManufacture"), &week) == NULL)
 diff --git a/src/modules/display/display.c b/src/modules/display/display.c
-index 8d73a67c..b2f25897 100644
+index c180d338..55c0c8bb 100644
 --- a/src/modules/display/display.c
 +++ b/src/modules/display/display.c
 @@ -4,9 +4,7 @@
@@ -403,10 +405,10 @@ index 8d73a67c..b2f25897 100644
          {
 -            double ppi = sqrt(result->width * result->width + result->height * result->height) / inch;
 -
-             FF_PRINT_FORMAT_CHECKED(key.chars, 0, &options->moduleArgs, FF_PRINT_TYPE_NO_CUSTOM_KEY, FF_DISPLAY_NUM_FORMAT_ARGS, ((FFformatarg[]) {
-                 {FF_FORMAT_ARG_TYPE_UINT, &result->width, "width"},
-                 {FF_FORMAT_ARG_TYPE_UINT, &result->height, "height"},
-@@ -150,12 +136,6 @@ void ffPrintDisplay(FFDisplayOptions* options)
+             char refreshRate[16];
+             if(result->refreshRate > 0)
+             {
+@@ -161,12 +147,6 @@ void ffPrintDisplay(FFDisplayOptions* options)
                  {FF_FORMAT_ARG_TYPE_STRING, displayType, "type"},
                  {FF_FORMAT_ARG_TYPE_UINT, &result->rotation, "rotation"},
                  {FF_FORMAT_ARG_TYPE_BOOL, &result->primary, "is-primary"},
@@ -419,7 +421,7 @@ index 8d73a67c..b2f25897 100644
              }));
          }
      }
-@@ -305,26 +285,16 @@ void ffGenerateDisplayJsonResult(FF_MAYBE_UNUSED FFDisplayOptions* options, yyjs
+@@ -316,26 +296,16 @@ void ffGenerateDisplayJsonResult(FF_MAYBE_UNUSED FFDisplayOptions* options, yyjs
      FF_LIST_FOR_EACH(FFDisplayResult, item, dsResult->displays)
      {
          yyjson_mut_val* obj = yyjson_mut_arr_add_obj(doc, arr);
@@ -450,7 +452,7 @@ index 8d73a67c..b2f25897 100644
  
          switch (item->type)
          {
-@@ -353,12 +323,6 @@ void ffPrintDisplayHelpFormat(void)
+@@ -364,12 +334,6 @@ void ffPrintDisplayHelpFormat(void)
          "Screen type (builtin, external or unknown) - type",
          "Screen rotation (in degrees) - rotation",
          "True if being the primary screen - is-primary",

--- a/sysutils/fastfetch/files/0019-CMakeLists-adjust-for-legacy-macOS.patch
+++ b/sysutils/fastfetch/files/0019-CMakeLists-adjust-for-legacy-macOS.patch
@@ -1,14 +1,14 @@
-From dd64fcef9a97059c5655f8bf8e4fcf6eaaedde8c Mon Sep 17 00:00:00 2001
+From dd45b3a06ff1f8dd19a47bac7e2bb21140064e05 Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
-Date: Sun, 4 Aug 2024 01:36:58 +0800
-Subject: [PATCH 17/19] CMakeLists: adjust for legacy macOS
+Date: Tue, 27 Aug 2024 16:06:55 +0800
+Subject: [PATCH 19/19] CMakeLists: adjust for legacy macOS
 
 ---
  CMakeLists.txt | 36 ++++++++++++++----------------------
  1 file changed, 14 insertions(+), 22 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 38cbb216..43e2a6e3 100644
+index 37013992..6b2a2bcf 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -112,10 +112,10 @@ else()
@@ -24,7 +24,7 @@ index 38cbb216..43e2a6e3 100644
  
  if(WIN32 OR ENABLE_DIRECTX_HEADERS)
      enable_language(CXX)
-@@ -632,11 +632,11 @@ elseif(APPLE)
+@@ -634,11 +634,11 @@ elseif(APPLE)
          src/common/sysctl.c
          src/detection/battery/battery_apple.c
          src/detection/bios/bios_apple.c
@@ -39,7 +39,7 @@ index 38cbb216..43e2a6e3 100644
          src/detection/chassis/chassis_nosupport.c
          src/detection/cpu/cpu_apple.c
          src/detection/cpucache/cpucache_apple.c
-@@ -645,7 +645,7 @@ elseif(APPLE)
+@@ -647,7 +647,7 @@ elseif(APPLE)
          src/detection/disk/disk_bsd.c
          src/detection/dns/dns_linux.c
          src/detection/physicaldisk/physicaldisk_apple.c
@@ -48,7 +48,7 @@ index 38cbb216..43e2a6e3 100644
          src/detection/diskio/diskio_apple.c
          src/detection/displayserver/displayserver_apple.c
          src/detection/font/font_apple.m
-@@ -659,15 +659,15 @@ elseif(APPLE)
+@@ -661,15 +661,15 @@ elseif(APPLE)
          src/detection/libc/libc_apple.c
          src/detection/locale/locale_linux.c
          src/detection/localip/localip_linux.c
@@ -67,7 +67,7 @@ index 38cbb216..43e2a6e3 100644
          src/detection/processes/processes_bsd.c
          src/detection/sound/sound_apple.c
          src/detection/swap/swap_apple.c
-@@ -678,8 +678,8 @@ elseif(APPLE)
+@@ -680,8 +680,8 @@ elseif(APPLE)
          src/detection/theme/theme_nosupport.c
          src/detection/uptime/uptime_bsd.c
          src/detection/users/users_linux.c
@@ -78,7 +78,7 @@ index 38cbb216..43e2a6e3 100644
          src/detection/wm/wm_apple.c
          src/detection/de/de_nosupport.c
          src/detection/wmtheme/wmtheme_apple.m
-@@ -881,7 +881,7 @@ else()
+@@ -885,7 +885,7 @@ else()
      # Used for dlopen finding dylibs installed by homebrew
      # `/opt/homebrew/lib` is not on in dlopen search path by default
      if(APPLE)
@@ -87,7 +87,7 @@ index 38cbb216..43e2a6e3 100644
      endif()
  endif()
  
-@@ -1101,25 +1101,17 @@ if(LINUX)
+@@ -1105,25 +1105,17 @@ if(LINUX)
      )
  elseif(APPLE)
      target_link_libraries(libfastfetch

--- a/sysutils/fastfetch/files/0020-swap_fat_arch_64-does-not-exist-in-10.6.patch
+++ b/sysutils/fastfetch/files/0020-swap_fat_arch_64-does-not-exist-in-10.6.patch
@@ -1,0 +1,32 @@
+From 2839bddf52dad7555e1728818de4b0d5b95dfa1a Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Tue, 27 Aug 2024 16:40:51 +0800
+Subject: [PATCH 20/20] swap_fat_arch_64 does not exist in 10.6
+
+---
+ src/util/binary_apple.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/util/binary_apple.c b/src/util/binary_apple.c
+index 940228af..7aad3f6c 100644
+--- a/src/util/binary_apple.c
++++ b/src/util/binary_apple.c
+@@ -141,13 +141,12 @@ static const char* dumpFatHeader(FILE *objFile, bool (*cb)(const char *str, uint
+         }
+         else
+         {
+-            struct fat_arch_64 arch;
++            struct fat_arch arch;
+             if (!readData(objFile, &arch, sizeof(arch), (off_t) (sizeof(header) + i * sizeof(arch))))
+                 continue;
+ 
+             if (needSwap)
+-                swap_fat_arch_64(&arch, 1, NX_UnknownByteOrder);
+-
++                swap_fat_arch(&arch, 1, NX_UnknownByteOrder);
+             machHeaderOffset = (off_t)arch.offset;
+         }
+ 
+-- 
+2.46.0
+

--- a/sysutils/fastfetch/files/0021-Tiger-specific-adjustments-to-CMakeLists.patch
+++ b/sysutils/fastfetch/files/0021-Tiger-specific-adjustments-to-CMakeLists.patch
@@ -1,17 +1,17 @@
-From fbd8a8e7a561b541c645402a8bc438e0d1b7fecb Mon Sep 17 00:00:00 2001
+From 58366c1126c0f3d4178e5d3a03edc1aa2d36eb6f Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <barracuda@macos-powerpc.org>
-Date: Tue, 6 Aug 2024 05:54:30 +0800
+Date: Tue, 27 Aug 2024 16:08:42 +0800
 Subject: [PATCH] Tiger-specific adjustments to CMakeLists
 
 ---
  CMakeLists.txt | 5 ++---
  1 file changed, 2 insertions(+), 3 deletions(-)
 
-diff --git CMakeLists.txt CMakeLists.txt
-index 9789682b..7ec8ff75 100644
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6b2a2bcf..ff70a643 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -627,7 +627,7 @@ elseif(APPLE)
+@@ -632,7 +632,7 @@ elseif(APPLE)
          src/common/networking_linux.c
          src/common/processing_linux.c
          src/common/sysctl.c
@@ -20,7 +20,7 @@ index 9789682b..7ec8ff75 100644
          src/detection/bios/bios_apple.c
          src/detection/bluetooth/bluetooth_nosupport.c
          src/detection/bluetoothradio/bluetoothradio_nosupport.c
-@@ -641,7 +641,7 @@ elseif(APPLE)
+@@ -646,7 +646,7 @@ elseif(APPLE)
          src/detection/cursor/cursor_nosupport.c
          src/detection/disk/disk_bsd.c
          src/detection/dns/dns_linux.c
@@ -29,7 +29,7 @@ index 9789682b..7ec8ff75 100644
          src/detection/physicalmemory/physicalmemory_nosupport.c
          src/detection/diskio/diskio_apple.c
          src/detection/displayserver/displayserver_apple.c
-@@ -1096,7 +1096,6 @@ elseif(APPLE)
+@@ -1108,7 +1108,6 @@ elseif(APPLE)
          PRIVATE "-framework Cocoa"
          PRIVATE "-framework CoreFoundation"
          PRIVATE "-framework CoreAudio"

--- a/sysutils/fastfetch/files/1001-CMakeLists-disable-bluetooth-modules.patch
+++ b/sysutils/fastfetch/files/1001-CMakeLists-disable-bluetooth-modules.patch
@@ -1,0 +1,24 @@
+From 48e84bb0963ab8e67148902a28d0c102699145c9 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Tue, 27 Aug 2024 16:07:50 +0800
+Subject: [PATCH] CMakeLists: disable bluetooth modules
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 35469bfd..6b2a2bcf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -634,8 +634,8 @@ elseif(APPLE)
+         src/common/sysctl.c
+         src/detection/battery/battery_apple.c
+         src/detection/bios/bios_apple.c
+-        src/detection/bluetooth/bluetooth_apple.m
+-        src/detection/bluetoothradio/bluetoothradio_apple.m
++        src/detection/bluetooth/bluetooth_nosupport.c
++        src/detection/bluetoothradio/bluetoothradio_nosupport.c
+         src/detection/board/board_apple.c
+         src/detection/bootmgr/bootmgr_apple.c
+         src/detection/brightness/brightness_nosupport.c


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/70616

#### Description

@herbygillot Bluetooth patch added. I am not sure if that will be sufficient, but let’s see.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
