### PR TITLE
valkey: backport a fix from upstream

### DIFF
--- a/databases/valkey/Portfile
+++ b/databases/valkey/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 github.setup        valkey-io valkey 8.0.0
 github.tarball_from archive
-revision            0
+revision            1
 categories          databases
 license             BSD
 
@@ -33,6 +33,10 @@ patchfiles          patch-valkey.conf.diff \
                     patch-hiredis.diff \
                     patch-gh-12585.diff \
                     patch-remove-brewism.diff
+
+# Backport of upstream fix, see: https://github.com/valkey-io/valkey/issues/1051
+# https://trac.macports.org/ticket/70794
+patchfiles-append   d07c29791a4cecd8bce76b05d046981f39fe5fcd.patch
 
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" \

--- a/databases/valkey/files/d07c29791a4cecd8bce76b05d046981f39fe5fcd.patch
+++ b/databases/valkey/files/d07c29791a4cecd8bce76b05d046981f39fe5fcd.patch
@@ -1,0 +1,32 @@
+From d07c29791a4cecd8bce76b05d046981f39fe5fcd Mon Sep 17 00:00:00 2001
+From: Binbin <binloveplay1314@qq.com>
+Date: Sun, 22 Sep 2024 20:20:55 +0800
+Subject: [PATCH] Use _Thread_local to solve threads.h build issue (#1053)
+
+Apparently this will fail to compile in some masOS version.
+And internet claims _Thread_local is portable.
+
+Fixes #1051.
+
+Signed-off-by: Binbin <binloveplay1314@qq.com>
+---
+ src/zmalloc.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/src/zmalloc.c b/src/zmalloc.c
+index 7b19107b66..7f9d7f6888 100644
+--- src/zmalloc.c
++++ src/zmalloc.c
+@@ -88,11 +88,7 @@ void zlibc_free(void *ptr) {
+ #define dallocx(ptr, flags) je_dallocx(ptr, flags)
+ #endif
+ 
+-#if __STDC_NO_THREADS__
+-#define thread_local __thread
+-#else
+-#include <threads.h>
+-#endif
++#define thread_local _Thread_local
+ 
+ #define MAX_THREADS_NUM (IO_THREADS_MAX_NUM + 3 + 1)
+ /* A thread-local storage which keep the current thread's index in the used_memory_thread array. */


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/70794

#### Description

Fix this

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
