### PR TITLE
clang-{17,18,19}: unbreak `@available` on MacOS 10.14

### DIFF
--- a/lang/llvm-17/Portfile
+++ b/lang/llvm-17/Portfile
@@ -29,7 +29,7 @@ version                 ${llvm_version}.0.6
 name                    llvm-${llvm_version}
 revision                1
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 clang-${llvm_version} { revision [ expr ${revision} + 2 ] }
+subport                 clang-${llvm_version} { revision [ expr ${revision} + 3 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
@@ -222,6 +222,16 @@ if {${os.platform} eq "darwin" && ${os.major} <= 16} {
 if {${os.platform} eq "darwin" && ${os.major} <= 16} {
     # https://github.com/llvm/llvm-project/issues/64226
     patchfiles-append 0042-mbstate_t-not-defined.patch
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # https://trac.macports.org/ticket/68522
+    # Undefined symbols for architecture x86_64:
+    #   "__availability_version_check", referenced from:
+    #       ___isPlatformVersionAtLeast in libclang_rt.osx.a(os_version_check.c.o)
+    #       __initializeAvailabilityCheck in libclang_rt.osx.a(os_version_check.c.o)
+    # Upstream discussion at https://reviews.llvm.org/D150397
+    patchfiles-append 0130-10.14-and-less-availability.patch
 }
 
 post-patch {

--- a/lang/llvm-17/files/0130-10.14-and-less-availability.patch
+++ b/lang/llvm-17/files/0130-10.14-and-less-availability.patch
@@ -1,0 +1,32 @@
+This is a conditional revert of https://github.com/llvm/llvm-project/commit/b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0.
+__attribute__((weak_import)) does not prevent Undefined symbol error.
+
+--- a/compiler-rt/lib/builtins/os_version_check.c.orig	2023-11-28 09:52:28.000000000 +0100
++++ b/compiler-rt/lib/builtins/os_version_check.c	2024-08-28 18:19:16.000000000 +0200
+@@ -86,9 +86,11 @@
+                                             CFStringEncoding);
+ typedef void (*CFReleaseFuncTy)(CFTypeRef);
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+ extern __attribute__((weak_import))
+ bool _availability_version_check(uint32_t count,
+                                  dyld_build_version_t versions[]);
++#endif
+ 
+ static void _initializeAvailabilityCheck(bool LoadPlist) {
+   if (AvailabilityVersionCheck && !LoadPlist) {
+@@ -98,8 +100,14 @@
+   }
+ 
+   // Use the new API if it's is available.
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+   if (_availability_version_check)
+     AvailabilityVersionCheck = &_availability_version_check;
++#else
++  // __attribute__((weak_import)) does not prevent Undefined symbol error on 10.14
++  AvailabilityVersionCheck = (AvailabilityVersionCheckFuncTy)dlsym(
++      RTLD_DEFAULT, "_availability_version_check");
++#endif
+ 
+   if (AvailabilityVersionCheck && !LoadPlist) {
+     // New API is supported and we're not being asked to load the plist,

--- a/lang/llvm-18/Portfile
+++ b/lang/llvm-18/Portfile
@@ -29,7 +29,7 @@ version                 ${llvm_version}.1.8
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 clang-${llvm_version} { revision [ expr ${revision} + 3 ] }
+subport                 clang-${llvm_version} { revision [ expr ${revision} + 4 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
@@ -179,6 +179,16 @@ if {${os.platform} eq "darwin"} {
 if {${os.platform} eq "darwin" && ${os.major} <= 16} {
     # error: 'utimensat' is only available on macOS 10.13 or newer
     patchfiles-append 0041-no-Werror-unguarded-availability-new.patch
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # https://trac.macports.org/ticket/68522
+    # Undefined symbols for architecture x86_64:
+    #   "__availability_version_check", referenced from:
+    #       ___isPlatformVersionAtLeast in libclang_rt.osx.a(os_version_check.c.o)
+    #       __initializeAvailabilityCheck in libclang_rt.osx.a(os_version_check.c.o)
+    # Upstream discussion at https://reviews.llvm.org/D150397
+    patchfiles-append 0130-10.14-and-less-availability.patch
 }
 
 post-patch {

--- a/lang/llvm-18/files/0130-10.14-and-less-availability.patch
+++ b/lang/llvm-18/files/0130-10.14-and-less-availability.patch
@@ -1,0 +1,40 @@
+This is a conditional revert of https://github.com/llvm/llvm-project/commit/b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0.
+__attribute__((weak_import)) does not prevent Undefined symbol error.
+
+--- a/compiler-rt/lib/builtins/os_version_check.c.orig	2023-11-28 09:52:28.000000000 +0100
++++ b/compiler-rt/lib/builtins/os_version_check.c	2024-08-29 15:29:18.000000000 +0200
+@@ -13,6 +13,7 @@
+ 
+ #ifdef __APPLE__
+ 
++#include <AvailabilityMacros.h>
+ #include <TargetConditionals.h>
+ #include <dispatch/dispatch.h>
+ #include <dlfcn.h>
+@@ -86,9 +87,11 @@
+                                             CFStringEncoding);
+ typedef void (*CFReleaseFuncTy)(CFTypeRef);
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+ extern __attribute__((weak_import))
+ bool _availability_version_check(uint32_t count,
+                                  dyld_build_version_t versions[]);
++#endif
+ 
+ static void _initializeAvailabilityCheck(bool LoadPlist) {
+   if (AvailabilityVersionCheck && !LoadPlist) {
+@@ -98,8 +101,14 @@
+   }
+ 
+   // Use the new API if it's is available.
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+   if (_availability_version_check)
+     AvailabilityVersionCheck = &_availability_version_check;
++#else
++  // __attribute__((weak_import)) does not prevent Undefined symbol error on 10.14
++  AvailabilityVersionCheck = (AvailabilityVersionCheckFuncTy)dlsym(
++      RTLD_DEFAULT, "_availability_version_check");
++#endif
+ 
+   if (AvailabilityVersionCheck && !LoadPlist) {
+     // New API is supported and we're not being asked to load the plist,

--- a/lang/llvm-19/Portfile
+++ b/lang/llvm-19/Portfile
@@ -29,7 +29,7 @@ version                 ${llvm_version}.1.6
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 clang-${llvm_version} { revision [ expr ${revision} + 0 ] }
+subport                 clang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
 
@@ -174,6 +174,16 @@ if {${os.platform} eq "darwin"} {
 if {${os.platform} eq "darwin" && ${os.major} <= 16} {
     # error: 'utimensat' is only available on macOS 10.13 or newer
     patchfiles-append 0041-no-Werror-unguarded-availability-new.patch
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # https://trac.macports.org/ticket/68522
+    # Undefined symbols for architecture x86_64:
+    #   "__availability_version_check", referenced from:
+    #       ___isPlatformVersionAtLeast in libclang_rt.osx.a(os_version_check.c.o)
+    #       __initializeAvailabilityCheck in libclang_rt.osx.a(os_version_check.c.o)
+    # Upstream discussion at https://reviews.llvm.org/D150397
+    patchfiles-append 0130-10.14-and-less-availability.patch
 }
 
 post-patch {

--- a/lang/llvm-19/files/0130-10.14-and-less-availability.patch
+++ b/lang/llvm-19/files/0130-10.14-and-less-availability.patch
@@ -1,0 +1,40 @@
+This is a conditional revert of https://github.com/llvm/llvm-project/commit/b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0.
+__attribute__((weak_import)) does not prevent Undefined symbol error.
+
+--- a/compiler-rt/lib/builtins/os_version_check.c.orig	2023-11-28 09:52:28.000000000 +0100
++++ b/compiler-rt/lib/builtins/os_version_check.c	2024-08-29 15:29:18.000000000 +0200
+@@ -13,6 +13,7 @@
+ 
+ #ifdef __APPLE__
+ 
++#include <AvailabilityMacros.h>
+ #include <TargetConditionals.h>
+ #include <dispatch/dispatch.h>
+ #include <dlfcn.h>
+@@ -86,9 +87,11 @@
+                                             CFStringEncoding);
+ typedef void (*CFReleaseFuncTy)(CFTypeRef);
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+ extern __attribute__((weak_import))
+ bool _availability_version_check(uint32_t count,
+                                  dyld_build_version_t versions[]);
++#endif
+ 
+ static void _initializeAvailabilityCheck(bool LoadPlist) {
+   if (AvailabilityVersionCheck && !LoadPlist) {
+@@ -98,8 +101,14 @@
+   }
+ 
+   // Use the new API if it's is available.
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+   if (_availability_version_check)
+     AvailabilityVersionCheck = &_availability_version_check;
++#else
++  // __attribute__((weak_import)) does not prevent Undefined symbol error on 10.14
++  AvailabilityVersionCheck = (AvailabilityVersionCheckFuncTy)dlsym(
++      RTLD_DEFAULT, "_availability_version_check");
++#endif
+ 
+   if (AvailabilityVersionCheck && !LoadPlist) {
+     // New API is supported and we're not being asked to load the plist,


### PR DESCRIPTION
#### Description

After the [recent switch](https://github.com/macports/macports-ports/commit/c8cceb0dec2dfb15e3a54e38260a676cb59fc9af) of older OS versions to allow mp-clang-17 as the fallback compiler, [qt64-qtbase has stopped building on 10.14](https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/217224/steps/install-port/logs/stdio) with
```
Undefined symbols for architecture x86_64:
  "__availability_version_check", referenced from:
      ___isPlatformVersionAtLeast in libclang_rt.osx.a(os_version_check.c.o)
      __initializeAvailabilityCheck in libclang_rt.osx.a(os_version_check.c.o)
```
There is also https://trac.macports.org/ticket/68522 dealing with the same issue.
The reason is [this upstream clang change](https://reviews.llvm.org/D150397). It looks like a performance-only fix, and it does not prevent `ld` from reporting the undefined symbol on 10.14. It appears the `__attribute__((weak_import))` would work the way they wish only under very specific circumstances, e.g., linking with the flat namespace option.
The patch basically reverts that change for pre-10.15 MacOS versions. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
