### PR TITLE
openjdk22-openj9: update to OpenJ9 0.46.1

### DIFF
--- a/java/openjdk22-openj9/Portfile
+++ b/java/openjdk22-openj9/Portfile
@@ -2,7 +2,8 @@
 
 PortSystem       1.0
 
-name             openjdk22-openj9
+set feature 22
+name             openjdk${feature}-openj9
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        {darwin any}
@@ -14,28 +15,28 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      22.0.2
-revision     0
+version      ${feature}.0.2
+revision     1
 
 set build    9
-set openj9_version 0.46.0
+set openj9_version 0.46.1
 
-description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 22
+description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Short Term Support until September 2024)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru22-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  6323bfa47b2622e73e48ca38f125dfc8d20bd384 \
-                 sha256  24b49444a11f3e6a91e6f5dd2f298ea64da0f7953016b99e53cdb86e86d392eb \
-                 size    223473891
+    checksums    rmd160  c53c8e38e4b5ddf37cc9e5afce5016bf603cfaab \
+                 sha256  4bab7d10569c91f841616f8814b9ad51184ad7e87ea54ecc25764d59deff6809 \
+                 size    223495850
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  c4f0ea39e7098ded7c79ac19ffae8eb37ad343bc \
-                 sha256  b2018fd12ba90c0e030b4f499b0126360ebcac62042257df8c49b3fedf5979f9 \
-                 size    216744793
+    checksums    rmd160  b6079772168d063cd9d3760d0cf73d158584aa8c \
+                 sha256  f5b3903136a5d590cddb694cfb04bf541c8daf91c95214b4111f169d66ea0015 \
+                 size    216778116
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -43,8 +44,8 @@ worksrcdir   jdk-${version}+${build}
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
 livecheck.type      regex
-livecheck.url       https://github.com/ibmruntimes/semeru22-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(22\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
+livecheck.url       https://github.com/ibmruntimes/semeru${feature}-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(${feature}\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
 
 use_configure    no
 build {}
@@ -78,7 +79,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-22-ibm-semeru.jdk
+set jdk ${jvms}/jdk-${feature}-ibm-semeru.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Update to OpenJ9 0.46.1.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?