### PR TITLE
ngspice: fix the port for < 10.8

### DIFF
--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -169,8 +169,7 @@ subport ngspice-lib {
     }
 
     # Set CFLAGS and LDFLAGS
-    configure.cflags-append     -O2 -Wall -I${prefix}/include/freetype2 -I${prefix}/include
-    configure.ldflags-append    -L${prefix}/lib
+    configure.cflags-append     -Wall -I${prefix}/include/freetype2
 
     # Use the correct prefix
     use_configure       yes

--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -37,6 +37,9 @@ if {${name} eq ${subport}} {
     # freetype2 headers are not found by default
     configure.cppflags-prepend -I${prefix}/include/freetype2
 
+    # TASK_BASIC_INFO_COUNT and friends were renamed in 10.8
+    patchfiles-append   patch-ngspice-older-MACH-defines.diff
+
     depends_lib-append  port:readline \
                         port:libtool \
                         port:xorg-libX11 \
@@ -122,6 +125,9 @@ subport ngspice-lib {
 
     # freetype2 headers are not found by default
     configure.cppflags-prepend -I${prefix}/include/freetype2
+
+    # TASK_BASIC_INFO_COUNT and friends were renamed in 10.8
+    patchfiles-append   patch-ngspice-older-MACH-defines.diff
 
     depends_lib-append  port:autoconf \
                         port:automake \

--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -27,6 +27,11 @@ checksums       rmd160  577a26e18e70fdf1fceb87ae3c6a783c3cf00d8e \
 
 set docdir      ${prefix}/share/doc/${name}
 
+# checking whether C compiler accepts -std=gnu11... no
+# C compiler cannot compile C11 code, etc.
+compiler.c_standard     2011
+compiler.cxx_standard   2011
+
 if {${name} eq ${subport}} {
 
     # freetype2 headers are not found by default

--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -54,6 +54,13 @@ if {${name} eq ${subport}} {
                         --with-readline=${prefix} \
                         --with-x
 
+    # https://trac.macports.org/ticket/70665
+    # https://github.com/macports/macports-ports/commit/e485b0a0c8125cb9d8bcc6241a9c2016514188c8
+    if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+        configure.cppflags-append \
+                                -D__NOEXTENSIONS__
+    }
+
     # Set CFLAGS and LDFLAGS
     configure.ldflags-append -L${prefix}/lib
 
@@ -144,6 +151,13 @@ subport ngspice-lib {
                         --disable-openmp \
                         --with-readline=${prefix} \
                         --with-ngshared
+
+    # https://trac.macports.org/ticket/70665
+    # https://github.com/macports/macports-ports/commit/e485b0a0c8125cb9d8bcc6241a9c2016514188c8
+    if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+        configure.cppflags-append \
+                                -D__NOEXTENSIONS__
+    }
 
     # Set CFLAGS and LDFLAGS
     configure.cflags-append     -O2 -Wall -I${prefix}/include/freetype2 -I${prefix}/include

--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -40,6 +40,9 @@ if {${name} eq ${subport}} {
     # TASK_BASIC_INFO_COUNT and friends were renamed in 10.8
     patchfiles-append   patch-ngspice-older-MACH-defines.diff
 
+    # https://trac.macports.org/ticket/70175
+    patchfiles-append   patch-fix-linking.diff
+
     depends_lib-append  port:readline \
                         port:libtool \
                         port:xorg-libX11 \
@@ -51,6 +54,7 @@ if {${name} eq ${subport}} {
                         --enable-pss \
                         --enable-relpath \
                         --disable-openmp \
+                        --disable-silent-rules \
                         --with-readline=${prefix} \
                         --with-x
 
@@ -59,6 +63,11 @@ if {${name} eq ${subport}} {
     if {${os.platform} eq "darwin" && ${os.major} <= 10} {
         configure.cppflags-append \
                                 -D__NOEXTENSIONS__
+
+        # Do not let an arbitrary compiler be set as CC_FOR_BUILD,
+        # do not link C++ code with gcc.
+        patchfiles-append       patch-use-cxx-to-link-cxx-code.diff
+        configure.env-append    CC_FOR_BUILD=${configure.cc}
     }
 
     # Set CFLAGS and LDFLAGS

--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -64,7 +64,7 @@ if {${name} eq ${subport}} {
     # Set CFLAGS and LDFLAGS
     configure.ldflags-append -L${prefix}/lib
 
-    build.args            VERBOSE=1
+    build.args          VERBOSE=1
     post-destroot {
         xinstall -d ${destroot}${docdir}
         xinstall -m 644 -W ${worksrcpath} \
@@ -82,11 +82,11 @@ if {${name} eq ${subport}} {
     }
 
     variant manual description {Legacy compatibility variant} {
-        depends_run-append       port:ngspice-docs
+        depends_run-append      port:ngspice-docs
     }
 
     variant lib description {Enable dynamic lib} {
-        depends_run-append       port:ngspice-lib
+        depends_run-append      port:ngspice-lib
     }
 
     default_variants    +manual +lib

--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -140,8 +140,8 @@ subport ngspice-lib {
                         --with-ngshared
 
     # Set CFLAGS and LDFLAGS
-    configure.cflags-append -m64 -O2 -Wall -I${prefix}/include/freetype2 -I${prefix}/include
-    configure.ldflags-append -m64 -L${prefix}/lib
+    configure.cflags-append     -O2 -Wall -I${prefix}/include/freetype2 -I${prefix}/include
+    configure.ldflags-append    -L${prefix}/lib
 
     # Use the correct prefix
     use_configure       yes

--- a/science/ngspice/files/patch-fix-linking.diff
+++ b/science/ngspice/files/patch-fix-linking.diff
@@ -1,0 +1,12 @@
+--- src/Makefile.in	2024-07-13 01:09:10.000000000 +0800
++++ src/Makefile.in	2024-08-31 13:25:22.000000000 +0800
+@@ -875,7 +875,8 @@
+ 	-e 's|@XSPICEINIT[@]|$(XSPICEINIT)|g' \
+ 	-e 's|@pkglibdir[@]|$(spinitpath)|g'
+ 
+-AM_CFLAGS = -static
++# MacOS linker does not need this.
++# AM_CFLAGS = -static
+ CLEANFILES = ngspice.idx spinit tclspinit pkgIndex.tcl
+ MAINTAINERCLEANFILES = Makefile.in
+ @SHARED_MODULE_TRUE@lib_LTLIBRARIES = libngspice.la

--- a/science/ngspice/files/patch-ngspice-older-MACH-defines.diff
+++ b/science/ngspice/files/patch-ngspice-older-MACH-defines.diff
@@ -1,0 +1,17 @@
+--- src/frontend/get_resident_set_size.c.orig	2020-12-22 17:35:59.000000000 -0800
++++ src/frontend/get_resident_set_size.c	2020-12-22 17:39:53.000000000 -0800
+@@ -110,6 +110,14 @@
+         return (unsigned long long) info.WorkingSetSize;
+ 
+ #elif defined(__APPLE__) && defined(__MACH__)
++
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1080
++#  define MACH_TASK_BASIC_INFO_COUNT TASK_BASIC_INFO_COUNT
++#  define mach_task_basic_info_data_t task_basic_info_data_t
++#  define MACH_TASK_BASIC_INFO TASK_BASIC_INFO
++#  define mach_task_basic_info task_basic_info
++#endif
++
+     /* OSX ------------------------------------------------------ */
+     struct mach_task_basic_info info;
+     mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;

--- a/science/ngspice/files/patch-use-cxx-to-link-cxx-code.diff
+++ b/science/ngspice/files/patch-use-cxx-to-link-cxx-code.diff
@@ -1,0 +1,11 @@
+--- src/Makefile.in	2024-07-13 01:09:10.000000000 +0800
++++ src/Makefile.in	2024-08-31 14:02:16.000000000 +0800
+@@ -482,7 +482,7 @@
+ am__v_CC_ = $(am__v_CC_@AM_DEFAULT_V@)
+ am__v_CC_0 = @echo "  CC      " $@;
+ am__v_CC_1 = 
+-CCLD = $(CC)
++CCLD = $(CXX)
+ LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+ 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) \
+ 	$(AM_LDFLAGS) $(LDFLAGS) -o $@


### PR DESCRIPTION
#### Description

Fixes `ngspice` after a breaking update, fixes what was broken in the earlier version.

@markemer @bpdegnan 

P. S. Likely fixups which are for < 10.7 should be used unconditionally, but let maintainers decide on that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
