### PR TITLE
py-bottleneck: update to 1.4.0

### DIFF
--- a/python/py-bottleneck/Portfile
+++ b/python/py-bottleneck/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-bottleneck
-python.rootname     Bottleneck
-version             1.3.8
+version             1.4.0
 revision            0
 categories-append   math
 license             BSD
@@ -22,14 +21,30 @@ long_description    Bottleneck is a set of NumPy ufuncs rewritten in \
 
 homepage            https://github.com/pydata/bottleneck
 
-checksums           rmd160  8f7f0d89a72dc8be802e807015a864380d858f1b \
-                    sha256  6780d896969ba7f53c8995ba90c87c548beb3db435dc90c60b9a10ed1ab4d868 \
-                    size    103252
+checksums           rmd160  72c8063adff2379dca0b555461e442be87a523cf \
+                    sha256  beb36df519b8709e7d357c0c9639b03b885ca6355bbf5e53752c685de51605b8 \
+                    size    103490
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-versioneer
 
-    depends_lib-append  port:py${python.version}-oldest-supported-numpy \
-                        port:py${python.version}-numpy
+    depends_lib-append  port:py${python.version}-numpy
+
+    if {${python.version} == 38} {
+        python.rootname Bottleneck
+        version     1.3.8
+        revision    0
+
+        checksums   rmd160  8f7f0d89a72dc8be802e807015a864380d858f1b \
+                    sha256  6780d896969ba7f53c8995ba90c87c548beb3db435dc90c60b9a10ed1ab4d868 \
+                    size    103252
+
+        depends_lib-append \
+                    port:py${python.version}-oldest-supported-numpy
+    } else {
+        # py-numpy >= 2.0.0 is only required when building wheels for PyPI
+        # See: pyproject.toml
+        patchfiles  patch-pyproject.toml.diff
+    }
 }

--- a/python/py-bottleneck/files/patch-pyproject.toml.diff
+++ b/python/py-bottleneck/files/patch-pyproject.toml.diff
@@ -1,0 +1,9 @@
+--- pyproject.toml.orig	2024-06-17 17:24:33
++++ pyproject.toml	2024-09-08 06:38:40
+@@ -14,5 +14,5 @@
+     #      and disabling build isolation.
+     #   3. The <2.3 upper bound is for matching the numpy deprecation policy,
+     #      it should not be loosened
+-    "numpy>=2.0.0rc1,<2.3 ; python_version >= '3.9'",
++    "numpy ; python_version >= '3.9'",
+ ]


### PR DESCRIPTION
Work around PyPI py-numpy >= 2.0.0 requirement
See: https://github.com/pydata/bottleneck/blob/master/pyproject.toml
See: https://trac.macports.org/ticket/70251

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] update

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
