### PR TITLE
guile-3.0: use 3.0.9 on 32-bit archs until 3.0.10 regression is fixed

### DIFF
--- a/lang/guile-3.0/Portfile
+++ b/lang/guile-3.0/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 PortGroup           select 1.0
+PortGroup           legacysupport 1.1
+
+# dprintf
+legacysupport.newest_darwin_requires_legacy 10
 
 name                guile-3.0
 categories          lang
@@ -14,6 +18,18 @@ revision            0
 checksums           rmd160  c42990081a8fffaf63874d16f457d8e50db8bc36 \
                     sha256  2dbdbc97598b2faf31013564efb48e4fed44131d28e996c26abe8a5b23b56c2a \
                     size    9738824
+
+# At the moment 3.0.10 is broken on 32-bit platforms.
+if {${configure.build_arch} in [list i386 ppc]} {
+    version         3.0.9
+    revision        0
+    checksums       rmd160  e5c6a757cc188f137edd2046a3d015152efad7fb \
+                    sha256  18525079ad29a0d46d15c76581b5d91c8702301bfd821666d2e1d13726162811 \
+                    size    9734735
+
+    depends_build-append    port:gmake
+    build.cmd               ${prefix}/bin/gmake
+}
 
 compiler.c_standard 2011
 
@@ -43,6 +59,11 @@ master_sites        https://ftp.gnu.org/gnu/guile/
 # Fix MacOS specific bugs and make the test suite pass.
 # Sent to upstream: https://www.mail-archive.com/bug-guile@gnu.org/msg11370.html
 use_autoreconf      yes
+# On legacy systems passing -f is needed:
+# autoreconf: error: /opt/local/bin/autopoint failed with exit status: 1
+# Since autoreconf is used anyway, we can add these flags unconditionally:
+autoreconf.args     -fvi
+
 patchfiles \
                     0001-tests-Check-TCP_NODELAY-for-non-zero-instead-of-1.patch    \
                     0002-tests-Skip-tests-of-abstract-Unix-sockets-on-Darwin.patch  \
@@ -91,6 +112,37 @@ configure.args      --program-suffix=-3.0                    \
                     --disable-lto                            \
                     --infodir="${prefix}/share/info/${name}" \
                     --mandir="${prefix}/share/man"
+
+platform darwin powerpc {
+    # Do we need this for ppc64 as well?
+    post-extract {
+        # the prebuilt guile binaries are broken for Darwin PPC
+        move ${worksrcpath}/prebuilt/32-bit-big-endian ${worksrcpath}/prebuilt/32-bit-big-endian-disabled
+        ui_msg "*** This build can take some time, as guile has to do a full bootstrap on PPC."
+    }
+}
+
+if {${configure.build_arch} eq "ppc"} {
+    # We override patches here on purpose. Test suite will be dealt with once 3.0.10 is fixed.
+    patchfiles              0009-posix.c-Set-errno-when-pipe2-is-not-available-and-fl.patch \
+                            0010-filesys.patch \
+                            0011-powerpc.patch
+
+    configure.args-append   --disable-error-on-warning \
+                            --disable-jit \
+                            --without-64-calls \
+                            --without-threads
+
+} elseif {${configure.build_arch} eq "i386"} {
+    # We override patches here on purpose. Test suite will be dealt with once 3.0.10 is fixed.
+    patchfiles              0009-posix.c-Set-errno-when-pipe2-is-not-available-and-fl.patch \
+                            0010-filesys.patch
+
+    # Notice that i386 build is untested. It may or may not require
+    # disabling JIT and threads.
+    configure.args-append   --disable-error-on-warning \
+                            --without-64-calls
+}
 
 # fixes: sed: -i may not be used with stdin
 depends_build-append port:gsed

--- a/lang/guile-3.0/files/0010-filesys.patch
+++ b/lang/guile-3.0/files/0010-filesys.patch
@@ -1,0 +1,13 @@
+--- a/libguile/filesys.c.orig	2024-09-22 13:46:53.000000000 +0800
++++ b/libguile/filesys.c	2024-09-22 14:12:07.000000000 +0800
+@@ -46,6 +46,10 @@
+ #include <unistd.h>
+ #include <string.h>
+ 
++#ifdef __APPLE__
++#include <sys/stdio.h> /* for renameat */
++#endif
++
+ #ifdef HAVE_DIRECT_H
+ #include <direct.h>
+ #endif

--- a/lang/guile-3.0/files/0011-powerpc.patch
+++ b/lang/guile-3.0/files/0011-powerpc.patch
@@ -1,0 +1,30 @@
+See: https://issues.guix.gnu.org/47615
+https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=977223
+
+--- a/am/bootstrap.am	2022-02-02 02:57:14.000000000 +0800
++++ b/am/bootstrap.am	2022-04-16 23:50:55.000000000 +0800
+@@ -19,7 +19,8 @@
+ 
+ # These variables can be set before you include bootstrap.am.
+ GUILE_WARNINGS ?= -W1
+-GUILE_OPTIMIZATIONS ?= -O2
++GUILE_OPTIMIZATIONS ?= -O1
++
+ GUILE_TARGET ?= $(host)
+ GUILE_BUILD_TAG ?= BOOTSTRAP($(GUILE_BOOTSTRAP_STAGE))
+ 
+
+--- a/stage0/Makefile.am	2022-02-02 02:57:14.000000000 +0800
++++ b/stage0/Makefile.am	2022-04-16 23:50:24.000000000 +0800
+@@ -22,7 +22,10 @@
+ 
+ 
+ GUILE_WARNINGS = -W0
+-GUILE_OPTIMIZATIONS = -O1
++
++$(info Note: adjusting GUILE_OPTIMIZATIONS for 32-bit big-endian architecture)
++GUILE_OPTIMIZATIONS = -O1 -Oresolve-primitives -Ocps
++
+ GUILE_BOOTSTRAP_STAGE = stage0
+ 
+ include $(top_srcdir)/am/bootstrap.am


### PR DESCRIPTION
#### Description

Guile 3.0.10 is still broken and Debian reverted to 3.0.9. Do the same until upstream fixes the regression.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
