### PR TITLE
gitui: update to 0.26.3

### DIFF
--- a/devel/gitui/Portfile
+++ b/devel/gitui/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        extrawurst gitui 0.26.2 v
+github.setup        extrawurst gitui 0.26.3 v
 github.tarball_from archive
 revision            0
 
@@ -19,14 +19,16 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  058d70116e56072cd154f579558116725ade7bc9 \
-                    sha256  c69eccba2457c53c18b933794aa4ff3dfecb71af42349282108354d543e4d956 \
-                    size    34964001
+                    rmd160  606088a2eff949995a03a8859638b4034dab7f91 \
+                    sha256  8075e180f3b01ff0c290b690488a7628c44b4de12346e04a77d823914a48918b \
+                    size    34964445
 
 build.args-append   {--features "vendor-openssl"}
 
 depends_lib-append  path:lib/pkgconfig/libgit2.pc:libgit2 \
                     port:zlib
+
+build.env-append    GITUI_RELEASE=${version}
 
 destroot {
     xinstall -m 0755 \
@@ -50,7 +52,7 @@ cargo.crates \
     anstyle-parse                    0.2.4  c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4 \
     anstyle-query                    1.0.3  a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5 \
     anstyle-wincon                   3.0.3  61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19 \
-    anyhow                          1.0.83  25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3 \
+    anyhow                          1.0.86  b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da \
     autocfg                          1.3.0  0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0 \
     backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
     base16ct                         0.2.0  4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf \
@@ -73,7 +75,7 @@ cargo.crates \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     castaway                         0.2.2  8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc \
     cbc                              0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                              1.0.97  099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4 \
+    cc                              1.0.98  41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
@@ -86,11 +88,11 @@ cargo.crates \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
     cpufeatures                     0.2.12  53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504 \
-    crc32fast                        1.4.0  b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa \
-    crossbeam-channel               0.5.12  ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95 \
+    crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
+    crossbeam-channel               0.5.13  33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2 \
     crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                 0.8.19  248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345 \
+    crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
     crossterm                       0.27.0  f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df \
     crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crypto-bigint                    0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
@@ -108,7 +110,7 @@ cargo.crates \
     ecdsa                           0.16.9  ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca \
     ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                    2.1.1  4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871 \
-    either                          1.11.0  a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2 \
+    either                          1.12.0  3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b \
     elliptic-curve                  0.13.8  b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47 \
     env_filter                       0.1.0  a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea \
     env_logger                      0.11.3  38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9 \
@@ -150,7 +152,6 @@ cargo.crates \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
     indexmap                         2.2.6  168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26 \
-    indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inotify                          0.9.6  f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff \
     inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
     inout                            0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
@@ -162,18 +163,18 @@ cargo.crates \
     kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
     kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.154  ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346 \
+    libc                           0.2.155  97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c \
     libgit2-sys                   0.16.2+1.7.2  ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8 \
     libm                             0.2.8  4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
     libz-sys                        1.1.16  5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9 \
-    linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
+    linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
     log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
     lru                             0.12.3  d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc \
     memchr                           2.7.2  6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d \
-    miniz_oxide                      0.7.2  9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7 \
+    miniz_oxide                      0.7.3  87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae \
     mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
     notify                           6.1.1  6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d \
     notify-debouncer-mini            0.4.1  5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43 \
@@ -214,12 +215,12 @@ cargo.crates \
     ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
     pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
     primeorder                      0.13.6  353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6 \
-    proc-macro2                     1.0.82  8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b \
+    proc-macro2                     1.0.83  0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43 \
     quote                           1.0.36  0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
-    ratatui                         0.26.2  a564a852040e82671dc50a37d88f3aa83bbc690dfc6844cfe7a2591620206a80 \
+    ratatui                         0.26.3  f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
@@ -270,12 +271,12 @@ cargo.crates \
     strum                           0.26.2  5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29 \
     strum_macros                    0.26.2  c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946 \
     subtle                           2.5.0  81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc \
-    syn                             2.0.63  bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704 \
+    syn                             2.0.65  d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106 \
     syntect                          5.2.0  874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     tempfile                        3.10.1  85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1 \
-    thiserror                       1.0.60  579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18 \
-    thiserror-impl                  1.0.60  e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524 \
+    thiserror                       1.0.61  c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709 \
+    thiserror-impl                  1.0.61  46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     time                            0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \


### PR DESCRIPTION
#### Description
https://github.com/extrawurst/gitui/releases/tag/v0.26.3

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
