### PR TITLE
google-cloud-sdk: update to 490.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             489.0.0
+version             490.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  d0ba7a06f38f3f20c8848940e229d3e26a1720b3 \
-                    sha256  bb1634998f332176283a7f2824697f6b04dbe986f204937d16e6035586eba6bb \
-                    size    51518986
+    checksums       rmd160  519059bf32a28bb68cf2a386885a9c8b4572a4c8 \
+                    sha256  86c1dc5dd4cff6b2b411b4bbff53040bb76644b68b9e9d919c2413950985172a \
+                    size    51651256
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3ed9f274afd0622fcb0505c2d5c90554905296db \
-                    sha256  39968a0ca540ee26ed07b0e998d9dbdda19f98ce71a6690f7025aed1e03c9628 \
-                    size    52869501
+    checksums       rmd160  ea2744b56cf92e82de9ea4bc50d41a7d16b9f7a6 \
+                    sha256  fa396909acc763cf831dd5d89e778999debf37ceadccb3c1bdec606e59ba2694 \
+                    size    53000340
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  28ab7167d259b3c6873ef4c05192124e90961596 \
-                    sha256  5266fd5830eb72e1e3b41ce2fc184456dd7a64ed4331d622644c58a362fc79a0 \
-                    size    52817636
+    checksums       rmd160  3f8727122ed350934dd4d15f7a004488bdfcd16a \
+                    sha256  a3a098a5f067b561e003c37284a9b164f28f37fd0d6371bb55e326679f48641c \
+                    size    52948531
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 490.0.0.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?