### PR TITLE
    zig: update to version 0.13.0

### DIFF
--- a/lang/zig/Portfile
+++ b/lang/zig/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 
 legacysupport.use_static  yes
 
-github.setup        ziglang zig 0.12.1
+github.setup        ziglang zig 0.13.0
 github.tarball_from archive
 revision            0
 
@@ -23,19 +23,19 @@ long_description    Zig is a general-purpose programming language designed for \
 
 homepage            https://ziglang.org/
 
-set llvm_version    17
+set llvm_version    18
 
-depends_lib-append  port:clang-${llvm_version} \
-                    port:ncurses \
+depends_lib-append  port:ncurses \
                     port:libxml2 \
                     port:zlib \
                     port:zstd
 depends_build-append \
-                    port:llvm-${llvm_version}
+                    port:llvm-${llvm_version} \
+                    port:clang-${llvm_version}
 
-checksums           rmd160  bc0f9330a016ea1ba1d271820d746d6c3580f550 \
-                    sha256  22c7b41238b808db5f62be1d08099f841bb812ec2fea9d7de9fcbb6b8e347b14 \
-                    size    26451610
+checksums           rmd160  6d81a7d1f3e6f67ebfffc453b5a45b39f88ae641 \
+                    sha256  d3912858003e340f315224bf177d0f441d86b81f62854f5c141b6d51ab6b5516 \
+                    size    26656532
 
 set llvm_config     LLVM_CONFIG=llvm-config-mp-${llvm_version}
 
@@ -46,6 +46,9 @@ cmake_share_module_dir \
                     ${prefix}/libexec/llvm-${llvm_version}
 cmake.install_rpath-append \
                     ${prefix}/libexec/llvm-${llvm_version}/lib
+
+# We need to link LLVM statically until a way is found to force zig to link the system libc++ dynamically.
+configure.args-append -DZIG_STATIC_LLVM=ON
 
 platform darwin {
     # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),


### PR DESCRIPTION
    - Update to version 0.13.0
    - Force static linking of llvm/clang; this was the default previously
    - Since llvm/clang are linking statically these can be build-only dependencies.

    Closes: https://trac.macports.org/ticket/70584
    Supersedes: https://github.com/macports/macports-ports/pull/24430 (draft)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.9 22G830 x86_64
Xcode 15.2 15C500b

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

There is a [draft PR](https://github.com/macports/macports-ports/pull/24430) for this that seems to have died on the vine.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
