### PR TITLE
tenfourfox: Add Aquafox subport and update tenfourfox-devel

### DIFF
--- a/www/tenfourfox/Portfile
+++ b/www/tenfourfox/Portfile
@@ -31,11 +31,11 @@ if {${subport} eq "${name}"} {
     description         Clone of Firefox, compatible with macOS 10.4+. Tracks latest commit on GitHub.
     long_description    ${description}
 
-    github.setup        classilla tenfourfox 656875dfebe724c31896e3073780638e2c213f81
-    version             20230921-FPR32
-    checksums           rmd160  82d5229d46ab25ec9850754d97fd4f7ccad8c5e3 \
-                        sha256  a523c6a9985f1df83c167839b36f8c3ed6a67e133baf42859cf0d826e3d17bda \
-                        size    326149990
+    github.setup        classilla tenfourfox cdc8b5a989ce0b8ced48edbf8166d460c67a6a0d
+    version             20240505-FPR32
+    checksums           rmd160  3ad5aa53b5d127c8d46da03cb9e94e5573193db8 \
+                        sha256  2a9bf00d8b535cc78111f1f9ece6c185aeac3635b08dad09c9efb082356d3631 \
+                        size    326144707
 }
 
 # Verify we have the required SDK:

--- a/www/tenfourfox/Portfile
+++ b/www/tenfourfox/Portfile
@@ -4,10 +4,11 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 categories              www
-maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
+maintainers             {@barracuda156 gmail.com:vital.had} {@BlackBirdLC netcourrier.com:thewireless} openmaintainer
 license                 GPL-2
 name                    tenfourfox
 subport                 tenfourfox-devel {}
+subport                 aquafox {}
 
 # Re ppc64: https://github.com/classilla/tenfourfox/issues/655
 supported_archs         ppc
@@ -25,6 +26,7 @@ if {${subport} eq "${name}"} {
     checksums           rmd160  e9a499d3acfe69c622eeafc7ea68ef957b7bdf3c \
                         sha256  b5aef01b6d031e4b582460955e3a3b95f7b3bfb994cdfa0171f0cd6279ca21ce \
                         size    325688845
+    set appname 	TenFourFox
 
 } elseif {${subport} eq "${name}-devel"} {
     conflicts           ${name}
@@ -36,6 +38,18 @@ if {${subport} eq "${name}"} {
     checksums           rmd160  3ad5aa53b5d127c8d46da03cb9e94e5573193db8 \
                         sha256  2a9bf00d8b535cc78111f1f9ece6c185aeac3635b08dad09c9efb082356d3631 \
                         size    326144707
+    set appname 	TenFourFox
+
+} elseif {${subport} eq "aquafox"} {
+    description         TenFourFox fork with extra optimizations.
+    long_description    ${description}
+
+    github.setup        BlackBirdLC Aquafox 1.0.0 v
+    checksums           rmd160  631a80fea5601ac7cb6aecb620ce146347774f3a \
+                        sha256  c79d49237249573dd59eeb45fb09600ce043ef70d498b17bddba64a3cd1febea \
+                        size    325246887
+    patchfiles-append 	0785667d630acf269af554f538c19da181e5253f.patch
+    set appname 	Aquafox
 }
 
 # Verify we have the required SDK:
@@ -125,9 +139,9 @@ build.cmd               gmake -f client.mk build
 # Make it self-contained. This could be removed if we want to keep it lean,
 # but then we'd have to copy the app from a different spot.
 pre-destroot {
-    system -W ${worksrcpath} "./104fx_copy.sh TenFourFox.app"
+    system -W ${worksrcpath} "./104fx_copy.sh ${appname}.app"
 }
 
 destroot {
-    move ${worksrcpath}/TenFourFox.app ${destroot}${applications_dir}
+    move ${worksrcpath}/${appname}.app ${destroot}${applications_dir}
 }

--- a/www/tenfourfox/files/0785667d630acf269af554f538c19da181e5253f.patch
+++ b/www/tenfourfox/files/0785667d630acf269af554f538c19da181e5253f.patch
@@ -1,0 +1,78 @@
+From 0785667d630acf269af554f538c19da181e5253f Mon Sep 17 00:00:00 2001
+From: wireless <thewireless@netcourrier.com>
+Date: Mon, 16 Sep 2024 18:28:31 +0200
+Subject: [PATCH] Add nostrip mozcfg for MacPorts compatibility
+
+---
+ G4-7450-nostrip.mozcfg | 25 +++++++++++++++++++++++++
+ G5-nostrip.mozcfg      | 26 ++++++++++++++++++++++++++
+ 2 files changed, 51 insertions(+)
+ create mode 100644 G4-7450-nostrip.mozcfg
+ create mode 100644 G5-nostrip.mozcfg
+
+diff --git a/G4-7450-nostrip.mozcfg b/G4-7450-nostrip.mozcfg
+new file mode 100644
+index 000000000..55ceca904
+--- /dev/null
++++ b/G4-7450-nostrip.mozcfg
+@@ -0,0 +1,25 @@
++. $topsrcdir/browser/config/mozconfig
++export CC="/opt/local/bin/gcc-mp-4.8 -flax-vector-conversions -O3 -mcpu=7450 -mtune=7450 -falign-loops=16 -falign-functions=16 -falign-labels=16 -falign-jumps=16 -read_only_relocs suppress -mdynamic-no-pic"
++export CXX="/opt/local/bin/g++-mp-4.8 -flax-vector-conversions -fpermissive -O3 -mcpu=7450 -mtune=7450 -falign-loops=16 -falign-functions=16 -falign-labels=16 -falign-jumps=16 -read_only_relocs suppress -mdynamic-no-pic"
++mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-ff-dbg
++mk_add_options MOZ_MAKE_FLAGS="-s -j2"
++mk_add_options AUTOCONF=autoconf213
++ac_add_options --disable-tests
++ac_add_options --disable-static
++ac_add_options --enable-optimize
++ac_add_options --disable-cpp-exceptions
++ac_add_options --disable-debug
++ac_add_options --disable-crashreporter
++ac_add_options --disable-webrtc
++ac_add_options --disable-necko-wifi
++ac_add_options --disable-webspeech
++ac_add_options --disable-accessibility
++ac_add_options --enable-printing
++ac_add_options --enable-prebinding
++ac_add_options --enable-macos-target=10.4
++ac_add_options --enable-chrome-format=jar
++ac_add_options --with-macos-sdk=/Developer/SDKs/MacOSX10.4u.sdk
++ac_add_options --enable-tenfourfox-vmx
++ac_add_options --with-system-jpeg
++ac_add_options --with-distribution-id=org.blackbirdlc
++
+diff --git a/G5-nostrip.mozcfg b/G5-nostrip.mozcfg
+new file mode 100644
+index 000000000..734baa38d
+--- /dev/null
++++ b/G5-nostrip.mozcfg
+@@ -0,0 +1,26 @@
++. $topsrcdir/browser/config/mozconfig
++export CC="/opt/local/bin/gcc-mp-4.8 -flax-vector-conversions -O3 -mcpu=G5 -m32 -falign-loops=32 -falign-functions=32 -falign-labels=32 -falign-jumps=32 -mmfcrf -mpowerpc-gpopt -read_only_relocs suppress -force_cpusubtype_ALL -mdynamic-no-pic -D_PPC970_"
++export CXX="/opt/local/bin/g++-mp-4.8 -flax-vector-conversions -fpermissive -O3 -mcpu=G5 -m32 -falign-loops=32 -falign-functions=32 -falign-labels=32 -falign-jumps=32 -mmfcrf -mpowerpc-gpopt -read_only_relocs suppress -force_cpusubtype_ALL -mdynamic-no-pic -D_PPC970_"
++mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-ff-dbg
++mk_add_options MOZ_MAKE_FLAGS="-s -j2"
++mk_add_options AUTOCONF=autoconf213
++ac_add_options --disable-tests
++ac_add_options --disable-static
++ac_add_options --enable-optimize
++ac_add_options --disable-cpp-exceptions
++ac_add_options --disable-debug
++ac_add_options --disable-crashreporter
++ac_add_options --disable-webrtc
++ac_add_options --disable-necko-wifi
++ac_add_options --disable-webspeech
++ac_add_options --disable-accessibility
++ac_add_options --enable-printing
++ac_add_options --enable-prebinding
++ac_add_options --enable-macos-target=10.4
++ac_add_options --enable-chrome-format=jar
++ac_add_options --with-macos-sdk=/Developer/SDKs/MacOSX10.4u.sdk
++ac_add_options --enable-tenfourfox-vmx
++ac_add_options --enable-tenfourfox-g5
++ac_add_options --with-system-jpeg
++ac_add_options --with-distribution-id=org.blackbirdlc
++
+-- 
+2.43.0
+


### PR DESCRIPTION
#### Description
Added Aquafox subport, a TenFourFox fork with extra optimizations, and updated tenfourfox-devel to the latest version 20240505.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.6
Xcode 3.2

**Note:** Testing was conducted by @barracuda156.

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? **(Testing of building and binary files was conducted by @barracuda156.)**
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
