### PR TITLE
amazon-ecr-credential-helper: new port (v0.9.0)

### DIFF
--- a/sysutils/amazon-ecr-credential-helper/Portfile
+++ b/sysutils/amazon-ecr-credential-helper/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/awslabs/amazon-ecr-credential-helper 0.9.0 v
+github.tarball_from archive
+revision            0
+
+description         Automatically gets credentials for Amazon ECR on docker \
+                    push/docker pull
+
+long_description    {*}${description}. The Amazon ECR Docker Credential \
+                    Helper is a credential helper for the Docker daemon that \
+                    makes it easier to use Amazon Elastic Container Registry.
+
+categories          sysutils
+installs_libs       no
+license             Apache-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  1fd1d767fd7491ebfb1d64c53997690f7850d052 \
+                    sha256  6067a2cb36f8b451878b4336e4bef202999281b6c31727bcda97f62cfb4aa19a \
+                    size    1934543
+
+build.cmd           make
+build.pre_args-append \
+                    VERSION=${version}
+build.args          build
+
+patch {
+    # Don't attempt to surmise the current commit SHA using git
+    # (this is not a git checkout)
+    reinplace -E {s|git rev-parse --short=7 HEAD|echo none|g} \
+        ${worksrcpath}/Makefile
+}
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/bin/local/docker-credential-ecr-login \
+        ${destroot}${prefix}/bin/
+
+    xinstall -m 0644 ${worksrcpath}/docs/docker-credential-ecr-login.1 \
+        ${destroot}${prefix}/share/man/man1/
+}

--- a/sysutils/docker-credential-helper-ecr/Portfile
+++ b/sysutils/docker-credential-helper-ecr/Portfile
@@ -1,47 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           golang 1.0
+PortGroup           obsolete 1.0
 
-go.setup            github.com/awslabs/amazon-ecr-credential-helper 0.8.0 v
-github.tarball_from archive
 name                docker-credential-helper-ecr
+version             0.8.0
 revision            0
 
-description         Automatically gets credentials for Amazon ECR on docker \
-                    push/docker pull
-
-long_description    {*}${description}. The Amazon ECR Docker Credential \
-                    Helper is a credential helper for the Docker daemon that \
-                    makes it easier to use Amazon Elastic Container Registry.
-
-categories          sysutils
-installs_libs       no
-license             Apache-2
-maintainers         {gmail.com:herby.gillot @herbygillot} \
-                    openmaintainer
-
-checksums           rmd160  4ce8f5bbda72d715e9c251c441685ea86e654e00 \
-                    sha256  7014f4c972ef360b7204d376bbd771aeebb8f1e9281948688de1bcebb0d0b0a4 \
-                    size    1914866
-
-build.cmd           make
-build.pre_args-append \
-                    VERSION=${version}
-build.args          build
-
-patch {
-    # Don't attempt to surmise the current commit SHA using git
-    # (this is not a git checkout)
-    reinplace -E {s|git rev-parse --short=7 HEAD|echo none|g} \
-        ${worksrcpath}/Makefile
-}
-
-destroot {
-    xinstall -m 0755 \
-        ${worksrcpath}/bin/local/docker-credential-ecr-login \
-        ${destroot}${prefix}/bin/
-
-    xinstall -m 0644 ${worksrcpath}/docs/docker-credential-ecr-login.1 \
-        ${destroot}${prefix}/share/man/man1/
-}
+replaced_by         amazon-ecr-credential-helper


### PR DESCRIPTION
- replace docker-credential-helper-ecr

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
