### PR TITLE
p5-test-simple: Fix dependency cycle

### DIFF
--- a/perl/p5-test-simple/Portfile
+++ b/perl/p5-test-simple/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         Test-Simple 1.302204 ../../authors/id/E/EX/EXODIST
-revision            0
+revision            1
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Test::Simple - Basic utilities for writing tests.
@@ -24,9 +24,16 @@ if {${perl5.major} != ""} {
 
     depends_lib-append \
                     port:p${perl5.major}-data-dumper \
-                    port:p${perl5.major}-module-pluggable \
                     port:p${perl5.major}-term-table \
                     port:p${perl5.major}-time-hires
+
+    # https://trac.macports.org/ticket/70547
+    # depends_lib-append \
+    #               port:p${perl5.major}-module-pluggable
+
+    notes-append    "$subport can optionally use\
+                    p${perl5.major}-module-pluggable,\
+                    but does not depend on it to avoid a dependency cycle."
 
     # As of version 1.302200, Test2::Suite is merged into Test::Simple.
     # Deactivate obsolete port p${perl5.major}-test2-suite, if active,


### PR DESCRIPTION
#### Description

* p5-module-pluggable is optional.  Remove it, fix dependency cycle.
* Add user note for optional dependency.
* Rev bump for dependency change.
* Closes: https://trac.macports.org/ticket/70547

###### Type(s)

- [x] bugfix

###### Tested on

macOS 14.6.1 23G93 Sonoma, x86_64
Xcode 15.4 / Command Line Tools 15.3.0

macOS 14.5 23F79 arm64
Xcode 16.0 16A242d

macOS 10.15.7 Macbookpro mid 2010 Intel i7 x86_64
Xcode 11.5 / Command Line Tools 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -s install`?
- [x] Confirmed absence of dependency cycle?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?