### PR TITLE
openssl3: do not build tests by default

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -95,6 +95,7 @@ configure.cmd       ./Configure
 configure.pre_args  --prefix=${my_prefix}
 configure.args      -L${prefix}/lib \
                     --openssldir=${my_prefix}/etc/openssl \
+                    no-tests \
                     shared \
                     zlib
 
@@ -142,9 +143,6 @@ if {(${configure.build_arch} eq "i386") || (${universal_possible} && [variant_is
     configure.args-append   -DBROKEN_CLANG_ATOMICS
 }
 
-test.run            yes
-test.target-append  HARNESS_JOBS=${build.jobs}
-
 pre-destroot {
     if {[variant_exists universal] && [variant_isset universal]} {
         global merger_dont_diff
@@ -182,6 +180,13 @@ variant rfc3779 description {enable RFC 3779: X.509 Extensions for IP Addresses 
 
 variant fips description {enable FIPS} {
     configure.args-append   enable-fips
+}
+
+variant tests description {enable tests} {
+    configure.args-delete   no-tests
+
+    test.run                yes
+    test.target-append      HARNESS_JOBS=${build.jobs}
 }
 
 variant legacy description {enable legacy providers by default} {


### PR DESCRIPTION
#### Description

Avoid building tests by default, move them to a variant.
Building tests takes forever on older hardware, and seems to cause troubles in VM builds.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
