### PR TITLE
eza: update to 0.19.1

### DIFF
--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        eza-community eza 0.19.0 v
+github.setup        eza-community eza 0.19.1 v
 github.tarball_from archive
 revision            0
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  75ef6701f8781fd013b226e30305a20505e694e3 \
-                    sha256  440fff093c23635d7c1a9955d42489a2f5c5839a0e85a03e39daeca39e9dbf84 \
-                    size    1385560
+                    rmd160  9d1b6a4f9beae1b75ae6e46bbd390587151817ea \
+                    sha256  a256ecdb9996933300bb54e19a68df61e27385e5df20ba1f780f2e454a7f8e8a \
+                    size    1385517
 
 depends_lib-append  port:libiconv \
                     path:lib/pkgconfig/libgit2.pc:libgit2 \
@@ -246,7 +246,7 @@ cargo.crates \
     url                              2.2.1  9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     uutils_term_grid                 0.6.0  f89defb4adb4ba5703a57abc879f96ddd6263a444cacc446db90bf2617f141fb \
-    uzers                           0.12.0  7d85875e16d59b3b1549efce83ff8251a64923b03bef94add0a1862847448de4 \
+    uzers                           0.12.1  4df81ff504e7d82ad53e95ed1ad5b72103c11253f39238bcc0235b90768a97dd \
     vcpkg                           0.2.12  cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
     walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \


### PR DESCRIPTION


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
