### PR TITLE
uv: Update to 0.4.0

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.3.5
+github.setup            astral-sh uv 0.4.0
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -17,9 +17,9 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for common pip and pip-tools workflows.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  a1a0cbdb5b56ea7f9bd42bc2761a20689b0273a7 \
-                        sha256  a5c86337496727ae7c86d2396306717212ffb66e6cf382cad9e7d67ef4f5b6a1 \
-                        size    2471050
+                        rmd160  3496e468291d95e9935e4be9d4dc9cc027e922ac \
+                        sha256  d4a734b4179ac56aeb23b986eb5e2324360eab45080d4d6fca1afa18b20828f8 \
+                        size    2486795
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -60,8 +60,6 @@ cargo.crates \
     adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
     ahash                            0.7.8  891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
-    alloc-no-stdlib                  2.0.4  cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3 \
-    alloc-stdlib                     0.2.2  94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
@@ -98,8 +96,6 @@ cargo.crates \
     bitvec                           1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     boxcar                           0.2.5  510a90332002c1af3317ef6b712f0dab697f30bbe809b86965eac2923c0bca8e \
-    brotli                           6.0.0  74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b \
-    brotli-decompressor              4.0.1  9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362 \
     bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytecheck                       0.6.12  23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.4.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
