### PR TITLE
qt5-qtbase: fix for macOS 15

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -19,6 +19,12 @@ version             ${qt_version}
 set middle_name     everywhere-opensource
 set worksrcdir_middle_name everywhere
 
+# qt5-qtbase is broken on macOS 15+, so fix needs to be done at the top level as all subports depends on it.
+# because of `error: 'CGDisplayCreateImageForRect' is unavailable: obsoleted in macOS 15.0 - Please use ScreenCaptureKit instead.`
+platform 24 {
+    macosx_deployment_target 14.0
+}
+
 if { ${subport} eq "${name}-qtwebkit" ||
      ${subport} eq "${name}-qtwebkit-docs" } {
     version         5.9.2


### PR DESCRIPTION
#### Description

* qt5-qtbase error for CGDIsplayImageForRect on macOS 15
* Set macosx_deployment_target 14.0 for qt5 in general to stop the following error: `error: 'CGDisplayCreateImageForRect' is unavailable: obsoleted in macOS 15.0 - Please use ScreenCaptureKit instead.`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.0 24A335
Xcode 16.0 16A242

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
