### PR TITLE
openssl: Mark architecture-specific

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            19
+revision            20
 
 categories          devel security
 license             MIT
@@ -18,7 +18,10 @@ long_description    {*}${description}
 homepage            https://www.openssl.org/
 
 conflicts           libressl libressl-devel
-supported_archs     noarch
+# This does not install architecture-specific files and will generate a warning
+# because of that, but it still needs to stay architecture specific because
+# otherwise +universal will not bubble through this when +universal ports only
+# directly depend on this port, rather than openssl3.
 
 distfiles
 use_configure       no


### PR DESCRIPTION
#### Description

See jmr's comment on https://github.com/macports/macports-ports/commit/e2ae2e44d6db356e9f18c825b76f5c7327f7b458

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
