### PR TITLE
clang-14, llvm-14: restore functionality on macOS 15 (Xcode 16)

### DIFF
--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -136,6 +136,7 @@ patchfiles-append \
     0015-Fixup-libstdc-header-search-paths-for-older-versions.patch \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
     0025-lldb-add-defines-needed-for-older-SDKs.patch \
+    0032-lldb-Add-cstdio-include-to-fix-a595b931f1f91897317a4.patch \
     MachOWriter.cpp-types.patch \
     SyntheticSections.cpp-types.patch \
     patch-lldb-stdc-macros-134877.diff \

--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -62,15 +62,14 @@ cmake.build_type        Release
 cmake.install_rpath
 
 configure.pre_args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib
+    -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib"
 
 configure.pre_args-replace \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
 configure.pre_args-replace \
-    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr" \
+    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;${cmake.install_prefix}\;/usr" \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \
@@ -449,6 +448,16 @@ post-destroot {
         xinstall -m 755 -W ${lldb_scripts_srcdir} \
             macos-setup-codesign.sh \
             ${lldb_scripts_destdir}
+    }
+
+    if {${subport} eq "clang-${llvm_version}"} {
+        # move libc++ libraries out of default location to prevent accidental linkage
+        set libcxx_dir ${destroot}${sub_prefix}/lib/libc++
+        xinstall -d ${libcxx_dir}
+        foreach f [glob -nocomplain ${destroot}${sub_prefix}/lib/libc++*.*] {
+            ui_debug "Moving ${f} to ${libcxx_dir}"
+            move ${f} ${libcxx_dir}
+        }
     }
 }
 

--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -20,8 +20,6 @@ categories              lang
 license                 NCSA
 maintainers             nomaintainer
 
-platforms               {darwin < 24}
-
 set llvm_version        14
 set clang_exe_version   ${llvm_version}
 version                 ${llvm_version}.0.6
@@ -29,7 +27,7 @@ version                 ${llvm_version}.0.6
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision 0 }
-subport                 clang-${llvm_version} { revision 2 }
+subport                 clang-${llvm_version} { revision 3 }
 subport                 lldb-${llvm_version}  { revision 1 }
 subport                 flang-${llvm_version} { revision 0 }
 
@@ -136,6 +134,8 @@ patchfiles-append \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
     0025-lldb-add-defines-needed-for-older-SDKs.patch \
     0032-lldb-Add-cstdio-include-to-fix-a595b931f1f91897317a4.patch \
+    0033-xray-Use-L-instead-of-.L-for-Mach-O.patch \
+    0034-builtins-Move-cfi-start-s-after-the-symbol-name-NFC.patch \
     MachOWriter.cpp-types.patch \
     SyntheticSections.cpp-types.patch \
     patch-lldb-stdc-macros-134877.diff \

--- a/lang/llvm-14/files/0032-lldb-Add-cstdio-include-to-fix-a595b931f1f91897317a4.patch
+++ b/lang/llvm-14/files/0032-lldb-Add-cstdio-include-to-fix-a595b931f1f91897317a4.patch
@@ -1,0 +1,26 @@
+From 73e15b5edb4fa4a77e68c299a6e3b21e610d351f Mon Sep 17 00:00:00 2001
+From: Dmitry Chernenkov <dmitryc@google.com>
+Date: Tue, 2 May 2023 12:45:28 +0000
+Subject: [PATCH] [lldb] Add cstdio include to fix
+ a595b931f1f91897317a4257df313bddfeb029a6
+
+---
+ lldb/include/lldb/API/SBFile.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lldb/include/lldb/API/SBFile.h b/lldb/include/lldb/API/SBFile.h
+index d8b348b25c81..ebdc5607b794 100644
+--- a/lldb/include/lldb/API/SBFile.h
++++ b/lldb/include/lldb/API/SBFile.h
+@@ -11,6 +11,8 @@
+ 
+ #include "lldb/API/SBDefines.h"
+ 
++#include <cstdio>
++
+ namespace lldb {
+ 
+ class LLDB_API SBFile {
+-- 
+2.46.1
+

--- a/lang/llvm-14/files/0033-xray-Use-L-instead-of-.L-for-Mach-O.patch
+++ b/lang/llvm-14/files/0033-xray-Use-L-instead-of-.L-for-Mach-O.patch
@@ -1,0 +1,121 @@
+From c57c7b7c99605021123b54c02e57943923874cbe Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Fri, 16 Jun 2023 12:04:28 -0700
+Subject: [PATCH] [xray] Use L* instead of .L* for Mach-O
+
+Note: Mach-O support is not yet done and check-xray is not allowed yet.
+---
+ compiler-rt/lib/xray/xray_trampoline_x86_64.S | 28 +++++++++----------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/compiler-rt/lib/xray/xray_trampoline_x86_64.S b/compiler-rt/lib/xray/xray_trampoline_x86_64.S
+index 02cf69f766c4..0f00bcc41508 100644
+--- a/compiler-rt/lib/xray/xray_trampoline_x86_64.S
++++ b/compiler-rt/lib/xray/xray_trampoline_x86_64.S
+@@ -124,14 +124,14 @@ ASM_SYMBOL(__xray_FunctionEntry):
+ 	// On x86/amd64, a simple (type-aligned) MOV instruction is enough.
+ 	movq	ASM_SYMBOL(_ZN6__xray19XRayPatchedFunctionE)(%rip), %rax
+ 	testq	%rax, %rax
+-	je	.Ltmp0
++	je	LOCAL_LABEL(tmp0)
+ 
+ 	// The patched function prologue puts its xray_instr_map index into %r10d.
+ 	movl	%r10d, %edi
+ 	xor	%esi,%esi
+ 	callq	*%rax
+ 
+-.Ltmp0:
++LOCAL_LABEL(tmp0):
+ 	RESTORE_REGISTERS
+ 	RESTORE_STACK_ALIGNMENT
+ 	retq
+@@ -162,13 +162,13 @@ ASM_SYMBOL(__xray_FunctionExit):
+ 	movq	%rdx, 0(%rsp)
+ 	movq	ASM_SYMBOL(_ZN6__xray19XRayPatchedFunctionE)(%rip), %rax
+ 	testq %rax,%rax
+-	je	.Ltmp2
++	je	LOCAL_LABEL(tmp2)
+ 
+ 	movl	%r10d, %edi
+ 	movl	$1, %esi
+ 	callq	*%rax
+ 
+-.Ltmp2:
++LOCAL_LABEL(tmp2):
+ 	// Restore the important registers.
+ 	movq  48(%rsp), %rbp
+ 	movupd	32(%rsp), %xmm0
+@@ -198,13 +198,13 @@ ASM_SYMBOL(__xray_FunctionTailExit):
+ 
+ 	movq	ASM_SYMBOL(_ZN6__xray19XRayPatchedFunctionE)(%rip), %rax
+ 	testq %rax,%rax
+-	je	.Ltmp4
++	je	LOCAL_LABEL(tmp4)
+ 
+ 	movl	%r10d, %edi
+ 	movl	$2, %esi
+ 	callq	*%rax
+ 
+-.Ltmp4:
++LOCAL_LABEL(tmp4):
+ 	RESTORE_REGISTERS
+ 	RESTORE_STACK_ALIGNMENT
+ 	retq
+@@ -227,14 +227,14 @@ ASM_SYMBOL(__xray_ArgLoggerEntry):
+ 	// Again, these function pointer loads must be atomic; MOV is fine.
+ 	movq	ASM_SYMBOL(_ZN6__xray13XRayArgLoggerE)(%rip), %rax
+ 	testq	%rax, %rax
+-	jne	.Larg1entryLog
++	jne	LOCAL_LABEL(arg1entryLog)
+ 
+ 	// If [arg1 logging handler] not set, defer to no-arg logging.
+ 	movq	ASM_SYMBOL(_ZN6__xray19XRayPatchedFunctionE)(%rip), %rax
+ 	testq	%rax, %rax
+-	je	.Larg1entryFail
++	je	LOCAL_LABEL(arg1entryFail)
+ 
+-.Larg1entryLog:
++LOCAL_LABEL(arg1entryLog):
+ 
+ 	// First argument will become the third
+ 	movq	%rdi, %rdx
+@@ -247,7 +247,7 @@ ASM_SYMBOL(__xray_ArgLoggerEntry):
+ 
+ 	callq	*%rax
+ 
+-.Larg1entryFail:
++LOCAL_LABEL(arg1entryFail):
+ 	RESTORE_REGISTERS
+ 	RESTORE_STACK_ALIGNMENT
+ 	retq
+@@ -270,11 +270,11 @@ ASM_SYMBOL(__xray_CustomEvent):
+ 	// already.
+ 	movq ASM_SYMBOL(_ZN6__xray22XRayPatchedCustomEventE)(%rip), %rax
+ 	testq %rax,%rax
+-	je .LcustomEventCleanup
++	je LOCAL_LABEL(customEventCleanup)
+ 
+ 	callq	*%rax
+ 
+-.LcustomEventCleanup:
++LOCAL_LABEL(customEventCleanup):
+ 	RESTORE_REGISTERS
+ 	retq
+ # LLVM-MCA-END
+@@ -296,11 +296,11 @@ ASM_SYMBOL(__xray_TypedEvent):
+ 	// and rdx without our intervention.
+ 	movq ASM_SYMBOL(_ZN6__xray21XRayPatchedTypedEventE)(%rip), %rax
+ 	testq %rax,%rax
+-	je .LtypedEventCleanup
++	je LOCAL_LABEL(typedEventCleanup)
+ 
+ 	callq	*%rax
+ 
+-.LtypedEventCleanup:
++LOCAL_LABEL(typedEventCleanup):
+ 	RESTORE_REGISTERS
+ 	retq
+ # LLVM-MCA-END
+-- 
+2.46.1
+

--- a/lang/llvm-14/files/0034-builtins-Move-cfi-start-s-after-the-symbol-name-NFC.patch
+++ b/lang/llvm-14/files/0034-builtins-Move-cfi-start-s-after-the-symbol-name-NFC.patch
@@ -1,0 +1,32 @@
+From 7939ce39dac0078fef7183d6198598b99c652c88 Mon Sep 17 00:00:00 2001
+From: Jon Roelofs <jonathan_roelofs@apple.com>
+Date: Fri, 17 Nov 2023 14:21:57 -0800
+Subject: [PATCH] [builtins] Move cfi start's after the symbol name [NFC]
+
+... in preparation for diagnosing improperly nested .cfi regions.
+
+See https://reviews.llvm.org/D155245
+---
+ compiler-rt/lib/builtins/assembly.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/compiler-rt/lib/builtins/assembly.h b/compiler-rt/lib/builtins/assembly.h
+index 169d49683f50..8c42fc773483 100644
+--- a/compiler-rt/lib/builtins/assembly.h
++++ b/compiler-rt/lib/builtins/assembly.h
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
+-  CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  name:                                                                        \
++  SEPARATOR CFI_START                                                          \
++  SEPARATOR BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \
+-- 
+2.46.1
+


### PR DESCRIPTION
This is a cherry-pick of:
https://github.com/llvm/llvm-project/commit/c57c7b7c99605021123b54c02e57943923874cbe https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88

This enables clang-14 to be built by Xcode 16, making it possible to build on macOS 15, and macOS 14 with Xcode 16. It also enables clang-14 to be built by clang-18 and newer.

References: https://trac.macports.org/ticket/70779

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
@cjones051073