### PR TITLE
swiftformat: new port

### DIFF
--- a/devel/swiftformat/Portfile
+++ b/devel/swiftformat/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        nicklockwood swiftformat 0.54.3
+github.tarball_from archive
+revision            0
+
+platforms           {darwin >= 21}
+categories          devel
+license             MIT
+maintainers         {fastmail.com:free_software @jrabinow} openmaintainer
+description         Swift formatter
+long_description    A tool to format Swift code
+
+checksums           rmd160  99a28b4b6b7cdfdca0fa25a7f8d82ff2b28f5b80 \
+                    sha256  f0fb5df2945d49207ef50da971810e6879acb0153267bec0be0d882f77781649 \
+                    size    3154784
+
+# Clearing CPATH because of header conflicts with MacOSX13.sdk when using swiftPM build system
+compiler.cpath
+
+use_configure       no
+use_xcode           yes
+
+build.cmd           swift
+build.target        build
+build.args          --configuration release --disable-sandbox
+
+test.run            yes
+test.cmd            swift
+test.target         test
+test.args           --disable-sandbox
+
+set builtproductdir ${worksrcpath}/.build/release
+
+destroot {
+    xinstall -m 755 ${builtproductdir}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

Add new port: swiftformat

###### Type(s)

###### Tested on
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`? `Error: Using openmaintainer without any other maintainer` who should I add
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? `-vs` since trace mode is broken on arm64
- [x] tested basic functionality of all binary files?
- [] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? N/A

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
