### PR TITLE
lttoolbox: set required C++14 standard

### DIFF
--- a/textproc/lttoolbox/Portfile
+++ b/textproc/lttoolbox/Portfile
@@ -7,7 +7,6 @@ version                 3.5.0
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              textproc
 license                 GPL-2+
-platforms               darwin
 maintainers             nomaintainer
 
 description             toolbox for lexical processing, morphological analysis \
@@ -30,8 +29,11 @@ checksums               rmd160  4cb9d266657a04cd29a685d236a0b0576c7f9728 \
                         sha256  cbfc6e38ba995d80114a250f9756bd28708e9b3510bde09fe7f91e0a83bbc623 \
                         size    483444
 
-depends_build           port:pkgconfig
+depends_build           path:bin/pkg-config:pkgconfig
 
 depends_lib             port:libxml2
+
+# configure: error: Could not enable at least C++1y (C++14) - upgrade your compiler
+compiler.cxx_standard   2014
 
 livecheck.regex         /${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

Fix compiler choice

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
