### PR TITLE
google-cloud-sdk: update to 491.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             490.0.0
+version             491.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  519059bf32a28bb68cf2a386885a9c8b4572a4c8 \
-                    sha256  86c1dc5dd4cff6b2b411b4bbff53040bb76644b68b9e9d919c2413950985172a \
-                    size    51651256
+    checksums       rmd160  61c2bcd1b920f451ce0f9b05c7a253ca8da4e92c \
+                    sha256  ef2c16960eb29a3d832b6e070f458c1dc8a54a10c466015dfa8acddd4bfcbd6a \
+                    size    51717580
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  ea2744b56cf92e82de9ea4bc50d41a7d16b9f7a6 \
-                    sha256  fa396909acc763cf831dd5d89e778999debf37ceadccb3c1bdec606e59ba2694 \
-                    size    53000340
+    checksums       rmd160  99f31239f396d703a47d8c0d4f39e333bdd82c82 \
+                    sha256  e55def2a7904400a2e5156c3845aefbcc37f1c6667b593044fff8f59ef0c96d2 \
+                    size    53069005
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  3f8727122ed350934dd4d15f7a004488bdfcd16a \
-                    sha256  a3a098a5f067b561e003c37284a9b164f28f37fd0d6371bb55e326679f48641c \
-                    size    52948531
+    checksums       rmd160  a777d152db7b5e473607129f67492067f595fd17 \
+                    sha256  b518d5cd33c93898d495561715e4cc9118a0c0bf24d8d0c6663b89bf413157f2 \
+                    size    53017409
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 491.0.0.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?