### PR TITLE
luajit: fix build on powerpc

### DIFF
--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -54,6 +54,11 @@ compiler.thread_local_storage yes
 # https://trac.macports.org/ticket/45343
 compiler.blacklist  {clang < 700} macports-clang-3.3 macports-clang-3.4
 
+platform powerpc {
+    depends_lib-append \
+                    port:libunwind
+}
+
 ## Fix universal builds, see:
 # - https://www.freelists.org/post/luajit/Building-universal-libraries-x86-64-and-arm64-for-osx,4
 # - https://git.openembedded.org/meta-openembedded/plain/meta-oe/recipes-devtools/luajit/luajit_git.bb

--- a/lang/luajit/files/powerpc.patch
+++ b/lang/luajit/files/powerpc.patch
@@ -11,3 +11,15 @@ https://www.freelists.org/post/luajit/LuaJIT-on-OS-X-Leopard-PowerPC,1
      /* Keep @plt etc. */
  #else
      *p = '\0';
+
+On powerpc same linking error as in https://github.com/ziglang/zig/issues/14089
+--- src/Makefile	2024-07-04 07:26:29.000000000 +0800
++++ src/Makefile	2024-09-14 05:49:30.000000000 +0800
+@@ -256,6 +256,7 @@
+     TARGET_ARCH= -DLJ_ARCH_ENDIAN=LUAJIT_BE
+   endif
+   TARGET_LJARCH= ppc
++  TARGET_XLIBS+= -lunwind
+ else
+ ifneq (,$(findstring LJ_TARGET_MIPS ,$(TARGET_TESTARCH)))
+   ifneq (,$(findstring MIPSEL ,$(TARGET_TESTARCH)))


### PR DESCRIPTION
#### Description

Finally, fix this

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
