### PR TITLE
npm portgroup: use nodejs22

### DIFF
--- a/_resources/port1.0/group/npm-1.0.tcl
+++ b/_resources/port1.0/group/npm-1.0.tcl
@@ -13,7 +13,7 @@ default distname        {${npm.rootname}-${version}}
 extract.suffix .tgz
 
 options npm.nodejs_version npm.version npm.add_dependencies
-default npm.nodejs_version 20
+default npm.nodejs_version 22
 default npm.version 10
 default npm.add_dependencies yes
 


### PR DESCRIPTION
- The npm portgroup is using npm10, but specifies nodejs20 as the nodejs version. This causes conflict with npm10, which requires nodejs22.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
