### PR TITLE
autoconf: fix Linux build

### DIFF
--- a/devel/autoconf/Portfile
+++ b/devel/autoconf/Portfile
@@ -50,6 +50,7 @@ if {${os.platform} eq "darwin"} {
     configure.perl  /usr/bin/perl
 } else {
     depends_build-append \
+                    port:help2man \
                     port:perl5
     # https://trac.macports.org/ticket/70673
     configure.perl  ${prefix}/bin/perl5

--- a/devel/autoconf/Portfile
+++ b/devel/autoconf/Portfile
@@ -44,9 +44,16 @@ post-patch {
     touch ${worksrcpath}/man/autoreconf.1
 }
 
-# It should be safe to use the system Perl, since the scripts only use
-# core modules. The README prescribes 5.6 or later, and Tiger has 5.8.6.
-configure.perl      /usr/bin/perl
+if {${os.platform} eq "darwin"} {
+    # It should be safe to use the system Perl, since the scripts only use
+    # core modules. The README prescribes 5.6 or later, and Tiger has 5.8.6.
+    configure.perl  /usr/bin/perl
+} else {
+    depends_build-append \
+                    port:perl5
+    # https://trac.macports.org/ticket/70673
+    configure.perl  ${prefix}/bin/perl5
+}
 
 test.run            yes
 test.env            CC=${configure.cc}

--- a/devel/libtool/Portfile
+++ b/devel/libtool/Portfile
@@ -49,7 +49,7 @@ configure.env           M4=${prefix}/bin/gm4
 if {${os.platform} eq "darwin"} {
     configure.env-append    GREP=/usr/bin/grep SED=/usr/bin/sed
 } else {
-    depends_lib-append      port:grep port:gsed
+    depends_lib-append      port:grep port:gsed port:help2man
 }
 
 # Don't look for broken compilers (#23684, #32321).


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/70673

#### Description

Non-macOS-only:

Use MacPorts perl5 on non-Darwin systems.
Also it may need `help2man`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Linux riscv64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
