### PR TITLE
expect: Add missing return type in configure tests

### DIFF
--- a/devel/expect/Portfile
+++ b/devel/expect/Portfile
@@ -5,8 +5,7 @@ PortSystem 1.0
 name            expect
 conflicts       bahamut whois
 version         5.45.4
-revision        1
-platforms       darwin
+revision        2
 categories      devel
 license         Tcl/Tk
 maintainers     nomaintainer
@@ -68,8 +67,7 @@ post-patch {
 
 configure.cppflags-append -I${workpath}/tcl${tclv}/generic -I${workpath}/tcl${tclv}/unix
 configure.ldflags-append -ltclstub8.6
-configure.args      --disable-shared \
-            --mandir=${prefix}/share/man \
+configure.args      --mandir=${prefix}/share/man \
             --with-tcl=${prefix}/lib \
             --with-tclinclude=${workpath}/tcl${tclv}/generic/
 

--- a/devel/expect/files/patch-implicitly-defined-functions.diff
+++ b/devel/expect/files/patch-implicitly-defined-functions.diff
@@ -1,5 +1,5 @@
---- configure.orig	2018-02-04 21:43:58.000000000 +1100
-+++ configure	2020-12-29 07:54:46.000000000 +1100
+--- configure.orig   2024-09-22 01:58:03
++++ configure  2024-09-22 01:58:06
 @@ -7994,7 +7994,7 @@
  {
  extern long timezone;
@@ -29,6 +29,24 @@
  int
  main ()
  {
+@@ -8831,7 +8833,7 @@
+ /* end confdefs.h.  */
+ 
+ #include <sys/wait.h>
+-main() {
++int main() {
+ #ifndef WNOHANG
+   return 0;
+ #else
+@@ -8867,7 +8869,7 @@
+ 
+ #include <stdio.h>
+ #include <sys/wait.h>
+-main() {
++int main() {
+ #ifdef WNOHANG
+   FILE *fp = fopen("wnohang","w");
+   fprintf(fp,"%d",WNOHANG);
 @@ -8935,7 +8937,10 @@
  /* end confdefs.h.  */
  
@@ -41,6 +59,15 @@
  
  int signal_rearms = 0;
  
+@@ -8952,7 +8957,7 @@
+ signal_rearms++;
+ }
+ 
+-main()
++int main()
+ {
+   signal(SIGINT,parent_sigint_handler);
+ 
 @@ -8966,7 +8971,7 @@
  
  		wait(&status);
@@ -50,8 +77,12 @@
  	}
  }
  _ACEOF
-@@ -9237,7 +9242,7 @@
- main()
+@@ -9234,10 +9239,10 @@
+ /* end confdefs.h.  */
+ 
+ #include <sgtty.h>
+-main()
++int main()
  {
    struct sgttyb tmp;
 -  exit(0);
@@ -59,8 +90,21 @@
  }
  _ACEOF
  if ac_fn_c_try_run "$LINENO"; then :
-@@ -9315,7 +9320,7 @@
-   main()
+@@ -9274,7 +9279,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <termio.h>
+-  main()
++  int main()
+   {
+     struct termio tmp;
+     exit(0);
+@@ -9312,10 +9317,10 @@
+ #  include <inttypes.h>
+ #  endif
+ #  include <termios.h>
+-  main()
++  int main()
    {
      struct termios tmp;
 -    exit(0);
@@ -68,7 +112,40 @@
    }
  _ACEOF
  if ac_fn_c_try_run "$LINENO"; then :
-@@ -9570,7 +9575,7 @@
+@@ -9350,7 +9355,7 @@
+ #include <inttypes.h>
+ #endif
+ #include <termios.h>
+-main() {
++int main() {
+ #if defined(TCGETS) || defined(TCGETA)
+   return 0;
+ #else
+@@ -9388,7 +9393,7 @@
+ #include <inttypes.h>
+ #endif
+ #include <termios.h>
+-main() {
++int main() {
+ #ifdef TIOCGWINSZ
+   return 0;
+ #else
+@@ -9423,7 +9428,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+-main(){
++int main(){
+ #ifdef CRAY
+   return 0;
+ #else
+@@ -9565,12 +9570,12 @@
+ 
+ extern char *tzname[2];
+ extern int daylight;
+-main()
++int main()
+ {
    int *x = &daylight;
    char **y = tzname;
  


### PR DESCRIPTION
#### Description

This fixes the build with Xcode 16.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1 24B5046f
Xcode 16.1 16B5014f 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
