### PR TITLE
stow: Update to 2.4.1

### DIFF
--- a/sysutils/stow/Portfile
+++ b/sysutils/stow/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                stow
 
-perl5.setup         Stow v2.4.0 ../../authors/id/A/AS/ASPIERS
+perl5.setup         Stow v2.4.1 ../../authors/id/A/AS/ASPIERS
 revision            0
 
 categories          sysutils
@@ -20,9 +20,9 @@ long_description    Stow is a symlink farm manager which takes distinct sets of 
                     and/or data located in separate directories on the filesystem, and makes \
                     them all appear to be installed in a single directory tree.
 
-checksums           rmd160  f8b6e973d77336e644f274c1a762dbe1a6efc2c5 \
-                    sha256  a777927b076b08ac96d8aa3e1b68573064b9a87eb4cdb7831e86915d4598af45 \
-                    size    782650
+checksums           rmd160  951175c342d99c86616e73de54b9f072d7e8aed6 \
+                    sha256  2918947348c5bb58a379e9761b99c3d07976ce7a556766d9dbd32d4894ec1f52 \
+                    size    787639
 
 post-patch {
     reinplace "s|^#!/usr/bin/perl|#!${perl5.bin}|" \


### PR DESCRIPTION
#### Description

Update `stow` to its latest released version, 2.4.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
