### PR TITLE
afl: unbreak for < 10.7

### DIFF
--- a/devel/afl/Portfile
+++ b/devel/afl/Portfile
@@ -1,11 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
+
+# memmem
+legacysupport.newest_darwin_requires_legacy 10
 
 name                afl
 version             2.52b
 categories          devel security
-platforms           darwin
 maintainers         nomaintainer
 license             Apache-2
 
@@ -22,9 +25,13 @@ master_sites        ${homepage}/releases
 extract.suffix      .tgz
 
 checksums           rmd160  b7c1174111cfc11d14a0982359ef903d5b8d1267 \
-                    sha256  43614b4b91c014d39ef086c5cc84ff5f068010c264c2c05bf199df60898ce045
+                    sha256  43614b4b91c014d39ef086c5cc84ff5f068010c264c2c05bf199df60898ce045 \
+                    size    835907
+
+patchfiles-append   patch-allow-32-bit.diff
 
 use_configure       no
+
 build.env           CC=${configure.cc} \
                     CXX=${configure.cxx} \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
@@ -32,14 +39,14 @@ build.env           CC=${configure.cc} \
                     "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]" \
                     PREFIX=${prefix}
 
-destroot.env        PREFIX=${prefix}
-
-pre-fetch {
-    if {${os.subplatform} eq "macosx" && [vercmp ${macosx_version} 10.7] < 0} {
-        ui_error "${name} ${version} requires memmem(3), only available on OS X 10.7 or greater."
-        return -code error "incompatible macOS version"
-    }
+if {${configure.build_arch} ni [list i386 x86_64]} {
+    build.args-append \
+                    AFL_NO_X86=1
+    destroot.args-append \
+                    AFL_NO_X86=1
 }
+
+destroot.env        PREFIX=${prefix}
 
 livecheck.type      regex
 livecheck.url       ${master_sites}

--- a/devel/afl/files/patch-allow-32-bit.diff
+++ b/devel/afl/files/patch-allow-32-bit.diff
@@ -1,0 +1,11 @@
+--- afl-as.c	2017-11-05 10:24:47.000000000 +0800
++++ afl-as.c	2024-09-20 00:28:05.000000000 +0800
+@@ -75,7 +75,7 @@
+ static u8   use_64bit = 0;
+ 
+ #ifdef __APPLE__
+-#  error "Sorry, 32-bit Apple platforms are not supported."
++#  warning "Sorry, 32-bit Apple platforms are not supported."
+ #endif /* __APPLE__ */
+ 
+ #endif /* ^__x86_64__ */


### PR DESCRIPTION
#### Description

Fix this

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
