### PR TITLE
openssl3: Update to 3.3.2, fix two CVEs

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            18
+revision            19
 
 categories          devel security
 platforms           darwin

--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -9,7 +9,6 @@ version             [openssl::default_branch]
 revision            19
 
 categories          devel security
-platforms           darwin
 license             MIT
 maintainers         {larryv @larryv} {cal @neverpanic}
 
@@ -19,6 +18,7 @@ long_description    {*}${description}
 homepage            https://www.openssl.org/
 
 conflicts           libressl libressl-devel
+supported_archs     noarch
 
 distfiles
 use_configure       no

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -4,16 +4,22 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 PortGroup           legacysupport 1.1
+PortGroup           github 1.0
 
 # Availability.h
 legacysupport.newest_darwin_requires_legacy 8
 
 set major_v         3
-name                openssl$major_v
 # For former rollback to 3.1.x release where needed. Must now stay.
 epoch               1
-version             ${major_v}.3.1
-revision            1
+github.setup        openssl openssl ${major_v}.3.2 openssl-
+name                openssl3
+revision            0
+
+github.tarball_from releases
+checksums           rmd160  a904b3c3c9fcb9ab9248bfc0225003fa610d382f \
+                    sha256  2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281 \
+                    size    18076531
 
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)
@@ -33,25 +39,11 @@ long_description    The OpenSSL Project is a collaborative effort to \
                     Security (TLS v1) protocols as well as \
                     a full-strength general purpose cryptography \
                     library.
-homepage            https://www.openssl.org
+homepage            https://www.openssl-library.org
 
 depends_lib         port:zlib
 
 distname            openssl-${version}
-
-# See https://www.openssl.org/source/mirror.html
-master_sites        ${homepage}/source \
-                    ftp://gd.tuwien.ac.at/infosys/security/openssl/source/ \
-                    http://mirror.switch.ch/ftp/mirror/openssl/source/ \
-                    ftp://ftp.fi.muni.cz/pub/openssl/source/ \
-                    ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
-                    http://artfiles.org/openssl.org/source/ \
-                    ftp://ftp.linux.hr/pub/openssl/source/ \
-                    ftp://guest.kuria.katowice.pl/pub/openssl/source/
-
-checksums           rmd160  f7d3736a023dcf7d40db016182ca6d1de5a6fa69 \
-                    sha256  777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e \
-                    size    18055752
 
 # Old obsolete subport for overriding version holdback
 # Make it explicitly obsolete for now

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             9.8p1
-revision            0
+revision            1
 categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                22
+revision                23
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588


### PR DESCRIPTION
#### Description

See https://openssl-library.org/news/secadv/20240903.txt and https://openssl-library.org/news/secadv/20240627.txt for the upstream advisories.

The changelog is at https://openssl-library.org/news/openssl-3.3-notes/.

The source code has moved to GitHub releases, so adjust the source accordingly.

CVE: CVE-2024-6119
CVE: CVE-2024-5535

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
