### PR TITLE
jdk23: new submission

### DIFF
--- a/java/jdk23/Portfile
+++ b/java/jdk23/Portfile
@@ -1,0 +1,96 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             jdk23
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          NFTC NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://www.oracle.com/java/technologies/downloads/#jdk23-mac
+set feature 23
+version      ${feature}
+revision     0
+
+description  Oracle Java SE Development Kit ${feature} (Short Term Support until March 2025)
+long_description Java Platform, Standard Edition Development Kit (JDK). \
+    The JDK is a development environment for building applications and components using the Java programming language. \
+    This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense).
+
+master_sites https://download.oracle.com/java/${feature}/archive/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     jdk-${version}_macos-x64_bin
+    checksums    rmd160  61d37f069d915a46fce2127707c75ab84247c086 \
+                 sha256  924de84fd5a5978ddcf1ce5176ff1b5f3c75460ab0215b29954bce95bb065a24 \
+                 size    240066832
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  b8ba2bea5c345090f041d3c9ca1996bcda7b992d \
+                 sha256  c3f370000b5c96cca426a3a82e51ef580dc0a7f81ad0328d77a7c3376b95533b \
+                 size    237178559
+}
+
+worksrcdir   jdk-${version}.jdk
+
+homepage     https://www.oracle.com/java/
+
+livecheck.type      regex
+livecheck.url       https://www.oracle.com/java/technologies/downloads/
+livecheck.regex     Java SE Development Kit (${feature}\.\[0-9\.\]+)
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-${feature}-oracle-java-se.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Oracle Java SE Development Kit 23.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?