### PR TITLE
mise: Upgrade to 2024.9.4

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.9.3 v
+github.setup        jdx mise 2024.9.4 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  4b06e4500ea3b9c63879d2e5ded54920aef807c3 \
-                    sha256  50ac063a1457ac5adea11b7528d4d38d65ddbaf796f5d5b98cb5ec2ee2ece764 \
-                    size    3105489
+                    rmd160  b7ced373340556cd346fd028d770b4c2de89db2f \
+                    sha256  a45b06c17e29e4dc3669adff215eb232460ee5644866dc16d1b2055bd5ddb169 \
+                    size    3108276
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -118,7 +118,7 @@ cargo.crates \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                              1.1.18  b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476 \
+    cc                              1.1.19  2d74707dde2ba56f86ae90effb3b43ddd369504387e718014de010cec7959800 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
@@ -303,7 +303,7 @@ cargo.crates \
     num_threads                      0.1.7  5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
-    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
+    once_cell                       1.20.0  33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe \
     openssl                        0.10.66  9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1 \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
@@ -348,7 +348,7 @@ cargo.crates \
     predicates                       3.1.2  7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97 \
     predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
     predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
-    pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
+    pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro2                     1.0.86  5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77 \
@@ -488,7 +488,7 @@ cargo.crates \
     unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
     unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
     unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
-    unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
+    unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
@@ -555,7 +555,7 @@ cargo.crates \
     xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
     xx                               1.1.8  fb963ecf2940991825550e580efaaa1ab882191027f45362c4376de15d09bfe9 \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
-    yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec \
+    yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
     zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \


### PR DESCRIPTION
#### Description

mise: Upgrade to 2024.9.4

##### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?