### PR TITLE
ferite: fix build

### DIFF
--- a/lang/ferite/Portfile
+++ b/lang/ferite/Portfile
@@ -4,11 +4,10 @@ PortSystem          1.0
 
 name                ferite
 version             1.1.17
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang
 license             BSD
-platforms           darwin
 maintainers         nomaintainer
 
 description         embeddable scripting language
@@ -21,7 +20,14 @@ homepage            http://ferite.org/
 master_sites        sourceforge:project/ferite/ferite/${branch}
 
 checksums           rmd160  c6c1236bdf04be8a47cd7ff996c6b003e8e65f23 \
-                    sha256  d407f3db45482e17f41820fb029cf8b06e6104699b8d7340f3946f57d3f4e690
+                    sha256  d407f3db45482e17f41820fb029cf8b06e6104699b8d7340f3946f57d3f4e690 \
+                    size    2174774
+
+# https://github.com/Homebrew/legacy-homebrew/issues/15105
+patchfiles-append   patch-pcre_info.diff
 
 depends_lib         port:pcre \
                     port:libxml2
+
+# ld: library not found for -lferitestream
+use_parallel_build  no

--- a/lang/ferite/files/patch-pcre_info.diff
+++ b/lang/ferite/files/patch-pcre_info.diff
@@ -1,0 +1,11 @@
+--- modules/regexp/regexp_Regexp.c	2009-07-17 14:59:19.000000000 +0800
++++ modules/regexp/regexp_Regexp.c	2024-08-31 15:10:36.000000000 +0800
+@@ -88,7 +88,7 @@
+ 		}
+ 		
+ 		/* get the number of subparts */
+-		captured_str_cnt = pcre_info( rgx->compiled_re, NULL, NULL ) + 1;
++		captured_str_cnt = pcre_fullinfo( rgx->compiled_re, NULL, 0, NULL ) + 1;
+ 		/* create an offset array */
+ 		size_offsets = (int)(captured_str_cnt * 3);
+ 		offsets = (int *)fmalloc(size_offsets * sizeof(int));


### PR DESCRIPTION
#### Description

Fix compatibility with current pcre

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
