### PR TITLE
uv: Upgrade to 0.4.16

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.4.15
+github.setup            astral-sh uv 0.4.16
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  bd8b5bff5b59c475d3977e0e93ecc592f92883e2 \
-                        sha256  fb9d134ccac8ce4088060705ccd5678d7825a22ca9951364efd5e7474d577602 \
-                        size    2650314
+                        rmd160  bcd3fbe3b6d1c2bd59c590fcd4a80f56bb1fe479 \
+                        sha256  28c40f5456afa30fac98bb0f3fe38740d8c3bda9425c75b21044efe30c9c3278 \
+                        size    2685666
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -112,12 +112,12 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.17  3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac \
-    clap_builder                    4.5.17  8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73 \
+    clap                            4.5.18  b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3 \
+    clap_builder                    4.5.18  4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b \
     clap_complete                   4.5.26  205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.3  5fe32110e006bccf720f8c9af3fee1ba7db290c724eab61544e1d3295be3a40e \
-    clap_derive                     4.5.13  501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0 \
+    clap_derive                     4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
     clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
     cmake                           0.1.51  fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a \
     codspeed                         2.7.2  450a0e9df9df1c154156f4344f99d8f6f6e69d0fc4de96ef6e2e68b2ec3bce97 \
@@ -264,6 +264,7 @@ cargo.crates \
     miette-derive                    7.2.0  dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c \
     mimalloc                        0.1.43  68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
+    mime_guess                       2.0.5  f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e \
     miniz_oxide                      0.7.4  b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08 \
     miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
     mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
@@ -432,8 +433,8 @@ cargo.crates \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
     testing_logger                   0.1.1  6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720 \
     textwrap                        0.16.1  23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9 \
-    thiserror                       1.0.63  c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724 \
-    thiserror-impl                  1.0.63  a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261 \
+    thiserror                       1.0.64  d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84 \
+    thiserror-impl                  1.0.64  08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tikv-jemalloc-sys 0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d \
     tikv-jemallocator                0.6.0  4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865 \
@@ -466,6 +467,7 @@ cargo.crates \
     ttf-parser                      0.18.1  0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633 \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
     ucd-trie                         0.1.6  ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9 \
+    unicase                          2.7.0  f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89 \
     unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
     unicode-bidi-mirroring           0.1.0  56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694 \
     unicode-ccc                      0.1.2  cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1 \


### PR DESCRIPTION
#### Description

uv: Upgrade to 0.4.16

##### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?