### PR TITLE
at-spi2-core: Update to version 2.44.1.

### DIFF
--- a/gnome/at-spi2-core/Portfile
+++ b/gnome/at-spi2-core/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 
 name                at-spi2-core
 # you probably want to keep this at the same version as at-spi2-atk
-version             2.38.0
+version             2.44.1
 
 license             LGPL
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -22,9 +22,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  0dbb814bd39676adb7484742ed0944f7bdda07a3 \
-                    sha256  84e36c3fe66862133f5fe229772b76aa2526e10de5014a3778f2fa46ce550da5 \
-                    size    190540
+checksums           rmd160  86db943d67b2bbb1365b018b67f25a958c79597c \
+                    sha256  4beb23270ba6cf7caf20b597354d75194d89afb69d2efcf15f4271688ba6f746 \
+                    size    209780
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description

at-spi2-core v2.38.0 fails to compile on macOS 15/Xcode 16. Updating to version 2.44.1 resolves the issue. 
Closes: https://trac.macports.org/ticket/70776

Note that at-spi2-atk has no updates, but as of at-spi2-core version 2.45.1, the two libraries are merged.  So updating at-spi2-core to v2.44.1 is simply a work-around until then.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d / Command Line Tools 16.0.0.0.1.1724870825


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
