### PR TITLE
Update avr-gcc to use GCC 14.2

### DIFF
--- a/cross/avr-gcc/Portfile
+++ b/cross/avr-gcc/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               crossgcc 1.0
 
-set gccversion          13.1.0
+set gccversion          14.2.0
 crossgcc.setup          avr ${gccversion}
 # TODO: Add support avr-libc
 # See http://download.savannah.gnu.org/releases/avr-libc/


### PR DESCRIPTION
GCC 13.1 does not compile on my macOS Sequoia machine. This breaks avr-gcc. Fix it by bumping version to 14.2.