### PR TITLE
openjdk21: fix build for clang 16

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -2,20 +2,21 @@
 
 PortSystem          1.0
 
-name                openjdk21
+set feature 21
+name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk21/ for the version and build number that matches the latest '-ga' version
-version             21.0.4
+version             ${feature}.0.4
 set build 7
-revision            0
+revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
 maintainers         {breun.nl:nils @breun} openmaintainer
-description         OpenJDK 21
-long_description    JDK 21 builds of OpenJDK, the Open-Source implementation \
+description         OpenJDK ${feature} (Long Term Support)
+long_description    JDK ${feature} builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
-homepage            https://openjdk.org/projects/jdk/21/
-master_sites        https://openjdk-sources.osci.io/openjdk21/
+homepage            https://openjdk.org/projects/jdk/${feature}/
+master_sites        https://openjdk-sources.osci.io/openjdk${feature}/
 distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
@@ -40,6 +41,9 @@ pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4
     reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
 }
+
+# Temporary workaround for clang 16: https://trac.macports.org/ticket/70819
+patchfiles          JDK-8340341-clang-16-workaround.patch
 
 set tpath ${prefix}/Library/Java
 use_xcode           yes
@@ -146,7 +150,7 @@ test.cmd            ${bundle_dir}/Home/bin/java
 test.target         --version
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-21-macports.jdk
+set jdk ${jvms}/jdk-${feature}-macports.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}
@@ -170,5 +174,5 @@ export JAVA_HOME=${jdk}/Contents/Home
 "
     
 livecheck.type      regex
-livecheck.url       https://openjdk-sources.osci.io/openjdk21/
-livecheck.regex     openjdk-(21\.\[0-9.\]+)-ga
+livecheck.url       ${master_sites}
+livecheck.regex     openjdk-(${feature}\.\[0-9.\]+)-ga

--- a/java/openjdk21/files/JDK-8340341-clang-16-workaround.patch
+++ b/java/openjdk21/files/JDK-8340341-clang-16-workaround.patch
@@ -1,0 +1,14 @@
+--- make/hotspot/lib/JvmOverrideFiles.gmk.orig	2024-06-04 18:47:50
++++ make/hotspot/lib/JvmOverrideFiles.gmk	2024-09-22 23:45:41
+@@ -89,6 +89,11 @@
+     # for the clang bug was still needed.
+     BUILD_LIBJVM_loopTransform.cpp_CXXFLAGS := $(CXX_O_FLAG_NONE)
+ 
++    # See JDK-8340341
++    ifeq "$(firstword $(subst ., ,$(CXX_VERSION_NUMBER)))" "16"
++      BUILD_LIBJVM_stackMapTable.cpp_CXXFLAGS := "-O1"
++    endif
++
+     # The following files are compiled at various optimization
+     # levels due to optimization issues encountered at the
+     # default level. The Clang compiler issues a compile


### PR DESCRIPTION
#### Description

Backport fix for https://trac.macports.org/ticket/70819 to OpenJDK 21.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?