### PR TITLE
openjdk23-temurin: new submission

### DIFF
--- a/java/openjdk23-temurin/Portfile
+++ b/java/openjdk23-temurin/Portfile
@@ -1,0 +1,92 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+set feature      23
+name             openjdk${feature}-temurin
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+license          GPL-2+
+# This port uses prebuilt binaries for a particular architecture
+# They are not universal binaries
+universal_variant no
+
+# https://adoptium.net/temurin/releases/
+supported_archs  x86_64 arm64
+
+version      ${feature}
+set build    37
+revision     0
+
+description  Eclipse Temurin, based on OpenJDK ${feature} (Short Term Support until March 2025)
+long_description Eclipse Temurin provides secure, TCK-tested and compliant, \
+    production-ready Java runtimes.
+
+master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk-${version}%2B${build}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
+    checksums    rmd160  94da6f8f4f4c156bc6b4fbca00140a0f0595d289 \
+                 sha256  0b4b14f7cb44cab89083fb72beafa6d4f12ee6722bf682e5dd026dab12cc8d23 \
+                 size    200977435
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
+    checksums    rmd160  a1f39d6a96a47ec46500170cb5ff97145b0371d0 \
+                 sha256  411934ca9ede95671afc1e7e1d9c8912c43247c7e4fba97730f20c0875287d44 \
+                 size    207118905
+}
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://adoptium.net
+
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin${feature}-binaries/releases
+livecheck.regex     OpenJDK${feature}U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under
+# /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-${feature}-eclipse-temurin.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under
+    # /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Eclipse Temurin 23.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?