### PR TITLE
mise: Upgrade to 2024.9.9

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.9.8 v
+github.setup        jdx mise 2024.9.9 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  deaa5f257a53e9ba1330fce0066a7c6f1c0461cd \
-                    sha256  921af5af50307b7618670d71f2246ba6e68d6fe55b6704a167458f8823065e8b \
-                    size    3120710
+                    rmd160  bbc384b23585aea53f6af0c0f4fcd502dfaa4aff \
+                    sha256  fc368d904d92b83342032734d6548093973af7b8c5f9035473548cd745bcbff3 \
+                    size    3121879
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -365,7 +365,7 @@ cargo.crates \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
-    redox_syscall                    0.5.5  62871f2d65009c0256aed1b9cfeeb8ac272833c404e13d53d400cd0dad7a2ac0 \
+    redox_syscall                    0.5.6  355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b \
     regex                           1.10.6  4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                   0.4.7  38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df \
@@ -552,7 +552,7 @@ cargo.crates \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                          0.6.19  c52ac009d615e79296318c1bcce2d422aaca15ad08515e344feeda07df67a587 \
+    winnow                          0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
     xx                               1.1.8  fb963ecf2940991825550e580efaaa1ab882191027f45362c4376de15d09bfe9 \


### PR DESCRIPTION
#### Description

mise: Upgrade to 2024.9.9

##### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
