### PR TITLE
GPXSee: update to 13.24

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.23
+github.setup        tumic0 GPXSee 13.24
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  f824b559e3463bdd9271ededc091e3d59f439be8 \
-                    sha256  676f8423b3ee56f37134ea52909b78e3cd1b05e73e287dc9e1863275d842fe17 \
-                    size    5635256
+checksums           rmd160  569342249a2dbfb8026e18bbc852d809f7c255ed \
+                    sha256  f15d503d0c5efcf42f6d4e6d4c924de9ad672722365adc6573ff1f9d755a71c2 \
+                    size    5638074
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
