### PR TITLE
py38-scikit-learn deps: drop python 3.8 or use 3.9

### DIFF
--- a/python/py-astroML/Portfile
+++ b/python/py-astroML/Portfile
@@ -14,7 +14,7 @@ platforms           {darwin any}
 supported_archs     noarch
 maintainers         {aronnax @lpsinger} openmaintainer
 
-python.versions     38 39
+python.versions     39
 
 description         tools for machine learning and data mining in astronomy
 

--- a/python/py-astroML_addons/Portfile
+++ b/python/py-astroML_addons/Portfile
@@ -13,7 +13,7 @@ license             BSD
 platforms           darwin
 maintainers         {aronnax @lpsinger} openmaintainer
 
-python.versions     38 39
+python.versions     39
 
 description         performance add-ons for the astroML package
 

--- a/python/py-beancount-import/Portfile
+++ b/python/py-beancount-import/Portfile
@@ -26,7 +26,7 @@ homepage            https://github.com/jbms/beancount-import
 
 use_zip             yes
 
-python.versions     38
+python.versions     39
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-eli5/Portfile
+++ b/python/py-eli5/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  cbdd276878809cd586e3f93e759dd8eab5cfe155 \
                     sha256  8e5e8ea78978137715e707c07df335647601bea65365e8b12b907cf0f5f69c21 \
                     size    6821953
 
-python.versions     38
+python.versions     39
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-geoplot/Portfile
+++ b/python/py-geoplot/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  1a38d9aee356e58891addb3819018bdc3aadeb08 \
                     sha256  9614b2caa193a42de943afa2fea953d0997b9daf25ab2949be0681361a122790 \
                     size    28092
 
-python.versions     38 39 310 311 312
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-hdbscan/Portfile
+++ b/python/py-hdbscan/Portfile
@@ -11,7 +11,7 @@ categories-append   science
 license             BSD
 supported_archs     arm64 x86_64
 
-python.versions     38 39 310 311
+python.versions     39 310 311
 
 maintainers         nomaintainer
 

--- a/python/py-librosa/Portfile
+++ b/python/py-librosa/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  25ae847aac6b9effde1b864637bcc86b1be0e564 \
                     sha256  63e913b0060bb85e8a21ac06a33803d659c1139b2756442ee419012cf6a1df38 \
                     size    2210477
 
-python.versions     38 39 310 311
+python.versions     39 310 311
 
 if {${name} ne ${subport}} {
     depends_run-append \

--- a/python/py-mapclassify/Portfile
+++ b/python/py-mapclassify/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  ea480b4e473be8e76bbf0167662979e151105786 \
                     sha256  b53a5f1d0d43342a333420aa5946c76ea1c3f97f38857f39b5e9f99c35272a3f \
                     size    4608681
 
-python.versions     38 39 310 311 312
+python.versions     39 310 311 312
 python.pep517       yes
 
 if {${name} ne ${subport}} {

--- a/python/py-note-seq/Portfile
+++ b/python/py-note-seq/Portfile
@@ -32,7 +32,7 @@ checksums           rmd160  a3b7d96c26bdd28eddd40bacc1303f757b3a5722 \
                     sha256  bb7fc03900f0e6504fb493879255c40e59f7baef085ca6e112fb0a1d2544125e \
                     size    953597
 
-python.versions     38 39 310 311
+python.versions     39 310 311
 python.pep517       yes
 
 if {${name} ne ${subport}} {

--- a/python/py-pmdarima/Portfile
+++ b/python/py-pmdarima/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pmdarima
-version             1.8.0
+version             2.0.4
 platforms           darwin
 license             MIT
 maintainers         nomaintainer
@@ -14,9 +14,9 @@ long_description    {*}${description}
 
 homepage            http://alkaline-ml.com/pmdarima
 
-checksums           rmd160  98c61a4ac2832ffa9c0d3d8ec74661ed64ee2836 \
-                    sha256  65f22f49ebc2271934a2bb346a6667b19094300eeaebf93a3674577c5440a6bc \
-                    size    1047702
+checksums           rmd160  c0b08e6499f6fd1d19d89c649ea19b734d4ace53 \
+                    sha256  b87f9d9f5b7dc2ddbd053687c2264e26ac98fd4118e843c7e9bc3dd7343e5c1a \
+                    size    630274
 
 python.versions     39
 
@@ -32,4 +32,10 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-scikit-learn \
                     port:py${python.version}-scipy \
                     port:py${python.version}-urllib3
+
+    build.args      --skip-dependency-check
+    build.env-append \
+                    CC=${configure.cc}
+    destroot.env-append \
+                    CC=${configure.cc}
 }

--- a/python/py-pmdarima/Portfile
+++ b/python/py-pmdarima/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  98c61a4ac2832ffa9c0d3d8ec74661ed64ee2836 \
                     sha256  65f22f49ebc2271934a2bb346a6667b19094300eeaebf93a3674577c5440a6bc \
                     size    1047702
 
-python.versions     38 39
+python.versions     39
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-seqeval/Portfile
+++ b/python/py-seqeval/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  a1a066fd76cbb4e9a8a9802c114cce8ba82f3dd5 \
                     sha256  f28e97c3ab96d6fcd32b648f6438ff2e09cfba87f05939da9b3970713ec56e6f \
                     size    43605
 
-python.versions     38 39 310 311
+python.versions     39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-tpot/Portfile
+++ b/python/py-tpot/Portfile
@@ -12,7 +12,7 @@ license             LGPL
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     38 39 310
+python.versions     39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-umap-learn/Portfile
+++ b/python/py-umap-learn/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  c922b5c74b1a72c19fbb7cd69167204c45545ae2 \
                     sha256  3e3e5e526109866012a9da79f423c922edc379c6cac9bf65ea08fbb9dd93ff3a \
                     size    80906
 
-python.versions     38 39
+python.versions     39
 python.pep517       yes
 
 if {${name} ne ${subport}} {

--- a/python/py-xraylarch/Portfile
+++ b/python/py-xraylarch/Portfile
@@ -34,7 +34,7 @@ checksums           rmd160  0736ee2e7d6ba40c8c55dc7111cb3c3067454fd2 \
                     sha256  92d558df4c8302a277ead4ad597920285abf3b7e69ca9ab13873e8dc319e452a \
                     size    21056444
 
-python.versions     38 39 310
+python.versions     39 310
 python.pep517       yes
 python.pep517_backend
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
