### PR TITLE
weechat: update to 4.4.2

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.2.2
-revision            1
-checksums           rmd160  7a56b376b8f306c53f319bcbd2938253dc4b0006 \
-                    sha256  20968b22c7f0f50df9cf6ff8598dd1bd017c5759b2c94593f5d9ed7b24ebb941 \
-                    size    2594452
+version             4.4.2
+revision            0
+checksums           rmd160  31a20f43cc2efcb7fd80939b10bed82d602f7359 \
+                    sha256  d4df289a9c5bca03a6d4fae006e52037064ef03bad6fbe959c538f3197434dec \
+                    size    2728232
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes
@@ -44,6 +44,7 @@ maintainers         {isi.edu:calvin @cardi} openmaintainer
 depends_build-append \
                     port:asciidoctor \
                     port:docbook-xsl-nons \
+                    port:libcjson \
                     port:libxslt \
                     path:bin/pkg-config:pkgconfig
 
@@ -70,7 +71,6 @@ configure.args-append \
                     -DENABLE_PERL=OFF \
                     -DENABLE_PHP=OFF \
                     -DENABLE_PYTHON=OFF \
-                    -DENABLE_PYTHON2=OFF \
                     -DENABLE_RUBY=OFF \
                     -DENABLE_SPELL=OFF \
                     -DENABLE_TCL=OFF \
@@ -192,6 +192,6 @@ variant tcl description {Bindings for Tcl plugins} {
 
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/weechat
-    xinstall -m 644 -W ${worksrcpath} AUTHORS.adoc COPYING ChangeLog.adoc README.adoc ${destroot}${prefix}/share/doc/weechat
+    xinstall -m 644 -W ${worksrcpath} AUTHORS.md COPYING CHANGELOG.md README.md ${destroot}${prefix}/share/doc/weechat
     xinstall -m 644 -W ${worksrcpath} {*}[glob doc/en/weechat*.adoc] ${destroot}${prefix}/share/doc/weechat
 }


### PR DESCRIPTION
#### Description
weechat: update to 4.4.2
* add new build dependency `libcjson`
* remove old, no longer used build option `ENABLE_PYTHON2`
* update AUTHORS, README, and CHANGELOG file extensions to `.md`

###### Tested on
macOS 12.7.6 21H1320 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?