### PR TITLE
KeePassXC: Fix by setting deployment target for darwin 24.

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -28,6 +28,10 @@ long_description        KeePassXC is a community fork of KeePassX with the \
 license                 {GPL-2 GPL-3}
 license_noconflict      openssl openssl10 openssl11 openssl3
 
+if { ${os.platform} eq "darwin" && ${os.major} >= 24 } {
+    macosx_deployment_target 14.0
+}
+
 if {${subport} eq ${name}} {
     # stable
     github.setup        keepassxreboot keepassxc 2.7.9


### PR DESCRIPTION
#### Description

**KeePassXC** fails to compile on macOS 15/Xcode 16. Setting the macOS deployment target to 14 (or less) resolves the issue.  See also:
https://trac.macports.org/wiki/SequoiaProblems#ScreenCaptureKitRequirementwithmacOS15SDK

NB: **KeePassXC** depends on ports **qt5-qtbase** and **libsodium**, which must be patched as well on macOS 15. **qt5-qtbase** can be patched in the same manner as this PR.  **libsodium** just needs to be updated - see PR #25833.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d / Command Line Tools 16.0.0.0.1.1724870825

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
