### PR TITLE
expect: Fix install name for libexpect dylib

### DIFF
--- a/devel/expect/Portfile
+++ b/devel/expect/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name            expect
 conflicts       bahamut whois
 version         5.45.4
-revision        2
+revision        3
 categories      devel
 license         Tcl/Tk
 maintainers     nomaintainer
@@ -74,7 +74,13 @@ configure.args      --mandir=${prefix}/share/man \
 test.run        yes
 test.target     test
 
-post-destroot       { ln -s expect${version}/libexpect${version}.a ${destroot}${prefix}/lib/libexpect.a
+post-destroot       { 
+            ln -s expect${version}/libexpect${version}.dylib ${destroot}${prefix}/lib/libexpect.dylib
+            # Fix libexpect's install name to match its new location.
+            system "install_name_tool -id ${prefix}/lib/libexpect.dylib ${destroot}${prefix}/lib/libexpect.dylib"
+            # The expect binary has already been linked against the old install
+            # name, so we need to fix that too.
+            system "install_name_tool -change libexpect${version}.dylib ${prefix}/lib/libexpect.dylib ${destroot}${prefix}/bin/expect"
 
             file mkdir ${destroot}${prefix}/share/doc/${name}/examples
             xinstall -m 644 {*}[glob ${worksrcpath}/example/*] \


### PR DESCRIPTION
#### Description

This fixes a bug introduced in #25873 and reported here: https://lists.macports.org/pipermail/macports-users/2024-September/053033.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1 24B5046f
Xcode 16.1 16B5014f 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
