### PR TITLE
groovy: update to 4.0.23

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         4.0.22
+version         4.0.23
 revision        0
 
 categories      lang java
@@ -15,35 +15,24 @@ supported_archs noarch
 
 description     Groovy -- a Java-based scripting language
 
-long_description Groovy... \
-                * is an agile and dynamic language for the Java Virtual Machine \
-                * builds upon the strengths of Java but has additional power \
-                  features inspired by languages like Python, Ruby and Smalltalk \
-                * makes modern programming features available to Java developers \
-                  with almost-zero learning curve \
-                * provides the ability to statically type check and statically \
-                  compile your code for robustness and performance \
-                * supports Domain-Specific Languages and other compact syntax so \
-                  your code becomes easy to read and maintain \
-                * makes writing shell and build scripts easy with its powerful \
-                  processing primitives, OO abilities and an Ant DSL \
-                * increases developer productivity by reducing scaffolding code \
-                  when developing web, GUI, database or console applications \
-                * simplifies testing by supporting unit testing and mocking \
-                  out-of-the-box \
-                * seamlessly integrates with all existing Java classes and \
-                  libraries \
-                * compiles straight to Java bytecode so you can use it anywhere \
-                  you can use Java
+long_description Apache Groovy is a powerful, optionally typed and dynamic \
+                 language, with static-typing and static compilation \
+                 capabilities, for the Java platform aimed at improving \
+                 developer productivity thanks to a concise, familiar and easy \
+                 to learn syntax. It integrates smoothly with any Java \
+                 program, and immediately delivers to your application \
+                 powerful features, including scripting capabilities, \
+                 Domain-Specific Language authoring, runtime and compile-time \
+                 meta-programming and functional programming.
 
 homepage        https://groovy-lang.org/
 master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  3d0a5466a09f1116195c5a35ea791c5682136dbd \
-                sha256  d91a3ddfe353871d4c2656d3d0a05c828bc3ff36e9d49dbdbec13dcd98f05877 \
-                size    29863966
+checksums       rmd160  c8f8cb59c5786204138a2e4814fdd99b4806907f \
+                sha256  7089dd7a1e84adc814d616f5ec2f7d7dac2044a0a0457f3341b3b92d30204229 \
+                size    29947951
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 4.0.23.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?