### PR TITLE
uv: Update to 0.4.2

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.4.1
+github.setup            astral-sh uv 0.4.2
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  499f747ca75d5d8c8cc8a3f10909ac428c635864 \
-                        sha256  25ca9028670d530596a8f4a0ac3f813796d13da2de3a051eb6d79f10402023a9 \
-                        size    2508515
+                        rmd160  5ab67281dc98e88d4e387284d310a202b3a8ba8f \
+                        sha256  8d1b1078b33ad3373b378d70ab3a24f43218b1497e0aee7ec66f3fde0db41ac5 \
+                        size    2511432
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -59,8 +59,6 @@ cargo.crates \
     adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
     ahash                            0.7.8  891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
-    android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
-    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
     anstream                        0.6.15  64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526 \
     anstyle                          1.0.8  1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1 \
@@ -70,7 +68,7 @@ cargo.crates \
     anyhow                          1.0.86  b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arrayref                         0.3.8  9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a \
-    arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
+    arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     assert_cmd                      2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     assert_fs                        1.1.2  7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674 \
@@ -83,7 +81,7 @@ cargo.crates \
     axoasset                         1.0.0  45e7b7ac1c1cd4fdcaa2f9e704defa9defd996039083d85e17efa5e8eefb3bd2 \
     axoprocess                       0.2.0  4de46920588aef95658797996130bacd542436aee090084646521260a74bda7d \
     axotag                           0.2.0  d888fac0b73e64cbdf36a743fc5a25af5ae955c357535cb420b389bf1e1a6c54 \
-    axoupdater                       0.7.0  3adfac228780fcf162617739408bd8edeb1ae1d497c95082759c5e607cac1e71 \
+    axoupdater                       0.7.1  14cd170d3b144de5288b99c69f30b36ee5eba837bed33f458f39c890e2049162 \
     backoff                          0.4.0  b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1 \
     backtrace                       0.3.73  5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a \
     backtrace-ext                    0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
@@ -99,32 +97,31 @@ cargo.crates \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytecheck                       0.6.12  23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2 \
     bytecheck_derive                0.6.12  3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659 \
-    bytemuck                        1.16.3  102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83 \
+    bytemuck                        1.17.1  773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2 \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     byteorder-lite                   0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
     bytes                            1.7.1  8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50 \
     bzip2                            0.4.4  bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8 \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
-    camino                           1.1.7  e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239 \
+    camino                           1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
     cargo-util                      0.2.13  14104698cb1694d43c2ff73492468ccf2bb0b047071a9838d999eeba9e984ffa \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
-    cc                               1.1.8  504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549 \
+    cc                              1.1.15  57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     charset                          0.1.5  f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e \
-    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
     clap                            4.5.16  ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019 \
     clap_builder                    4.5.15  216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6 \
-    clap_complete                   4.5.13  aa3c596da3cf0983427b0df0dba359df9182c13bd5b519b585a482b0c351f4e8 \
+    clap_complete                   4.5.24  6d7db6eca8c205649e8d3ccd05aa5042b1800a784e56bc7c43524fde8abbfa9b \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.3  5fe32110e006bccf720f8c9af3fee1ba7db290c724eab61544e1d3295be3a40e \
     clap_derive                     4.5.13  501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0 \
     clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
-    cmake                           0.1.50  a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130 \
+    cmake                           0.1.51  fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a \
     codspeed                         2.6.0  3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089 \
     codspeed-criterion-compat        2.6.0  722c36bdc62d9436d027256ce2627af81ac7a596dfc7d13d849d0d212448d7fe \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
@@ -134,8 +131,8 @@ cargo.crates \
     configparser                     3.1.0  e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b \
     console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
-    core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
-    cpufeatures                     0.2.12  53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504 \
+    core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    cpufeatures                     0.2.13  51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
     criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
     criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
@@ -170,9 +167,9 @@ cargo.crates \
     etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
     event-listener                   5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
     event-listener-strategy          0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
-    fastrand                         2.1.0  9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a \
+    fastrand                         2.1.1  e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6 \
     fdeflate                         0.3.4  4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645 \
-    filetime                        0.2.24  bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550 \
+    filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
     flate2                          1.0.33  324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253 \
     float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
@@ -201,16 +198,17 @@ cargo.crates \
     globset                         0.4.14  57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     goblin                           0.8.2  1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47 \
-    h2                               0.4.5  fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab \
+    h2                               0.4.6  524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205 \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
+    hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
-    homedir                          0.2.1  22074da8bba2ef26fc1737ae6c777b5baab5524c2dc403b5c6a76166766ccda5 \
+    homedir                          0.3.3  2bed305c13ce3829a09d627f5d43ff738482a09361ae4eb8039993b55fb10e5e \
     html-escape                     0.2.13  6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476 \
     http                             1.1.0  21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258 \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
@@ -221,36 +219,34 @@ cargo.crates \
     hyper                            1.4.1  50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05 \
     hyper-rustls                    0.27.2  5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155 \
     hyper-util                       0.1.7  cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9 \
-    iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
-    iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
     ignore                          0.4.22  b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1 \
     image                           0.25.2  99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10 \
     imagesize                       0.11.0  b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf \
-    indexmap                         2.4.0  93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c \
+    indexmap                         2.5.0  68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5 \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     insta                           1.39.0  810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5 \
     instant                         0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
     ipnet                            2.9.0  8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3 \
-    is-terminal                     0.4.12  f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b \
+    is-terminal                     0.4.13  261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b \
     is_ci                            1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
     itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
-    jiff                            0.1.10  8ef8bc400f8312944a9f879db116fed372c4f0859af672eba2a80f79c767dd19 \
+    jiff                            0.1.11  362be9c702bada57298130d0565e9c389e6d4024a541692f01819e21abc3e26a \
     jiff-tzdb                        0.1.0  05fac328b3df1c0f18a3c2ab6cb7e06e4e549f366017d796e3e66b6d6889abe6 \
     jiff-tzdb-platform               0.1.0  f8da387d5feaf355954c2c122c194d6df9c57d865125a67984bb453db5336940 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jpeg-decoder                     0.3.1  f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0 \
-    js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
+    js-sys                          0.3.70  1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a \
     junction                         1.1.0  1c9c415a9b7b1e86cd5738f39d34c9e78c765da7fb1756dbd7d31b3b0d2e7afa \
     kurbo                            0.8.3  7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449 \
     kurbo                            0.9.5  bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.155  97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c \
+    libc                           0.2.158  d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439 \
     libmimalloc-sys                 0.1.39  23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     libz-ng-sys                     1.1.16  4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438 \
@@ -274,7 +270,7 @@ cargo.crates \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     miniz_oxide                      0.7.4  b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08 \
     miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
-    mio                              1.0.1  4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4 \
+    mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
     miow                             0.6.0  359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044 \
     nanoid                           0.4.0  3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8 \
     nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
@@ -285,7 +281,7 @@ cargo.crates \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
-    object                          0.36.3  27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9 \
+    object                          0.36.4  084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a \
     once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     oorandom                        11.1.4  b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
@@ -323,7 +319,7 @@ cargo.crates \
     predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
     predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
     pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
-    priority-queue                   2.0.3  70c501afe3a2e25c9bd219aa56ec1e04cdb3fcdd763055be268778c13fa82c1f \
+    priority-queue                   2.1.0  560bcab673ff7f6ca9e270c17bf3affd8a05e3bd9207f123b0d45076fd8197e8 \
     proc-macro2                     1.0.86  5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77 \
     ptr_meta                         0.1.4  0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1 \
     ptr_meta_derive                  0.1.4  16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac \
@@ -348,7 +344,7 @@ cargo.crates \
     redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
     redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
     redox_syscall                    0.5.3  2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4 \
-    redox_users                      0.4.5  bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891 \
+    redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
     reflink-copy                    0.1.19  dc31414597d1cd7fdd2422798b7652a6329dda0fe0219e6335a13d5bcaa9aeb6 \
     regex                           1.10.6  4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
@@ -359,7 +355,7 @@ cargo.crates \
     reqwest                         0.12.7  f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63 \
     resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
     retry-policies                   0.4.0  5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c \
-    rgb                             0.8.48  0f86ae463694029097b846d8f99fd5536740602ae00022c0c50c5600720b2f71 \
+    rgb                             0.8.49  09cd5a1e95672f201913966f39baf355b53b5d92833431847295ae0346a5b939 \
     ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
     rkyv                            0.7.45  9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b \
     rkyv_derive                     0.7.45  503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0 \
@@ -371,12 +367,12 @@ cargo.crates \
     rust-netrc                       0.1.1  32662f97cbfdbad9d5f78f1338116f06871e7dae4fd37e9f59a0f57cf2044868 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
-    rustix                         0.38.34  70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f \
+    rustix                         0.38.35  a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f \
     rustls                         0.23.12  c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044 \
-    rustls-native-certs              0.7.1  a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba \
+    rustls-native-certs              0.7.3  e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5 \
     rustls-pemfile                   2.1.3  196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425 \
     rustls-pki-types                 1.8.0  fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0 \
-    rustls-webpki                  0.102.6  8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e \
+    rustls-webpki                  0.102.7  84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56 \
     rustybuzz                        0.7.0  162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
@@ -399,6 +395,7 @@ cargo.crates \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
+    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
     simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \
     simdutf8                         0.1.4  f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a \
@@ -448,7 +445,7 @@ cargo.crates \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.39.3  9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5 \
+    tokio                           1.40.0  e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998 \
     tokio-macros                     2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
     tokio-rustls                    0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
     tokio-stream                    0.1.15  267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af \
@@ -458,8 +455,8 @@ cargo.crates \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                      0.22.20  583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d \
     tower                           0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
-    tower-layer                      0.3.2  c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0 \
-    tower-service                    0.3.2  b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52 \
+    tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
+    tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
     tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
     tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
@@ -498,15 +495,15 @@ cargo.crates \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.92  4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8 \
-    wasm-bindgen-backend            0.2.92  614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da \
-    wasm-bindgen-futures            0.4.42  76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0 \
-    wasm-bindgen-macro              0.2.92  a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726 \
-    wasm-bindgen-macro-support      0.2.92  e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7 \
-    wasm-bindgen-shared             0.2.92  af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96 \
+    wasm-bindgen                    0.2.93  a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5 \
+    wasm-bindgen-backend            0.2.93  9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b \
+    wasm-bindgen-futures            0.4.43  61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed \
+    wasm-bindgen-macro              0.2.93  585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf \
+    wasm-bindgen-macro-support      0.2.93  afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836 \
+    wasm-bindgen-shared             0.2.93  c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484 \
     wasm-streams                     0.4.0  b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129 \
     wasm-timer                       0.2.5  be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f \
-    web-sys                         0.3.69  77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef \
+    web-sys                         0.3.70  26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0 \
     webpki-roots                    0.26.3  bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd \
     weezl                            0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
     which                            6.0.3  b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f \
@@ -515,15 +512,16 @@ cargo.crates \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows                         0.52.0  e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be \
+    windows                         0.57.0  12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143 \
     windows                         0.58.0  dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6 \
-    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
+    windows-core                    0.57.0  d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d \
     windows-core                    0.58.0  6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99 \
-    windows-implement               0.52.0  12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946 \
+    windows-implement               0.57.0  9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7 \
     windows-implement               0.58.0  2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b \
-    windows-interface               0.52.0  9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1 \
+    windows-interface               0.57.0  29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7 \
     windows-interface               0.58.0  053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515 \
     windows-registry                 0.2.0  e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0 \
+    windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
     windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
     windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
@@ -551,7 +549,6 @@ cargo.crates \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     winsafe                         0.0.22  7d6ad6cbd9c6e5144971e326303f0e453b61d82e4f72067fccf23106bccd8437 \
     wiremock                         0.6.1  6a59f8ae78a4737fb724f20106fb35ccb7cfe61ff335665d3042b3aa98e34717 \
-    wmi                             0.13.3  fc2f0a4062ca522aad4705a2948fd4061b3857537990202a8ddd5af21607f79a \
     wyz                              0.5.1  05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed \
     xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
     xmlparser                       0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.4.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
