### PR TITLE
verilator: update version 5.020->5.028

### DIFF
--- a/science/verilator/Portfile
+++ b/science/verilator/Portfile
@@ -3,18 +3,17 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            verilator verilator 5.020 v
+github.setup            verilator verilator 5.028 v
 revision                0
 categories              science electronics
 license                 {LGPL-3 Artistic-2}
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
-platforms               darwin
 description             Verilog compiler and simulator
 long_description        Verilator is a {*}${description}.
 
-checksums               rmd160  026dd626ba18f76b269dfbfb78c58433803991e4 \
-                        sha256  4d998f624b7d546ca18f811ade6b14c4e9e73b7f5cc6090ff173d45f8ec86508 \
-                        size    3526644
+checksums               rmd160  5d45fa63999302629f90488b340470fa6a619b73 \
+                        sha256  45d7381a1e3f7bcb3bd7117950490c9d870c1ad7a75dc61abf6245c98b1fc4c1 \
+                        size    32548221
 
 compiler.cxx_standard   2014
 


### PR DESCRIPTION
#### Description

Updated verilator from 5.020 to 5.028

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
