### PR TITLE
p5-test-simple: Remove optional dependency, fix circular deps.

### DIFF
--- a/perl/p5-test-simple/Portfile
+++ b/perl/p5-test-simple/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         Test-Simple 1.302204 ../../authors/id/E/EX/EXODIST
-revision            0
+revision            1
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Test::Simple - Basic utilities for writing tests.

--- a/perl/p5-test-simple/Portfile
+++ b/perl/p5-test-simple/Portfile
@@ -24,7 +24,6 @@ if {${perl5.major} != ""} {
 
     depends_lib-append \
                     port:p${perl5.major}-data-dumper \
-                    port:p${perl5.major}-module-pluggable \
                     port:p${perl5.major}-term-table \
                     port:p${perl5.major}-time-hires
 


### PR DESCRIPTION
#### Description

* Fix dependency cycle.
* Remove optional dependency p5-module-pluggable.
* Closes https://trac.macports.org/ticket/70547

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 14.6.1 23G93 Sonoma, x86_64
Xcode 15.4 15F31d
CLT 15.3.0

macOS 14.5 23F79 arm64
Xcode 16.0 16A242d

macOS 10.15.7 Macbookpro mid 2010 Intel i7 x86_64
Xcode 11.5
CommandLineTools 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -s install`?
- [x] Confirmed absence of dependency cycle?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?