### PR TITLE
libcoverart: fix build with gcc

### DIFF
--- a/devel/libcoverart/Portfile
+++ b/devel/libcoverart/Portfile
@@ -7,7 +7,6 @@ PortGroup           github 1.0
 github.setup        metabrainz libcoverart 1.0.0 release-
 github.tarball_from releases
 categories          devel
-platforms           darwin
 maintainers         nomaintainer
 license             LGPL-2.1+
 
@@ -28,7 +27,8 @@ cmake.out_of_source no
 patchfiles          \
                     patch-cmakelists-1.diff \
                     patch-cmakelists-2.diff \
-                    patch-cmakelists-3.diff
+                    patch-cmakelists-3.diff \
+                    patch-cmakelists-4.diff
 patch.pre_args-replace  -p0 -p1
 
 depends_lib-append  \
@@ -37,6 +37,6 @@ depends_lib-append  \
                     port:libxml2
 
 depends_build-append \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 github.livecheck.regex {([0-9.]+)}

--- a/devel/libcoverart/files/patch-cmakelists-4.diff
+++ b/devel/libcoverart/files/patch-cmakelists-4.diff
@@ -1,0 +1,11 @@
+--- a/src/CMakeLists.txt	2012-10-09 20:51:32.000000000 +0800
++++ b/src/CMakeLists.txt	2024-09-12 09:53:27.000000000 +0800
+@@ -60,7 +60,7 @@
+ ENDIF(WIN32)
+ 
+ IF(CMAKE_COMPILER_IS_GNUCXX)
+-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -pedantic-errors")
++		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
+ 		set_source_files_properties(mb4_c.cc PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
+ 		set_source_files_properties(ReleaseInfo.cc PROPERTIES COMPILE_FLAGS "-Wno-long-long")
+ 		set_source_files_properties(ImageList.cc PROPERTIES COMPILE_FLAGS "-Wno-long-long")


### PR DESCRIPTION
#### Description

Not sure why the source wants to break the build specifically with gcc, but anyway, this does not compiler with `-Werror` due to warnings been treated as errors then. Remove breaking flags.

There is no effect on clang builds.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
