### PR TITLE
py-gssapi: fix build with Xcode gcc

### DIFF
--- a/python/py-gssapi/Portfile
+++ b/python/py-gssapi/Portfile
@@ -8,7 +8,6 @@ github.setup        pythongssapi python-gssapi 1.8.3 v
 github.tarball_from releases
 
 name                py-gssapi
-platforms           darwin
 license             ISC
 maintainers         {toby @tobypeterson} openmaintainer
 
@@ -29,6 +28,9 @@ if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \
                             port:py${python.version}-cython
     depends_lib-append      port:py${python.version}-decorator
+
+    # pycore_frame.h:134: error: ‘for’ loop initial declaration used outside C99 mode
+    patchfiles-append       patch-c99.diff
 
     # Uses GSS.framework on macOS >= 10.9
     if {${os.platform} eq "darwin" && ${os.major} < 13} {

--- a/python/py-gssapi/files/patch-c99.diff
+++ b/python/py-gssapi/files/patch-c99.diff
@@ -1,0 +1,11 @@
+--- setup.py
++++ setup.py	2024-09-24 19:25:00.000000000 +0800
+@@ -121,6 +121,8 @@
+         compile_args = ['-fPIC']
+     else:
+         compile_args = shlex.split(get_output(f"{kc} --cflags gssapi"))
++        if sys.platform == 'darwin':
++            compile_args.append('-std=c99')
+ 
+ # add in the extra workarounds for different include structures
+ if winkrb_path:


### PR DESCRIPTION
#### Description

Fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
