### PR TITLE
ruby-build: Upgrade to 20240903

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20240727 v
+github.setup        rbenv ruby-build 20240903 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  0d5af7f4510e98c3f218c088df1abf7d2db3900a \
-                    sha256  c6359deb8694e19c00af37cadef239af7e3f00e63d89e9333870bbb0178d039c \
-                    size    90469
+checksums           rmd160  13085a625bf93e94707c76789d61f072c69a4443 \
+                    sha256  e6b763ecfc3e6fa7c5b5aeb8ed9df5eaabeb0639ca36b776afc26232efda1e25 \
+                    size    91578
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description



##### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
