### PR TITLE
uv: Update to 0.4.13

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.4.10
+github.setup            astral-sh uv 0.4.13
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  75e856d6bc7d7bc91a80e05f9f72fca6d85369c0 \
-                        sha256  8cba1109fa3d709a0ea6737a997fb272da196fcfab5ac4e50716fda4c34017c1 \
-                        size    2585899
+                        rmd160  d6ed9d16cc1299b23421246b5323c89c83543af3 \
+                        sha256  c0dab196cc4f8141a29f72ac9f02e6542812bf283a8af06db477d92cfedef308 \
+                        size    2606230
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -54,10 +54,9 @@ destroot {
 }
 
 cargo.crates \
-    addr2line                       0.22.0  6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678 \
+    addr2line                       0.24.1  f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375 \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
     adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
-    ahash                            0.7.8  891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
     anstream                        0.6.15  64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526 \
@@ -65,39 +64,38 @@ cargo.crates \
     anstyle-parse                    0.2.5  eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb \
     anstyle-query                    1.1.1  6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a \
     anstyle-wincon                   3.0.4  5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8 \
-    anyhow                          1.0.86  b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da \
+    anyhow                          1.0.89  86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
-    arrayref                         0.3.8  9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a \
+    arrayref                         0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     assert_cmd                      2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     assert_fs                        1.1.2  7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674 \
     async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
     async-compression               0.4.12  fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa \
-    async-trait                     0.1.81  6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107 \
+    async-trait                     0.1.82  a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1 \
     async_http_range_reader          0.8.0  f1a0e0571c5d724d17fbe0b608d31a91e94938722c141877d3a2982216b084c2 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.3.0  0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0 \
     axoasset                         1.0.0  45e7b7ac1c1cd4fdcaa2f9e704defa9defd996039083d85e17efa5e8eefb3bd2 \
     axoprocess                       0.2.0  4de46920588aef95658797996130bacd542436aee090084646521260a74bda7d \
     axotag                           0.2.0  d888fac0b73e64cbdf36a743fc5a25af5ae955c357535cb420b389bf1e1a6c54 \
-    axoupdater                       0.7.1  14cd170d3b144de5288b99c69f30b36ee5eba837bed33f458f39c890e2049162 \
+    axoupdater                       0.7.2  fa6f92ef9ab41a352f403f709ef0f09cda1f461795de52085cd46ed831ead02e \
     backoff                          0.4.0  b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1 \
-    backtrace                       0.3.73  5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a \
+    backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
     backtrace-ext                    0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     bisection                        0.1.0  021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
-    bitvec                           1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     boxcar                           0.2.5  510a90332002c1af3317ef6b712f0dab697f30bbe809b86965eac2923c0bca8e \
     bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
-    bytecheck                       0.6.12  23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2 \
-    bytecheck_derive                0.6.12  3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659 \
-    bytemuck                        1.17.1  773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2 \
+    bytecheck                        0.8.0  50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f \
+    bytecheck_derive                 0.8.0  523363cbe1df49b68215efdf500b103ac3b0fb4836aed6d15689a076eadb8fff \
+    bytemuck                        1.18.0  94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     byteorder-lite                   0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
     bytes                            1.7.1  8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50 \
@@ -105,25 +103,25 @@ cargo.crates \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
     camino                           1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
-    cargo-util                      0.2.13  14104698cb1694d43c2ff73492468ccf2bb0b047071a9838d999eeba9e984ffa \
+    cargo-util                      0.2.14  cc680c90073156fb5280c0c0127b779eef1f6292e41f7d6621acba3041e81c7d \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
-    cc                              1.1.15  57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6 \
+    cc                              1.1.19  2d74707dde2ba56f86ae90effb3b43ddd369504387e718014de010cec7959800 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     charset                          0.1.5  f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.16  ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019 \
-    clap_builder                    4.5.15  216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6 \
-    clap_complete                   4.5.24  6d7db6eca8c205649e8d3ccd05aa5042b1800a784e56bc7c43524fde8abbfa9b \
+    clap                            4.5.17  3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac \
+    clap_builder                    4.5.17  8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73 \
+    clap_complete                   4.5.26  205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.3  5fe32110e006bccf720f8c9af3fee1ba7db290c724eab61544e1d3295be3a40e \
     clap_derive                     4.5.13  501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0 \
     clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
     cmake                           0.1.51  fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a \
-    codspeed                         2.7.1  b0c6f324a032703f286b0fbbdb390971f914b41f3410e1615c59730e4b24ebc2 \
-    codspeed-criterion-compat        2.7.1  0ae52f6f2545ffcd2ac1308f34043eb6ab81e4c741af419b348b2325574f48ee \
+    codspeed                         2.7.2  450a0e9df9df1c154156f4344f99d8f6f6e69d0fc4de96ef6e2e68b2ec3bce97 \
+    codspeed-criterion-compat        2.7.2  8eb1a6cb9c20e177fde58cdef97c1c7c9264eb1424fe45c4fccedc2fb078a569 \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
     colorchoice                      1.0.2  d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0 \
     colored                          2.1.0  cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8 \
@@ -132,7 +130,7 @@ cargo.crates \
     console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
-    cpufeatures                     0.2.13  51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad \
+    cpufeatures                     0.2.14  608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
     criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
     criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
@@ -144,7 +142,7 @@ cargo.crates \
     csv                              1.3.0  ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe \
     csv-core                        0.1.11  5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70 \
     ctrlc                            3.4.5  90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3 \
-    dashmap                          6.0.1  804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28 \
+    dashmap                          6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
     data-encoding                    2.6.0  e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2 \
     data-url                         0.2.0  8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5 \
     deadpool                        0.10.0  fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490 \
@@ -178,7 +176,6 @@ cargo.crates \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fs-err                          2.11.0  88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41 \
     fs2                              0.4.3  9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
-    funty                            2.0.0  e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c \
     futures                         0.3.30  645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0 \
     futures-channel                 0.3.30  eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78 \
     futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
@@ -192,14 +189,13 @@ cargo.crates \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
     gif                             0.12.0  80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045 \
-    gimli                           0.29.0  40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd \
+    gimli                           0.31.0  32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64 \
     glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
-    globset                         0.4.14  57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1 \
+    globset                         0.4.15  15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     goblin                           0.8.2  1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47 \
     h2                               0.4.6  524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205 \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
-    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
@@ -216,18 +212,18 @@ cargo.crates \
     httparse                         1.9.4  0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     hyper                            1.4.1  50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05 \
-    hyper-rustls                    0.27.2  5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155 \
-    hyper-util                       0.1.7  cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9 \
+    hyper-rustls                    0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
+    hyper-util                       0.1.8  da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
-    ignore                          0.4.22  b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1 \
+    ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
     image                           0.25.2  99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10 \
     imagesize                       0.11.0  b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf \
     indexmap                         2.5.0  68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5 \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
-    insta                           1.39.0  810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5 \
+    insta                           1.40.0  6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60 \
     instant                         0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
-    ipnet                            2.9.0  8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3 \
+    ipnet                           2.10.0  187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4 \
     is-terminal                     0.4.13  261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b \
     is_ci                            1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
@@ -235,13 +231,13 @@ cargo.crates \
     itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
-    jiff                            0.1.11  362be9c702bada57298130d0565e9c389e6d4024a541692f01819e21abc3e26a \
-    jiff-tzdb                        0.1.0  05fac328b3df1c0f18a3c2ab6cb7e06e4e549f366017d796e3e66b6d6889abe6 \
-    jiff-tzdb-platform               0.1.0  f8da387d5feaf355954c2c122c194d6df9c57d865125a67984bb453db5336940 \
+    jiff                            0.1.13  8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb \
+    jiff-tzdb                        0.1.1  91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653 \
+    jiff-tzdb-platform               0.1.1  9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jpeg-decoder                     0.3.1  f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0 \
     js-sys                          0.3.70  1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a \
-    junction                         1.1.0  1c9c415a9b7b1e86cd5738f39d34c9e78c765da7fb1756dbd7d31b3b0d2e7afa \
+    junction                         1.2.0  72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16 \
     krata-tokio-tar                  0.4.2  e8bd5fee9b96acb5fc36b401896d601e6fdcce52b0e651ce24a3b21fb524e79f \
     kurbo                            0.8.3  7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449 \
     kurbo                            0.9.5  bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b \
@@ -261,7 +257,7 @@ cargo.crates \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     memmap2                         0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
-    memmap2                          0.9.4  fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322 \
+    memmap2                          0.9.5  fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f \
     memoffset                        0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
     memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     miette                           7.2.0  4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1 \
@@ -272,6 +268,8 @@ cargo.crates \
     miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
     mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
     miow                             0.6.0  359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044 \
+    munge                            0.4.1  64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df \
+    munge_macro                      0.4.1  1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e \
     nanoid                           0.4.0  3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8 \
     nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
@@ -282,13 +280,13 @@ cargo.crates \
     num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     object                          0.36.4  084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a \
-    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
+    once_cell                       1.20.0  33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe \
     oorandom                        11.1.4  b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
-    owo-colors                       4.0.0  caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f \
-    parking                          2.2.0  bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae \
+    owo-colors                       4.1.0  fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56 \
+    parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                 0.8.6  60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc \
@@ -297,10 +295,10 @@ cargo.crates \
     path-slash                       0.2.1  1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42 \
     pathdiff                         0.2.1  8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    pest                            2.7.11  cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95 \
-    pest_derive                     2.7.11  2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a \
-    pest_generator                  2.7.11  3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183 \
-    pest_meta                       2.7.11  a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f \
+    pest                            2.7.12  9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea \
+    pest_derive                     2.7.12  664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d \
+    pest_generator                  2.7.12  a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe \
+    pest_meta                       2.7.12  0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174 \
     petgraph                         0.6.5  b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db \
     pico-args                        0.5.0  5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315 \
     pin-project                      1.1.5  b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3 \
@@ -318,23 +316,23 @@ cargo.crates \
     predicates                       3.1.2  7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97 \
     predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
     predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
-    pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
+    pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     priority-queue                   2.1.0  560bcab673ff7f6ca9e270c17bf3affd8a05e3bd9207f123b0d45076fd8197e8 \
     proc-macro2                     1.0.86  5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77 \
-    ptr_meta                         0.1.4  0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1 \
-    ptr_meta_derive                  0.1.4  16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac \
+    ptr_meta                         0.3.0  fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90 \
+    ptr_meta_derive                  0.3.0  ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1 \
     pyo3                            0.21.2  a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8 \
     pyo3-build-config               0.21.2  7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50 \
     pyo3-ffi                        0.21.2  01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403 \
     pyo3-log                        0.10.0  2af49834b8d2ecd555177e63b273b708dea75150abc6f5341d0a6e1a9623976c \
     pyo3-macros                     0.21.2  77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c \
     pyo3-macros-backend             0.21.2  08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c \
-    quinn                           0.11.3  b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156 \
-    quinn-proto                     0.11.7  ea0a9b3a42929fad8a7c3de7f86ce0814cfa893328157672680e9fb1145549c5 \
-    quinn-udp                        0.5.4  8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285 \
+    quinn                           0.11.5  8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684 \
+    quinn-proto                     0.11.8  fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6 \
+    quinn-udp                        0.5.5  4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b \
     quote                           1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
     quoted_printable                 0.5.1  640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73 \
-    radium                           0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
+    rancor                           0.1.0  caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
@@ -343,7 +341,7 @@ cargo.crates \
     rctree                           0.5.0  3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f \
     redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
     redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
-    redox_syscall                    0.5.3  2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4 \
+    redox_syscall                    0.5.4  0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853 \
     redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
     reflink-copy                    0.1.19  dc31414597d1cd7fdd2422798b7652a6329dda0fe0219e6335a13d5bcaa9aeb6 \
     regex                           1.10.6  4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619 \
@@ -351,14 +349,14 @@ cargo.crates \
     regex-automata                   0.4.7  38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.4  7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b \
-    rend                             0.4.2  71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c \
+    rend                             0.5.1  a31c1f1959e4db12c985c0283656be0925f1539549db1e47c4bd0b8b599e1ef7 \
     reqwest                         0.12.7  f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63 \
     resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
     retry-policies                   0.4.0  5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c \
-    rgb                             0.8.49  09cd5a1e95672f201913966f39baf355b53b5d92833431847295ae0346a5b939 \
+    rgb                             0.8.50  57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a \
     ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
-    rkyv                            0.7.45  9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b \
-    rkyv_derive                     0.7.45  503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0 \
+    rkyv                             0.8.8  395027076c569819ea6035ee62e664f5e03d74e281744f55261dd1afd939212b \
+    rkyv_derive                      0.8.8  09cb82b74b4810f07e460852c32f522e979787691b0b7b7439fe473e49d49b2f \
     rmp                             0.8.14  228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4 \
     rmp-serde                        1.3.0  52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db \
     rosvgtree                        0.1.0  bdc23d1ace03d6b8153c7d16f0708cd80b61ee8e80304954803354e67e40d150 \
@@ -367,16 +365,17 @@ cargo.crates \
     rust-netrc                       0.1.1  32662f97cbfdbad9d5f78f1338116f06871e7dae4fd37e9f59a0f57cf2044868 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
-    rustix                         0.38.35  a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f \
-    rustls                         0.23.12  c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044 \
+    rustix                         0.38.37  8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811 \
+    rustls                         0.23.13  f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8 \
     rustls-native-certs              0.7.3  e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5 \
+    rustls-native-certs              0.8.0  fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a \
     rustls-pemfile                   2.1.3  196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425 \
     rustls-pki-types                 1.8.0  fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0 \
-    rustls-webpki                  0.102.7  84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56 \
+    rustls-webpki                  0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
     rustybuzz                        0.7.0  162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    schannel                        0.1.23  fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534 \
+    schannel                        0.1.24  e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b \
     schemars                        0.8.21  09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92 \
     schemars_derive                 0.8.21  b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
@@ -386,10 +385,10 @@ cargo.crates \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework-sys          2.11.1  75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
-    serde                          1.0.209  99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09 \
-    serde_derive                   1.0.209  a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170 \
+    serde                          1.0.210  c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a \
+    serde_derive                   1.0.210  243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                     1.0.127  8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad \
+    serde_json                     1.0.128  6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8 \
     serde_spanned                    0.6.7  eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
@@ -410,19 +409,17 @@ cargo.crates \
     strict-num                       0.1.1  6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
-    supports-color                   3.0.0  9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f \
+    supports-color                   3.0.1  8775305acf21c96926c900ad056abeef436701108518cf890020387236ac5a77 \
     supports-hyperlinks              3.0.0  2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee \
     supports-unicode                 3.0.0  b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2 \
     svg                             0.17.0  700efb40f3f559c23c18b446e8ed62b08b56b2bb3197b36d57e0470b4102779e \
     svgfilters                       0.4.0  639abcebc15fdc2df179f37d6f5463d660c1c79cd552c12343a4600827a04bce \
     svgtypes                         0.9.0  c9ee29c1407a5b18ccfe5f6ac82ac11bab3b14407e09c209a6c1a32098b19734 \
     svgtypes                        0.10.0  98ffacedcdcf1da6579c907279b4f3c5492fbce99fbbf227f5ed270a589c2765 \
-    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.76  578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525 \
+    syn                             2.0.77  9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed \
     sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     tagu                             0.1.6  eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a \
-    tap                              1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
     target-lexicon                 0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
     temp-env                         0.3.6  96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050 \
     tempfile                        3.12.0  04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64 \
@@ -448,11 +445,12 @@ cargo.crates \
     tokio                           1.40.0  e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998 \
     tokio-macros                     2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
     tokio-rustls                    0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
-    tokio-stream                    0.1.15  267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af \
-    tokio-util                      0.7.11  9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1 \
+    tokio-socks                      0.5.2  0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f \
+    tokio-stream                    0.1.16  4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1 \
+    tokio-util                      0.7.12  61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a \
     toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
-    toml_edit                      0.22.20  583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d \
+    toml_edit                      0.22.21  3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf \
     tower                           0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
@@ -472,7 +470,7 @@ cargo.crates \
     unicode-bidi-mirroring           0.1.0  56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694 \
     unicode-ccc                      0.1.2  cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1 \
     unicode-general-category         0.6.0  2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7 \
-    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
     unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
     unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
     unicode-script                   0.5.6  ad8d71f5726e5f285a935e9fe8edfd53f0491eb6e9a5774097fdabee7cd8c9cd \
@@ -503,7 +501,7 @@ cargo.crates \
     wasm-streams                     0.4.0  b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129 \
     wasm-timer                       0.2.5  be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f \
     web-sys                         0.3.70  26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0 \
-    webpki-roots                    0.26.3  bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd \
+    webpki-roots                    0.26.5  0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a \
     weezl                            0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
     which                            6.0.3  b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f \
     widestring                       1.1.0  7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311 \
@@ -547,12 +545,11 @@ cargo.crates \
     winreg                          0.52.0  a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5 \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     winsafe                         0.0.22  7d6ad6cbd9c6e5144971e326303f0e453b61d82e4f72067fccf23106bccd8437 \
-    wiremock                         0.6.1  6a59f8ae78a4737fb724f20106fb35ccb7cfe61ff335665d3042b3aa98e34717 \
-    wyz                              0.5.1  05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed \
+    wiremock                         0.6.2  7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646 \
     xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
     xmlparser                       0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
-    yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec \
+    yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
     zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.4.13

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
