### PR TITLE
openjdk21-openj9: update to OpenJ9 0.46.1

### DIFF
--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -2,7 +2,8 @@
 
 PortSystem       1.0
 
-name             openjdk21-openj9
+set feature 21
+name             openjdk${feature}-openj9
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        {darwin any}
@@ -14,28 +15,28 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      21.0.4
-revision     0
+version      ${feature}.0.4
+revision     1
 
 set build    7
-set openj9_version 0.46.0
+set openj9_version 0.46.1
 
-description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 21
+description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  2172f491f85239b65276ba48c3cedeab7ad22189 \
-                 sha256  b36371d5844ed7d56ae03a8287fe724199b1b047c22eb175f20247f605be6e9c \
-                 size    225669765
+    checksums    rmd160  fab7f8fc73757fa0bbad1a7b907cf319cfeb4146 \
+                 sha256  97455456a43f06beb984df20dc275a621f712618bf3815c834b697f53d4cb9d6 \
+                 size    225687571
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  20c89ec891001833c44f5c11ac54565bc403bb59 \
-                 sha256  3f13030a8c36d02110145874ebdb71b5a526e053a2a2cbfdcbf45eb123b96dae \
-                 size    218850739
+    checksums    rmd160  6eae22ff20ee54f7c4a80658042274feed23091d \
+                 sha256  2ca92c44997fb7ed5ede97e7df89cb51164a24f5aa3097068536e86a00315213 \
+                 size    218880261
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -43,8 +44,8 @@ worksrcdir   jdk-${version}+${build}
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
 livecheck.type      regex
-livecheck.url       https://github.com/ibmruntimes/semeru21-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(21\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
+livecheck.url       https://github.com/ibmruntimes/semeru${feature}-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(${feature}\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
 
 use_configure    no
 build {}
@@ -78,7 +79,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-21-ibm-semeru.jdk
+set jdk ${jvms}/jdk-${feature}-ibm-semeru.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Update to OpenJ9 0.46.1.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?