### PR TITLE
openssl3: fix build with older versions of Perl

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -57,6 +57,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
     }
 }
 
+# https://trac.macports.org/ticket/70684
+# https://github.com/openssl/openssl/pull/25367
+# remove this patch in the next release
+patchfiles-append  patch-mkinstallvars.diff
+
 # Use timegm() in crypto/asn1/a_time.c
 # Fixes build on 10.4, and is generally preferable, anyway
 #

--- a/devel/openssl3/files/patch-mkinstallvars.diff
+++ b/devel/openssl3/files/patch-mkinstallvars.diff
@@ -1,0 +1,77 @@
+From 40c8ebe5d2781339709554d166adb006aa495ec8 Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Tue, 3 Sep 2024 19:16:05 +0200
+Subject: [PATCH] util/mkinstallvars.pl: replace List::Util::pairs with out own
+
+Unfortunately, List::Util::pairs didn't appear in perl core modules
+before 5.19.3, and our minimum requirement is 5.10.
+
+Fortunately, we already have a replacement implementation, and can
+re-apply it in this script.
+
+Fixes #25366
+
+Reviewed-by: Dmitry Belyavskiy <beldmit@gmail.com>
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/25367)
+
+(cherry picked from commit 210dc9a50dfd99caa1cf7c3d2fa42850124b1bbc)
+--- util/mkinstallvars.pl
++++ util/mkinstallvars.pl
+@@ -10,8 +10,14 @@
+ # form, or passed as variable assignments on the command line.
+ # The result is a Perl module creating the package OpenSSL::safe::installdata.
+ 
++use 5.10.0;
++use strict;
++use warnings;
++use Carp;
++
+ use File::Spec;
+-use List::Util qw(pairs);
++#use List::Util qw(pairs);
++sub _pairs (@);
+ 
+ # These are expected to be set up as absolute directories
+ my @absolutes = qw(PREFIX libdir);
+@@ -19,9 +25,9 @@
+ # as subdirectories to PREFIX or LIBDIR.  The order of the pairs is important,
+ # since the LIBDIR subdirectories depend on the calculation of LIBDIR from
+ # PREFIX.
+-my @subdirs = pairs (PREFIX => [ qw(BINDIR LIBDIR INCLUDEDIR APPLINKDIR) ],
+-                     LIBDIR => [ qw(ENGINESDIR MODULESDIR PKGCONFIGDIR
+-                                    CMAKECONFIGDIR) ]);
++my @subdirs = _pairs (PREFIX => [ qw(BINDIR LIBDIR INCLUDEDIR APPLINKDIR) ],
++                      LIBDIR => [ qw(ENGINESDIR MODULESDIR PKGCONFIGDIR
++                                     CMAKECONFIGDIR) ]);
+ # For completeness, other expected variables
+ my @others = qw(VERSION LDLIBS);
+ 
+@@ -151,3 +157,26 @@ package OpenSSL::safe::installdata;
+ 
+ 1;
+ _____
++
++######## Helpers
++
++# _pairs LIST
++#
++# This operates on an even-sized list, and returns a list of "ARRAY"
++# references, each containing two items from the given LIST.
++#
++# It is a quick cheap reimplementation of List::Util::pairs(), a function
++# we cannot use, because it only appeared in perl v5.19.3, and we claim to
++# support perl versions all the way back to v5.10.
++
++sub _pairs (@) {
++    croak "Odd number of arguments" if @_ & 1;
++
++    my @pairlist = ();
++
++    while (@_) {
++        my $x = [ shift, shift ];
++        push @pairlist, $x;
++    }
++    return @pairlist;
++}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/70684

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
