### PR TITLE
nusmv: fix the build on older systems

### DIFF
--- a/devel/nusmv/Portfile
+++ b/devel/nusmv/Portfile
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                nusmv
@@ -36,7 +36,7 @@ checksums           ${nusmv_distfile} \
                     size    77725
 
 depends_build-append \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib         port:libxml2 \
                     port:readline
@@ -49,7 +49,8 @@ post-extract {
 universal_variant   no
 cmake.source_dir    ${worksrcpath}/NuSMV
 
-if {${os.platform} eq "darwin" && ${os.major} < 21} {
+if {${os.platform} eq "darwin" && \
+    (${os.major} > 10 && ${os.major} < 21)} {
     configure.python /usr/bin/python
 } else {
     set python_version 2.7
@@ -60,6 +61,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 21} {
 configure.args      -DDOXYGEN_EXECUTABLE= \
                     -DPDFLATEX_COMPILER= \
                     -DPYTHON_EXECUTABLE=${configure.python}
+
+# make[1]: *** read jobs pipe: Resource temporarily unavailable. Stop.
+use_parallel_build  no
 
 livecheck.type      regex
 livecheck.url       ${homepage}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/70360

#### Description

Fix this one

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
