### PR TITLE
stunnel: prevent opportunistic linking to mimalloc, add a variant

### DIFF
--- a/security/stunnel/Portfile
+++ b/security/stunnel/Portfile
@@ -5,10 +5,9 @@ PortGroup           openssl 1.0
 
 name                stunnel
 version             5.73
-revision            0
+revision            1
 set major           [lindex [split ${version} .] 0]
 categories          security net
-platforms           darwin
 maintainers         {mps @Schamschula} openmaintainer
 license             GPL-2+
 
@@ -37,7 +36,8 @@ patchfiles          patch-configure \
                     patch-src-client.c.diff
 
 configure.args      --disable-libwrap \
-                    --disable-silent-rules
+                    --disable-silent-rules \
+                    ac_cv_search_mi_malloc=no
 
 variant openssl1 conflicts openssl3 description (Use openssl 1.1.1) {
     openssl.branch  1.1
@@ -58,6 +58,11 @@ default_variants    +openssl3
 variant libwrap description {Include libwrap support} {
     depends_lib-append      port:tcp_wrappers
     configure.args-delete   --disable-libwrap
+}
+
+variant mimalloc description {Build with mimalloc support} {
+    depends_lib-append      port:mimalloc
+    configure.args-delete   ac_cv_search_mi_malloc=no
 }
 
 if {${os.arch} ne "powerpc"} {


### PR DESCRIPTION
#### Description

Currently the build checks for `mimalloc` and links to it if it is found. Fix that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
