### PR TITLE
xmms2: fix the port

### DIFF
--- a/audio/xmms2/Portfile
+++ b/audio/xmms2/Portfile
@@ -2,7 +2,11 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
+PortGroup               legacysupport 1.1
 PortGroup               waf 1.0
+
+# strndup
+legacysupport.newest_darwin_requires_legacy 10
 
 name                    xmms2
 github.setup            xmms2 xmms2-devel 0.9.3
@@ -59,7 +63,15 @@ configure.args          --conf-prefix=${prefix} --with-optionals=
 # 'void (DNSServiceRef, DNSServiceFlags, uint32_t, DNSServiceErrorType,
 # const char *, const char *, uint16_t, uint16_t, const char *, void *)'
 # to parameter of type 'DNSServiceResolveReply'
-configure.cflags-append -Wno-error=incompatible-function-pointer-types
+if {[string match *clang* ${configure.compiler}]} {
+    configure.cflags-append -Wno-error=incompatible-function-pointer-types
+}
+
+# Xcode gcc fails to build this at least due to pragmas inside functions.
+# Rather use a newer compiler than carry a patch indefinitely.
+# This does not hurt, since a newer gcc is strictly required
+# anyway due to several dependencies, beginning from python312.
+compiler.blacklist-append   *gcc-4.0 *gcc-4.2
 
 options optionals
 

--- a/audio/xmms2/Portfile
+++ b/audio/xmms2/Portfile
@@ -27,37 +27,39 @@ checksums               rmd160  b887dcad040dd6f90c14c147faa06821d91e337f \
                         sha256  fe24798db2e6cd8d8eb131ee9800d211525ffebe561c1c5c057710cd7b90a81b \
                         size    1741548
 
-depends_build-append    port:pkgconfig
+depends_build-append    path:bin/pkg-config:pkgconfig
 
 set ffmpeg_ver          6
-depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2 \
+depends_lib-append      port:faad2 \
                         port:ffmpeg${ffmpeg_ver} \
-                        port:libcdio-paranoia \
-                        port:libdiscid \
-                        port:faad2 \
+                        port:fftw-3-single \
                         port:flac \
                         port:fluidsynth \
-                        port:libshout2 \
+                        path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                        port:libcdio-paranoia \
+                        port:libdiscid \
                         port:libmad \
                         port:libmms \
                         port:libmodplug \
-                        port:mpg123 \
                         port:libmpcdec \
-                        port:opusfile \
-                        port:libxml2 \
-                        port:libsndfile \
-                        path:lib/libspeex.dylib:speex \
-                        port:fftw-3-single \
                         port:libsamplerate \
+                        port:libshout2 \
+                        port:libsndfile \
                         port:libvorbis \
+                        port:libxml2 \
+                        port:mpg123 \
+                        port:opusfile \
+                        path:lib/libspeex.dylib:speex \
                         port:wavpack
 
 patchfiles              patch-waftools-podselect.diff
 
 waf.python_branch       3.12
 
-configure.pkg_config_path   ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
-configure.args          --conf-prefix=${prefix} --with-optionals=
+configure.pkg_config_path \
+                        ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
+configure.args          --conf-prefix=${prefix} \
+                        --with-optionals=
 
 # error: incompatible function pointer types passing
 # 'void (DNSServiceRef, DNSServiceFlags, uint32_t, DNSServiceErrorType,

--- a/audio/xmms2/Portfile
+++ b/audio/xmms2/Portfile
@@ -58,8 +58,7 @@ waf.python_branch       3.12
 
 configure.pkg_config_path \
                         ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
-configure.args          --conf-prefix=${prefix} \
-                        --with-optionals=
+configure.args-append   --conf-prefix=${prefix}
 
 # error: incompatible function pointer types passing
 # 'void (DNSServiceRef, DNSServiceFlags, uint32_t, DNSServiceErrorType,
@@ -77,15 +76,22 @@ compiler.blacklist-append   *gcc-4.0 *gcc-4.2
 
 options optionals
 
+options disabled_plugins
+default disabled_plugins {jack pulse}
+
 # not supported
 configure.post_args-delete  --nocache
 
 variant pulse description {Pulseaudio support} {
     depends_lib-append  port:pulseaudio
+
+    disabled_plugins-delete pulse
 }
 
 variant jack description {Jack audio support} {
     depends_lib-append  port:jack
+
+    disabled_plugins-delete jack
 }
 
 variant cpp description {C++ development support} {
@@ -123,8 +129,9 @@ variant python description {Support for Python 3.12} {
 }
 
 pre-configure {
-    configure.args-replace  --with-optionals= \
-                            --with-optionals=[join ${optionals} ,]
+    configure.args-append \
+                        --with-optionals=[join ${optionals} ,] \
+                        --without-plugins=[join ${disabled_plugins} ,]
 }
 
 default_variants +python


### PR DESCRIPTION
#### Description

1. Unbreak build with gcc and on < 10.7.
2. Prevent opportunistic linking to jack and pulseaudio: current variants do not do that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
