### PR TITLE
libgdiplus: unbreak build on < 10.8

### DIFF
--- a/devel/libgdiplus/Portfile
+++ b/devel/libgdiplus/Portfile
@@ -7,7 +7,6 @@ name                    libgdiplus
 version                 6.0.5
 revision                3
 categories              devel
-platforms               darwin
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 license                 MIT
 description             An Open Source implementation of the GDI+ API
@@ -22,7 +21,7 @@ checksums               rmd160  dca604e6298a95d55a5e4d45d0186c4e0e592b38 \
                         sha256  b81e4e5cc3e4831b2945de08bef26eb1bdcd795aeaf8f971b221c51213a025ef \
                         size    1391332
 
-depends_build           port:pkgconfig
+depends_build           path:bin/pkg-config:pkgconfig
 
 depends_lib             path:include/turbojpeg.h:libjpeg-turbo \
                         port:tiff \
@@ -38,9 +37,16 @@ patchfiles              patch-no_zlib.diff \
                         patch-fix_flags.diff \
                         patch-fix_pangoft2.diff
 
+# jmorecfg.h: error: redefinition of typedef ‘UINT16’
+compiler.c_standard     2011
+
 configure.args-append   --without-x11 \
                         --with-pango
-configure.ldflags-append -framework CoreGraphics
+
+if {${os.platform} eq "darwin" && ${os.major} > 11} {
+    configure.ldflags-append \
+                        -framework CoreGraphics
+}
 
 test.run                yes
 test.target             check


### PR DESCRIPTION
#### Description

Portfile code unnecessarily breaks building on old systems by forcing linking to a non-existing before 10.8 framework. (Also, obviously, that gonna break the build on any non-Apple OS.)
Use a correct condition.

Since the source redefines types, set C11 standard.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
