### PR TITLE
gnuplot: update to 6.0.1

### DIFF
--- a/math/gnuplot/Portfile
+++ b/math/gnuplot/Portfile
@@ -6,7 +6,7 @@ PortGroup           xcodeversion    1.0
 PortGroup           wxWidgets       1.0
 
 name                gnuplot
-version             5.4.8
+version             6.0.1
 revision            0
 
 categories          math science
@@ -30,9 +30,9 @@ homepage            http://gnuplot.sourceforge.net/
 master_sites        sourceforge:project/gnuplot/gnuplot/${version}
 dist_subdir         ${name}/${version}
 
-checksums           rmd160  a469a3089502de08244c78ee6e9f0d7e810bb701 \
-                    sha256  931279c7caad1aff7d46cb4766f1ff41c26d9be9daf0bcf0c79deeee3d91f5cf \
-                    size    5684061
+checksums           rmd160  4604a77bef5146eedcf8b2277f6364969bd2a8e4 \
+                    sha256  e85a660c1a2a1808ff24f7e69981ffcbac66a45c9dcf711b65610b26ea71379a \
+                    size    7528936
 
 depends_build       port:pkgconfig
 
@@ -132,7 +132,7 @@ variant old_bitmap_terminals description "Enable PBM (Portable Bit Map) and othe
     configure.args-replace      --without-bitmap-terminals --with-bitmap-terminals
 }
 
-default_variants                +luaterm +pangocairo +x11
+default_variants                +luaterm +pangocairo +qt
 
 # aquaterm is currently not building on 10.4
 if {${os.platform} eq "darwin" && ${os.major} > 8} {


### PR DESCRIPTION
#### Description

Simple update to upstream version 6.0.1.
Also took up the recommendation from @markemer to replace `+x11` by `+qt` in the `default_variants`.

Closes https://trac.macports.org/ticket/70357

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
