### PR TITLE
p5-object-pad: fix build on old macOS

### DIFF
--- a/perl/p5-object-pad/Portfile
+++ b/perl/p5-object-pad/Portfile
@@ -24,8 +24,12 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-xs-parse-keyword \
                     port:p${perl5.major}-xs-parse-sublike
 
-# uses C99-style struct assignments
+    # uses C99-style struct assignments
     compiler.c_standard 1999
+    # class.c:291: error: ‘ClassMeta’ has no member named ‘cls’
+    # class.c:988: error: ‘ParamMeta’ has no member named ‘adjust’
+    compiler.blacklist-append \
+                        *gcc-4.0 *gcc-4.2
 
     perl5.use_module_build
 }


### PR DESCRIPTION
#### Description

Avoid archaic Xcode gcc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
