### PR TITLE
micronaut: update to 4.6.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.6.1 v
+github.setup    micronaut-projects micronaut-starter 4.6.2 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  615697f53f5133be915feaa584cdac6908c5b53e \
-                 sha256  f94e938b5c217092261630e4bd539de20b8909ecc6ae72cf77e802bd6593473e \
-                 size    25492517
+    checksums    rmd160  51b21a4164c23b78d006e92f036e7ca7d723c0f4 \
+                 sha256  9824806be6df9be9c265f2c778f3e3535c199b88194afa73cb24f8aeef65e43c \
+                 size    25508107
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  1ae65974cbae9b4c1d1916916e83b650872a73bc \
-                 sha256  1ec4c4ab4924dc9691e7c4012085dd93fe7dec47dae7355ad6e821363a279f2b \
-                 size    25296017
+    checksums    rmd160  6340e75533fe4c8f388b7acbc6d03dfbbec22439 \
+                 sha256  461edcdb44fd68973186b599aa2ab5a5ce0c0af30b483788e0e32b17dedddf48 \
+                 size    25311055
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.6.2.

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?