### PR TITLE
libsodium: Update to version 1.0.20.

### DIFF
--- a/devel/libsodium/Portfile
+++ b/devel/libsodium/Portfile
@@ -7,7 +7,7 @@ PortGroup           muniversal 1.0
 # In case releases are not frequent, fall back to the stable branch.
 # https://doc.libsodium.org/installation
 
-github.setup        jedisct1 libsodium 1.0.19
+github.setup        jedisct1 libsodium 1.0.20
 github.tarball_from archive
 categories          devel security
 license             ISC
@@ -16,9 +16,9 @@ description         Portable and packageable NaCl-based crypto library
 long_description    ${name} is a library for network communication, \
                     encryption, decryption, signatures, etc.
 
-checksums           rmd160  21a9a0891c6ada1eee15f7bedb937cf4bb5734e0 \
-                    sha256  1d281a8a5e299a38e5c16ff60f293bba0796dc0fda8e49bc582d4bc1935572ed \
-                    size    2149654
+checksums           rmd160  780f54c7f719d0092266f1c6f7ea22567dfda486 \
+                    sha256  ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19 \
+                    size    1925167
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description
libsodium v1.0.19 fails to compile on macOS 15/Xcode 16.  Updating to version 1.0.20 resolves the issue.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d/Command Line Tools 16.0.0.0.1.1724870825

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
