### PR TITLE
ffmpeg7: allow disabling bin symlinks and suffices

### DIFF
--- a/multimedia/ffmpeg7/Portfile
+++ b/multimedia/ffmpeg7/Portfile
@@ -393,13 +393,20 @@ post-destroot {
     }
 
     # Create bin symlinks
-    set port_bin_list \
-        [glob -type f -directory ${destroot}${port_bindir} *]
-    foreach f ${port_bin_list} {
-        set fname [file tail ${f}]
-        ui_info "Symlinking bin: ${prefix}/bin/${fname} -> ${port_bindir}/${fname}"
-        ln -s ${port_bindir}/${fname} ${destroot}${prefix}/bin/${fname}
+    if {![variant_isset no_symlink]} {
+        set port_bin_list \
+            [glob -type f -directory ${destroot}${port_bindir} *]
+        foreach f ${port_bin_list} {
+            set fname [file tail ${f}]
+            ui_info "Symlinking bin: ${prefix}/bin/${fname} -> ${port_bindir}/${fname}"
+            ln -s ${port_bindir}/${fname} ${destroot}${prefix}/bin/${fname}
+        }
     }
+}
+
+variant no_symlink description {Disable binary suffices and symlinks} {
+    configure.pre_args-delete \
+                    --progs-suffix=${port_ver_major}
 }
 
 variant x11 {
@@ -549,6 +556,22 @@ notes-append "
 This build of ${name} includes no GPLed or nonfree code and is therefore licensed under LGPL v2.1 or later.
 "
 }
+
+notes-append ""
+if {[variant_isset no_symlink]} {
+    notes-append "
+    To use the ${name} command-line programs, add\
+    ${prefix}/libexec/ffmpeg${port_ver_major}/bin to your \$PATH,\
+    in front of the normal ${prefix}/bin; or else use full paths.
+    "
+}
+notes-append "
+To compile and link with ${name}, add\
+-I${prefix}/libexec/ffmpeg${port_ver_major}/include and\
+-L${prefix}/libexec/ffmpeg${port_ver_major}/lib to your compile command.
+For builds using pkg-config, add\
+${prefix}/libexec/ffmpeg${port_ver_major}/lib/pkgconfig to \$PKG_CONFIG_PATH.
+"
 
 livecheck.type      regex
 livecheck.url       ${master_sites}


### PR DESCRIPTION
add usage notes

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
