### PR TITLE
abseil: update to 20240722.0, fixing MacOS 10.14 build

### DIFF
--- a/devel/Bear/Portfile
+++ b/devel/Bear/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 19
 legacysupport.use_mp_libcxx                 yes
 
 github.setup        rizsotto Bear 3.1.3
-revision            4
+revision            5
 
 checksums           rmd160  909b90269b3528c4960a634c47b76a534e389a87 \
                     sha256  389a5251a835cd156fad4f4e598d0bf8c66783a0d5835eba7f113ab5f26637f5 \

--- a/devel/abseil/Portfile
+++ b/devel/abseil/Portfile
@@ -10,9 +10,9 @@ PortGroup           compiler_blacklist_versions 1.0
 legacysupport.newest_darwin_requires_legacy 15
 
 # Ports that depend on this port must be revbump after update.
-github.setup        abseil abseil-cpp 20240116.2
+github.setup        abseil abseil-cpp 20240722.0
 name                abseil
-revision            1
+revision            0
 categories          devel
 maintainers         {judaew @judaew} openmaintainer
 license             Apache-2
@@ -24,9 +24,9 @@ long_description    Abseil is an open-source collection of C++ library \
                     Google's own C++ code base, has been extensively \
                     tested and used in production.
 
-checksums           rmd160  201d3e068662fd8305cd65a5391c712ecdcc8d8e \
-                    sha256  e2ceb7f9c6a7f5768f93b64655f8b228a03788cce43a367b38b5affc4d776d8c \
-                    size    2151740
+checksums           rmd160  d97a59b6b28276e5ed4718b5665f2f7596d683c8 \
+                    sha256  59b04c117c74fd3e088c803e13c5b93f9adbb5fd639570a55da861bffedf0daa \
+                    size    2242795
 
 patchfiles          patch-remove-Xarch-from-pkg-config.diff
 

--- a/devel/abseil/files/patch-remove-Xarch-from-pkg-config.diff
+++ b/devel/abseil/files/patch-remove-Xarch-from-pkg-config.diff
@@ -5,10 +5,10 @@
      string(TOUPPER "${_arch}" _arch_uppercase)
      string(REPLACE "X86_64" "X64" _arch_uppercase ${_arch_uppercase})
 -    foreach(_flag IN LISTS ABSL_RANDOM_HWAES_${_arch_uppercase}_FLAGS)
--      list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch}" "${_flag}")
+-      list(APPEND ABSL_RANDOM_RANDEN_COPTS "SHELL:-Xarch_${_arch} ${_flag}")
 -    endforeach()
 +    # foreach(_flag IN LISTS ABSL_RANDOM_HWAES_${_arch_uppercase}_FLAGS)
-+    #   list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch}" "${_flag}")
++    #   list(APPEND ABSL_RANDOM_RANDEN_COPTS "SHELL:-Xarch_${_arch} ${_flag}")
 +    # endforeach()
    endforeach()
    # If a compiler happens to deal with an argument for a currently unused

--- a/devel/apache-arrow/Portfile
+++ b/devel/apache-arrow/Portfile
@@ -15,7 +15,7 @@ legacysupport.newest_darwin_requires_legacy 15
 boost.version       1.81
 
 github.setup        apache arrow 17.0.0 apache-arrow-
-revision            0
+revision            1
 name                ${github.author}-${github.project}
 
 categories          devel

--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 # NOTE: Also rev-bump 'apache-arrow' when updating this port
 github.setup        grpc grpc 1.48.4 v
-revision            9
+revision            10
 categories          devel
 maintainers         nomaintainer
 license             Apache-2

--- a/devel/protobuf3-cpp-upstream/Portfile
+++ b/devel/protobuf3-cpp-upstream/Portfile
@@ -20,7 +20,7 @@ set release_version \
 name            protobuf3-cpp-upstream
 github.setup    protocolbuffers protobuf 3.${release_version} v
 git.branch      v${release_version}
-revision        4
+revision        5
 
 categories      devel
 maintainers     {mascguy @mascguy} openmaintainer

--- a/devel/re2/Portfile
+++ b/devel/re2/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport   1.1
 github.setup        google re2 2024-04-01
 github.tarball_from archive
 epoch               1
-revision            2
+revision            3
 
 checksums           rmd160 6cff98a2c0ce263f8e76127830117994ec202e11 \
                     sha256 3f6690c3393a613c3a0b566309cf04dc381d61470079b653afc47c67fb898198 \

--- a/math/s2geometry/Portfile
+++ b/math/s2geometry/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
 github.setup        google s2geometry 0.11.1 v
-revision            2
+revision            3
 categories          math science
 license             Apache-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer

--- a/net/mtxclient/Portfile
+++ b/net/mtxclient/Portfile
@@ -8,7 +8,7 @@ PortGroup           boost 1.0
 
 github.setup        Nheko-Reborn mtxclient 0.9.2 v
 epoch               2
-revision            12
+revision            13
 
 checksums           rmd160  4584fdcd4d6632a531343f235ec2258f7ba38204 \
                     sha256  14df722738830510edf8768b24648568d46f392953c9b2f8d1bf749f0c12435d \


### PR DESCRIPTION
#### Description
 
Updated devel/abseil to 20240722.0, where MacOS 10.14 build is fixed. Revbumped abseil's dependents according to the Portfile note.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
