### PR TITLE
clang-17, llvm-17: restore functionality on macOS 15 (Xcode 16)

### DIFF
--- a/lang/llvm-17/Portfile
+++ b/lang/llvm-17/Portfile
@@ -18,7 +18,7 @@ legacysupport.use_static              yes
 legacysupport.disable_function_wrap   yes
 
 categories              lang
-platforms               {darwin > 10 < 24}
+platforms               {darwin > 10}
 license                 NCSA
 maintainers             nomaintainer
 
@@ -144,6 +144,7 @@ patchfiles-append \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
     0025-lldb-add-defines-needed-for-older-SDKs.patch \
     0026-llvm-set-memrchr-unavailable.patch \
+    0043-builtins-Move-cfi-start-s-after-the-symbol-name-NFC.patch \
     0999-i386-fix.diff \
     add-missed-i386-host.diff
 

--- a/lang/llvm-17/files/0043-builtins-Move-cfi-start-s-after-the-symbol-name-NFC.patch
+++ b/lang/llvm-17/files/0043-builtins-Move-cfi-start-s-after-the-symbol-name-NFC.patch
@@ -1,0 +1,32 @@
+From 7939ce39dac0078fef7183d6198598b99c652c88 Mon Sep 17 00:00:00 2001
+From: Jon Roelofs <jonathan_roelofs@apple.com>
+Date: Fri, 17 Nov 2023 14:21:57 -0800
+Subject: [PATCH] [builtins] Move cfi start's after the symbol name [NFC]
+
+... in preparation for diagnosing improperly nested .cfi regions.
+
+See https://reviews.llvm.org/D155245
+---
+ compiler-rt/lib/builtins/assembly.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/compiler-rt/lib/builtins/assembly.h b/compiler-rt/lib/builtins/assembly.h
+index 169d49683f50..8c42fc773483 100644
+--- a/compiler-rt/lib/builtins/assembly.h
++++ b/compiler-rt/lib/builtins/assembly.h
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
+-  CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  name:                                                                        \
++  SEPARATOR CFI_START                                                          \
++  SEPARATOR BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \
+-- 
+2.46.1
+


### PR DESCRIPTION
This is a cherry-pick of
https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.

Xcode 16 runs on macOS 14 and 15, so the patch is applied on macOS ≥ 14.

Closes: https://trac.macports.org/ticket/70779

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
