### PR TITLE
jdk23-graalvm: new submission

### DIFF
--- a/java/jdk23-graalvm/Portfile
+++ b/java/jdk23-graalvm/Portfile
@@ -1,0 +1,96 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+set feature 23
+name             jdk${feature}-graalvm
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+# GraalVM Free Terms and Conditions: https://www.oracle.com/downloads/licenses/graal-free-license.html
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GFTC NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://www.oracle.com/java/technologies/downloads/#graalvmjava23-mac
+supported_archs  x86_64 arm64
+
+version     ${feature}
+set build 37
+revision    0
+
+master_sites https://download.oracle.com/graalvm/${feature}/archive/
+
+homepage     https://www.oracle.com/java/graalvm/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+description  Oracle GraalVM for JDK ${feature} (Short Term Support until March 2025)
+long_description Oracle GraalVM for JDK ${feature} compiles your Java applications ahead of time into standalone \
+    binaries that start instantly, provide peak performance with no warmup, and use fewer cloud resources.
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     graalvm-jdk-${version}_macos-x64_bin
+    checksums    rmd160  c826b3f79204c09dfaae8b3ba3263012afa03ed5 \
+                 sha256  d516ea854e361a821c7679d127ff7126c254b8c43c99e571e203df218df2764b \
+                 size    336258583
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     graalvm-jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  765bb038039e8a5c5cd9b2526b35e78b762fea4d \
+                 sha256  63290bf6242836ac46ca4c8c4ad048e4482fdb3f8276b9689088f059be430687 \
+                 size    350455170
+}
+
+worksrcdir   graalvm-jdk-${version}+${build}.1
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-${feature}-oracle-graalvm.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"
+


### PR DESCRIPTION
#### Description

New port for Oracle GraalVM for JDK 23.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?