### PR TITLE
screen: Fix invalid value 'c17' in '-std=c17'

### DIFF
--- a/sysutils/screen/Portfile
+++ b/sysutils/screen/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                screen
 version             5.0.0
-revision            0
+revision            1
 homepage            https://www.gnu.org/software/screen/
 description         Screen manager with VT100/ANSI terminal emulation
 long_description    \
@@ -18,7 +18,6 @@ long_description    \
     regions between windows.
 categories          sysutils
 license             GPL-3+
-platforms           darwin
 maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 master_sites        gnu:${name} \
                     http://www.ryandesign.com/macports/distfiles/screen/:encoding \
@@ -56,6 +55,8 @@ configure.args      --mandir=${prefix}/share/man \
                     --disable-utmp \
                     --enable-telnet
 configure.cflags-append -DRUN_LOGIN
+
+compiler.c_standard     2017
 
 post-destroot {
     xinstall -m 644 ${workpath}/18 ${destroot}${prefix}/share/${name}/utf8encodings


### PR DESCRIPTION
#### Description

Fix building `screen` on < OSX 10.12 by setting `compiler.c_standard` to support value "c17" in "-std=c17"

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
