### PR TITLE
Wine devel,wine staging update to 9.17

### DIFF
--- a/cross/mingw-w64-wine-mono/Portfile
+++ b/cross/mingw-w64-wine-mono/Portfile
@@ -21,7 +21,7 @@ build {}
 
 if {${subport} eq ${name}} {
     PortGroup       stub 1.0
-    version         9.2.0
+    version         9.3.0
     revision        0
     depends_run     port:mingw-w64-wine-mono-${version}
 
@@ -31,6 +31,17 @@ if {${subport} eq ${name}} {
             registry_deactivate_composite mingw-w64-wine-mono-${version} "" [list ports_nodepcheck 1]
         }
     }
+}
+
+# wine-devel (9.17)
+subport ${name}-9.3.0 {
+    version         9.3.0
+    revision        0
+    distname        wine-mono-${version}-x86
+    checksums       rmd160  e7f87fe3ecb4b9b84bcbfd63b5d2725e000bf7dd \
+                    sha256  c23deb9e3217a574f242b78d74cb94c4948a37d1f2715941b803a02e535854a6 \
+                    size    43906032
+    use_xz          yes
 }
 
 # wine-devel (9.12)

--- a/emulators/wine-devel/Portfile
+++ b/emulators/wine-devel/Portfile
@@ -7,7 +7,7 @@ PortGroup                   muniversal 1.1
 
 # Keep the wine-stable, wine-devel and wine-crossover portfiles as similar as possible.
 
-github.setup                wine-mirror wine 9.16 wine-
+github.setup                wine-mirror wine 9.17 wine-
 github.tarball_from         archive
 name                        wine-devel
 conflicts                   wine-stable wine-staging wine-crossover
@@ -37,9 +37,9 @@ long_description \
 
 checksums \
     ${distname}${extract.suffix} \
-    rmd160  d8a37ecef52b2a3f091365725544cdbc468eb7d5 \
-    sha256  f5bbf6f0008e42f2bae3f46f67dfb8bcb96bd741f94e24d3e6f8a8f7991c685e \
-    size    49763292
+    rmd160  2293c1c6b36d74e18a6b460d3a9c0ce4ad032c95 \
+    sha256  a5933231567c07f4afafaab410e90d4a69717e080e2ce539a1364192297dd024 \
+    size    49839986
 
 depends_build \
     port:bison \
@@ -58,7 +58,7 @@ depends_lib \
 
 depends_run \
     port:mingw-w64-wine-gecko-2.47.4 \
-    port:mingw-w64-wine-mono-9.2.0
+    port:mingw-w64-wine-mono-9.3.0
 
 patch.pre_args-replace -p0 -p1
 
@@ -144,9 +144,9 @@ subport wine-staging {
 
     checksums-append \
         ${wine_staging_distfile} \
-        rmd160  0dcc1d1154aae29b8d35ec9bc5afdc75837ec8b6 \
-        sha256  fdff5f26fb2b872ab702d540c86248f09c971c8e7b80ba3899d4e5c19a12f7c3 \
-        size    9506127
+        rmd160  872d7c3be456d1abe7ed948a7c67f4a597b7673b \
+        sha256  8b75c8fe4802eb00084b7b7c274a9941f06b28ed6496efa612476b9760852392 \
+        size    9383269
 
     depends_patch-append    port:autoconf
 

--- a/emulators/wine-devel/files/1001-devel-msync.diff
+++ b/emulators/wine-devel/files/1001-devel-msync.diff
@@ -2162,8 +2162,8 @@ index 74bf0f0c839..fd84ee0d1a9 100644
  
  /* ### protocol_version begin ### */
  
--#define SERVER_PROTOCOL_VERSION 837
-+#define SERVER_PROTOCOL_VERSION 841
+-#define SERVER_PROTOCOL_VERSION 840
++#define SERVER_PROTOCOL_VERSION 844
  
  /* ### protocol_version end ### */
  

--- a/emulators/wine-devel/files/1001-staging-msync.diff
+++ b/emulators/wine-devel/files/1001-staging-msync.diff
@@ -2224,8 +2224,8 @@ index 44f18710766..e6610d3cab5 100644
  
  /* ### protocol_version begin ### */
  
--#define SERVER_PROTOCOL_VERSION 838
-+#define SERVER_PROTOCOL_VERSION 839
+-#define SERVER_PROTOCOL_VERSION 841
++#define SERVER_PROTOCOL_VERSION 845
  
  /* ### protocol_version end ### */
  


### PR DESCRIPTION
#### Description

Also adds `mingw-w64-wine-mono-9.3.0` subport as it's required for wine-9.17

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
