### PR TITLE
Fixed libcxx math.h for doxygen

### DIFF
--- a/devel/libstdcxx_clang_fix/files/math.h
+++ b/devel/libstdcxx_clang_fix/files/math.h
@@ -10,7 +10,9 @@
 
 #ifdef __clang__
 // these prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available
+#ifdef __cplusplus
 extern "C" {
+#endif
     extern long long int llrintl(long double);
     extern long long int llrint(double);
     extern long long int llrintf(float);
@@ -18,7 +20,9 @@ extern "C" {
     extern long long int llroundl(long double);
     extern long long int llround(double);
     extern long long int llroundf(float);
+#ifdef __cplusplus
 }
+#endif
 #endif
 
 #endif

--- a/lang/clang-11-bootstrap/files/0016-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/clang-11-bootstrap/files/0016-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/libcxx-powerpc/files/0013-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/libcxx-powerpc/files/0013-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/libcxx/files/2002-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/libcxx/files/2002-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 8c30ba85d..023943ca2 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 8c30ba85d..023943ca2 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-10/files/3001-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-10/files/3001-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 194df2077..14d14fe08 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 194df2077..14d14fe08 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-11/files/3001-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-11/files/3001-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 194df2077..14d14fe08 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 194df2077..14d14fe08 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-12/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-12/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -29,7 +29,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -37,7 +39,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-13/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-13/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -29,7 +29,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -37,7 +39,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-14/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-14/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -29,7 +29,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -37,7 +39,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-15/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-15/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -29,7 +29,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -37,7 +39,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-16/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-16/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -29,7 +29,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -37,7 +39,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-17/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-17/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -29,7 +29,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -37,7 +39,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-3.3/files/snowleopard-cmath.patch
+++ b/lang/llvm-3.3/files/snowleopard-cmath.patch
@@ -8,7 +8,9 @@
 +#include <Availability.h>
 +#if __MAC_OS_X_VERSION_MAX_ALLOWED < 1070
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -16,7 +18,9 @@
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +#endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-3.4/files/3004-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-3.4/files/3004-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -22,7 +22,9 @@ index 75087ae..12da454 100644
 +#include <Availability.h>
 +#if __MAC_OS_X_VERSION_MAX_ALLOWED < 1070
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -30,7 +32,9 @@ index 75087ae..12da454 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +#endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-3.7/files/3004-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-3.7/files/3004-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -21,7 +21,9 @@ index d3aa4be..eb91dfb 100644
 +#include <Availability.h>
 +#if __MAC_OS_X_VERSION_MAX_ALLOWED < 1070
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -29,7 +31,9 @@ index d3aa4be..eb91dfb 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +#endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-5.0/files/3002-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-5.0/files/3002-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 8c30ba85d..023943ca2 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 8c30ba85d..023943ca2 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-6.0/files/3002-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-6.0/files/3002-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 8c30ba85d..023943ca2 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 8c30ba85d..023943ca2 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-7.0/files/3002-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-7.0/files/3002-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 8c30ba85d..023943ca2 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 8c30ba85d..023943ca2 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-8.0/files/3002-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-8.0/files/3002-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 3cc72aa27..6fb2d8b51 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 3cc72aa27..6fb2d8b51 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-9.0/files/3001-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-9.0/files/3001-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -31,7 +31,9 @@ index 194df2077..14d14fe08 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -39,7 +41,9 @@ index 194df2077..14d14fe08 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +

--- a/lang/llvm-devel/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
+++ b/lang/llvm-devel/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
@@ -29,7 +29,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +
 +# if __APPLE_BAD_MATH_H
 +/* These prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available */
++#ifdef __cplusplus
 +extern "C" {
++#endif
 +    extern long long int llrintl(long double);
 +    extern long long int llrint(double);
 +    extern long long int llrintf(float);
@@ -37,7 +39,9 @@ index 1603d5748e2d..d64e6a52ccd3 100644
 +    extern long long int llroundl(long double);
 +    extern long long int llround(double);
 +    extern long long int llroundf(float);
++#ifdef __cplusplus
 +}
++#endif
 +# endif
 +#endif // __APPLE__
 +


### PR DESCRIPTION
Doxygen includes math.h using "C" code which will fail compilation when including math.h due to a patch that was applied that assumed that "extern "C" {" is acceptable when compiling "C" code. By wrapping this line with #ifdef __cplusplus, Doxygen 1.11 compiles fine on Snow Leopard.

#### Description

When building Doxygen 1.11 on Snow Leopard, the compilation will fail due to math.h not being compatible with the C compiler that that port is using. Simply wrapping the 'extern "C" {' with #ifdef __cplusplus allowed doxygen to build with no errors.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [X ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ X] checked your Portfile with `port lint --nitpick`?
- [X ] tried existing tests with `sudo port test`?
- [ X] tried a full install with `sudo port -vst install`?
- [ X] tested basic functionality of all binary files?
- [ X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
