### PR TITLE
mise: Upgrade to 2024.8.15

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.8.14 v
+github.setup        jdx mise 2024.8.15 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  601240bfe166945f8a4570154b48edbe1898ba03 \
-                    sha256  c5ab7b875be95d6094a3e42c3800511214fb0ac8065c6b59de9c07e2debf78aa \
-                    size    3098357
+                    rmd160  b47693f310f9fb08a03a1783a76f77125c04182d \
+                    sha256  f544f01381a42e4c7225bbce99dce876390fc6c45dd4697fbca2a47b2e0b4e0a \
+                    size    3100084
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -376,10 +376,10 @@ cargo.crates \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
-    rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
+    rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.35  a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f \
     rustls                         0.23.12  c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044 \
-    rustls-native-certs              0.7.2  04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa \
+    rustls-native-certs              0.7.3  e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5 \
     rustls-pemfile                   2.1.3  196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425 \
     rustls-pki-types                 1.8.0  fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0 \
     rustls-webpki                  0.102.7  84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56 \
@@ -493,14 +493,14 @@ cargo.crates \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                        0.3.0  169665ca600da05053b6c2df83d243fc45cf58e8373dd7b939aaf87f664629fe \
+    usage-lib                        0.3.1  90e782a5477c492c1c900deafb948024689d2e169c603b780e269f782cd03b7b \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
-    vfox                             0.1.2  c63d042a549f54fd9de2efd62e5afd4ae7b200d463a47e0828dcd1a5fce56a78 \
+    vfox                             0.1.3  74d3110af29f3d681ae75f6645e6d7b3e19fb4dadccd126654d75958f878f1ec \
     vte                             0.10.1  6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983 \
     vte_generate_state_changes       0.1.2  2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \


### PR DESCRIPTION
#### Description

mise: Upgrade to 2024.8.15

##### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
