### PR TITLE
pike: remove postgresql variant

### DIFF
--- a/lang/pike/Portfile
+++ b/lang/pike/Portfile
@@ -67,11 +67,6 @@ variant odbc description {ODBC database support for Pike} {
     depends_lib-append port:unixODBC
 }
 
-variant postgresql description {Postgres database support for Pike} {
-    configure.args-append --with-postgres
-    depends_lib-append port:postgresql83
-}
-
 variant gtk description {GTK support for Pike} {
     configure.args-append --with-gtk
     depends_lib-append path:lib/pkgconfig/gtk+-2.0.pc:gtk2


### PR DESCRIPTION
#### Description

I put some effort into trying to get this to build.

- the current portfile does not build, with or without postgresql.
- I tried to update pike as this is a long-outdated version. It seems upstream has redone their build system, the portfile likely needs to be rewritten/redesigned.

I am OK with just disabling the postgresql variant but there's a strong argument to be made here to just remove pike entirely until someone can redo the portfile and get it building again.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 x86_64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
