### PR TITLE
openjdk23-corretto: update to 23.0.0.37.1

### DIFF
--- a/java/openjdk23-corretto/Portfile
+++ b/java/openjdk23-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-23/releases
-version      23.0.0.36.1
+version      23.0.0.37.1
 revision     0
 
 description  Amazon Corretto OpenJDK 23 (Short Term Support until March 2025)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  d3481e2ca8942dc71a19104ccabec176aeb3a3b3 \
-                 sha256  5d53ddd667eb6e025954fcc66f18a331593972de1bd38c486f09b4ba4eaa64bb \
-                 size    210057865
+    checksums    rmd160  cecab8386904156f7e266bbdbdd1615f9820997b \
+                 sha256  a01c65e3e5284d9a591d7ae7ce62917b0e3a10d8eaa05e1f7ca10d430fc9df20 \
+                 size    210028401
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  6c02b72cab2e8533413ad7f6995201b0154acf6a \
-                 sha256  d241972eaa310bae3f7f3e2acf29dd2ab0d8e4df47cc73012fc77f0d20d1eea6 \
-                 size    207795535
+    checksums    rmd160  2a3acd2bd7bc81473bd7f7fe26a9a90aed884837 \
+                 sha256  68849fd895c6a647031322da5e81ded1209755f2dddd31331a46e88899380eaf \
+                 size    207753443
 }
 
 worksrcdir   amazon-corretto-23.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 23.0.0.37.1.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?