### PR TITLE
openjdk17-openj9: update to OpenJ9 0.46.1

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -2,7 +2,8 @@
 
 PortSystem       1.0
 
-name             openjdk17-openj9
+set feature 17
+name             openjdk${feature}-openj9
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
@@ -14,28 +15,28 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      17.0.12
-revision     0
+version      ${feature}.0.12
+revision     1
 
 set build    7
-set openj9_version 0.46.0
+set openj9_version 0.46.1
 
-description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 17
+description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  d3a0f50e3f9eea412f40ea76b5cec7fc155a6a8e \
-                 sha256  7deda0966edee2d9af447f848bd28d8889149d3fc2e534627136c029edd25689 \
-                 size    213139862
+    checksums    rmd160  514f047b4d03d2b2f3dc9016507db103f1d35277 \
+                 sha256  e6038c81a736fae8ef05924248601c7db8a87aa8193de6bfb45295aa8b756aab \
+                 size    213182081
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  fa0becace070bf8a9085148ef4252b93ca4f45ac \
-                 sha256  cd17c6adc0e4c2da99c74dfd19d9c7745a2d0ee8277b16a83f5cf124711bef78 \
-                 size    206381295
+    checksums    rmd160  d89eb1ccddcd538609d81db024dbed7cfb083317 \
+                 sha256  a406b3f51177c10f1dfe7e3a29fe3595bf51122c2d5ee8bcd8ad53a8cecd0b4d \
+                 size    206405252
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -43,8 +44,8 @@ worksrcdir   jdk-${version}+${build}
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
 livecheck.type      regex
-livecheck.url       https://github.com/ibmruntimes/semeru17-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(17\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
+livecheck.url       https://github.com/ibmruntimes/semeru${feature}-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(${feature}\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to OpenJ9 0.46.1.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?