### PR TITLE
llvm-{16,17,18,19,devel}: fix cmake variable handling

### DIFF
--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -60,15 +60,14 @@ cmake.build_type        Release
 cmake.install_rpath
 
 configure.pre_args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib
+    -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib"
 
 configure.pre_args-replace \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
 configure.pre_args-replace \
-    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr" \
+    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;${cmake.install_prefix}\;/usr" \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \

--- a/lang/llvm-17/Portfile
+++ b/lang/llvm-17/Portfile
@@ -64,15 +64,14 @@ cmake.build_type        Release
 cmake.install_rpath
 
 configure.pre_args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib
+    -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib"
 
 configure.pre_args-replace \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
 configure.pre_args-replace \
-    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr" \
+    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;${cmake.install_prefix}\;/usr" \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \

--- a/lang/llvm-18/Portfile
+++ b/lang/llvm-18/Portfile
@@ -64,15 +64,14 @@ cmake.build_type        Release
 cmake.install_rpath
 
 configure.pre_args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib
+    -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib"
 
 configure.pre_args-replace \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
 configure.pre_args-replace \
-    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr" \
+    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;${cmake.install_prefix}\;/usr" \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \
@@ -381,7 +380,7 @@ post-destroot {
         file rename ${destroot}${sub_prefix}/bin/clang-${clang_exe_version} ${destroot}${sub_prefix}/bin/clang
     }
 
-    # If only 'flang-new' created, link to 'flang' 
+    # If only 'flang-new' created, link to 'flang'
     if {[file exists ${destroot}${sub_prefix}/bin/flang-new]} {
         if {![file exists ${destroot}${sub_prefix}/bin/flang]} {
             ln -s ${sub_prefix}/bin/flang-new ${destroot}${sub_prefix}/bin/flang

--- a/lang/llvm-19/Portfile
+++ b/lang/llvm-19/Portfile
@@ -64,15 +64,14 @@ cmake.build_type        Release
 cmake.install_rpath
 
 configure.pre_args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib
+    -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib"
 
 configure.pre_args-replace \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
 configure.pre_args-replace \
-    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr" \
+    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;${cmake.install_prefix}\;/usr" \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \
@@ -376,7 +375,7 @@ post-destroot {
         file rename ${destroot}${sub_prefix}/bin/clang-${clang_exe_version} ${destroot}${sub_prefix}/bin/clang
     }
 
-    # If only 'flang-new' created, link to 'flang' 
+    # If only 'flang-new' created, link to 'flang'
     if {[file exists ${destroot}${sub_prefix}/bin/flang-new]} {
         if {![file exists ${destroot}${sub_prefix}/bin/flang]} {
             ln -s ${sub_prefix}/bin/flang-new ${destroot}${sub_prefix}/bin/flang

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -77,15 +77,14 @@ cmake.build_type        Release
 cmake.install_rpath
 
 configure.pre_args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib
+    -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib"
 
 configure.pre_args-replace \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
 configure.pre_args-replace \
-    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr" \
+    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;${cmake.install_prefix}\;/usr" \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \
@@ -156,9 +155,9 @@ patchfiles-append \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
     0025-lldb-add-defines-needed-for-older-SDKs.patch
 
-# patches that longer apply when cloned from llvmm-17. To be seen if needed still.
-# 0010-compiler-rt-cmake-config-ix.cmake-was-Leopard-No-ASA.patch 
-# 0011-Fix-missing-long-long-math-prototypes-when-using-the.patch 
+# patches that longer apply when cloned from llvm-17. To be seen if needed still.
+# 0010-compiler-rt-cmake-config-ix.cmake-was-Leopard-No-ASA.patch
+# 0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
 
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     patchfiles-append \


### PR DESCRIPTION
The Portfiles for these llvm versions were mishandling `CMAKE_INSTALL_NAME_DIR` in `configure.pre_args-delete`, failing to delete the intended variable set by the _resources/port1.0/group/cmake-1.1.tcl port group because [the port group encloses the value in quotes](https://github.com/macports/macports-ports/blob/a69f475c8f10a886fec1c440a280fdb0cc11362a/_resources/port1.0/group/cmake-1.1.tcl#L236), but the Portfiles omitted the quotes.

`CMAKE_INSTALL_RPATH` was being mishandled in the same way, but because these Portfiles specify `cmake.install_rpath` as empty, [the port group does not set `CMAKE_INSTALL_RPATH` at all](https://github.com/macports/macports-ports/blob/a69f475c8f10a886fec1c440a280fdb0cc11362a/_resources/port1.0/group/cmake-1.1.tcl#L96), so the `configure.pre_args-delete` entry for that variable can be removed from the Portfiles altogether.

These Portfiles’ `configure.pre_args-replace` item for `CMAKE_SYSTEM_PREFIX_PATH` has been updated to reflect [the value actually set by the port group](https://github.com/macports/macports-ports/blob/a69f475c8f10a886fec1c440a280fdb0cc11362a/_resources/port1.0/group/cmake-1.1.tcl#L114).

For llvm-16 and later, these Portfile updates should not cause any meaningful change to the build output, so these Portfiles’ `revision` fields are not updated. This same change would have impact to llvm-15 and earlier. llvm-15 was handled more carefully in #25918, and llvm-14 in #25919. A more comprehensive explanation of the change appears at https://github.com/macports/macports-ports/pull/25918#issuecomment-2377971503.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
