### PR TITLE
libgit2-glib: enable vala on powerpc

### DIFF
--- a/gnome/libgit2-glib/Portfile
+++ b/gnome/libgit2-glib/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson  1.0
 
 gitlab.instance     https://gitlab.gnome.org
 gitlab.setup        GNOME libgit2-glib 1.2.0 v
-revision            1
+revision            2
 
 categories          gnome devel
 license             LGPL-2+
@@ -34,7 +34,7 @@ post-patch {
 }
 
 depends_build-append \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
@@ -49,12 +49,6 @@ configure.args-append \
                     -Dgtk_doc=false \
                     -Dpython=false \
                     -Dtranslate_windows_paths=false
-
-platform darwin powerpc {
-    # vapigen is broken on PPC at the moment.
-    configure.args-append \
-                    -Dvapi=false
-}
 
 # Work around lack of @rpath on Tiger, i.e. this error:
 # dyld: Library not loaded: @loader_path/libgit2-glib-1.0.0.dylib


### PR DESCRIPTION
#### Description

Vala works now, no reason to disable it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
