### PR TITLE
lagrange: update to 1.18.0, the_Foundation: update to 1.9.0

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -10,7 +10,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 gitea.domain        git.skyjake.fi
-gitea.setup         skyjake the_Foundation 1.8.1 v
+gitea.setup         skyjake the_Foundation 1.9.0 v
 revision            0
 categories          devel
 license             BSD
@@ -19,9 +19,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Opinionated C11 library for low-level functionality
 long_description    {*}${description}
 
-checksums           rmd160  7bd00d5e3af782fee8794d47aba3436de3644335 \
-                    sha256  d86ce34a864464b482ca3dcde93a77bf5f986bddb00c9b05380a8211741483e2 \
-                    size    219300
+checksums           rmd160  9cdbf1b0c567a6950f309296210a4ee8ebf9ee83 \
+                    sha256  4e781fc75fd917670d884cc9074b4bb31a34ae8405cb7d875e917d073d1dcb3d \
+                    size    221354
 
 depends_build-append \
                     port:pkgconfig

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.17.6 v
+gitea.setup         gemini lagrange 1.18.0 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,46 +15,41 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  fe1dbf94aa98182a9262fd318022887a2cf213a3 \
-                    sha256  e114b8af2636ccc18a4317a8c765a1d740c8834895248b2f4d8e7dacd22de671 \
-                    size    7733581
+checksums           rmd160  f3eb60734b82c2b8ba5403d508aa9c6319e01431 \
+                    sha256  9137dcdba01dd52a316a3ff21ad847469a6944770a0bdbae2600a73f911c07b7 \
+                    size    7780416
 
 worksrcdir          ${name}
 
 depends_build-append \
                     port:pkgconfig \
                     port:zip
-depends_lib-append  port:the_Foundation
-
-variant gui conflicts tui description {Build the GUI interface} {
-    depends_lib-append \
+depends_lib-append  port:the_Foundation \
                     port:fribidi \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:libsdl2 \
                     port:mpg123 \
+                    port:opusfile  \
                     port:webp
 
-    destroot {
-        copy ${build.dir}/Lagrange.app ${destroot}${applications_dir}
-    }
+destroot {
+    copy ${build.dir}/Lagrange.app ${destroot}${applications_dir}
 }
 
-variant tui conflicts gui description {Build the TUI interface} {
+variant tui description {Build the TUI interface} {
     configure.args-append \
-                    -DENABLE_TUI=YES \
-                    -DENABLE_MPG123=NO \
-                    -DENABLE_WEBP=NO \
-                    -DENABLE_FRIBIDI=NO \
-                    -DENABLE_HARFBUZZ=NO \
-                    -DENABLE_POPUP_MENUS=NO \
-                    -DENABLE_IDLE_SLEEP=NO
+                    -DENABLE_TUI=YES
 
     depends_lib-append \
                     port:ncurses \
                     port:sealcurses
-}
 
-default_variants    +gui
+    post-destroot {
+        copy ${build.dir}/clagrange ${destroot}${prefix}/bin
+        file mkdir ${destroot}${prefix}/share/lagrange
+        copy ${build.dir}/Lagrange.app/Contents/Resources/resources.lgr ${destroot}${prefix}/share/lagrange
+    }
+}
 
 compiler.c_standard 2011
 compiler.blacklist-append {clang < 800}


### PR DESCRIPTION
#### Description
* https://github.com/skyjake/lagrange/releases/tag/v1.18.0
* https://git.skyjake.fi/skyjake/the_Foundation/src/tag/v1.9.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
