### PR TITLE
screen: Use `legacysupport` to support OSX 10.6

### DIFF
--- a/sysutils/screen/Portfile
+++ b/sysutils/screen/Portfile
@@ -42,7 +42,8 @@ checksums           ${distname}${extract.suffix} \
 
 patchfiles          patch-apple-screen.diff \
                     patch-apple-window.diff \
-                    patch-tic.diff
+                    patch-tic.diff \
+                    patch-use-right-environ.diff
 depends_lib         port:ncurses
 
 extract.only        ${distname}${extract.suffix}
@@ -73,9 +74,9 @@ platform darwin {
     }
 }
 
-platform darwin 8 {
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
     # Tiger lacks vproc.h and _CS_DARWIN_USER_TEMP_DIR, just nix the screen.c patch
-    patchfiles-delete patch-apple-screen.diff
+    patchfiles-delete   patch-apple-screen.diff
 }
 
 notes "

--- a/sysutils/screen/Portfile
+++ b/sysutils/screen/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
+
+# strndup
+legacysupport.newest_darwin_requires_legacy 10
 
 name                screen
 version             5.0.0
@@ -44,7 +48,7 @@ patchfiles          patch-apple-screen.diff \
                     patch-apple-window.diff \
                     patch-tic.diff \
                     patch-use-right-environ.diff
-depends_lib         port:ncurses
+depends_lib-append  port:ncurses
 
 extract.only        ${distname}${extract.suffix}
 post-extract {
@@ -54,7 +58,8 @@ post-extract {
 configure.args      --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info \
                     --disable-utmp \
-                    --enable-telnet
+                    --enable-telnet \
+                    --with-system_screenrc=${prefix}/etc
 configure.cflags-append -DRUN_LOGIN
 
 compiler.c_standard     2017

--- a/sysutils/screen/files/patch-use-right-environ.diff
+++ b/sysutils/screen/files/patch-use-right-environ.diff
@@ -1,0 +1,15 @@
+--- screen.c.orig	2024-08-29 03:55:03.000000000 +0800
++++ screen.c	2024-09-07 14:59:55.000000000 +0800
+@@ -59,7 +59,12 @@
+ #include "utmp.h"
+ #include "winmsg.h"
+ 
++#ifdef __APPLE__
++#include <crt_externs.h>
++#define environ (*_NSGetEnviron())
++#else
+ extern char **environ;
++#endif
+ 
+ int           force_vt = 1;
+ int           VBellWait;


### PR DESCRIPTION
#### Descriptio

Fix `screen` on OSX 10.6 by using the `legacysupport` PG for `strndup`. Other patches were added to use appropriate functions and fix building on OSX 10.5 and lower.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
