### PR TITLE
uv: Update to 0.4.17

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.4.16
+github.setup            astral-sh uv 0.4.17
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  bcd3fbe3b6d1c2bd59c590fcd4a80f56bb1fe479 \
-                        sha256  28c40f5456afa30fac98bb0f3fe38740d8c3bda9425c75b21044efe30c9c3278 \
-                        size    2685666
+                        rmd160  220ce4547e34061477017cfed3948a72ed625ed4 \
+                        sha256  8fe5579b1235517992622b19f395cfd7fc86b5b532b0e42d881f424f653b324c \
+                        size    2698002
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -83,7 +83,6 @@ cargo.crates \
     axoupdater                       0.7.2  fa6f92ef9ab41a352f403f709ef0f09cda1f461795de52085cd46ed831ead02e \
     backoff                          0.4.0  b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1 \
     backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
-    backtrace-ext                    0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     bisection                        0.1.0  021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.4.17

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
