### PR TITLE
libsvm: update to 3.35 and add py312-libsvm subport

### DIFF
--- a/gis/grass/Portfile
+++ b/gis/grass/Portfile
@@ -12,7 +12,7 @@ epoch               1
 github.setup        osgeo grass 8.4.0
 github.tarball_from releases
 # version             8.4.0
-revision            2
+revision            3
 
 maintainers         {yahoo.com:n_larsson @nilason} openmaintainer
 categories          gis

--- a/gis/orfeotoolbox/Portfile
+++ b/gis/orfeotoolbox/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 name                orfeotoolbox
 version             9.0.0
-revision            2
+revision            3
 categories          gis graphics
 license             Apache-2
 

--- a/gis/orfeotoolbox/Portfile
+++ b/gis/orfeotoolbox/Portfile
@@ -187,4 +187,4 @@ if {${subport} eq ${name}} {
 
 livecheck.type      regex
 livecheck.url       ${master_sites}
-livecheck.regex     {OTB-(\d+(?:\.\d+)*)[quotemeta ${extract.suffix}]}
+livecheck.regex     OTB-(\[0-9.\]+)[quotemeta ${extract.suffix}]

--- a/math/libsvm/Portfile
+++ b/math/libsvm/Portfile
@@ -5,7 +5,7 @@ PortGroup           makefile 1.0
 
 name                libsvm
 epoch               3
-version             3.33
+version             3.35
 revision            0
 
 categories          math
@@ -22,9 +22,9 @@ long_description    {*}${description} By Chih-Chung Chang and Chih-Jen Lin of   
 
 homepage            https://www.csie.ntu.edu.tw/~cjlin/libsvm/
 master_sites        ${homepage}
-checksums           rmd160  19078031589d2222cc963f4438a71eca4e49d2c4 \
-                    sha256  d5da12ccc3d0eed8453fbdf6fac7d9f0052f3e8a5f07a2174e4ef0a9d83dcdf8 \
-                    size    945003
+checksums           rmd160  4908ac8a3adbbc0a52a5e532e957df22716d0f8b \
+                    sha256  ea5633fc84b1c2fa58aa4c44b62e437573020297a1dfbe73bf1531ec817a8478 \
+                    size    944855
 
 patchfiles          patch-Makefile.diff
 
@@ -38,7 +38,7 @@ destroot.env-append VERSION=${libver}
 set docdir          ${prefix}/share/doc/${name}
 
 # create Python subports
-set python_versions {310 311}
+set python_versions {310 311 312}
 foreach v ${python_versions} {
     subport py${v}-${name} {
         set python_branch   [string index ${v} 0].[string range ${v} 1 end]

--- a/math/libsvm/files/patch-Makefile.diff
+++ b/math/libsvm/files/patch-Makefile.diff
@@ -3,7 +3,7 @@
 @@ -1,28 +1,67 @@
 -CXX ?= g++
 -CFLAGS = -Wall -Wconversion -O3 -fPIC
--SHVER = 3
+-SHVER = 4
 -OS = $(shell uname)
 -ifeq ($(OS),Darwin)
 -	SHARED_LIB_FLAG = -dynamiclib -Wl,-install_name,libsvm.so.$(SHVER)

--- a/php/php-svm/Portfile
+++ b/php/php-svm/Portfile
@@ -14,13 +14,13 @@ php.pecl.prerelease     yes
 
 if {[vercmp ${php.branch} >= 7.0]} {
     version             0.2.3
-    revision            2
+    revision            3
     checksums           rmd160  0df66ac9fb15b82efbf8de56439aabc7cfca4e69 \
                         sha256  80cf414942cc558a6934d0a508f056daaaa7399df5bd8dc556bff5ee1ebf5c9a \
                         size    130776
 } elseif {[vercmp ${php.branch} >= 5.2]} {
     version             0.1.9
-    revision            3
+    revision            4
     checksums           rmd160  174f667f56c051bf29f3e36766d92b68012b976b \
                         sha256  28c0eda03b47fb79a7a584143e8fb539fd796aacbcb11dc8dcc7b66d42cd007f \
                         size    111685

--- a/python/py-pymvpa/Portfile
+++ b/python/py-pymvpa/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 github.setup        PyMVPA PyMVPA 2.6.5 upstream/
 
 name                py-pymvpa
-revision            3
+revision            4
 categories-append   science math
 license             MIT
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update `libsvm` to version 3.35.

As this rev-bumps `orfeotoolbox`, I took the opportunity to include a fix for livecheck regex (which used to include rc versions as well).



###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
