### PR TITLE
openjdk23-openj9: correct support end date

### DIFF
--- a/java/openjdk23-openj9/Portfile
+++ b/java/openjdk23-openj9/Portfile
@@ -21,7 +21,7 @@ revision     0
 set build    37
 set openj9_version 0.47.0
 
-description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Short Term Support until September 2024)
+description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Short Term Support until March 2025)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 


### PR DESCRIPTION
#### Description

Support for OpenJDK 23 ends in March 2025 instead of September 2024.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
