### PR TITLE
rage: add port

### DIFF
--- a/security/rage/Portfile
+++ b/security/rage/Portfile
@@ -1,0 +1,440 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        str4d rage 0.10.0 v
+github.tarball_from archive
+revision            0
+categories          security
+installs_libs       no
+license             MIT Apache-2
+maintainers         {gmail.com:turbocool3r @turbocool3r} \
+                    openmaintainer
+
+description         Rust implementation of age
+long_description    rage is a simple, modern, and secure file encryption tool, using \
+                    the age format. It features small explicit keys, no config options, \
+                    and UNIX-style composability.
+
+cargo.crates \
+    addr2line                       0.21.0  8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    aead                             0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
+    aes                              0.8.3  ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2 \
+    aes-gcm                         0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
+    ahash                            0.8.7  77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01 \
+    aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
+    android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
+    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
+    anstream                         0.3.2  0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163 \
+    anstyle                          1.0.2  15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea \
+    anstyle-parse                    0.2.1  938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333 \
+    anstyle-query                    1.0.0  5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b \
+    anstyle-wincon                   1.0.2  c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c \
+    arc-swap                         1.6.0  bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6 \
+    arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    backtrace                       0.3.69  2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837 \
+    base64                          0.21.5  35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9 \
+    base64ct                         1.6.0  8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b \
+    bcrypt-pbkdf                    0.10.0  6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2 \
+    bech32                           0.9.1  d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445 \
+    bit-set                          0.5.3  0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1 \
+    bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                         2.4.1  327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07 \
+    block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
+    block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    block-padding                    0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
+    blowfish                         0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
+    bumpalo                         3.14.0  7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec \
+    bytemuck                        1.14.1  ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9 \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
+    bzip2                            0.4.4  bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8 \
+    bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
+    cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
+    cbc                              0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
+    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
+    chacha20poly1305                0.10.1  10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35 \
+    chrono                          0.4.33  9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb \
+    ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
+    ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
+    ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
+    cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
+    clap                            4.3.24  fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487 \
+    clap_builder                    4.3.24  5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e \
+    clap_complete                    4.3.2  5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce \
+    clap_derive                     4.3.12  54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050 \
+    clap_lex                         0.5.0  2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b \
+    clap_mangen                     0.2.12  8f2e32b579dae093c2424a8b7e2bea09c89da01e1ce5065eb2f0a6f1cc15cc1f \
+    colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
+    console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
+    const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
+    constant_time_eq                 0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    content_inspector                0.2.4  b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38 \
+    cookie-factory                   0.3.2  396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b \
+    core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
+    cpp_demangle                     0.4.3  7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119 \
+    cpufeatures                     0.2.11  ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0 \
+    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
+    criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
+    criterion-cycles-per-byte        0.6.0  5281161544b8f2397e14942c2045efa3446470348121a65c37263f8e76c1e2ff \
+    criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
+    crossbeam-deque                  0.8.4  fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751 \
+    crossbeam-epoch                 0.9.17  0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d \
+    crossbeam-utils                 0.8.18  c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c \
+    crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
+    crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
+    ctr                              0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
+    ctrlc                            3.4.2  b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b \
+    curve25519-dalek                 4.1.1  e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c \
+    curve25519-dalek-derive           0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
+    dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
+    debugid                          0.8.0  bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d \
+    der                              0.7.8  fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c \
+    digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    displaydoc                       0.2.4  487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d \
+    dunce                            1.0.4  56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b \
+    either                           1.9.0  a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07 \
+    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    env_logger                      0.10.2  4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580 \
+    equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+    errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
+    fastrand                         2.0.1  25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5 \
+    fiat-crypto                      0.2.5  27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7 \
+    filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
+    find-crate                       0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
+    findshlibs                      0.10.2  40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64 \
+    flate2                          1.0.28  46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e \
+    fluent                          0.16.0  61f69378194459db76abd2ce3952b790db103ceb003008d3d50d97c41ff847a7 \
+    fluent-bundle                   0.15.2  e242c601dec9711505f6d5bbff5bedd4b61b2469f2e8bb8e57ee7c9747a87ffd \
+    fluent-langneg                  0.13.0  2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94 \
+    fluent-syntax                   0.11.0  c0abed97648395c902868fee9026de96483933faa54ea3b40d652f7dfe61ca78 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    fuse_mt                          0.6.1  e098b8dc4cd32e9ba31d9c8cdfef11271d8191233c64c2a671432ff19d354948 \
+    fuser                           0.13.0  21370f84640642c8ea36dfb2a6bfc4c55941f476fcf431f6fef25a5ddcf0169b \
+    futures                         0.3.30  645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0 \
+    futures-channel                 0.3.30  eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78 \
+    futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
+    futures-executor                0.3.30  a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d \
+    futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
+    futures-macro                   0.3.30  87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac \
+    futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
+    futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
+    futures-test                    0.3.30  ce388237b32ac42eca0df1ba55ed3bbda4eaf005d7d4b5dbc0b20ab962928ac9 \
+    futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
+    generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
+    getrandom                       0.2.12  190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5 \
+    ghash                            0.5.0  d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40 \
+    gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
+    glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
+    half                             2.2.1  02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0 \
+    hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
+    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    hermit-abi                       0.3.4  5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f \
+    hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
+    hkdf                            0.12.4  7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7 \
+    hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
+    home                             0.5.5  5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb \
+    humantime                        2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
+    humantime-serde                  1.1.1  57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c \
+    i18n-config                      0.4.5  6691f16c6a35c1bb99a0f01aa39dd2b884d342b646689e9b8e4d51faf2cfdbd9 \
+    i18n-embed                      0.14.1  94205d95764f5bb9db9ea98fa77f89653365ca748e27161f5bbea2ffd50e459c \
+    i18n-embed-fl                    0.7.0  9fc1f8715195dffc4caddcf1cf3128da15fe5d8a137606ea8856c9300047d5a2 \
+    i18n-embed-impl                  0.8.3  81093c4701672f59416582fe3145676126fd23ba5db910acad0793c1108aaa58 \
+    iana-time-zone                  0.1.59  b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539 \
+    iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
+    indexmap                         2.1.0  d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f \
+    inferno                        0.11.19  321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9 \
+    inout                            0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
+    intl-memoizer                    0.5.1  c310433e4a310918d6ed9243542a6b83ec1183df95dff8f23f87bb88a264a66f \
+    intl_pluralrules                 7.0.2  078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972 \
+    io_tee                           0.1.1  4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304 \
+    is-terminal                     0.4.10  0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455 \
+    itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
+    itoa                            1.0.10  b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c \
+    jobserver                       0.1.26  936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2 \
+    js-sys                          0.3.66  cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
+    libm                             0.2.8  4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058 \
+    linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
+    locale_config                    0.3.0  08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934 \
+    lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
+    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
+    memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \
+    memmap2                          0.9.4  fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322 \
+    minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
+    miniz_oxide                      0.7.1  e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7 \
+    nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
+    nix                             0.27.1  2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053 \
+    nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
+    normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
+    num-bigint-dig                   0.8.4  dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151 \
+    num-format                       0.4.4  a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3 \
+    num-integer                     0.1.45  225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9 \
+    num-iter                        0.1.43  7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252 \
+    num-traits                      0.2.17  39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c \
+    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
+    objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
+    objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
+    objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
+    object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
+    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
+    oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
+    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
+    os_pipe                          1.1.5  57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9 \
+    page_size                        0.5.0  1b7663cbd190cfd818d08efa8497f6cd383076688c49a391ef7c0d03cd12b561 \
+    parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
+    parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
+    password-hash                    0.4.2  7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700 \
+    pbkdf2                          0.11.0  83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917 \
+    pbkdf2                          0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
+    percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    pin-project                      1.1.4  0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0 \
+    pin-project-internal             1.1.4  266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690 \
+    pin-project-lite                0.2.13  8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58 \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    pinentry                         0.5.0  bfa5b8bc68be6a5e2ba84ee86db53f816cba1905b94fcb7c236e606221cc8fc8 \
+    pkcs1                            0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
+    pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
+    pkg-config                      0.3.29  2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb \
+    platforms                        3.3.0  626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c \
+    plotters                         0.3.5  d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45 \
+    plotters-backend                 0.3.5  9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609 \
+    plotters-svg                     0.3.5  38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab \
+    poly1305                         0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
+    polyval                          0.6.1  d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb \
+    pprof                           0.13.0  ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb \
+    ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
+    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro2                     1.0.74  2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db \
+    proptest                         1.4.0  31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf \
+    quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
+    quick-xml                       0.26.0  7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd \
+    quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+    rand_xorshift                    0.3.0  d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f \
+    rayon                            1.8.0  9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1 \
+    rayon-core                      1.12.0  5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed \
+    redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
+    regex                           1.10.2  380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343 \
+    regex-automata                   0.4.3  5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f \
+    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    rgb                             0.8.37  05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8 \
+    roff                             0.2.1  b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316 \
+    rpassword                        7.3.1  80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f \
+    rsa                              0.9.6  5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc \
+    rtoolbox                         0.0.2  c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e \
+    rust-embed                       8.2.0  a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f \
+    rust-embed-impl                  8.2.0  6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16 \
+    rust-embed-utils                 8.2.0  8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665 \
+    rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
+    rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
+    rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
+    rustix                         0.38.31  6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949 \
+    rusty-fork                       0.3.0  cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f \
+    ryu                             1.0.16  f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c \
+    salsa20                         0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    scrypt                          0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
+    secrecy                          0.8.0  9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e \
+    self_cell                       0.10.3  e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d \
+    self_cell                        1.0.3  58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba \
+    semver                          1.0.21  b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0 \
+    serde                          1.0.194  0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773 \
+    serde_derive                   1.0.194  a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0 \
+    serde_json                     1.0.110  6fbd975230bada99c8bb618e0c365c2eefa219158d5c6c29610fd09ff1833257 \
+    serde_spanned                    0.6.3  96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186 \
+    sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
+    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    signature                        2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
+    similar                          2.4.0  32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21 \
+    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    smallvec                        1.13.1  e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7 \
+    snapbox                         0.4.11  f6bccd62078347f89a914e3004d94582e13824d4e3d8a816317862884c423835 \
+    snapbox-macros                   0.3.4  eaaf09df9f0eeae82be96290918520214530e738a7fe5a351b0f24cf77c0ca31 \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
+    stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
+    str_stack                        0.1.0  9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    subtle                           2.5.0  81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc \
+    symbolic-common                 12.8.0  1cccfffbc6bb3bb2d3a26cd2077f4d055f6808d266f9d4d158797a4c60510dfe \
+    symbolic-demangle               12.8.0  76a99812da4020a67e76c4eb41f08c87364c14170495ff780f30dd519c221a68 \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+    syn                             2.0.46  89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e \
+    tar                             0.4.40  b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb \
+    tempfile                         3.9.0  01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa \
+    termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
+    test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
+    test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
+    test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
+    thiserror                       1.0.56  d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad \
+    thiserror-impl                  1.0.56  fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471 \
+    threadpool                       1.8.1  d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa \
+    time                            0.3.23  59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446 \
+    time-core                        0.1.1  7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb \
+    tinystr                          0.7.1  7ac3f5b6856e931e15e07b478e98c8045239829a65f9156d4fa7e7788197a5ef \
+    tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
+    tokio                           1.35.1  c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104 \
+    tokio-macros                     2.2.0  5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b \
+    toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
+    toml                             0.7.6  c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542 \
+    toml_datetime                    0.6.3  7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b \
+    toml_edit                      0.19.14  f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a \
+    trycmd                         0.14.16  2925e71868a12b173c1eb166018c2d2f9dfaedfcaec747bdb6ea2246785d258e \
+    type-map                         0.4.0  b6d3364c5e96cb2ad1603037ab253ddd34d7fb72a58bdddf4b7350760fc69a46 \
+    typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
+    unarray                          0.1.4  eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94 \
+    unic-langid                      0.9.4  238722e6d794ed130f91f4ea33e01fcff4f188d92337a21297892521c72df516 \
+    unic-langid-impl                 0.9.4  4bd55a2063fdea4ef1f8633243a7b0524cbeef1905ae04c31a1c9b9775c55bc6 \
+    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    universal-hash                   0.5.1  fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea \
+    utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
+    uuid                             1.7.0  f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
+    walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasm-bindgen                    0.2.89  0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e \
+    wasm-bindgen-backend            0.2.89  1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826 \
+    wasm-bindgen-macro              0.2.89  0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2 \
+    wasm-bindgen-macro-support      0.2.89  f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283 \
+    wasm-bindgen-shared             0.2.89  7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f \
+    web-sys                         0.3.66  50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f \
+    which                            4.4.2  87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.6  f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
+    windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-targets                 0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows-targets                 0.52.0  8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd \
+    windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_gnullvm         0.52.0  cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea \
+    windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_aarch64_msvc            0.52.0  bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef \
+    windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_gnu                0.52.0  a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313 \
+    windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_i686_msvc               0.52.0  ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a \
+    windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnu              0.52.0  3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd \
+    windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_gnullvm          0.52.0  1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e \
+    windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    windows_x86_64_msvc             0.52.0  dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04 \
+    winnow                          0.5.37  a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5 \
+    wsl                              0.1.0  f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4 \
+    x25519-dalek                     2.0.0  fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96 \
+    xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
+    zerocopy                         0.6.6  854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6 \
+    zerocopy                        0.7.32  74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be \
+    zerocopy-derive                  0.6.6  125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91 \
+    zerocopy-derive                 0.7.32  9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6 \
+    zeroize                          1.7.0  525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d \
+    zeroize_derive                   1.4.2  ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69 \
+    zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
+    zstd                 0.11.2+zstd.1.5.2  20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4 \
+    zstd-safe             5.0.2+zstd.1.5.2  1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db \
+    zstd-sys              2.0.9+zstd.1.5.5  9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656
+
+checksums-append    ${distname}${extract.suffix} \
+                    rmd160  8a990f5329504fd90d0678d6433e79a5aff72de1 \
+                    sha256  34c39c28f8032c144a43aea96e58159fe69526f5ff91cb813083530adcaa6ea4 \
+                    size    1642089
+
+set cargo_builddir ${worksrcpath}/target/[cargo.rust_platform]/release
+
+destroot {
+    # Install rage
+    xinstall -m 0755 ${cargo_builddir}/rage ${destroot}${prefix}/bin/
+    xinstall -m 0755 ${cargo_builddir}/rage-keygen ${destroot}${prefix}/bin/
+    if {[variant_isset mount]} {
+        xinstall -m 0755 ${cargo_builddir}/rage-mount ${destroot}${prefix}/bin/
+    }
+
+    # Install shell completions
+    xinstall -d -m 0755 ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0644 ${cargo_builddir}/completions/rage.bash \
+        ${destroot}${prefix}/share/bash-completion/completions/rage
+    xinstall -m 0644 ${cargo_builddir}/completions/rage-keygen.bash \
+        ${destroot}${prefix}/share/bash-completion/completions/rage-keygen
+    if {[variant_isset mount]} {
+        xinstall -m 0644 ${cargo_builddir}/completions/rage-mount.bash \
+            ${destroot}${prefix}/share/bash-completion/completions/rage-mount
+    }
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0644 ${cargo_builddir}/completions/rage.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/
+    xinstall -m 0644 ${cargo_builddir}/completions/rage-keygen.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/
+    if {[variant_isset mount]} {
+        xinstall -m 0644 ${cargo_builddir}/completions/rage-mount.fish \
+            ${destroot}${prefix}/share/fish/vendor_completions.d/
+    }
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0644 ${cargo_builddir}/completions/_rage \
+        ${destroot}${prefix}/share/zsh/site-functions/
+    xinstall -m 0644 ${cargo_builddir}/completions/_rage-keygen \
+        ${destroot}${prefix}/share/zsh/site-functions/
+    if {[variant_isset mount]} {
+        xinstall -m 0644 ${cargo_builddir}/completions/_rage-mount \
+            ${destroot}${prefix}/share/zsh/site-functions/
+    }
+
+    # Install man pages
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 {*}[glob ${cargo_builddir}/manpages/man1/*] \
+        ${destroot}${prefix}/share/man/man1/
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/es_AR/man1
+    xinstall -m 0644 {*}[glob ${cargo_builddir}/manpages/es_AR/man1/*] \
+        ${destroot}${prefix}/share/man/es_AR/man1/
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/it/man1
+    xinstall -m 0644 {*}[glob ${cargo_builddir}/manpages/it/man1/*] \
+        ${destroot}${prefix}/share/man/it/man1/
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/ru/man1
+    xinstall -m 0644 {*}[glob ${cargo_builddir}/manpages/ru/man1/*] \
+        ${destroot}${prefix}/share/man/ru/man1/
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/zh_CN/man1
+    xinstall -m 0644 {*}[glob ${cargo_builddir}/manpages/zh_CN/man1/*] \
+        ${destroot}${prefix}/share/man/zh_CN/man1/
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/zh_TW/man1
+    xinstall -m 0644 {*}[glob ${cargo_builddir}/manpages/zh_TW/man1/*] \
+        ${destroot}${prefix}/share/man/zh_TW/man1/
+}
+
+variant mount description {Build with FUSE/MacFUSE} {
+    build.args-append       --features 'mount'
+    depends_lib-append      port:macfuse
+}


### PR DESCRIPTION
#### Description

This adds a portfile for [rage](https://github.com/str4d/rage), a Rust implementation of [age](https://github.com/C2SP/C2SP/blob/main/age.md).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
