### PR TITLE
resticprofile: update to 0.28.0

### DIFF
--- a/sysutils/resticprofile/Portfile
+++ b/sysutils/resticprofile/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/creativeprojects/resticprofile 0.27.1 v
+go.setup            github.com/creativeprojects/resticprofile 0.28.0 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
@@ -25,9 +25,9 @@ license             GPL-3
 maintainers         {fsoj.de:lheise @lucaheise} \
                     openmaintainer
 
-checksums           rmd160  b4a704c4d88e6f3f795d62768a16ea325eebf726 \
-                    sha256  9c9b5b5e56c633ab4969355fff139b3c36979f88b815bdd02ff8d1dd14e69765 \
-                    size    3195445
+checksums           rmd160  baf94249b9e831e598b4a265547b82634dc068c2 \
+                    sha256  ff04de5b6e664f58519e9a9d42cb21615e3177b06f20b4729bd110d11dc670a2 \
+                    size    3201557
 
 depends_run         port:restic
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
update resticprofile to 0.28.0 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
