### PR TITLE
valkey: add redis_compat variant with redis symlinks

### DIFF
--- a/databases/valkey/Portfile
+++ b/databases/valkey/Portfile
@@ -111,6 +111,11 @@ post-activate {
     }
 }
 
+variant redis_compat description {Install redis compatibility symlinks} {
+    conflicts               redis
+    destroot.args-delete    USE_REDIS_SYMLINKS=no
+}
+
 add_users           ${name} group=${name} realname=Valkey\ Database\ Server
 startupitem.create  yes
 startupitem.user    ${name}


### PR DESCRIPTION
#### Description

The purpose of this variant is to ease transition from the redis package.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
