### PR TITLE
qt3: remove postgresql variant

### DIFF
--- a/x11/qt3/Portfile
+++ b/x11/qt3/Portfile
@@ -188,14 +188,4 @@ variant odbc description {Enable unixODBC SQL Driver} {
                             -plugin-sql-odbc
 }
 
-variant psql description {Enable PostgreSQL 8.3 SQL Driver} {
-    depends_lib-append      port:postgresql83
-    configure.args-delete   -no-sql-psql
-    configure.args-append   -qt-sql-psql \
-                            -L${prefix}/lib/postgresql83 \
-                            -I${prefix}/include/postgresql83 \
-                            -I${prefix}/include/postgresql83/server \
-                            -plugin-sql-psql
-}
-
 livecheck.type      none


### PR DESCRIPTION
#### Description

The postgresql variant does not build with newer postgresqls so removing it.

I attempted to get the entire thing to compile and it does build on macOS 14! However, there are still enough problems I didn't want to push it all the way through. I left a comment on trac #57350 explaining what I did. However, that ticket is calling for qt3 to be removed anyway which seems sensible.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 x86_64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
