### PR TITLE
mise: Upgrade to 2024.9.5

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.9.4 v
+github.setup        jdx mise 2024.9.5 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b7ced373340556cd346fd028d770b4c2de89db2f \
-                    sha256  a45b06c17e29e4dc3669adff215eb232460ee5644866dc16d1b2055bd5ddb169 \
-                    size    3108276
+                    rmd160  f12683d53d7573dbba6d0245fa2ef38175e7a64f \
+                    sha256  fef5148de32be77b7e479d90f4af5a2d19c150e4ad866a81284c0df0edddb653 \
+                    size    3108090
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -239,7 +239,7 @@ cargo.crates \
     hyper-rustls                    0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
     hyper-tls                        0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                       0.1.8  da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba \
-    iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
+    iana-time-zone                  0.1.61  235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
@@ -303,7 +303,7 @@ cargo.crates \
     num_threads                      0.1.7  5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
-    once_cell                       1.20.0  33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe \
+    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     openssl                        0.10.66  9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1 \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
@@ -466,7 +466,7 @@ cargo.crates \
     tokio-util                      0.7.12  61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a \
     toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
-    toml_edit                      0.22.20  583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d \
+    toml_edit                      0.22.21  3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf \
     tower                           0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \


### PR DESCRIPTION
#### Description

mise: Upgrade to 2024.9.5

##### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
