### PR TITLE
wxWidgets-3.2: fix error on macOS 15

### DIFF
--- a/graphics/wxWidgets-3.2/Portfile
+++ b/graphics/wxWidgets-3.2/Portfile
@@ -35,6 +35,9 @@ checksums           rmd160  77df801aa2344874ff789ae9530a0849913d9413 \
 
 # see https://trac.macports.org/ticket/62087
 platforms           {darwin >= 16}
+platform darwin 24 {
+    macosx_deployment_target 14.0
+}
 
 dist_subdir         wxWidgets/${version}
 worksrcdir          ${distname}/build


### PR DESCRIPTION
#### Description

* Another victim of the CoreGraphics deprecations in the macOS 15 SDK in favor of screen capture kit
* macos_deployment_target of 14.0 fixed it

Closes: https://trac.macports.org/ticket/70844

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.0 24A335
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
