### PR TITLE
qt5: update postgresql variants

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -801,66 +801,34 @@ array set sql_plugins {
     }
     {psql PostgreSQL "revision 0"} {
         {
+            "postgresql16"
+            "port:postgresql16"
+            "${prefix}/include/postgresql16"
+            "${prefix}/lib/postgresql16"
+            "-lpq"
+            ""
+        }
+        {
+            "postgresql15"
+            "port:postgresql15"
+            "${prefix}/include/postgresql15"
+            "${prefix}/lib/postgresql15"
+            "-lpq"
+            ""
+        }
+        {
+            "postgresql14"
+            "port:postgresql14"
+            "${prefix}/include/postgresql14"
+            "${prefix}/lib/postgresql14"
+            "-lpq"
+            ""
+        }
+        {
             "postgresql13"
             "port:postgresql13"
             "${prefix}/include/postgresql13"
             "${prefix}/lib/postgresql13"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql12"
-            "port:postgresql12"
-            "${prefix}/include/postgresql12"
-            "${prefix}/lib/postgresql12"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql11"
-            "port:postgresql11"
-            "${prefix}/include/postgresql11"
-            "${prefix}/lib/postgresql11"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql10"
-            "port:postgresql10"
-            "${prefix}/include/postgresql10"
-            "${prefix}/lib/postgresql10"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql96"
-            "port:postgresql96"
-            "${prefix}/include/postgresql96"
-            "${prefix}/lib/postgresql96"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql95"
-            "port:postgresql95"
-            "${prefix}/include/postgresql95"
-            "${prefix}/lib/postgresql95"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql94"
-            "port:postgresql94"
-            "${prefix}/include/postgresql94"
-            "${prefix}/lib/postgresql94"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql84"
-            "port:postgresql84"
-            "${prefix}/include/postgresql84"
-            "${prefix}/lib/postgresql84"
             "-lpq"
             ""
         }

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -717,34 +717,10 @@ array set sql_plugins {
     }
     {psql PostgreSQL "revision 0"} {
         {
-            "postgresql96"
-            "port:postgresql96"
-            "${prefix}/include/postgresql96"
-            "${prefix}/lib/postgresql96"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql95"
-            "port:postgresql95"
-            "${prefix}/include/postgresql95"
-            "${prefix}/lib/postgresql95"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql94"
-            "port:postgresql94"
-            "${prefix}/include/postgresql94"
-            "${prefix}/lib/postgresql94"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql84"
-            "port:postgresql84"
-            "${prefix}/include/postgresql84"
-            "${prefix}/lib/postgresql84"
+            "postgresql16"
+            "port:postgresql16"
+            "${prefix}/include/postgresql16"
+            "${prefix}/lib/postgresql16"
             "-lpq"
             ""
         }

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -717,34 +717,10 @@ array set sql_plugins {
     }
     {psql PostgreSQL "revision 0"} {
         {
-            "postgresql96"
-            "port:postgresql96"
-            "${prefix}/include/postgresql96"
-            "${prefix}/lib/postgresql96"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql95"
-            "port:postgresql95"
-            "${prefix}/include/postgresql95"
-            "${prefix}/lib/postgresql95"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql94"
-            "port:postgresql94"
-            "${prefix}/include/postgresql94"
-            "${prefix}/lib/postgresql94"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql84"
-            "port:postgresql84"
-            "${prefix}/include/postgresql84"
-            "${prefix}/lib/postgresql84"
+            "postgresql16"
+            "port:postgresql16"
+            "${prefix}/include/postgresql16"
+            "${prefix}/lib/postgresql16"
             "-lpq"
             ""
         }

--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -481,31 +481,10 @@ array set sql_plugins {
     }
     {psql PostgreSQL "revision 0"} {
         {
-            "postgresql96"
-            "port:postgresql96"
-            "${prefix}/include/postgresql96"
-            "-L${prefix}/lib/postgresql96 -lpq"
-            ""
-        }
-        {
-            "postgresql95"
-            "port:postgresql95"
-            "${prefix}/include/postgresql95"
-            "-L${prefix}/lib/postgresql95 -lpq"
-            ""
-        }
-        {
-            "postgresql94"
-            "port:postgresql94"
-            "${prefix}/include/postgresql94"
-            "-L${prefix}/lib/postgresql94 -lpq"
-            ""
-        }
-        {
-            "postgresql84"
-            "port:postgresql84"
-            "${prefix}/include/postgresql84"
-            "-L${prefix}/lib/postgresql84 -lpq"
+            "postgresql16"
+            "port:postgresql16"
+            "${prefix}/include/postgresql16"
+            "-L${prefix}/lib/postgresql16 -lpq"
             ""
         }
     }

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -538,31 +538,10 @@ array set sql_plugins {
     }
     {psql PostgreSQL "revision 1"} {
         {
-            "postgresql96"
-            "port:postgresql96"
-            "${prefix}/include/postgresql96"
-            "-L${prefix}/lib/postgresql96 -lpq"
-            ""
-        }
-        {
-            "postgresql95"
-            "port:postgresql95"
-            "${prefix}/include/postgresql95"
-            "-L${prefix}/lib/postgresql95 -lpq"
-            ""
-        }
-        {
-            "postgresql94"
-            "port:postgresql94"
-            "${prefix}/include/postgresql94"
-            "-L${prefix}/lib/postgresql94 -lpq"
-            ""
-        }
-        {
-            "postgresql84"
-            "port:postgresql84"
-            "${prefix}/include/postgresql84"
-            "-L${prefix}/lib/postgresql84 -lpq"
+            "postgresql16"
+            "port:postgresql16"
+            "${prefix}/include/postgresql16"
+            "-L${prefix}/lib/postgresql16 -lpq"
             ""
         }
     }

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -574,31 +574,10 @@ array set sql_plugins {
     }
     {psql PostgreSQL "revision 0"} {
         {
-            "postgresql96"
-            "port:postgresql96"
-            "${prefix}/include/postgresql96"
-            "-L${prefix}/lib/postgresql96 -lpq"
-            ""
-        }
-        {
-            "postgresql95"
-            "port:postgresql95"
-            "${prefix}/include/postgresql95"
-            "-L${prefix}/lib/postgresql95 -lpq"
-            ""
-        }
-        {
-            "postgresql94"
-            "port:postgresql94"
-            "${prefix}/include/postgresql94"
-            "-L${prefix}/lib/postgresql94 -lpq"
-            ""
-        }
-        {
-            "postgresql84"
-            "port:postgresql84"
-            "${prefix}/include/postgresql84"
-            "-L${prefix}/lib/postgresql84 -lpq"
+            "postgresql16"
+            "port:postgresql16"
+            "${prefix}/include/postgresql16"
+            "-L${prefix}/lib/postgresql16 -lpq"
             ""
         }
     }

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -666,31 +666,10 @@ array set sql_plugins {
     }
     {psql PostgreSQL "revision 0"} {
         {
-            "postgresql96"
-            "port:postgresql96"
-            "${prefix}/include/postgresql96"
-            "-L${prefix}/lib/postgresql96 -lpq"
-            ""
-        }
-        {
-            "postgresql95"
-            "port:postgresql95"
-            "${prefix}/include/postgresql95"
-            "-L${prefix}/lib/postgresql95 -lpq"
-            ""
-        }
-        {
-            "postgresql94"
-            "port:postgresql94"
-            "${prefix}/include/postgresql94"
-            "-L${prefix}/lib/postgresql94 -lpq"
-            ""
-        }
-        {
-            "postgresql84"
-            "port:postgresql84"
-            "${prefix}/include/postgresql84"
-            "-L${prefix}/lib/postgresql84 -lpq"
+            "postgresql16"
+            "port:postgresql16"
+            "${prefix}/include/postgresql16"
+            "-L${prefix}/lib/postgresql16 -lpq"
             ""
         }
     }

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -681,34 +681,10 @@ array set sql_plugins {
     }
     {psql PostgreSQL "revision 0"} {
         {
-            "postgresql96"
-            "port:postgresql96"
-            "${prefix}/include/postgresql96"
-            "${prefix}/lib/postgresql96"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql95"
-            "port:postgresql95"
-            "${prefix}/include/postgresql95"
-            "${prefix}/lib/postgresql95"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql94"
-            "port:postgresql94"
-            "${prefix}/include/postgresql94"
-            "${prefix}/lib/postgresql94"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql84"
-            "port:postgresql84"
-            "${prefix}/include/postgresql84"
-            "${prefix}/lib/postgresql84"
+            "postgresql16"
+            "port:postgresql16"
+            "${prefix}/include/postgresql16"
+            "${prefix}/lib/postgresql16"
             "-lpq"
             ""
         }

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -700,34 +700,10 @@ array set sql_plugins {
     }
     {psql PostgreSQL "revision 0"} {
         {
-            "postgresql96"
-            "port:postgresql96"
-            "${prefix}/include/postgresql96"
-            "${prefix}/lib/postgresql96"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql95"
-            "port:postgresql95"
-            "${prefix}/include/postgresql95"
-            "${prefix}/lib/postgresql95"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql94"
-            "port:postgresql94"
-            "${prefix}/include/postgresql94"
-            "${prefix}/lib/postgresql94"
-            "-lpq"
-            ""
-        }
-        {
-            "postgresql84"
-            "port:postgresql84"
-            "${prefix}/include/postgresql84"
-            "${prefix}/lib/postgresql84"
+            "postgresql16"
+            "port:postgresql16"
+            "${prefix}/include/postgresql16"
+            "${prefix}/lib/postgresql16"
             "-lpq"
             ""
         }


### PR DESCRIPTION
#### Description

I was able to build the qt5-psql-plugin against postgresql16 successfully and confirmed the plugin binary was correctly linked against postgresql16. However, I didn't test any functionality. I also tried to build qt57 to test the plugin but couldn't get the qt base package to build at all. Maybe a consequence of the new xcode?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 x86_64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
