### PR TITLE
catch2: update to 3.7.0

### DIFF
--- a/devel/catch2/Portfile
+++ b/devel/catch2/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        catchorg Catch2 3.5.2 v
+github.setup        catchorg Catch2 3.7.0 v
 github.tarball_from archive
 name                catch2
 revision            0
@@ -17,9 +17,9 @@ maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
 description         Catch 2: a modern, C++-native, header-only, test framework for unit-tests
 long_description    ${description}, TDD and BDD - using C++14, C++17 and later.
 
-checksums           rmd160  d711022fe9a29886f1797175fab3b165ffcc16a5 \
-                    sha256  269543a49eb76f40b3f93ff231d4c24c27a7e16c90e47d2e45bcc564de470c6e \
-                    size    1159985
+checksums           rmd160  59c62fd1b383c6f4575c746c40c2c7523d412a8e \
+                    sha256  5b10cd536fa3818112a82820ce0787bd9f2a906c618429e7c4dea639983c8e88 \
+                    size    1190454
 
 compiler.cxx_standard 2014
 


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
