### PR TITLE
openmpi: add clang18, clang19, and gcc14 sub-ports

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -25,7 +25,6 @@ revision            0
 
 license             BSD
 categories          science parallel net
-platforms           darwin
 maintainers         {mascguy @mascguy}
 
 description         Message Passing Interface (MPI) Library
@@ -72,6 +71,7 @@ dict set clist gcc10   {macports-gcc-10}
 dict set clist gcc11   {macports-gcc-11}
 dict set clist gcc12   {macports-gcc-12}
 dict set clist gcc13   {macports-gcc-13}
+dict set clist gcc14   {macports-gcc-14}
 dict set clist clang11 {macports-clang-11}
 dict set clist clang12 {macports-clang-12}
 dict set clist clang13 {macports-clang-13}
@@ -79,6 +79,8 @@ dict set clist clang14 {macports-clang-14}
 dict set clist clang15 {macports-clang-15}
 dict set clist clang16 {macports-clang-16}
 dict set clist clang17 {macports-clang-17}
+dict set clist clang18 {macports-clang-18}
+dict set clist clang19 {macports-clang-19}
 
 # Only enable Xcode clang builds for MacOS 10.7 and later
 if { ${os.major} >= 11 } {

--- a/science/openmpi/files/portselect/openmpi-clang18
+++ b/science/openmpi/files/portselect/openmpi-clang18
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang18
+-
+bin/mpicxx-openmpi-clang18
+bin/mpiexec-openmpi-clang18
+bin/mpirun-openmpi-clang18
+-
+-
+-
+lib/openmpi-clang18/pkgconfig/ompi.pc
+lib/openmpi-clang18/pkgconfig/orte.pc
+-

--- a/science/openmpi/files/portselect/openmpi-clang18-fortran
+++ b/science/openmpi/files/portselect/openmpi-clang18-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang18
+-
+bin/mpicxx-openmpi-clang18
+bin/mpiexec-openmpi-clang18
+bin/mpirun-openmpi-clang18
+bin/mpif77-openmpi-clang18
+bin/mpif90-openmpi-clang18
+-
+lib/openmpi-clang18/pkgconfig/ompi.pc
+lib/openmpi-clang18/pkgconfig/orte.pc
+bin/mpifort-openmpi-clang18

--- a/science/openmpi/files/portselect/openmpi-clang19
+++ b/science/openmpi/files/portselect/openmpi-clang19
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang19
+-
+bin/mpicxx-openmpi-clang19
+bin/mpiexec-openmpi-clang19
+bin/mpirun-openmpi-clang19
+-
+-
+-
+lib/openmpi-clang19/pkgconfig/ompi.pc
+lib/openmpi-clang19/pkgconfig/orte.pc
+-

--- a/science/openmpi/files/portselect/openmpi-clang19-fortran
+++ b/science/openmpi/files/portselect/openmpi-clang19-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang19
+-
+bin/mpicxx-openmpi-clang19
+bin/mpiexec-openmpi-clang19
+bin/mpirun-openmpi-clang19
+bin/mpif77-openmpi-clang19
+bin/mpif90-openmpi-clang19
+-
+lib/openmpi-clang19/pkgconfig/ompi.pc
+lib/openmpi-clang19/pkgconfig/orte.pc
+bin/mpifort-openmpi-clang19

--- a/science/openmpi/files/portselect/openmpi-gcc14-fortran
+++ b/science/openmpi/files/portselect/openmpi-gcc14-fortran
@@ -1,0 +1,12 @@
+bin/mpicc-openmpi-gcc14
+-
+bin/mpicxx-openmpi-gcc14
+bin/mpiexec-openmpi-gcc14
+bin/mpirun-openmpi-gcc14
+bin/mpif77-openmpi-gcc14
+bin/mpif90-openmpi-gcc14
+-
+-
+lib/openmpi-gcc14/pkgconfig/ompi.pc
+lib/openmpi-gcc14/pkgconfig/orte.pc
+bin/mpifort-openmpi-gcc14


### PR DESCRIPTION
#### Description
<!-- Note: it is best to make pull requests from a branch rather than from master -->

Add `clang18`, `clang19`, and `gcc14` sub-ports to `openmpi`.

These sub-ports help addressing tickets like [this](https://trac.macports.org/ticket/70458).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
