### PR TITLE
openjdk9-openj9: update to OpenJ9 0.46.1

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -2,7 +2,8 @@
 
 PortSystem       1.0
 
-name             openjdk8-openj9
+set feature 8
+name             openjdk${feature}-openj9
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        {darwin any}
@@ -14,30 +15,30 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
-version      8u422
-revision     0
+version      ${feature}u422
+revision     1
 
 set build    05
-set openj9_version 0.46.0
+set openj9_version 0.46.1
 
-description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 8
+description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
 distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  1b4648d1dc961debac32ffb29a91451a0a8f836c \
-             sha256  3cb422d24fb258b8c3b4c1daa0269f0664e1ddf3d4fd6e366c96dff7eed1d26a \
-             size    130899491
+checksums    rmd160  04a6641cba0505ca783b1ce5632ee2ff18ba3a8d \
+             sha256  24801efbebc51beb6e2ebb55d0004a89bed97e024a4dbfd2bff9146606f014f7 \
+             size    122625962
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
 livecheck.type      regex
-livecheck.url       https://github.com/ibmruntimes/semeru8-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(8u\[0-9\.\]+).*_openj9-\[0-9\.\]+\.tar\.gz
+livecheck.url       https://github.com/ibmruntimes/semeru${feature}-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(${feature}u\[0-9\.\]+).*_openj9-\[0-9\.\]+\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to OpenJ9 0.46.1.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?