### PR TITLE
gallery-dl: update to 1.27.4, remove youtube-dl

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.27.3 v
+github.setup        mikf gallery-dl 1.27.4 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  650ba7a7d1c668d77d98d6e3a2337ea944947505 \
-                    sha256  20b9e76e7422267041395f3b996c35c4753c0ed097215570470cff3dfcd54922 \
-                    size    470066
+checksums           rmd160  730aa81666940cf20c40305817ca4018304e0fb4 \
+                    sha256  dbccb9b14f689cf1c8aa54c8633210f89d8a12526871bbb029037f139d09188f \
+                    size    476074
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites
@@ -35,10 +35,6 @@ depends_lib-append  port:py${python.version}-brotli \
 
 variant ffmpeg description {Add ffmpeg dependency to enable Pixiv Ugoira to WebM conversion} {
     depends_run-append path:bin/ffmpeg:ffmpeg
-}
-
-variant youtubedl description {Add youtube-dl dependency to enable video downloads} {
-     depends_run-append port:youtube-dl
 }
 
 variant ytdlp description {Add yt-dlp dependency to enable video downloads} {


### PR DESCRIPTION
#### Description

- update to 1.27.4
- removed the youtube-dl variant, kept the yt-dlp variant

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
