### PR TITLE
qt64-qtbase: fix building with 10.15 SDK

### DIFF
--- a/aqua/qt64/files/patch-qtbase-macos_10.14_sdk.diff
+++ b/aqua/qt64/files/patch-qtbase-macos_10.14_sdk.diff
@@ -43,7 +43,8 @@ Upstream-Status: Inappropriate [violates DRY]
      caps.baseVertexAndInstance = true;
 +#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
      if (@available(macOS 10.15, *))
-         caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamilyApple7];
+-        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamilyApple7];
++        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamily(1007)]; // MTLGPUFamilyApple7
 +#endif
      caps.maxThreadGroupSize = 1024;
  #elif defined(Q_OS_TVOS)


### PR DESCRIPTION
#### Description

The 10.15 build [reports](https://build.macports.org/builders/ports-10.15_x86_64-builder/builds/194249/steps/install-port/logs/stdio):

```
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_aqua_qt64/qt64-qtbase/work/qtbase-everywhere-src-6.4.3/src/gui/rhi/qrhimetal.mm:407:50: error: use of undeclared identifier 'MTLGPUFamilyApple7'
        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamilyApple7];
                                                 ^
```
SDK 10.15 does not define this, so handle it like other such cases in the proximity: replace with a constant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

I could not test it on a 10.15 system, but I'm fairly sure the Buildbot will get further with this patch.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
