### PR TITLE
bpytop: Fix theme path detection

### DIFF
--- a/sysutils/bpytop/Portfile
+++ b/sysutils/bpytop/Portfile
@@ -6,7 +6,7 @@ PortGroup           makefile    1.0
 
 github.setup        aristocratos bpytop 1.0.68 v
 github.tarball_from archive
-revision            2
+revision            3
 
 description         \
     Linux/macOS/FreeBSD resource monitor
@@ -35,7 +35,8 @@ depends_run-append  port:python${python_version} \
 
 makefile.has_destdir yes
 
-patchfiles-append   patch-pr413.diff
+patchfiles-append   patch-pr413.diff \
+                    patch-pr422.diff
 
 post-patch {
     reinplace "s|/usr/bin/env python3|${python_bin}|" ${worksrcpath}/bpytop.py

--- a/sysutils/bpytop/files/patch-pr422.diff
+++ b/sysutils/bpytop/files/patch-pr422.diff
@@ -1,0 +1,35 @@
+From 117f61a906a13e5220d3e368787bf1392ab58144 Mon Sep 17 00:00:00 2001
+From: Clemens Lang <cal@macports.org>
+Date: Tue, 24 Sep 2024 13:31:43 +0200
+Subject: [PATCH] Added: Search for themes relative to binary
+
+When installed in non-default paths (i.e., not /usr or /usr/local),
+bpytop cannot find its themes in $prefix/share/bpytop/themes. Start from
+the path of the executable to handle non-default values of $prefix.
+
+Upstream-Status: Submitted [https://github.com/aristocratos/bpytop/pull/422]
+---
+ bpytop.py | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/bpytop.py b/bpytop.py
+index eff3704..9ffa394 100755
+--- ./bpytop.py
++++ ./bpytop.py
+@@ -256,7 +256,12 @@ if os.path.isdir(f'{os.path.dirname(__file__)}/bpytop-themes'):
+ elif os.path.isdir(f'{os.path.dirname(__file__)}/themes'):
+ 	THEME_DIR = f'{os.path.dirname(__file__)}/themes'
+ else:
+-	for td in ["/usr/local/", "/usr/", "/snap/bpytop/current/usr/"]:
++	for td in [
++            os.path.dirname(os.path.dirname(__file__)).rstrip("/") + "/",
++            "/usr/local/",
++            "/usr/",
++            "/snap/bpytop/current/usr/"
++        ]:
+ 		if os.path.isdir(f'{td}share/bpytop/themes'):
+ 			THEME_DIR = f'{td}share/bpytop/themes'
+ 			break
+-- 
+2.46.1
+


### PR DESCRIPTION
#### Description

In MacPorts, bpytop didn't find its themes, because it did not search relative to its executable, and only search default paths /usr and /usr/local.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.7 23H124 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
