### PR TITLE
alpine: Fix build with Xcode 16/clang 16 (macOS 15)

### DIFF
--- a/mail/alpine/Portfile
+++ b/mail/alpine/Portfile
@@ -34,7 +34,8 @@ depends_lib-append  port:gettext-runtime \
                     port:libiconv \
                     port:ncurses
 
-patchfiles-append   patch-fix-applekeychain.diff
+patchfiles-append   patch-fix-applekeychain.diff \
+                    patch-werror_implicit-int.diff
 patch.pre_args-replace  -p0 -p1
 
 configure.env       SSLDIR=${prefix}

--- a/mail/alpine/files/patch-fix-applekeychain.diff
+++ b/mail/alpine/files/patch-fix-applekeychain.diff
@@ -164,19 +164,6 @@ index 5a61bde..05b09b2 100644
    if test -z "$alpine_SYSTEM_PASSFILE" ; then
       alpine_PASSFILE=".alpine.pwd"
    else
-diff --git a/pith/pine.hlp b/pith/pine.hlp
-index 74c2d25..60ee304 100644
---- a/pith/pine.hlp
-+++ b/pith/pine.hlp
-@@ -147,7 +147,7 @@ with help text for the config screen and the composer that didn't have any
- reasonable place to be called from.
- Dummy change to get revision in pine.hlp
- ============= h_revision =================
--Alpine Commit 649 2022-06-02 18:13:05
-+Alpine Commit 659 2022-08-27 15:11:35
- ============= h_news =================
- <HTML>
- <HEAD>
 -- 
 2.11.4.GIT
 

--- a/mail/alpine/files/patch-werror_implicit-int.diff
+++ b/mail/alpine/files/patch-werror_implicit-int.diff
@@ -1,0 +1,41 @@
+From 0c44e2ae8b861e06139cfc6377cc59db0f12f781 Mon Sep 17 00:00:00 2001
+From: Eduardo Chappa <chappa@washington.edu>
+Date: Sun, 27 Nov 2022 17:24:57 -0700
+Subject: [PATCH]    * Fixes to the configure script by Florian Meyer (to fix
+ an implicit      cast to int in a declaration of a function).
+
+---
+ configure     | 2 +-
+ configure.ac  | 2 +-
+ pith/pine.hlp | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/configure b/configure
+index e6d7a705fb88..5d29dc3ba6c3 100755
+--- a/configure
++++ b/configure
+@@ -22039,7 +22039,7 @@ else
+ #endif
+ 
+ extern void *base;
+-extern sortf(const void *, const void *);
++extern int sortf(const void *, const void *);
+ int sortf(a, b)
+   const void *a;
+   const void *b; { return 0; }
+diff --git a/configure.ac b/configure.ac
+index 05b09b2e9537..f96a4c248b39 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1969,7 +1969,7 @@ ac_cv_func_qsort_argtype,
+ #endif
+ 
+ extern void *base;
+-extern sortf(const void *, const void *);
++extern int sortf(const void *, const void *);
+ int sortf(a, b)
+   const void *a;
+   const void *b; { return 0; }
+-- 
+2.46.1
+


### PR DESCRIPTION
Alpine’s configure script contains a check to detect the parameter type accepted by qsort’s comparison function. It does this by doing a trial compilation of a program with a comparison function that accepts two void* parameters, which is the modern form specified by the standard, and checking whether compilation succeeded. If compilation fails, it assumes the historic pre-standard form, which uses char* parameters, and configures Alpine accordingly.

The program for the test comparison is written in an archaic style that, among other things, does not explicitly declare the comparison function’s return type. This can be the subject of a compiler warning, -Wimplicit-int.

Clang 16, included in Xcode 16, enables -Werror=implicit-int by default[1], as does GCC 14[2]. Because this condition is now an error, the trial compilation began failing under these compilers, causing Alpine to be configured to use char* parameters in qsort comparison functions. Because this does not match qsort’s actual declaration, where comparison functions are expected to use void* parameters, this would result in a build failure.

The program used to detect the proper type to use for qsort’s comparison functions is updated to avoid the -Wimplicit-int problem.

[1] https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes
[2] https://gcc.gnu.org/gcc-14/porting_to.html#warnings-as-errors

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
