### PR TITLE
crfsuite: unbreak build on non-x86 archs

### DIFF
--- a/math/crfsuite/Portfile
+++ b/math/crfsuite/Portfile
@@ -13,11 +13,11 @@ long_description    CRFsuite is an implementation of Conditional Random Fields (
                     for labeling sequential data.
 
 homepage            http://www.chokkan.org/software/crfsuite/
-platforms           darwin
 license             BSD
 
 checksums           rmd160  ba5e127e3d8e5d1bb2a344e7e96259bb328f9bb7 \
-                    sha256  8931f215e6f9b230cc2dc440fcd890c37afa3b1df3e8da512c7e74cafba8f0c5
+                    sha256  8931f215e6f9b230cc2dc440fcd890c37afa3b1df3e8da512c7e74cafba8f0c5 \
+                    size    244953
 
 depends_build       port:libtool  \
                     port:autoconf \
@@ -33,6 +33,12 @@ pre-configure {
 }
 
 configure.args      --with-liblbfgs=${prefix}
+
+# https://github.com/chokkan/crfsuite/issues/126
+if {${configure.build_arch} ni [list i386 x86_64]} {
+    configure.args-append \
+                    --disable-sse2
+}
 
 post-destroot {
     # install additional documents.


### PR DESCRIPTION
#### Description

Do not use Intel vectorization on non-Intel archs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
