### PR TITLE
ipsw: Update to 3.1.547

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/blacktop/ipsw 3.1.546 v
+go.setup                github.com/blacktop/ipsw 3.1.547 v
 github.tarball_from     archive
 revision                0
 categories              security devel
@@ -18,9 +18,9 @@ long_description        {*}${description}. Everything you need to start \
 
 homepage                https://blacktop.github.io/ipsw
 
-checksums               rmd160  34b929879a2bbe77b63ad467fcc126fcd9c1496f \
-                        sha256  75e1942b9e6659a60d0ec938f93bf00d3d2bd92719c0d1b4897f2360e1c652a3 \
-                        size    12555070
+checksums               rmd160  ca46026c6d50b6bff13e2651df0d9133fffb9196 \
+                        sha256  48abc9548885bdb78e4f85a6e36ddc6155e89a2addccb74d285bb43db09f2e83 \
+                        size    12557167
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, 3.1.547

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
