### PR TITLE
ImageMagick7: Update to 7.1.1-38

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -21,12 +21,12 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-github.setup        ImageMagick ImageMagick 7.1.1-34
+github.setup        ImageMagick ImageMagick 7.1.1-38
 revision            0
 
-checksums           rmd160  7b1518c89c3ba420470825d63d1d77b6a76e1e63 \
-                    sha256  69f6c7d1043e96d68e80fb3df2c248d189b3374552ae1cfe8e3913a88239e742 \
-                    size    15659326
+checksums           rmd160  9b461dc2111125fd05ca0949db5480794b87bef2 \
+                    sha256  109c4ce940db01e6e45ede67800e58ad1beaac9b04f27c618ffc4a1ec317159d \
+                    size    15657803
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \


### PR DESCRIPTION
#### Description

ImageMagick7: Update to 7.1.1-38

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 12-x86, 13-x86, 14-arm only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?