### PR TITLE
google-cloud-sdk: update to 492.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             491.0.0
+version             492.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  61c2bcd1b920f451ce0f9b05c7a253ca8da4e92c \
-                    sha256  ef2c16960eb29a3d832b6e070f458c1dc8a54a10c466015dfa8acddd4bfcbd6a \
-                    size    51717580
+    checksums       rmd160  8ade3b1a2b93bd20086f1365f72fb1568c70fb4b \
+                    sha256  b3e2c12b9281f08028a3deaafe800db82b7763bff9d62fedeb081af778b2682e \
+                    size    51999972
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  99f31239f396d703a47d8c0d4f39e333bdd82c82 \
-                    sha256  e55def2a7904400a2e5156c3845aefbcc37f1c6667b593044fff8f59ef0c96d2 \
-                    size    53069005
+    checksums       rmd160  b37283013a90ea9f5d24b9cac2a36141c67eed18 \
+                    sha256  e08bbf590a040b9d2053ba1a830c598ccb068037ef49c9cfebc373869d23e241 \
+                    size    53351047
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  a777d152db7b5e473607129f67492067f595fd17 \
-                    sha256  b518d5cd33c93898d495561715e4cc9118a0c0bf24d8d0c6663b89bf413157f2 \
-                    size    53017409
+    checksums       rmd160  19ac55faf36c646124e7726ce62918166e55d2a3 \
+                    sha256  ebaed844aa862a188abe1a3693644fa8c747f1849eb633a3da1b4409de3a2e78 \
+                    size    53298766
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -97,6 +97,7 @@ variant kubectl_oidc description {Add kubectl-oidc} { dict set variant_to_compon
 variant kustomize description {Add Kustomize} { dict set variant_to_component kustomize kustomize }
 variant local_extract description {Add On-Demand Scanning API extraction helper} { dict set variant_to_component local_extract local-extract }
 variant log_streaming description {Add Log Streaming} { dict set variant_to_component log_streaming log-streaming }
+variant managed_flink_client description {Add managed Flink client} { dict set variant_to_component managed_flink_client managed-flink-client }
 variant minikube description {Add Minikube} { dict set variant_to_component minikube minikube }
 variant nomos description {Add Nomos CLI} { dict set variant_to_component nomos nomos }
 variant package_go_module description {Add Artifact Registry Go Module Package Helper} { dict set variant_to_component package_go_module package-go-module }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 492.0.0.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?