### PR TITLE
input-leap: update port

### DIFF
--- a/aqua/input-leap/Portfile
+++ b/aqua/input-leap/Portfile
@@ -6,8 +6,8 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
-github.setup        input-leap input-leap 3a95e113435c6433d2f718ee55a4f688ec1ff893
-version             2.4.0-20240801
+github.setup        input-leap input-leap 5fbf52bfa84069b316dbd63070a36f292ad30199
+version             2.4.0-20240912
 revision            0
 categories          aqua net sysutils
 platforms           {darwin >= 16}
@@ -19,9 +19,9 @@ long_description    ${name} shares a keyboard, mouse, and clipboard over the net
                     Linux, FreeBSD, OpenBSD, and Windows. It is a fork of barrier,\
                     which in turn is a fork of synergy.
 
-checksums           rmd160  044253f86390dabf07ea7d8ad33ee969ad1f58ff \
-                    sha256  5dbc6057119bc53c7a2f9cdfdb73d6afb462bdbd15519cc6351cb9a8c113852f \
-                    size    1758781
+checksums           rmd160  b950a45d8ba239c09e069e4a1816174b598e48ef \
+                    sha256  0364365f9600f8f07016367d47777db3f57b1186a42a8185098166bc5b1bff1a \
+                    size    1758915
 
 patchfiles          set-cmake-revision.patch \
                     fix-macos-scroll.patch
@@ -61,8 +61,7 @@ if { (${os.platform} eq "darwin" && ${os.major} < 16) || (![variant_isset gui]) 
     PortGroup           app 1.0
 
     qt6.depends_build \
-        qttools \
-        qt5compat
+        qttools
 
     app.create yes
     app.icon   dist/macos/bundle/InputLeap.app/Contents/Resources/InputLeap.icns


### PR DESCRIPTION
Minor build fix, remove unnecessary dependency to 'qt5compat'.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?