### PR TITLE
uv: Update to 0.4.6

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.4.4
+github.setup            astral-sh uv 0.4.6
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  7553e8ed3984496c24a9a89e549e7e5dff05d635 \
-                        sha256  84e5335787086c22cb7ada6508a4034817c91347b65f175c5c04e52dea4362d6 \
-                        size    2529092
+                        rmd160  d5dfc1b823fab45f93a054038bcea35c1896af73 \
+                        sha256  d89a43e32851bd5df7c6c78d77718a68b75b61dccebee76efb717ae9c3349f63 \
+                        size    2553065
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `uv` to its latest released verison, 0.4.6

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
