### PR TITLE
fastfetch: minor fix for legacy macOS (no revbump)

### DIFF
--- a/sysutils/fastfetch/Portfile
+++ b/sysutils/fastfetch/Portfile
@@ -95,7 +95,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
                     0017-Fix-compatibility-with-10.4.patch \
                     0018-Revert-some-breakages.patch \
                     0019-CMakeLists-adjust-for-legacy-macOS.patch \
-                    0020-swap_fat_arch_64-does-not-exist-in-10.6.patch
+                    0020-swap_fat_arch_64-does-not-exist-in-10.6.patch \
+                    0021-CMakeLists-do-not-use-Linux-ldflag-on-macOS.patch
 
     # Leopard needs this at least due to physicaldisk_apple module,
     # which uses definitions from storage/IOStorageDeviceCharacteristics.h (IOKit framework);
@@ -103,7 +104,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # that SDK version, or otherwise disable physicaldisk_apple (see the patch).
     if {${os.major} < 10} {
         patchfiles-append \
-                    0021-Tiger-specific-adjustments-to-CMakeLists.patch
+                    0022-Tiger-specific-adjustments-to-CMakeLists.patch
     }
 
     # To make sure OpenCL is not accidentally enabled.

--- a/sysutils/fastfetch/files/0021-CMakeLists-do-not-use-Linux-ldflag-on-macOS.patch
+++ b/sysutils/fastfetch/files/0021-CMakeLists-do-not-use-Linux-ldflag-on-macOS.patch
@@ -1,0 +1,22 @@
+From 01a73b6ce087eb402daa238dab5e5c61aab4f8c5 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Sat, 7 Sep 2024 18:06:12 +0800
+Subject: [PATCH] CMakeLists: do not use Linux ldflag on macOS
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6b2a2bcf..f8fd30bd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -136,7 +136,7 @@ if(ENABLE_ASAN)
+ endif()
+ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${FASTFETCH_FLAGS_DEBUG}")
+ set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} ${FASTFETCH_FLAGS_DEBUG} -fstack-protector-all -fno-delete-null-pointer-checks")
+-if(NOT WIN32)
++if(NOT WIN32 AND NOT APPLE)
+     set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -rdynamic")
+ endif()
+ 

--- a/sysutils/fastfetch/files/0022-Tiger-specific-adjustments-to-CMakeLists.patch
+++ b/sysutils/fastfetch/files/0022-Tiger-specific-adjustments-to-CMakeLists.patch
@@ -4,11 +4,11 @@ Date: Tue, 27 Aug 2024 16:08:42 +0800
 Subject: [PATCH] Tiger-specific adjustments to CMakeLists
 
 ---
- CMakeLists.txt | 5 ++---
- 1 file changed, 2 insertions(+), 3 deletions(-)
+ CMakeLists.txt | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6b2a2bcf..ff70a643 100644
+diff --git CMakeLists.txt CMakeLists.txt
+index 6b2a2bcf..b607fabf 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -632,7 +632,7 @@ elseif(APPLE)
@@ -29,6 +29,15 @@ index 6b2a2bcf..ff70a643 100644
          src/detection/physicalmemory/physicalmemory_nosupport.c
          src/detection/diskio/diskio_apple.c
          src/detection/displayserver/displayserver_apple.c
+@@ -689,7 +689,7 @@ elseif(APPLE)
+         src/util/apple/cf_helpers.c
+         src/util/apple/osascript.m
+         src/util/platform/FFPlatform_unix.c
+-        src/util/binary_apple.c
++        src/util/binary_linux.c
+     )
+ elseif(WIN32)
+     list(APPEND LIBFASTFETCH_SRC
 @@ -1108,7 +1108,6 @@ elseif(APPLE)
          PRIVATE "-framework Cocoa"
          PRIVATE "-framework CoreFoundation"


### PR DESCRIPTION
#### Description

Hopefully should fix build on 10.5, which reportedly fails on recently added module `binary_apple`.
A patch to remove `-rdynamic` is a matter of neatness.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
