### PR TITLE
lima: Upgrade to 0.23.2

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 0.23.1 v
+go.setup            github.com/lima-vm/lima 0.23.2 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 depends_run         port:qemu
 
-checksums           rmd160  59c1fcdc58ea99e939f31f8858fb4f1906dcb9ad \
-                    sha256  90485789d02071106864a3003b62975bc213dcedbcc96e53c07adc4c2a91c38d \
-                    size    6116493
+checksums           rmd160  228dc7a5f29ac5a3270e73054c572ce57eab8151 \
+                    sha256  fc21295f78d717efc921f8f6d1ec22f64da82bfe685d0d2d505aee76c53da1ff \
+                    size    6116462
 
 build.cmd           make
 


### PR DESCRIPTION
#### Description

lima: Upgrade to 0.23.2

##### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
