### PR TITLE
asmotor: update to 1.3.1

### DIFF
--- a/devel/asmotor/Portfile
+++ b/devel/asmotor/Portfile
@@ -5,25 +5,28 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 # Verify the correct util commit for each asmotor version update.
-github.setup        asmotor asmotor 1.0.4
-set util_commit     abccd359a697501f44b82d1e60c5daa5306cb057
+github.setup        asmotor asmotor 1.3.1 release-
+set util_commit     9eda7afa576ee9b691f6389eaaef1c715174b32d
 revision            0
 
+worksrcdir          ${name}-release-${version}
+
 categories          devel
-platforms           darwin
 maintainers         {gmail.com:csoren @csoren}
 license             GPL-3
 
 description         A cross assembler, linker and librarian for several CPUs.
 
 long_description    ASMotor is a portable and generic assembler engine and \
-                    development system written in ANSI C. The package \
-                    consists of the assembler, the librarian and the linker. \
-                    It can be used as either a cross or native development \
-                    system. The assembler syntax is based on the A68k style \
-                    macro language. Currently supported CPUs are the 680x0 \
-                    family, 6502, MIPS32, SChip/Chip-8, DCPU-16, Z80 and \
-                    Gameboy.
+                    development system written in ANSI C99 and licensed under \
+                    the GNU Public License v3. The package consists of the \
+                    assembler, the librarian and the linker. It can be used \
+                    as either a cross or native development system. The \
+                    assembler syntax is based on the friendly, well-known \
+                    Motorola style macro language. Currently supported CPUs \
+                    are the 680x0 family, 6809, 6502 and derivatives, 65816, \
+                    MIPS32, Z80, Game Boy, DCPU-16, CHIP-8/SCHIP and the \
+                    RC811 CPU core.
 
 github.tarball_from archive
 master_sites        ${master_sites}:main \
@@ -36,13 +39,13 @@ distfiles           ${main_distfile}:main \
                     ${util_distfile}:util
 
 checksums           ${main_distfile} \
-                    rmd160  c96850f73e162ea331ea14789f71efadf6f6bd74 \
-                    sha256  ba4d5e6500aea8c1588c2da01916ccb39a26c84b67e17f44bd32a5bb20f58468 \
-                    size    179288 \
+                    rmd160  b92dcbd789b47340c1c907c3815b1b85820af655 \
+                    sha256  edd6fea6129881d741f179ccdce6d5eaa135792062af83dc2f37dcd4ddbda7e8 \
+                    size    274915 \
                     ${util_distfile} \
-                    rmd160  a94d2e5014b865e0b5ce63eb6c71ebb057def511 \
-                    sha256  5ba07a3c94c85372894ce8a9a7c92f4a14df79a868c5a47eda7fa23fddf073f0 \
-                    size    13280
+                    rmd160  bf16d79447e27b77f503d3a27b87cbb53cbae063 \
+                    sha256  514da08b74d123b8b6b0935003d8aac48be448ea5d1c24555c705e4820d01379 \
+                    size    18307
 
 post-extract {
     delete ${worksrcpath}/util


### PR DESCRIPTION
#### Description

Update `asmotor` to the latest released version, 1.3.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.7 23H124 x86_64
Command Line Tools 16.0.0.0.1.1724870825

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
