### PR TITLE
help2man: do not break build on Linux

### DIFF
--- a/textproc/help2man/Portfile
+++ b/textproc/help2man/Portfile
@@ -42,7 +42,13 @@ configure.universal_args-delete --disable-dependency-tracking
 variant universal {}
 
 post-patch {
-    reinplace "s|-shared|-bundle ${configure.ldflags} [get_canonical_archflags ld]|" ${worksrcpath}/Makefile.in
+    if {${os.platform} eq "darwin"} {
+        reinplace "s|-shared|-bundle ${configure.ldflags} [get_canonical_archflags ld]|" \
+                ${worksrcpath}/Makefile.in
+    } else {
+        reinplace "s|-shared|-shared ${configure.ldflags} [get_canonical_archflags ld]|" \
+                ${worksrcpath}/Makefile.in
+    }
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

Using `-bundle` flag breaks build on Linux.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Linux pinetab 5.15

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
