### PR TITLE
qt64-qtbase: Fix building on 10.14 and 10.15 and a minor patch

### DIFF
--- a/aqua/qt64/Portfile
+++ b/aqua/qt64/Portfile
@@ -106,7 +106,7 @@ array set modules {
          "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 6"
+        "revision 7"
         "License: "
     }
     qtsvg {
@@ -1035,6 +1035,9 @@ if { ${subport} eq "${name}-qtbase" || ${subport} eq "${name}-qtbase-docs" } {
     # see https://trac.macports.org/ticket/64345
     patchfiles-append               patch-qtbase-macos_10.14_sdk.diff
 
+    # allow building with macports-clang
+    patchfiles-append               patch-qtbase-macports-clang-qt64.diff
+
     # error: no matching function for call to '_mm256_maskz_cvtps_ph'
     # note: candidate function not viable: requires 2 arguments, but 3 were provided
     # see https://trac.macports.org/ticket/67802
@@ -1055,6 +1058,9 @@ if { ${subport} eq "${name}-qtbase" || ${subport} eq "${name}-qtbase-docs" } {
 
     # see https://trac.macports.org/ticket/68713
     patchfiles-append               patch-qtbase-fix-cmake-3.28.diff
+
+    # see https://bugreports.qt.io/browse/QTBUG-111443
+    patchfiles-append               patch-qtbase-QTBUG-111443-qt64.diff
 
     configure.pre_args-replace      --prefix=${prefix} \
                                     "-prefix ${qt6.dir}"

--- a/aqua/qt64/files/patch-qtbase-QTBUG-111443-qt64.diff
+++ b/aqua/qt64/files/patch-qtbase-QTBUG-111443-qt64.diff
@@ -1,0 +1,171 @@
+Fix locale warnings on Darwin.
+https://github.com/qt/qtbase/commit/f03ccd29bd5d36a79c6b73eccc6485c1b49a109c
+https://github.com/qt/qtbase/commit/611777e084c503c7f3195adbdbfb10a5f74308f9
+https://github.com/qt/qtbase/commit/7aac60beea47130b9e9d435579143794fa2e2edc
+
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
+index 355d1e42ccf..96efb94b0ca 100644
+--- src/corelib/kernel/qcoreapplication.cpp
++++ src/corelib/kernel/qcoreapplication.cpp
+@@ -548,22 +548,30 @@ QString qAppName()
+ 
+ void QCoreApplicationPrivate::initLocale()
+ {
+-#if defined(Q_OS_UNIX) && !defined(QT_BOOTSTRAPPED)
++#if defined(QT_BOOTSTRAPPED)
++    // Don't try to control bootstrap library locale or encoding.
++#elif defined(Q_OS_UNIX)
+     Q_CONSTINIT static bool qt_locale_initialized = false;
+     if (qt_locale_initialized)
+         return;
+     qt_locale_initialized = true;
+ 
+-#  ifdef Q_OS_INTEGRITY
++    // By default the portable "C"/POSIX locale is selected and active.
++    // Apply the locale from the environment, via setlocale(), which will
++    // read LC_ALL, LC_<category>, and LANG, in order (for each category).
++    const char *locale = setlocale(LC_ALL, "");
++
++    // Next, let's ensure that LC_CTYPE is UTF-8, since QStringConverter's
++    // QLocal8Bit hard-codes this, and we need to be consistent.
++#  if defined(Q_OS_INTEGRITY)
+     setlocale(LC_CTYPE, "UTF-8");
++#  elif defined(Q_OS_QNX)
++    // QNX has no nl_langinfo, so we can't check.
++    // FIXME: Shouldn't we still setlocale("UTF-8")?
++#  elif defined(Q_OS_ANDROID) && __ANDROID_API__ < __ANDROID_API_O__
++    // Android 6 still lacks nl_langinfo(), so we can't check.
++    // FIXME: Shouldn't we still setlocale("UTF-8")?
+ #  else
+-#    if defined(Q_OS_QNX) || (defined(Q_OS_ANDROID) && __ANDROID_API__ < __ANDROID_API_O__)
+-    // Android 6 still lacks nl_langinfo(), as does QNX, so we just assume it's
+-    // always UTF-8 on these platforms.
+-    auto nl_langinfo = [](int) { return "UTF-8"; };
+-#   endif // QNX or Android NDK < 26, "O".
+-
+-    const char *locale = setlocale(LC_ALL, "");
+     const char *codec = nl_langinfo(CODESET);
+     if (Q_UNLIKELY(qstricmp(codec, "UTF-8") != 0 && qstricmp(codec, "utf8") != 0)) {
+         QByteArray oldLocale = locale;
+@@ -575,8 +583,8 @@ void QCoreApplicationPrivate::initLocale()
+         newLocale += ".UTF-8";
+         newLocale = setlocale(LC_CTYPE, newLocale);
+ 
+-        // if locale doesn't exist, try some fallbacks
+-#    ifdef Q_OS_DARWIN
++        // If that locale doesn't exist, try some fallbacks:
++#    if defined(Q_OS_DARWIN)
+         if (newLocale.isEmpty())
+             newLocale = setlocale(LC_CTYPE, "UTF-8");
+ #    endif
+@@ -590,7 +598,7 @@ void QCoreApplicationPrivate::initLocale()
+                  "reconfigure your locale. See the locale(1) manual for more information.",
+                  codec, oldLocale.constData(), newLocale.constData());
+     }
+-#  endif // Integrity
++#  endif // Platform choice
+ #endif // Unix
+ }
+ 
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
+index 96efb94b0ca..d38cb742424 100644
+--- src/corelib/kernel/qcoreapplication.cpp
++++ src/corelib/kernel/qcoreapplication.cpp
+@@ -559,7 +559,7 @@ void QCoreApplicationPrivate::initLocale()
+     // By default the portable "C"/POSIX locale is selected and active.
+     // Apply the locale from the environment, via setlocale(), which will
+     // read LC_ALL, LC_<category>, and LANG, in order (for each category).
+-    const char *locale = setlocale(LC_ALL, "");
++    setlocale(LC_ALL, "");
+ 
+     // Next, let's ensure that LC_CTYPE is UTF-8, since QStringConverter's
+     // QLocal8Bit hard-codes this, and we need to be consistent.
+@@ -572,9 +572,9 @@ void QCoreApplicationPrivate::initLocale()
+     // Android 6 still lacks nl_langinfo(), so we can't check.
+     // FIXME: Shouldn't we still setlocale("UTF-8")?
+ #  else
+-    const char *codec = nl_langinfo(CODESET);
+-    if (Q_UNLIKELY(qstricmp(codec, "UTF-8") != 0 && qstricmp(codec, "utf8") != 0)) {
+-        QByteArray oldLocale = locale;
++    const char *charEncoding = nl_langinfo(CODESET);
++    if (Q_UNLIKELY(qstricmp(charEncoding, "UTF-8") != 0 && qstricmp(charEncoding, "utf8") != 0)) {
++        const QByteArray oldLocale = setlocale(LC_ALL, nullptr);
+         QByteArray newLocale = setlocale(LC_CTYPE, nullptr);
+         if (qsizetype dot = newLocale.indexOf('.'); dot != -1)
+             newLocale.truncate(dot);    // remove encoding, if any
+@@ -593,10 +593,20 @@ void QCoreApplicationPrivate::initLocale()
+         if (newLocale.isEmpty())
+             newLocale = setlocale(LC_CTYPE, "C.utf8");
+ 
+-        qWarning("Detected system locale encoding (%s, locale \"%s\") is not UTF-8.\n"
+-                 "Qt shall use a UTF-8 locale (\"%s\") instead. If this causes problems,\n"
+-                 "reconfigure your locale. See the locale(1) manual for more information.",
+-                 codec, oldLocale.constData(), newLocale.constData());
++        if (newLocale.isEmpty()) {
++            // Failed to set a UTF-8 locale.
++            qWarning("Detected locale \"%s\" with character encoding \"%s\", which is not UTF-8.\n"
++                     "Qt depends on a UTF-8 locale, but has failed to switch to one.\n"
++                     "If this causes problems, reconfigure your locale. See the locale(1) manual\n"
++                     "for more information.", oldLocale.constData(), charEncoding);
++        } else {
++            // Let the user know we over-rode their configuration.
++            qWarning("Detected locale \"%s\" with character encoding \"%s\", which is not UTF-8.\n"
++                     "Qt depends on a UTF-8 locale, and has switched to \"%s\" instead.\n"
++                     "If this causes problems, reconfigure your locale. See the locale(1) manual\n"
++                     "for more information.",
++                     oldLocale.constData(), charEncoding, newLocale.constData());
++        }
+     }
+ #  endif // Platform choice
+ #endif // Unix
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
+index d38cb742424..7f53931a3d3 100644
+--- src/corelib/kernel/qcoreapplication.cpp
++++ src/corelib/kernel/qcoreapplication.cpp
+@@ -575,7 +575,20 @@ void QCoreApplicationPrivate::initLocale()
+     const char *charEncoding = nl_langinfo(CODESET);
+     if (Q_UNLIKELY(qstricmp(charEncoding, "UTF-8") != 0 && qstricmp(charEncoding, "utf8") != 0)) {
+         const QByteArray oldLocale = setlocale(LC_ALL, nullptr);
+-        QByteArray newLocale = setlocale(LC_CTYPE, nullptr);
++        QByteArray newLocale;
++        bool warnOnOverride = true;
++#    if defined(Q_OS_DARWIN)
++        // Don't warn unless the char encoding has been changed from the
++        // default "C" encoding, or the user touched any of the locale
++        // environment variables to force the "C" char encoding.
++        warnOnOverride = qstrcmp(setlocale(LC_CTYPE, nullptr), "C") != 0
++            || getenv("LC_ALL") || getenv("LC_CTYPE") || getenv("LANG");
++
++        // No need to try language or region specific CTYPEs, as they
++        // all point back to the same generic UTF-8 CTYPE.
++        newLocale = setlocale(LC_CTYPE, "UTF-8");
++#    else
++        newLocale = setlocale(LC_CTYPE, nullptr);
+         if (qsizetype dot = newLocale.indexOf('.'); dot != -1)
+             newLocale.truncate(dot);    // remove encoding, if any
+         if (qsizetype at = newLocale.indexOf('@'); at != -1)
+@@ -584,14 +597,11 @@ void QCoreApplicationPrivate::initLocale()
+         newLocale = setlocale(LC_CTYPE, newLocale);
+ 
+         // If that locale doesn't exist, try some fallbacks:
+-#    if defined(Q_OS_DARWIN)
+-        if (newLocale.isEmpty())
+-            newLocale = setlocale(LC_CTYPE, "UTF-8");
+-#    endif
+         if (newLocale.isEmpty())
+             newLocale = setlocale(LC_CTYPE, "C.UTF-8");
+         if (newLocale.isEmpty())
+             newLocale = setlocale(LC_CTYPE, "C.utf8");
++#    endif
+ 
+         if (newLocale.isEmpty()) {
+             // Failed to set a UTF-8 locale.
+@@ -599,7 +609,7 @@ void QCoreApplicationPrivate::initLocale()
+                      "Qt depends on a UTF-8 locale, but has failed to switch to one.\n"
+                      "If this causes problems, reconfigure your locale. See the locale(1) manual\n"
+                      "for more information.", oldLocale.constData(), charEncoding);
+-        } else {
++        } else if (warnOnOverride) {
+             // Let the user know we over-rode their configuration.
+             qWarning("Detected locale \"%s\" with character encoding \"%s\", which is not UTF-8.\n"
+                      "Qt depends on a UTF-8 locale, and has switched to \"%s\" instead.\n"

--- a/aqua/qt64/files/patch-qtbase-macos_10.14_sdk.diff
+++ b/aqua/qt64/files/patch-qtbase-macos_10.14_sdk.diff
@@ -43,7 +43,8 @@ Upstream-Status: Inappropriate [violates DRY]
      caps.baseVertexAndInstance = true;
 +#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
      if (@available(macOS 10.15, *))
-         caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamilyApple7];
+-        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamilyApple7];
++        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamily(1007)]; // MTLGPUFamilyApple7
 +#endif
      caps.maxThreadGroupSize = 1024;
  #elif defined(Q_OS_TVOS)

--- a/aqua/qt64/files/patch-qtbase-macports-clang-qt64.diff
+++ b/aqua/qt64/files/patch-qtbase-macports-clang-qt64.diff
@@ -1,0 +1,16 @@
+Fix error: Invalid option: '-no_warning_for_no_symbols'
+https://github.com/qt/qtbase/commit/05a7cbef5b6a32edd31f42da4ace2e7ab1fd35da
+
+diff --git a/cmake/QtBuild.cmake b/cmake/QtBuild.cmake
+index 6bf4a9edd56..322926a5b3a 100644
+--- cmake/QtBuild.cmake
++++ cmake/QtBuild.cmake
+@@ -426,7 +426,7 @@ set(QT_TOP_LEVEL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+ # Prevent warnings about object files without any symbols. This is a common
+ # thing in Qt as we tend to build files unconditionally, and then use ifdefs
+ # to compile out parts that are not relevant.
+-if(CMAKE_HOST_APPLE AND APPLE)
++if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+     foreach(lang ASM C CXX)
+         # We have to tell 'ar' to not run ranlib by itself, by passing the 'S' option
+         set(CMAKE_${lang}_ARCHIVE_CREATE "<CMAKE_AR> qcS <TARGET> <LINK_FLAGS> <OBJECTS>")


### PR DESCRIPTION
#### Description

One patch fixes an error when passing incorrect options to non-Apple CLang.
The other fixes useless locale warnings when running any QCoreApplication-based app compiled with Qt 6.4.3.
Both patches are taken from the upstream Qt repository.
P.S. Added a 10.15 SDK build fix.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
