### PR TITLE
boost181: Install Boost CMake find scripts by default

### DIFF
--- a/devel/boost181/Portfile
+++ b/devel/boost181/Portfile
@@ -240,8 +240,7 @@ build.args      -d2 \
                 threading=single,multi \
                 link=static,shared \
                 runtime-link=shared \
-                -j${build.jobs} \
-                --no-cmake-config
+                -j${build.jobs}
 
 destroot.cmd    ${worksrcpath}/b2
 destroot.post_args
@@ -541,16 +540,4 @@ platform darwin 8 powerpc {
     if {[variant_isset universal]} {
         build.args-append   macosx-version=10.4
     }
-}
-
-# As of Boost 1.70.0, Boost provides CMake find scripts for itself
-# that are installed by default. Those provided in 1.70.0 were broken
-# in multiple ways; many fixed were added before 1.71.0. That said,
-# we're not installing them by default at this time, but instead
-# providing an option to install them for testing / evaluation
-# purposes. We will likely enable these scripts in the future since it
-# is likely that CMake will stop providing them once the
-# Boost-provided version is stable.
-variant cmake_scripts description {Install Boost CMake find scripts} {
-    build.args-delete --no-cmake-config
 }


### PR DESCRIPTION
#### Description

CMake transitions more and more towards using Boost's `BoostConfig.cmake`, which is only installed if the option `--no-cmake-config` is _not_ given. The documentation of the variant also mentions that these CMake scripts should be installed by default.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Unfortunately, I have no macOS available to test this on. I would argue that, since I am effectively turning the variant on by default, the risk of this change is small.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
