### PR TITLE
asciidoc @10.2.0 Warning: invalid escape sequence '\S'

### DIFF
--- a/textproc/asciidoc/Portfile
+++ b/textproc/asciidoc/Portfile
@@ -5,11 +5,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        asciidoc asciidoc-py3 10.2.0
-revision            3
-checksums           rmd160  e6369eddc6d72a4ea910f06f320881be105cd348 \
-                    sha256  f830cb726d0b1448a451e916a7e60abfd27fce7f4dbce4c0c8f1ff856c1765ee \
-                    size    1199960
+github.setup        asciidoc-py asciidoc-py 10.2.1
+revision            0
+checksums           rmd160  f7a190ae21ba4664cae18915038e0cdd9eccd15f \
+                    sha256  c3d9df7d0150bd8431c44bcc85fb29bc953a76b86ad3b8ccb34272208bf7ab4c \
+                    size    1200113
 name                asciidoc
 
 categories          textproc


### PR DESCRIPTION
asciidoc: Update to 10.2.1

Closes: https://trac.macports.org/ticket/70039
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7
Xcode 11.5 / Command Line Tools 11.5.0
Compiler Apple clang 11.0.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
