### PR TITLE
syncthing: update to 1.27.11

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.27.10 v
+go.setup            github.com/syncthing/syncthing 1.27.11 v
 github.tarball_from archive
 revision            0
 
@@ -17,9 +17,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
                     where it is stored, if it is shared with some third party \
                     and how it's transmitted over the Internet.
 
-checksums           rmd160  816db344aad97e499cf21d95d6cbf78fc839c66b \
-                    sha256  e2cd7126a10fe317c2a0be52bb3bc359ad8f2974f746b6093a86e611390907da \
-                    size    6560396
+checksums           rmd160  40c24e3095ec71b88dd350f20133b6c9f969a867 \
+                    sha256  b1d52d4b975595d6f5af694788d9025a62599b73dcf4b98c398129df7e731780 \
+                    size    6585359
 
 categories          net
 installs_libs       no


### PR DESCRIPTION
#### Description
update syncthing to 1.27.11
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
