### PR TITLE
pybind11: update to 2.13.5

### DIFF
--- a/devel/pybind11/Portfile
+++ b/devel/pybind11/Portfile
@@ -4,12 +4,12 @@ PortSystem              1.0
 PortGroup               cmake  1.1
 PortGroup               github 1.0
 
-github.setup            pybind pybind11 2.12.0 v
+github.setup            pybind pybind11 2.13.5 v
 revision                0
 
-checksums               rmd160  47106b7310b60584e0ec0f40fa418f9bd764e18d \
-                        sha256  bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7 \
-                        size    771004
+checksums               rmd160  1eab955a47d8d50bbedecab8c443ac23f89e1d2c \
+                        sha256  b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252 \
+                        size    794599
 github.tarball_from     archive
 
 categories              devel


### PR DESCRIPTION
This port must be at par with py-pybind11.
See: https://github.com/contourpy/contourpy/issues/436 Closes: https://trac.macports.org/ticket/70648

#### Description

P. S. Why do we even have two `pybind11` ports which are essentially independent?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
