### PR TITLE
py-rasterio: unbreak build with libstdc++

### DIFF
--- a/python/py-rasterio/Portfile
+++ b/python/py-rasterio/Portfile
@@ -37,4 +37,14 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-click-plugins \
                         port:py${python.version}-setuptools \
                         port:gdal
+
+    # cc1plus: error: unrecognized command line option "-stdlib=libc++"
+    if {${configure.cxx_stdlib} ne "libc++"} {
+        patchfiles-append   patch-fix-setup.py.diff
+    }
+
+    # pycore_frame.h: error: ‘for’ loop initial declaration used outside C99 mode
+    # cc1plus: error: unrecognized command line option "-std=c++11"
+    compiler.c_standard     1999
+    compiler.cxx_standard   2011
 }

--- a/python/py-rasterio/files/patch-fix-setup.py.diff
+++ b/python/py-rasterio/files/patch-fix-setup.py.diff
@@ -1,0 +1,10 @@
+--- setup.py	2023-10-12 05:17:50.000000000 +0800
++++ setup.py	2024-09-03 22:22:39.000000000 +0800
+@@ -202,7 +202,6 @@
+         if cpp11_flag not in eca:
+             eca.append(cpp11_flag)
+ 
+-        eca += [cpp11_flag, '-mmacosx-version-min=10.9', '-stdlib=libc++']
+ 
+     # TODO: Windows
+ 


### PR DESCRIPTION
#### Description

@stromnov Should we just apply this patch unconditionally? Compiler is supposed to handle it, but I cannot test on every system.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
