### PR TITLE
google-cloud-sdk: update to 493.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             492.0.0
+version             493.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  8ade3b1a2b93bd20086f1365f72fb1568c70fb4b \
-                    sha256  b3e2c12b9281f08028a3deaafe800db82b7763bff9d62fedeb081af778b2682e \
-                    size    51999972
+    checksums       rmd160  184eb340ac5e64d8c10670aa16cbd6442d1effc1 \
+                    sha256  256916052bdf4ccf19e1607d6536ba800bcd241ce85c31c328a84c72f7189c27 \
+                    size    52119551
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b37283013a90ea9f5d24b9cac2a36141c67eed18 \
-                    sha256  e08bbf590a040b9d2053ba1a830c598ccb068037ef49c9cfebc373869d23e241 \
-                    size    53351047
+    checksums       rmd160  ea79ca46daf86a4c657054f4f9d5303a4b6633e3 \
+                    sha256  839190b130fe4a273bacb2dc96f9df36fe06846af9ec0ffd251c94e37577d2b1 \
+                    size    53471242
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  19ac55faf36c646124e7726ce62918166e55d2a3 \
-                    sha256  ebaed844aa862a188abe1a3693644fa8c747f1849eb633a3da1b4409de3a2e78 \
-                    size    53298766
+    checksums       rmd160  f875a04f1dbc06356f13f51aea371b7b22acf3bb \
+                    sha256  c928bac4c9b7c88ab28f0d25d6b269158b1f3272311ce87a1bb7e4df6e803e14 \
+                    size    53418841
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 493.0.0.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?