### PR TITLE
uv: Update to 0.4.1

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.4.0
+github.setup            astral-sh uv 0.4.1
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -12,14 +12,13 @@ license                 {Apache-2 MIT}
 platforms               {darwin >= 17}
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
-description             Extremely fast Python package installer and resolver
-long_description        {*}${description}, written in Rust. Designed as a drop-in \
-                        replacement for common pip and pip-tools workflows.
+description             Extremely fast Python package and project manager
+long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  3496e468291d95e9935e4be9d4dc9cc027e922ac \
-                        sha256  d4a734b4179ac56aeb23b986eb5e2324360eab45080d4d6fca1afa18b20828f8 \
-                        size    2486795
+                        rmd160  499f747ca75d5d8c8cc8a3f10909ac428c635864 \
+                        sha256  25ca9028670d530596a8f4a0ac3f813796d13da2de3a051eb6d79f10402023a9 \
+                        size    2508515
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.4.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
