### PR TITLE
spellutils: patch configure build script to allow building with modern gcc

### DIFF
--- a/mail/spellutils/Portfile
+++ b/mail/spellutils/Portfile
@@ -4,7 +4,6 @@ name		spellutils
 version		0.7
 categories	mail
 maintainers	{geeklair.net:dluke @danielluke} openmaintainer
-platforms	darwin
 description	Spellutils provides the newsbody and pospell programs.
 license		GPL-2+
 
@@ -19,10 +18,12 @@ homepage	http://home.worldonline.dk/byrial/spellutils/
 master_sites	${homepage}
 
 use_bzip2	yes
-checksums	md5	e2f64d49aabb359e79ba588e6c14c3c2 \
-		sha1	438ea1109bbffb080cbc088f26286fef2c855564 \
-		rmd160	dcb4a52687ac967f67624aa4a13174adcd67c7aa
+checksums           rmd160  dcb4a52687ac967f67624aa4a13174adcd67c7aa \
+                    sha256  0d5723321b6d60f31a93a43708904b2fddfcff3ec2fdd30e13214c64dd28e875 \
+                    size    110421
 
 depends_lib	port:gettext
 
 configure.env	LIBS=-lintl
+
+patchfiles  patch-configure.diff

--- a/mail/spellutils/files/patch-configure.diff
+++ b/mail/spellutils/files/patch-configure.diff
@@ -1,0 +1,11 @@
+--- configure
++++ configure
+@@ -916,7 +916,7 @@ cat > conftest.$ac_ext << EOF
+ #line 917 "configure"
+ #include "confdefs.h"
+ 
+-main(){return(0);}
++int main(){return(0);}
+ EOF
+ if { (eval echo configure:922: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+   ac_cv_prog_cc_works=yes


### PR DESCRIPTION
#### Description

The configure script for spellutils attempts to check if the compiler can create an executable with this C code:
```
main(){return(0);}
```
On my system, this is the output:
```
gcc foo.c
foo.c:1:1: error: return type defaults to 'int' [-Wimplicit-int]
    1 | main(){return(0);}
      | ^~~~
[Exit 1]
```
This commit adds a patch to ensure that the configure command succeeds. I also took the opportunity to fix the lint errors.

Ideally, the issue would be fixed upstream but the [upstream project webpage](http://home.worldonline.dk/byrial/spellutils/) is currently timing out for me.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
