### PR TITLE
osxfuse: fix build for powerpc

### DIFF
--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -163,9 +163,14 @@ pre-build {
 
 if { ! $use_signed_kext } {
     patchfiles      patch-build.d_targets_packagemanager.sh.diff
+
+    if {${configure.build_arch} in [list ppc ppc64]} {
+        patchfiles-append \
+                    patch-fix-valid-archs.diff
+    }
 }
 
-patchfiles-append       patch-IDECustomDerivedData.diff
+patchfiles-append   patch-IDECustomDerivedData.diff
 
 post-patch {
     reinplace "s|@@WORKSRCPATH@@|${worksrcpath}|" ${worksrcpath}/build.sh

--- a/fuse/osxfuse/files/patch-fix-valid-archs.diff
+++ b/fuse/osxfuse/files/patch-fix-valid-archs.diff
@@ -1,0 +1,27 @@
+--- kext/osxfuse.xcodeproj/project.pbxproj	2018-11-10 19:01:00.000000000 +0800
++++ kext/osxfuse.xcodeproj/project.pbxproj	2024-09-28 00:39:47.000000000 +0800
+@@ -466,8 +466,8 @@
+ 				"VALID_ARCHS[sdk=macosx10.12]" = x86_64;
+ 				"VALID_ARCHS[sdk=macosx10.13]" = x86_64;
+ 				"VALID_ARCHS[sdk=macosx10.14]" = x86_64;
+-				"VALID_ARCHS[sdk=macosx10.5]" = "i386 ppc";
+-				"VALID_ARCHS[sdk=macosx10.6]" = "i386 x86_64";
++				"VALID_ARCHS[sdk=macosx10.5]" = "i386 ppc ppc64";
++				"VALID_ARCHS[sdk=macosx10.6]" = "i386 x86_64 ppc";
+ 				"VALID_ARCHS[sdk=macosx10.7]" = "i386 x86_64";
+ 				"VALID_ARCHS[sdk=macosx10.8]" = x86_64;
+ 				"VALID_ARCHS[sdk=macosx10.9]" = x86_64;
+
+--- build.d/defaults.sh	2018-12-18 13:34:11.000000000 +0800
++++ build.d/defaults.sh	2024-09-28 01:02:50.000000000 +0800
+@@ -41,8 +41,8 @@
+ declare -ra DEFAULT_SDK_10_5_ARCHITECURES=("ppc" "ppc64" "i386" "x86_64")
+ declare -r  DEFAULT_SDK_10_5_COMPILER="4.2"
+ 
+-declare -ra DEFAULT_SDK_10_6_ARCHITECURES=("i386" "x86_64")
+-declare -r  DEFAULT_SDK_10_6_COMPILER="com.apple.compilers.llvmgcc42"
++declare -ra DEFAULT_SDK_10_6_ARCHITECURES=("ppc" "i386" "x86_64")
++declare -r  DEFAULT_SDK_10_6_COMPILER="4.2"
+ 
+ declare -ra DEFAULT_SDK_10_7_ARCHITECURES=("i386" "x86_64")
+ declare -r  DEFAULT_SDK_10_7_COMPILER="com.apple.compilers.llvmgcc42"


### PR DESCRIPTION
#### Description

To test https://github.com/macports/macports-ports/pull/25953 in Rosetta I had to fix this first.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Rosetta
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
