### PR TITLE
lang/ruby33: update to 3.3.5

### DIFF
--- a/lang/ruby33/Portfile
+++ b/lang/ruby33/Portfile
@@ -17,11 +17,11 @@ legacysupport.newest_darwin_requires_legacy 14
 # This property should be preserved.
 
 set ruby_ver        3.3
-set ruby_patch      4
+set ruby_patch      5
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
-revision            3
+revision            0
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} \
@@ -42,9 +42,9 @@ master_sites        ruby:${ruby_ver}
 distname            ruby-${version}
 dist_subdir         ruby${ruby_ver_nodot}
 
-checksums           rmd160  a140a40891dfe33dfd622bf8b6ad52b68189a48e \
-                    sha256  fe6a30f97d54e029768f2ddf4923699c416cdbc3a6e96db3e2d5716c7db96a34 \
-                    size    22110179
+checksums           rmd160  6b997a751809a5f84376ad653ea75e26734af085 \
+                    sha256  3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196 \
+                    size    22129139
 
 # Universal builds don't currently work, including via the approach used
 # in ruby30.

--- a/lang/ruby33/files/patch-sources.diff
+++ b/lang/ruby33/files/patch-sources.diff
@@ -139,14 +139,3 @@
  #  define UNW_LOCAL_ONLY
  #  include <libunwind.h>
  #  include <sys/mman.h>
---- vm_insnhelper.c.orig	2024-07-08 16:28:22.000000000 -0700
-+++ vm_insnhelper.c	2024-07-14 16:28:09.000000000 -0700
-@@ -396,7 +396,7 @@ vm_push_frame(rb_execution_context_t *ec
-     This is a no-op in all cases we've looked at (https://godbolt.org/z/3oxd1446K), but should guarantee it for all
-     future/untested compilers/platforms. */
- 
--    #ifdef HAVE_DECL_ATOMIC_SIGNAL_FENCE
-+    #if defined HAVE_DECL_ATOMIC_SIGNAL_FENCE && HAVE_DECL_ATOMIC_SIGNAL_FENCE
-     atomic_signal_fence(memory_order_seq_cst);
-     #endif
- 


### PR DESCRIPTION
#### Description

[ruby 3.3.5](https://www.ruby-lang.org/en/news/2024/09/03/3-3-5-released/)

Removed an [upstreamed patch](https://bugs.ruby-lang.org/issues/20633)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
