### PR TITLE
nlohmann-json-schema-validator: new port

### DIFF
--- a/devel/nlohmann-json-schema-validator/Portfile
+++ b/devel/nlohmann-json-schema-validator/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        pboettch json-schema-validator 2.3.0
+github.tarball_from archive
+revision            0
+name                nlohmann-json-schema-validator
+categories          devel
+platforms           any
+supported_archs     noarch
+license             MIT
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+description         JSON schema validator for JSON for Modern C++
+long_description    {*}${description}
+
+checksums           rmd160  08baad87e528addc3bafc63161e1828078459fcd \
+                    sha256  2c00b50023c7d557cdaa71c0777f5bcff996c4efd7a539e58beaa4219fa2a5e1 \
+                    size    77869
+
+depends_lib-append  port:nlohmann-json


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
