### PR TITLE
qrcp: update to 0.11.3

### DIFF
--- a/sysutils/qrcp/Portfile
+++ b/sysutils/qrcp/Portfile
@@ -3,18 +3,19 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/claudiodangelis/qrcp 0.11.2
+go.setup            github.com/claudiodangelis/qrcp 0.11.3
 categories          sysutils net
 maintainers         {cal @neverpanic} openmaintainer
 
 license             MIT MPL-2 BSD LGPL-3 Apache-2
 description         Transfer files over wifi from your computer to your mobile device by scanning a QR code without leaving the terminal.
-long_description    ${description}
+long_description    {*}${description}
+homepage            https://qrcp.sh/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  cdc90d43a1eb328d7d2d9c8bc7fcb4b2281c714e \
-                        sha256  c7182adc97dcd9f7efccf103fef37b497744c10172a00be1f43d5e9f11ad8e71 \
-                        size    13295556
+                        rmd160  04cbf7ea59ab04045f3f60cd9a3ba4e8a1b28be7 \
+                        sha256  983dc23bc6e5d437965d49203a794f6e0ecb1e061a15c56c3b8576a41432fa59 \
+                        size    13295679
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
@@ -254,6 +255,24 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  1a1276ed8071b21d00f417eff83dc3a77d4a7878e3064f117bc22421902e0cfe \
                         size    20032
 
+set go_ldflags      "-s -w -X github.com/claudiodangelis/qrcp/version.version=${version}"
+build.args          -ldflags \"${go_ldflags}\"
+
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    set bash_completion ${prefix}/share/bash-completion/completions
+    xinstall -d ${destroot}${bash_completion}
+    exec ${destroot}${prefix}/bin/${name} completion bash >> \
+        ${destroot}${bash_completion}/${name}
+
+    set zsh_completion ${prefix}/share/zsh/site-functions
+    xinstall -d ${destroot}${zsh_completion}
+    exec ${destroot}${prefix}/bin/${name} completion zsh >> \
+        ${destroot}${zsh_completion}/_${name}
+
+    set fish_completion ${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${destroot}${fish_completion}
+    exec ${destroot}${prefix}/bin/${name} completion fish >> \
+        ${destroot}${fish_completion}/${name}.fish
 }


### PR DESCRIPTION
#### Description
* changelog: https://github.com/claudiodangelis/qrcp/releases/tag/0.11.3
* install completions
* add ldflags

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

