### PR TITLE
gdb: Update to 15.1

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 name            gdb
-version         13.2
+version         15.1
 revision        0
 categories      devel
 license         GPL-3+
@@ -32,13 +32,9 @@ supported_archs x86_64 i386
 
 master_sites    gnu
 
-checksums       rmd160  ef57e9d16e34b6820791edaf3b4ec9c992cfaa3a \
-                sha256  7ead13d9e19fa0c57bb19104e1a5f67eefa9fc79f2e6360de491e8fddeda1e30 \
-                size    40251050
-
-
-# fix test for makeinfo version in libctf
-patchfiles      patch-gdb-libctf-makeinfo-test.diff
+checksums       rmd160  8aa43c69e2d24fa49ac566d3eaf1e2312eea3e8b \
+                sha256  8b61b0c2bdd9d9c83b113c9167866bdb474651d291fedcaa5eb7cde49bd47036 \
+                size    41290077
 
 # Ventura+ do not have makeinfo in the system
 depends_build   bin:makeinfo:texinfo
@@ -53,6 +49,7 @@ depends_lib     port:boehmgc \
                 port:gmp \
                 port:gettext-runtime \
                 port:libiconv \
+                port:mpfr \
                 port:ncurses \
                 port:zlib
 
@@ -105,7 +102,7 @@ post-destroot {
     }
 }
 
-set pythons_suffixes {27 35 36 37 38 39 310 311}
+set pythons_suffixes {27 35 36 37 38 39 310 311 312}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {


### PR DESCRIPTION
#### Description

* Update gdb 13.2 --> 15.1.
* Add new dependency mpfr.
* Add python 3.12.
* Remove broken makeinfo patch.

* Tried enabling ARM builds, did not work.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 12, 13 only.  X86 only.
Tried OS 14/ARM build on CI, did not work.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
