### PR TITLE
halloy: update to 2024.12

### DIFF
--- a/irc/halloy/Portfile
+++ b/irc/halloy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        squidowl halloy 2024.4
+github.setup        squidowl halloy 2024.12
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  bc1ab88178eb11aeda57acb63cc46a4c8865fe4b \
-                    sha256  d051692b053ee425a7cbffe08f3dd6737f396682031823062a1c621de5a3583f \
-                    size    10512206
+                    rmd160  5799b57cbcd8ce03d25d15a22207ca870be2b958 \
+                    sha256  df773c2e7ad6bf335fe2cdfd721f8873550cfb5554a9c1734bae76cee1282871 \
+                    size    25115571
 
 build.pre_args-delete \
                     --frozen --offline
@@ -36,472 +36,586 @@ destroot {
 }
 
 cargo.crates \
-    ab_glyph                        0.2.23  80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225 \
+    ab_glyph                        0.2.28  79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb \
     ab_glyph_rasterizer              0.1.8  c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046 \
-    addr2line                       0.21.0  8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb \
+    addr2line                       0.22.0  6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678 \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    ahash                            0.7.8  891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9 \
     ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
-    aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
+    aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     aliasable                        0.1.3  250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd \
-    allocator-api2                  0.2.16  0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5 \
-    android-activity                 0.5.2  ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289 \
+    allocator-api2                  0.2.18  5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f \
+    alsa                             0.9.0  37fe60779335388a88c01ac6c3be40304d1e349de3ada3b15f7808bb90fa9dce \
+    alsa-sys                         0.3.1  db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527 \
+    android-activity                 0.6.0  ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046 \
     android-properties               0.2.2  fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04 \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    anyhow                          1.0.86  b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da \
     approx                           0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
-    arrayref                         0.3.7  6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545 \
+    arrayref                         0.3.8  9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a \
     arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
     as-raw-xcb-connection            1.0.1  175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b \
     ash                     0.37.3+1.3.251  39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a \
-    async-broadcast                  0.5.1  7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b \
-    async-channel                    2.2.0  f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3 \
-    async-executor                   1.8.0  17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c \
-    async-fs                         1.6.0  279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06 \
-    async-io                        1.13.0  0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af \
-    async-io                         2.3.2  dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884 \
-    async-lock                       2.8.0  287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b \
-    async-lock                       3.3.0  d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b \
-    async-process                    1.8.1  ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88 \
-    async-recursion                  1.0.5  5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0 \
-    async-signal                     0.2.5  9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5 \
-    async-task                       4.7.0  fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799 \
-    async-trait                     0.1.77  c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9 \
+    ashpd                            0.8.1  dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093 \
+    async-broadcast                  0.7.1  20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e \
+    async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
+    async-executor                  1.13.0  d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7 \
+    async-fs                         2.1.2  ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a \
+    async-http-proxy                 1.2.5  29faa5d4d308266048bd7505ba55484315a890102f9345b9ff4b87de64201592 \
+    async-io                         2.3.4  444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8 \
+    async-lock                       3.4.0  ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18 \
+    async-process                    2.2.4  a8a07789659a4d385b79b18b9127fc27e1a59e1e89117c78c5ea3b806f016374 \
+    async-recursion                  1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
+    async-signal                    0.2.10  637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3 \
+    async-task                       4.7.1  8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de \
+    async-trait                     0.1.81  6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
-    backtrace                       0.3.69  2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837 \
+    autocfg                          1.3.0  0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0 \
+    backtrace                       0.3.73  5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a \
+    base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
+    base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
+    bindgen                         0.69.4  a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0 \
     bit-set                          0.5.3  0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1 \
     bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
     bit_field                       0.10.2  dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                         2.4.2  ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf \
+    bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    block-sys                        0.2.1  ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7 \
-    block2                           0.3.0  15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68 \
-    blocking                         1.5.1  6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118 \
-    bumpalo                         3.15.4  7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa \
-    bytemuck                        1.15.0  5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15 \
-    bytemuck_derive                  1.6.0  4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60 \
+    block2                           0.5.1  2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f \
+    blocking                         1.6.1  703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea \
+    bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
+    by_address                       1.2.1  64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06 \
+    bytemuck                        1.17.0  6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31 \
+    bytemuck_derive                  1.7.1  0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26 \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                            1.5.0  a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223 \
+    bytes                            1.7.1  8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50 \
+    bytesize                         1.3.0  a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc \
     calloop                         0.12.4  fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298 \
+    calloop                         0.13.0  b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec \
     calloop-wayland-source           0.2.0  0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02 \
-    cc                              1.0.90  8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5 \
+    calloop-wayland-source           0.3.0  95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20 \
+    cc                              1.1.13  72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48 \
     cesu8                            1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
+    cexpr                            0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.1.1  fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e \
-    cfg_aliases                      0.2.0  77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f \
-    chrono                          0.4.35  8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a \
-    clipboard-win                    5.2.0  12f9a0700e0127ba15d1d52dd742097f821cd9c65939303a44d970465040a297 \
+    cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
+    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
+    clang-sys                        1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
+    claxon                           0.4.3  4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688 \
+    clipboard-win                    5.4.0  15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892 \
     clipboard_macos                  0.1.0  145a7f9e9b89453bc0a5e32d166456405d389cea5b578f57f1274b1397588a95 \
     clipboard_wayland                0.2.2  003f886bc4e2987729d10c1db3424e7f80809f3fc22dbc16c685738887cb37b8 \
     clipboard_x11                    0.4.2  4274ea815e013e0f9f04a2633423e14194e408a0576c943ce3d14ca56c50031c \
-    cocoa                           0.25.0  f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c \
-    cocoa-foundation                 0.1.2  8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7 \
     codespan-reporting              0.11.1  3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
     com                              0.6.0  7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6 \
     com_macros                       0.6.0  d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5 \
     com_macros_support               0.6.0  ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c \
-    combine                          4.6.6  35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4 \
-    concurrent-queue                 2.4.0  d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363 \
+    combine                          4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
+    concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
+    const_format                    0.2.32  e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673 \
+    const_format_proc_macros        0.2.32  c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500 \
+    convert_case                     0.6.0  ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
-    core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
-    core-graphics                   0.23.1  970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212 \
+    core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    core-graphics                   0.23.2  c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081 \
     core-graphics-types              0.1.3  45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf \
-    cosmic-text                     0.10.0  75acbfb314aeb4f5210d379af45ed1ec2c98c7f1790bf57b8a4c562ac0c51b71 \
-    cpufeatures                     0.2.12  53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504 \
-    crc32fast                        1.4.0  b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa \
+    coreaudio-rs                    0.11.3  321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace \
+    coreaudio-sys                   0.2.15  7f01585027057ff5f0a5bf276174ae4c1594a2c5bde93d5f46a016d76270f5a9 \
+    cosmic-text                     0.12.1  59fd57d82eb4bfe7ffa9b1cec0c05e2fd378155b47f255a67983cb4afe0e80c2 \
+    cpal                            0.15.3  873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779 \
+    cpufeatures                     0.2.13  51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad \
+    crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
     crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                 0.8.19  248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345 \
+    crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
-    ctor                             0.2.7  ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c \
+    ctor-lite                        0.1.0  1f791803201ab277ace03903de1594460708d2d54df6053f2d9e82f592b19e3b \
     cursor-icon                      1.1.0  96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991 \
     d3d12                           0.19.0  3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307 \
+    dark-light                       1.1.1  2a76fa97167fa740dcdbfe18e8895601e1bc36525f09b044e00916e717c03a3c \
+    dasp_sample                     0.11.0  0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f \
+    dconf_rs                         0.3.0  7046468a81e6a002061c01e6a7c83139daf91b11c30e66795b13217c2d885c8b \
     deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
-    derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
+    derive_more                      1.0.0  4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05 \
+    derive_more-impl                 1.0.0  cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22 \
+    detect-desktop-environment       0.2.0  21d8ad60dd5b13a4ee6bd8fa2d5d88965c597c67bce32b5fc49c94f55cb50810 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    dirs                             4.0.0  ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059 \
     dirs-next                        2.0.0  b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1 \
+    dirs-sys                         0.3.7  1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6 \
     dirs-sys-next                    0.1.2  4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d \
     dispatch                         0.2.0  bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b \
     dlib                             0.5.2  330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412 \
-    downcast-rs                      1.2.0  9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650 \
-    drm                             0.11.1  a0f8a69e60d75ae7dab4ef26a59ca99f2a89d4c142089b537775ae0c198bdcde \
-    drm-ffi                          0.7.1  41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6 \
+    dlv-list                         0.3.0  0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257 \
+    downcast-rs                      1.2.1  75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2 \
+    drm                             0.12.0  98888c4bbd601524c11a7ed63f814b8825f420514f78e96f752c437ae9cbb5d1 \
+    drm-ffi                          0.8.0  97c98727e48b7ccb4f4aea8cfe881e5b07f702d17b7875991881b41af7278d53 \
     drm-fourcc                       2.2.0  0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4 \
-    drm-sys                          0.6.1  2d09ff881f92f118b11105ba5e34ff8f4adf27b30dae8f12e28c193af1c83176 \
-    either                          1.10.0  11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a \
-    embed-resource                   2.4.2  c6985554d0688b687c5cb73898a34fbe3ad6c24c58c238a4d91d5e840670ee9d \
-    enumflags2                       0.7.9  3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d \
-    enumflags2_derive                0.7.9  5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4 \
+    drm-sys                          0.7.0  fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986 \
+    either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
+    embed-resource                   2.4.3  4edcacde9351c33139a41e3c97eb2334351a81a2791bebb0b243df837128f602 \
+    encoding_rs                     0.8.34  b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59 \
+    endi                             1.1.0  a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf \
+    enumflags2                      0.7.10  d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d \
+    enumflags2_derive               0.7.10  de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8 \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
-    errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
+    errno                            0.3.9  534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba \
     error-code                       3.2.0  a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b \
-    etagere                         0.2.10  306960881d6c46bd0dd6b7f07442a441418c08d0d3e63d8d080b0f64c6343e4e \
-    euclid                          0.22.9  87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787 \
-    event-listener                   2.5.3  0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0 \
-    event-listener                   3.1.0  d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2 \
-    event-listener                   4.0.3  67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e \
-    event-listener                   5.2.0  2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91 \
-    event-listener-strategy          0.4.0  958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3 \
-    event-listener-strategy          0.5.0  feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291 \
+    etagere                         0.2.13  0e2f1e3be19fb10f549be8c1bf013e8675b4066c445e36eb76d2ebb2f54ee495 \
+    euclid                         0.22.10  e0f0eb73b934648cd7a4a61f1b15391cd95dab0b4da6e2e66c2a072c144b4a20 \
+    event-listener                   5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
+    event-listener-strategy          0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
     exr                             1.72.0  887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4 \
+    fast-socks5                      0.9.6  f89f36d4ee12370d30d57b16c7e190950a1a916e7dbbb5fd5a412f5ef913fe84 \
     fast-srgb8                       1.0.0  dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1 \
-    fastrand                         1.9.0  e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be \
-    fastrand                         2.0.1  25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5 \
+    fastrand                         2.1.0  9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a \
     fdeflate                         0.3.4  4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645 \
     fern                             0.6.2  d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee \
-    flate2                          1.0.28  46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e \
+    flate2                          1.0.31  7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920 \
     flume                           0.11.0  55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181 \
-    font-types                       0.4.3  5b7f6040d337bd44434ab21fc6509154edf2cece88b23758d9d64654c4e7730b \
-    fontconfig-parser                0.5.6  6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d \
-    fontdb                          0.15.0  020e203f177c0fb250fb19455a252e838d2bbbce1f80f25ecc42402aafa8cd38 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    font-types                       0.6.0  8f0189ccb084f77c5523e08288d418cbaa09c451a08515678a0aa265df9a8b60 \
+    fontconfig-parser                0.5.7  c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7 \
+    fontdb                          0.16.2  b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types                    0.5.0  d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965 \
     foreign-types-macros             0.2.3  1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     foreign-types-shared             0.3.1  aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b \
+    form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     futures                         0.3.30  645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0 \
     futures-channel                 0.3.30  eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78 \
     futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
     futures-executor                0.3.30  a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d \
     futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
-    futures-lite                    1.13.0  49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce \
-    futures-lite                     2.2.0  445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba \
+    futures-lite                     2.3.0  52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5 \
     futures-macro                   0.3.30  87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac \
     futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
     futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
     futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     gethostname                      0.4.3  0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818 \
-    getrandom                       0.2.12  190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5 \
+    getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
     gif                             0.13.1  3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2 \
-    gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
+    gimli                           0.29.0  40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd \
     gl_generator                    0.14.0  1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d \
     glam                            0.25.0  151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3 \
+    glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
     glow                            0.13.1  bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1 \
     glutin_wgl_sys                   0.5.0  6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead \
-    glyphon                          0.5.0  6a62d0338e4056db6a73221c2fb2e30619452f6ea9651bac4110f51b0f7a7581 \
     gpu-alloc                        0.6.0  fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171 \
     gpu-alloc-types                  0.3.0  98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4 \
     gpu-allocator                   0.25.0  6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884 \
     gpu-descriptor                   0.2.4  cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c \
     gpu-descriptor-types             0.1.2  6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c \
     guillotiere                      0.6.2  b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782 \
-    half                             2.4.0  b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e \
-    hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
+    h2                               0.4.5  fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab \
+    half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
+    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hassle-rs                       0.11.0  af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
+    hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hexf-parse                       0.2.1  dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df \
+    hound                            3.5.1  62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f \
+    http                             1.1.0  21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258 \
+    http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
+    http-body-util                   0.1.2  793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f \
+    httparse                         1.9.4  0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9 \
+    hyper                            1.4.1  50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05 \
+    hyper-rustls                    0.27.2  5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155 \
+    hyper-tls                        0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
+    hyper-util                       0.1.7  cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9 \
     iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
-    icrate                           0.0.4  99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319 \
+    idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
     image                           0.24.9  5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d \
-    indexmap                         2.2.5  7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4 \
-    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
-    io-lifetimes                    1.0.11  eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2 \
+    indexmap                         2.4.0  93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c \
+    instant                         0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
+    interprocess                     1.2.1  81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb \
+    intmap                           0.7.1  ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9 \
+    ipnet                            2.9.0  8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3 \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-wsl                           0.4.0  173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5 \
+    isolang                          2.4.0  fe50d48c77760c55188549098b9a7f6e37ae980c586a24693d6b01c3b2010c3c \
     itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
-    itoa                            1.0.10  b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c \
+    itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
+    itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
     jni                             0.21.1  1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97 \
     jni-sys                          0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
-    jobserver                       0.1.28  ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6 \
+    jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jpeg-decoder                     0.3.1  f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0 \
-    js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
+    js-sys                          0.3.70  1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a \
     kamadak-exif                     0.5.5  ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077 \
     khronos-egl                      6.0.0  6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76 \
     khronos_api                      3.1.0  e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc \
     kurbo                           0.10.4  1618d4ebd923e97d67e7cd363d80aef35fe961005cbbbb3d2dad8bdd1bc63440 \
-    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
+    lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
     lebe                             0.5.2  03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8 \
-    libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
+    lewton                          0.10.2  777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030 \
+    libc                           0.2.156  a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a \
     libloading                       0.7.4  b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f \
-    libloading                       0.8.3  0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19 \
+    libloading                       0.8.5  4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4 \
     libm                             0.2.8  4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058 \
-    libredox                         0.0.1  85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8 \
     libredox                         0.0.2  3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607 \
-    linux-raw-sys                    0.3.8  ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519 \
-    linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
-    linux-raw-sys                    0.6.4  f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4 \
-    lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
-    log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
-    lru                             0.12.3  d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc \
+    libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
+    linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
+    linux-raw-sys                    0.6.5  2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7 \
+    lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
+    log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
+    lru                             0.12.4  37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904 \
     mac-notification-sys             0.6.1  51fca4d74ff9dbaac16a01b924bc3693fa2bba0862c2c633abc73f9a8ea21f64 \
+    mach2                            0.4.2  19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709 \
     malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
-    memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \
-    memmap2                          0.8.0  43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed \
+    memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     memmap2                          0.9.4  fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322 \
-    memoffset                        0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
-    memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
+    memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     metal                           0.27.0  c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25 \
+    mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
-    miniz_oxide                      0.7.2  9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7 \
-    mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
+    miniz_oxide                      0.7.4  b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08 \
+    mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
     mutate_once                      0.1.1  16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b \
     naga                            0.19.2  50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843 \
-    native-tls                      0.2.11  07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e \
+    native-tls                      0.2.12  a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466 \
     ndk                              0.8.0  2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7 \
+    ndk                              0.9.0  c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4 \
     ndk-context                      0.1.1  27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b \
     ndk-sys             0.5.0+25.2.9519653  8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691 \
-    nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
+    ndk-sys                 0.6.0+11769913  ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873 \
+    nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
-    notify-rust                     4.10.0  827c5edfa80235ded4ab3fe8e9dc619b4f866ef16fe9b1c6b8a7f8692c0f2226 \
+    notify-rust                     4.11.1  26a1d03b6305ecefdd9c6c60150179bb8d9f0cd4e64bbcad1e41419e7bf5e414 \
     num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
-    num-traits                      0.2.18  da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a \
+    num-derive                       0.4.2  ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202 \
+    num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
-    num_enum                         0.7.2  02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845 \
-    num_enum_derive                  0.7.2  681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b \
+    num_enum                         0.7.3  4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179 \
+    num_enum_derive                  0.7.3  af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56 \
     objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
     objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
-    objc-sys                         0.3.2  c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459 \
-    objc2                            0.4.1  559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d \
-    objc2-encode                     3.0.0  d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666 \
+    objc-sys                         0.3.5  cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310 \
+    objc2                            0.5.2  46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804 \
+    objc2-app-kit                    0.2.2  e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff \
+    objc2-cloud-kit                  0.2.2  74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009 \
+    objc2-contacts                   0.2.2  a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889 \
+    objc2-core-data                  0.2.2  617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef \
+    objc2-core-image                 0.2.2  55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80 \
+    objc2-core-location              0.2.2  000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781 \
+    objc2-encode                     4.0.3  7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8 \
+    objc2-foundation                 0.2.2  0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8 \
+    objc2-link-presentation          0.2.2  a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398 \
+    objc2-metal                      0.2.2  dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6 \
+    objc2-quartz-core                0.2.2  e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a \
+    objc2-symbols                    0.2.2  0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc \
+    objc2-ui-kit                     0.2.2  b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f \
+    objc2-uniform-type-identifiers   0.2.2  44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe \
+    objc2-user-notifications         0.2.2  76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3 \
     objc_exception                   0.1.2  ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4 \
     objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
-    object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
+    object                          0.36.3  27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9 \
+    oboe                             0.6.1  e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb \
+    oboe-sys                         0.6.1  6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d \
+    ogg                              0.8.0  6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e \
     once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
-    open                             5.1.2  449f0ff855d85ddbf1edd5b646d65249ead3f5e422aaa86b7d2d0b049b103e32 \
-    openssl                        0.10.64  95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f \
+    open                             5.3.0  61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3 \
+    openssl                        0.10.66  9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1 \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
-    openssl-sys                    0.9.101  dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff \
+    openssl-sys                    0.9.103  7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6 \
     orbclient                       0.3.47  52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166 \
+    ordered-multimap                 0.4.3  ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a \
     ordered-stream                   0.2.0  9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50 \
-    ouroboros                       0.18.3  97b7be5a8a3462b752f4be3ff2b2bf2f7f1d00834902e46be2a4d68b87b0573c \
-    ouroboros_macro                 0.18.3  b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33 \
-    owned_ttf_parser                0.20.0  d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7 \
-    palette                          0.7.5  ebfc23a4b76642983d57e4ad00bb4504eb30a8ce3c70f4aee1f725610e36d97a \
-    palette_derive                   0.7.5  e8890702dbec0bad9116041ae586f84805b13eecd1d8b1df27c29998a9969d6d \
+    ouroboros                       0.18.4  944fa20996a25aded6b4795c6d63f10014a7a83f8be9828a11860b08c5fc4a67 \
+    ouroboros_macro                 0.18.4  39b0deead1528fd0e5947a8546a9642a9777c25f6e1e26f34c97b204bbb465bd \
+    owned_ttf_parser                0.24.0  490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90 \
+    palette                          0.7.6  4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6 \
+    palette_derive                   0.7.6  f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30 \
     parking                          2.2.0  bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae \
     parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
-    parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
+    parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                 0.8.6  60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc \
-    parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
-    paste                           1.0.14  de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c \
+    parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
+    paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
     pathdiff                         0.2.1  8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
     phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
     phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
     phf_macros                      0.11.2  3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b \
     phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
-    pin-project-lite                0.2.13  8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58 \
+    pin-project                      1.1.5  b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3 \
+    pin-project-internal             1.1.5  2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965 \
+    pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    piper                            0.2.1  668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4 \
+    piper                            0.2.4  96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066 \
     pkg-config                      0.3.30  d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec \
     png                            0.17.13  06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1 \
-    polling                          2.8.0  4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce \
-    polling                          3.5.0  24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9 \
+    polling                          3.7.3  cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511 \
+    pollster                         0.3.0  22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
-    ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
+    ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
     presser                          0.3.1  e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa \
-    proc-macro-crate                 1.3.1  7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919 \
     proc-macro-crate                 3.1.0  6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284 \
-    proc-macro2                     1.0.79  e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e \
+    proc-macro2                     1.0.86  5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77 \
     proc-macro2-diagnostics         0.10.1  af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8 \
     profiling                       1.0.15  43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58 \
     qoi                              0.4.1  7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001 \
-    quick-xml                       0.30.0  eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956 \
     quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
-    quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
+    quick-xml                       0.34.0  6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4 \
+    quote                           1.0.36  0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     range-alloc                      0.1.3  9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab \
     rangemap                         1.5.1  f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684 \
-    raw-window-handle                0.6.0  42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544 \
-    rayon                            1.9.0  e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd \
+    raw-window-handle                0.6.2  20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539 \
+    rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
-    read-fonts                      0.15.6  17ea23eedb4d938031b6d4343222444608727a6aa68ec355e13588d9947ffe92 \
+    read-fonts                      0.20.0  8c141b9980e1150201b2a3a32879001c8f975fe313ec3df5471a9b5c79a880cd \
     redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
-    redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
     redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
-    redox_users                      0.4.4  a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4 \
-    regex                           1.10.3  b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15 \
-    regex-automata                   0.4.6  86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea \
-    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    redox_syscall                    0.5.3  2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4 \
+    redox_users                      0.4.5  bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891 \
+    regex                           1.10.6  4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619 \
+    regex-automata                   0.4.7  38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df \
+    regex-syntax                     0.8.4  7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b \
     renderdoc-sys                    1.1.0  19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832 \
-    roxmltree                       0.19.0  3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f \
-    rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
+    reqwest                         0.12.5  c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37 \
+    rfd                             0.14.1  25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251 \
+    ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
+    rodio                           0.19.0  6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb \
+    roxmltree                       0.20.0  6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97 \
+    rust-ini                        0.18.0  f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df \
+    rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
+    rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
     rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
-    rustix                         0.37.27  fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2 \
-    rustix                         0.38.31  6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949 \
-    rustybuzz                       0.11.0  2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa \
-    ryu                             1.0.17  e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1 \
+    rustix                         0.38.34  70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f \
+    rustls                         0.23.12  c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044 \
+    rustls-native-certs              0.7.1  a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba \
+    rustls-pemfile                   2.1.3  196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425 \
+    rustls-pki-types                 1.8.0  fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0 \
+    rustls-webpki                  0.102.6  8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e \
+    rustversion                     1.0.17  955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6 \
+    rustybuzz                       0.14.1  cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c \
+    ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.23  fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534 \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    sctk-adwaita                     0.8.1  82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550 \
+    sctk-adwaita                     0.9.1  7555fcb4f753d095d734fdefebb0ad8c98478a21db500492d87c55913d3b0086 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
-    security-framework               2.9.2  05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de \
-    security-framework-sys           2.9.1  e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a \
-    self_cell                        1.0.3  58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba \
-    semver                          1.0.22  92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca \
-    serde                          1.0.197  3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2 \
-    serde_derive                   1.0.197  7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b \
-    serde_json                     1.0.114  c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0 \
-    serde_repr                      0.1.18  0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb \
-    serde_spanned                    0.6.5  eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1 \
-    serde_yaml                      0.9.32  8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f \
+    security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
+    security-framework-sys          2.11.1  75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf \
+    self_cell                        1.0.4  d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a \
+    semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
+    serde                          1.0.208  cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2 \
+    serde_derive                   1.0.208  24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf \
+    serde_json                     1.0.125  83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed \
+    serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
+    serde_spanned                    0.6.7  eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d \
+    serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
-    signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
+    sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
+    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
     simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \
     siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
+    skrifa                          0.20.0  abea4738067b1e628c6ce28b2c216c19e9ea95715cdb332680e821c3bec2ef23 \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     slotmap                          1.0.7  dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a \
-    smallvec                        1.13.1  e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7 \
+    smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
     smithay-client-toolkit          0.18.1  922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a \
-    smithay-clipboard                0.7.1  c091e7354ea8059d6ad99eace06dd13ddeedbb0ac72d40a9a6e7ff790525882d \
-    smol_str                         0.2.1  e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49 \
-    socket2                         0.4.10  9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d \
-    socket2                          0.5.6  05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871 \
-    softbuffer                       0.4.1  071916a85d1db274b4ed57af3a14afb66bd836ae7f82ebb6f1fd3455107830d9 \
+    smithay-client-toolkit          0.19.2  3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016 \
+    smithay-clipboard                0.7.2  cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846 \
+    smol_str                         0.2.2  dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead \
+    socket2                          0.5.7  ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c \
+    softbuffer                       0.4.5  d623bff5d06f60d738990980d782c8c866997d9194cfe79ecad00aa2f76826dd \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
+    spinning                         0.1.0  2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b \
     spirv              0.3.0+sdk-1.3.268.0  eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strict-num                       0.1.1  6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731 \
-    svg_fmt                          0.4.2  f83ba502a3265efb76efb89b0a2f7782ad6f2675015d4ce37e4b547dda42b499 \
-    swash                           0.1.12  d06ff4664af8923625604261c645f5c4cc610cc83c84bec74b50d76237089de7 \
+    strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
+    strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
+    subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
+    svg_fmt                          0.4.3  20e16a0f46cf5fd675563ef54f26e83e20f2366bcf027bcb3cc3ed2b98aaf2ca \
+    swash                           0.1.18  93cdc334a50fcc2aa3f04761af3b28196280a6aaadb1ef11215c478ae32615ac \
+    symphonia                        0.5.4  815c942ae7ee74737bb00f965fa5b5a2ac2ce7b6c01c0cc169bbeaf7abd5f5a9 \
+    symphonia-bundle-mp3             0.5.4  c01c2aae70f0f1fb096b6f0ff112a930b1fb3626178fba3ae68b09dce71706d4 \
+    symphonia-core                   0.5.4  798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3 \
+    symphonia-metadata               0.5.4  bc622b9841a10089c5b18e99eb904f4341615d5aa55bbf4eedde1be721a4023c \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.52  b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07 \
+    syn                             2.0.74  1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7 \
+    sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
     sys-locale                       0.3.1  e801cf239ecd6ccd71f03d270d67dd53d13e90aab208bf4b8fe4ad957ea949b0 \
-    tauri-winrt-notification         0.1.3  006851c9ccefa3c38a7646b8cec804bb429def3da10497bfa977179869c3e8e2 \
-    tempfile                        3.10.1  85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1 \
+    system-configuration             0.5.1  ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7 \
+    system-configuration-sys         0.5.0  a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9 \
+    tauri-winrt-notification         0.2.1  f89f5fb70d6f62381f5d9b2ba9008196150b40b75f3068eb24faeddf1c686871 \
+    tempfile                        3.12.0  04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64 \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
-    thiserror                       1.0.58  03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297 \
-    thiserror-impl                  1.0.58  c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7 \
+    thiserror                       1.0.63  c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724 \
+    thiserror-impl                  1.0.63  a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261 \
     tiff                             0.9.1  ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e \
-    time                            0.3.34  c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749 \
+    time                            0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
+    timeago                          0.4.2  a1710e589de0a76aaf295cd47a6699f6405737dbfd3cf2b75c92d000b548d0e6 \
     tiny-skia                       0.11.4  83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab \
     tiny-skia-path                  0.11.4  9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93 \
-    tiny-xlib                        0.2.2  d4098d49269baa034a8d1eae9bd63e9fa532148d772121dace3bcd6a6c98eb6d \
-    tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+    tiny-xlib                        0.2.3  1d52f22673960ad13af14ff4025997312def1223bfa7c8e4949d099e6b3d5d1c \
+    tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.36.0  61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931 \
-    tokio-macros                     2.2.0  5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b \
+    to_method                        1.1.0  c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8 \
+    tokio                           1.39.2  daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1 \
+    tokio-macros                     2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
-    tokio-stream                    0.1.14  397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842 \
-    tokio-util                      0.7.10  5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15 \
-    toml                            0.8.11  af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e \
-    toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
-    toml_edit                      0.19.15  1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421 \
+    tokio-rustls                    0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
+    tokio-stream                    0.1.16  4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1 \
+    tokio-util                      0.7.11  9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1 \
+    toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
+    toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                       0.21.1  6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1 \
-    toml_edit                       0.22.7  18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992 \
+    toml_edit                      0.22.20  583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d \
+    tower                           0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
+    tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
+    tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
     tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
     tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
-    ttf-parser                      0.19.2  49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1 \
+    try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     ttf-parser                      0.20.0  17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4 \
+    ttf-parser                      0.21.1  2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8 \
+    ttf-parser                      0.24.1  5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
     uds_windows                      1.1.0  89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9 \
     unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
-    unicode-bidi-mirroring           0.1.0  56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694 \
-    unicode-ccc                      0.1.2  cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1 \
+    unicode-bidi-mirroring           0.2.0  23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86 \
+    unicode-ccc                      0.2.0  1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656 \
     unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
     unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
+    unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
     unicode-properties               0.1.1  e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291 \
     unicode-script                   0.5.6  ad8d71f5726e5f285a935e9fe8edfd53f0491eb6e9a5774097fdabee7cd8c9cd \
     unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
-    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    unicode-width                   0.1.13  0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d \
     unicode-xid                      0.2.4  f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c \
-    unsafe-libyaml                  0.2.10  ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b \
-    uuid                             1.7.0  f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a \
+    untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
+    url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
+    urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
+    uuid                            1.10.0  81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314 \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
-    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     vswhom                           0.1.0  be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b \
     vswhom-sys                       0.1.2  d3b17ae1f6c8a2b28506cd96d412eebf83b4a0ff2cbefeeb952f2f9dfa44ba18 \
-    waker-fn                         1.1.1  f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
+    want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.92  4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8 \
-    wasm-bindgen-backend            0.2.92  614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da \
-    wasm-bindgen-futures            0.4.42  76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0 \
-    wasm-bindgen-macro              0.2.92  a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726 \
-    wasm-bindgen-macro-support      0.2.92  e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7 \
-    wasm-bindgen-shared             0.2.92  af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96 \
+    wasm-bindgen                    0.2.93  a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5 \
+    wasm-bindgen-backend            0.2.93  9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b \
+    wasm-bindgen-futures            0.4.43  61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed \
+    wasm-bindgen-macro              0.2.93  585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf \
+    wasm-bindgen-macro-support      0.2.93  afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836 \
+    wasm-bindgen-shared             0.2.93  c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484 \
     wasm-timer                       0.2.5  be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f \
-    wayland-backend                  0.3.3  9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40 \
-    wayland-client                  0.31.2  82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f \
+    wayland-backend                  0.3.6  f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993 \
+    wayland-client                  0.31.5  7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943 \
     wayland-csd-frame                0.3.0  625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e \
-    wayland-cursor                  0.31.1  71ce5fa868dd13d11a0d04c5e2e65726d0897be8de247c0c5a65886e283231ba \
+    wayland-cursor                  0.31.5  6ef9489a8df197ebf3a8ce8a7a7f0a2320035c3743f3c1bd0bdbccf07ce64f95 \
     wayland-protocols               0.31.2  8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4 \
+    wayland-protocols               0.32.3  62989625a776e827cc0f15d41444a3cea5205b963c3a25be48ae1b52d6b4daaa \
     wayland-protocols-plasma         0.2.0  23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479 \
     wayland-protocols-wlr            0.2.0  ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6 \
-    wayland-scanner                 0.31.1  63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283 \
-    wayland-sys                     0.31.1  15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af \
-    web-sys                         0.3.67  58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed \
-    web-time                         0.2.4  aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0 \
+    wayland-protocols-wlr            0.3.3  fd993de54a40a40fbe5601d9f1fbcaef0aebcc5fda447d7dc8f6dcbaae4f8953 \
+    wayland-scanner                 0.31.4  d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6 \
+    wayland-sys                     0.31.4  43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148 \
+    web-sys                         0.3.70  26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0 \
+    web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     weezl                            0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
-    wgpu                            0.19.3  a4b1213b52478a7631d6e387543ed8f642bc02c578ef4e3b49aca2a29a7df0cb \
-    wgpu-core                       0.19.3  f9f6b033c2f00ae0bc8ea872c5989777c60bc241aac4e58b24774faa8b391f78 \
-    wgpu-hal                        0.19.3  49f972c280505ab52ffe17e94a7413d9d54b58af0114ab226b9fc4999a47082e \
+    wgpu                            0.19.4  cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01 \
+    wgpu-core                       0.19.4  28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a \
+    wgpu-hal                        0.19.5  bfabcfc55fd86611a855816326b2d54c3b2fd7972c27ce414291562650552703 \
     wgpu-types                      0.19.2  b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805 \
-    widestring                       1.0.2  653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8 \
+    widestring                       1.1.0  7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.6  f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596 \
+    winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     window_clipboard                 0.4.1  f6d692d46038c433f9daee7ad8757e002a4248c20b0a3fbc991d99521d3bcb6d \
-    windows                         0.51.1  ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9 \
     windows                         0.52.0  e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be \
-    windows-core                    0.51.1  f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64 \
+    windows                         0.54.0  9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49 \
+    windows                         0.56.0  1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132 \
     windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
+    windows-core                    0.54.0  12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65 \
+    windows-core                    0.56.0  4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6 \
+    windows-implement               0.56.0  f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b \
+    windows-interface               0.56.0  08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc \
+    windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
     windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-targets                 0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
     windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
-    windows-targets                 0.52.4  7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b \
+    windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-version                  0.1.1  6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515 \
     windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
     windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
-    windows_aarch64_gnullvm         0.52.4  bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9 \
+    windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
     windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
     windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
-    windows_aarch64_msvc            0.52.4  da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675 \
+    windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_exe_info                 0.4.2  f7e7bfd02caf5cd98a197cec15c852685c8c42605f91d7be3083541a0b40a7ff \
     windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
     windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
-    windows_i686_gnu                0.52.4  b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3 \
+    windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
     windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
     windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
-    windows_i686_msvc               0.52.4  1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02 \
+    windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
     windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
     windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
-    windows_x86_64_gnu              0.52.4  5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03 \
+    windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
     windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
     windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
-    windows_x86_64_gnullvm          0.52.4  77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177 \
+    windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
-    windows_x86_64_msvc             0.52.4  32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8 \
+    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     winnow                          0.5.40  f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876 \
-    winnow                           0.6.5  dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8 \
+    winnow                          0.6.18  68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f \
+    winreg                          0.10.1  80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d \
     winreg                          0.52.0  a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5 \
     x11-dl                          2.21.0  38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f \
-    x11rb                           0.13.0  f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a \
-    x11rb-protocol                  0.13.0  e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34 \
-    xcursor                          0.3.5  6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911 \
-    xdg-home                         1.1.0  21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e \
+    x11rb                           0.13.1  5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12 \
+    x11rb-protocol                  0.13.1  ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d \
+    xcursor                          0.3.8  0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61 \
+    xdg                              2.5.2  213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546 \
+    xdg-home                         1.3.0  ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6 \
     xkbcommon-dl                     0.4.2  d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5 \
-    xkeysym                          0.2.0  054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621 \
-    xml-rs                          0.8.19  0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a \
-    xxhash-rust                     0.8.10  927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03 \
+    xkeysym                          0.2.1  b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56 \
+    xml-rs                          0.8.21  539a77ee7c0de333dcc6da69b177380a0b81e0dacfa4f7344c465a36871ee601 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yazi                             0.1.6  c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1 \
-    zbus                            3.15.2  675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6 \
-    zbus_macros                     3.15.2  7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5 \
-    zbus_names                       2.6.1  437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d \
+    zbus                             4.4.0  bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725 \
+    zbus_macros                      4.4.0  267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e \
+    zbus_names                       3.0.0  4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c \
     zeno                             0.2.3  dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697 \
-    zerocopy                        0.7.32  74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be \
-    zerocopy-derive                 0.7.32  9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6 \
+    zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
+    zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
+    zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
     zune-inflate                    0.2.54  73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02 \
-    zvariant                        3.15.2  4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db \
+    zvariant                         4.2.0  2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe \
+    zvariant_derive                  4.2.0  73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449 \
+    zvariant_utils                   2.1.0  c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340 \
     zvariant_derive                 3.15.2  37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9 \
     zvariant_utils                   1.0.1  7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200


### PR DESCRIPTION
#### Description

This commit updates `halloy` to `2024.12`.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.0, bleeding edge xcode

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
