### PR TITLE
google-cloud-sdk: update to 494.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             493.0.0
+version             494.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  184eb340ac5e64d8c10670aa16cbd6442d1effc1 \
-                    sha256  256916052bdf4ccf19e1607d6536ba800bcd241ce85c31c328a84c72f7189c27 \
-                    size    52119551
+    checksums       rmd160  64b38fe11ef8c49ef7a6a548324a623c82cf1a6c \
+                    sha256  60d93661bed8abf2270dea3d2214b4d90a137a4a158a70ef1febd61d269bf1d7 \
+                    size    52190060
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  ea79ca46daf86a4c657054f4f9d5303a4b6633e3 \
-                    sha256  839190b130fe4a273bacb2dc96f9df36fe06846af9ec0ffd251c94e37577d2b1 \
-                    size    53471242
+    checksums       rmd160  2f6c4e4ff61ebaf6388ccd45f8093b35569bb034 \
+                    sha256  1f430d7a5e6a4921412a6af37e3e0cbdc936496dfd33c59b1d2d0b365641fe36 \
+                    size    53541729
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  f875a04f1dbc06356f13f51aea371b7b22acf3bb \
-                    sha256  c928bac4c9b7c88ab28f0d25d6b269158b1f3272311ce87a1bb7e4df6e803e14 \
-                    size    53418841
+    checksums       rmd160  c174c0413aa622959b377482420b8320f63f3012 \
+                    sha256  39caeeee8104cf4d8e60005314151a59391479a362bd00e709195a02957ed808 \
+                    size    53489007
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 494.0.0.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?