### PR TITLE
xcircuit: revbump after ghostscript update

### DIFF
--- a/x11/xcircuit/Portfile
+++ b/x11/xcircuit/Portfile
@@ -5,10 +5,9 @@ PortGroup           active_variants 1.1
 
 name                xcircuit
 version             3.10.30
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          x11 cad
-platforms           darwin
 maintainers         {khindenburg @kurthindenburg} openmaintainer
 # asg subdir licensed for noncommercial use only, linked to GPL code, conflicts.
 license             GPL-2+ Noncommercial Restrictive
@@ -36,7 +35,7 @@ checksums           rmd160  85ceb248824ccb85b39dec4a1e8215273e3c57fe \
 
 depends_build       port:autoconf \
                     port:automake \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:ghostscript \


### PR DESCRIPTION
#### Description

Forgotten revbump

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
