### PR TITLE
ruby33: update to v3.3.5

### DIFF
--- a/lang/ruby33/Portfile
+++ b/lang/ruby33/Portfile
@@ -17,11 +17,11 @@ legacysupport.newest_darwin_requires_legacy 14
 # This property should be preserved.
 
 set ruby_ver        3.3
-set ruby_patch      4
+set ruby_patch      5
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
-revision            3
+revision            0
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} \
@@ -42,9 +42,9 @@ master_sites        ruby:${ruby_ver}
 distname            ruby-${version}
 dist_subdir         ruby${ruby_ver_nodot}
 
-checksums           rmd160  a140a40891dfe33dfd622bf8b6ad52b68189a48e \
-                    sha256  fe6a30f97d54e029768f2ddf4923699c416cdbc3a6e96db3e2d5716c7db96a34 \
-                    size    22110179
+checksums           rmd160  6b997a751809a5f84376ad653ea75e26734af085 \
+                    sha256  3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196 \
+                    size    22129139
 
 # Universal builds don't currently work, including via the approach used
 # in ruby30.
@@ -69,7 +69,7 @@ select.file         ${filespath}/ruby${ruby_ver_nodot}
 
 # patch-sources.diff: fixes for various issues.
 #
-# This diff is from v3_3_4 vs. macports-3_3_4r2.
+# This diff is from v3_3_5 vs. macports-3_3_5.
 #
 patchfiles-append   patch-sources.diff
 
@@ -162,7 +162,7 @@ variant jemalloc description "use jemalloc" {
         depends_lib-append      port:jemalloc
 }
 
-variant yjit description "enable YJIT" {
+variant yjit description "enable YJIT (requires rust)" {
         configure.args-delete   --disable-yjit
         configure.args-append   --enable-yjit
         depends_build-append    port:rust

--- a/lang/ruby33/files/patch-sources.diff
+++ b/lang/ruby33/files/patch-sources.diff
@@ -1,5 +1,5 @@
---- .gdbinit.orig	2024-07-08 16:28:22.000000000 -0700
-+++ .gdbinit	2024-07-14 16:28:09.000000000 -0700
+--- .gdbinit.orig	2024-09-02 09:09:08.000000000 -0700
++++ .gdbinit	2024-09-14 16:02:32.000000000 -0700
 @@ -1,4 +1,5 @@
 -set startup-with-shell off
 +# Move this to end, so failure on older gdbs doesn't blow the rest
@@ -14,8 +14,8 @@
 +
 +# Moved from beginning, since it fails on older gdbs
 +set startup-with-shell off
---- ext/digest/md5/md5cc.h.orig	2024-07-08 16:28:22.000000000 -0700
-+++ ext/digest/md5/md5cc.h	2024-07-14 16:28:09.000000000 -0700
+--- ext/digest/md5/md5cc.h.orig	2024-09-02 09:09:08.000000000 -0700
++++ ext/digest/md5/md5cc.h	2024-09-14 16:02:32.000000000 -0700
 @@ -17,3 +17,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(MD5
  #undef MD5_Finish
  #define MD5_Update rb_digest_MD5_update
@@ -28,8 +28,8 @@
 + */
 +#undef MD5_Init
 +#define MD5_Init CC_MD5_Init
---- ext/digest/sha1/sha1cc.h.orig	2024-07-08 16:28:22.000000000 -0700
-+++ ext/digest/sha1/sha1cc.h	2024-07-14 16:28:09.000000000 -0700
+--- ext/digest/sha1/sha1cc.h.orig	2024-09-02 09:09:08.000000000 -0700
++++ ext/digest/sha1/sha1cc.h	2024-09-14 16:02:32.000000000 -0700
 @@ -12,3 +12,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(SHA
  #undef SHA1_Finish
  #define SHA1_Update rb_digest_SHA1_update
@@ -42,8 +42,8 @@
 + */
 +#undef SHA1_Init
 +#define SHA1_Init CC_SHA1_Init
---- ext/digest/sha2/sha2cc.h.orig	2024-07-08 16:28:22.000000000 -0700
-+++ ext/digest/sha2/sha2cc.h	2024-07-14 16:28:09.000000000 -0700
+--- ext/digest/sha2/sha2cc.h.orig	2024-09-02 09:09:08.000000000 -0700
++++ ext/digest/sha2/sha2cc.h	2024-09-14 16:02:32.000000000 -0700
 @@ -1,6 +1,33 @@
  #define COMMON_DIGEST_FOR_OPENSSL 1
  #include <CommonCrypto/CommonDigest.h>
@@ -94,8 +94,8 @@
 +#define SHA384_Init CC_SHA384_Init
 +#undef SHA512_Init
 +#define SHA512_Init CC_SHA512_Init
---- lib/bundler/gem_helper.rb.orig	2024-07-08 16:28:22.000000000 -0700
-+++ lib/bundler/gem_helper.rb	2024-07-14 16:28:09.000000000 -0700
+--- lib/bundler/gem_helper.rb.orig	2024-09-02 09:09:08.000000000 -0700
++++ lib/bundler/gem_helper.rb	2024-09-14 16:02:32.000000000 -0700
 @@ -231,7 +231,7 @@ module Bundler
      end
  
@@ -105,8 +105,8 @@
      end
    end
  end
---- signal.c.orig	2024-07-08 16:28:22.000000000 -0700
-+++ signal.c	2024-07-14 16:28:09.000000000 -0700
+--- signal.c.orig	2024-09-02 09:09:08.000000000 -0700
++++ signal.c	2024-09-14 16:02:32.000000000 -0700
 @@ -803,7 +803,8 @@ check_stack_overflow(int sig, const uint
      const greg_t bp = mctx->gregs[REG_EBP];
  #   endif
@@ -117,8 +117,8 @@
  #     define MCTX_SS_REG(reg) __ss.__##reg
  #   else
  #     define MCTX_SS_REG(reg) ss.reg
---- vm_dump.c.orig	2024-07-08 16:28:22.000000000 -0700
-+++ vm_dump.c	2024-07-14 16:28:09.000000000 -0700
+--- vm_dump.c.orig	2024-09-02 09:09:08.000000000 -0700
++++ vm_dump.c	2024-09-14 16:02:32.000000000 -0700
 @@ -490,7 +490,8 @@ rb_vmdebug_thread_dump_state(FILE *errou
  }
  
@@ -139,14 +139,3 @@
  #  define UNW_LOCAL_ONLY
  #  include <libunwind.h>
  #  include <sys/mman.h>
---- vm_insnhelper.c.orig	2024-07-08 16:28:22.000000000 -0700
-+++ vm_insnhelper.c	2024-07-14 16:28:09.000000000 -0700
-@@ -396,7 +396,7 @@ vm_push_frame(rb_execution_context_t *ec
-     This is a no-op in all cases we've looked at (https://godbolt.org/z/3oxd1446K), but should guarantee it for all
-     future/untested compilers/platforms. */
- 
--    #ifdef HAVE_DECL_ATOMIC_SIGNAL_FENCE
-+    #if defined HAVE_DECL_ATOMIC_SIGNAL_FENCE && HAVE_DECL_ATOMIC_SIGNAL_FENCE
-     atomic_signal_fence(memory_order_seq_cst);
-     #endif
- 


### PR DESCRIPTION
See:
https://www.ruby-lang.org/en/news/2024/09/03/3-3-5-released/

As usual, all source patches are in a single patchfile derived from the ruby fork at github.com/fhgwright/ruby.  The changes are much more readable in the git repo.

The patches no longer include the atomic_signal_fence fix, which is now upstream.  Otherwise, the only patchfile changes are for the newer file mtimes.

Also updates the +yjit description to indicate that it requires rust.

TESTED:
Built successfully with no variants on 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-14.x arm64.
Built with all variants except jemalloc and yjit on 10.4-10.5, all variants except yjit on 10.6-10.12, and all variants on 10.13+. Tests not run due to test framework issues.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.6.9 22G830, arm64, Xcode 15.2 15C500b
macOS 14.6.1 23G93, arm64, Xcode 15.4 15F31d
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - The test framework has issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
