### PR TITLE
cmake PG: fix installation of libraries on Linux

### DIFF
--- a/_resources/port1.0/group/cmake-1.1.tcl
+++ b/_resources/port1.0/group/cmake-1.1.tcl
@@ -252,6 +252,14 @@ default configure.pre_args {[list \
                     -Wno-dev
 ]}
 
+# On macOS install destination on libraries is set by CMAKE_INSTALL_NAME_DIR.
+# On non-Apple platforms that setting has no effect. In result, at least on Linux
+# CMake may install libraries in ${prefix}/lib64, which we do not want to happen.
+if {${os.platform} ne "darwin"} {
+    configure.pre_args-append \
+                    -DCMAKE_INSTALL_LIBDIR="${cmake.install_prefix}/lib"
+}
+
 # make sure configure.args is set but don't reset it
 configure.args-append
 


### PR DESCRIPTION
#### Description

cmake PG uses Apple-specific argument to configure, that does not work for Linux. In result, CMake dumps libraries into lib64, and dependents cannot find anything.

Fix this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
PinIx 2.1 riscv64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
