### PR TITLE
dbeaver-community: Update to 24.2.0

### DIFF
--- a/databases/dbeaver-community/Portfile
+++ b/databases/dbeaver-community/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dbeaver dbeaver 24.1.5
+github.setup        dbeaver dbeaver 24.2.0
 github.tarball_from releases
 revision            0
 name                dbeaver-community
@@ -32,15 +32,15 @@ use_dmg             yes
 switch ${build_arch} {
     x86_64 {
         distfiles           dbeaver-ce-${version}-macos-x86_64${extract.suffix}
-        checksums           rmd160  340a2848545b60bf34758198699355954ae0b1b7 \
-                            sha256  61c98c64f8a0ca403dbcd105df637309058c58fb7518ced5696192019a7fd583 \
-                            size    127642020
+        checksums           rmd160  90252c3949c19fe6859778c8ffd2261bf06d68fe \
+                            sha256  a145287f51d87942cfdea3ebf6607af5953cdd5b88e21274f70d377e373ed58e \
+                            size    125051631
     }
     arm64 {
         distfiles           dbeaver-ce-${version}-macos-aarch64${extract.suffix}
-        checksums           rmd160  c9066a64f88cc9e5052fc63710922aa12ed62ca3 \
-                            sha256  b73f80a7f61925b73ea1b08baaad9bd8781150e45691a38754610426dc04257a \
-                            size    126571761
+        checksums           rmd160  a3492011880d3c45043d9da51ffbac2eea1173ff \
+                            sha256  2597e3d1d81aa849ddcf22e007016b15e6d6c73eceff9dea03d69378e116bcb1 \
+                            size    123980694
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Update dbeaver-community to 24.2.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
