### PR TITLE
qt5: fix qt-base error for CGDIsplayImageForRect [Waiting for macOS 15 release]

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -19,6 +19,13 @@ version             ${qt_version}
 set middle_name     everywhere-opensource
 set worksrcdir_middle_name everywhere
 
+# qt-base is broken on macOS 15+, but that locks us in to this on all of them for now,
+# because of `error: 'CGDisplayCreateImageForRect' is unavailable: obsoleted in macOS 15.0 - Please use ScreenCaptureKit instead.`
+# This is going to be busted with any sdk over 15 for all qts, which is why it's >=24
+if { ${os.platform} eq "darwin" && ${os.major} >= 24 }  {
+    macosx_deployment_target 14.0
+}
+
 if { ${subport} eq "${name}-qtwebkit" ||
      ${subport} eq "${name}-qtwebkit-docs" } {
     version         5.9.2


### PR DESCRIPTION
#### Description

* Set macosx_deployment_target 14.0 for qt5 in general to stop the following error: `error: 'CGDisplayCreateImageForRect' is unavailable: obsoleted in macOS 15.0 - Please use ScreenCaptureKit instead.`
* I was able to build a full, working qt5 app on macOS 15 with this fix. It should not effect < mac15 in any way.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A5331b
Xcode 16.0 16A5230g

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
