### PR TITLE
openjdk11-openj9: update to OpenJ9 0.46.1

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -2,7 +2,8 @@
 
 PortSystem       1.0
 
-name             openjdk11-openj9
+set feature 11
+name             openjdk${feature}-openj9
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
@@ -14,28 +15,28 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      11.0.24
-revision     0
+version      ${feature}.0.24
+revision     1
 
 set build    8
-set openj9_version 0.46.0
+set openj9_version 0.46.1
 
-description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 11
+description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  c7cc0a2c59f88053ac8fd7cb50748a74049679aa \
-                 sha256  3fee7c12ebb89eebff89ae401f793237f5ebf4064b063d2a5adc208f69f71e7a \
-                 size    208047776
+    checksums    rmd160  ac2d62e850649a3b4742ec2132e5d63f101c6d8b \
+                 sha256  668439028f64472bcc26a374e8ebda6b4dc99dc75a6061bd5701d1a8ab67a8e9 \
+                 size    208046646
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  a55cc8862f640bdac7820fbf0add1843991c3389 \
-                 sha256  6688e7bb5a385f245c28b077094f4625270c696a92aab5a261f6c75f7310215b \
-                 size    202290319
+    checksums    rmd160  e94f0638708f588778ec3eb1e3de31ec2960f69f \
+                 sha256  667ff31987c5d28ef7f5beb4a9294c85c04e9cd7c3fd4ede9815cde6627f637a \
+                 size    202298504
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -43,8 +44,8 @@ worksrcdir   jdk-${version}+${build}
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
 livecheck.type      regex
-livecheck.url       https://github.com/ibmruntimes/semeru11-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(11\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
+livecheck.url       https://github.com/ibmruntimes/semeru${feature}-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(${feature}\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to OpenJ9 0.46.1.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?