### PR TITLE
edid-decode: update to version 20240903

### DIFF
--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           meson 1.0
 
 name                edid-decode
-version             20240811
+version             20240903
 categories          sysutils
 maintainers         @wwalexander openmaintainer
 license             MIT
@@ -14,7 +14,7 @@ set domain          linuxtv.org
 homepage            https://git.${domain}/${name}.git
 fetch.type          git
 git.url             git://${domain}/${name}.git
-git.branch          c370882
+git.branch          88d457c
 
 compiler.cxx_standard \
                     2011


### PR DESCRIPTION
#### Description

* add options to read EDID and HDCP data directly from DDC
* fix emscripten build
* check if linux/i2c-dev.h is available
* report if InfoFrame size is too small
* Fix Visual Studio builds. Add utf-8 option and parse-if.cpp file.

###### Type(s)
- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?