### PR TITLE
mise: Update to 2024.9.12

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.9.11 v
+github.setup        jdx mise 2024.9.12 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  540a50d08ecacea30cb35e22018bf6444eaafda9 \
-                    sha256  749fee7aacdf4aa104593a43dfbd711e887f22f673eaa08c7b955c9327d84f9f \
-                    size    3136356
+                    rmd160  1dc4ae28f7f90c705fb39ef8a2029f19b1798f5b \
+                    sha256  3e2482ce2f68ba548b83fb18625b62f796a30a9c44d8bd7584ecbfc7696ed690 \
+                    size    3129903
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -344,7 +344,7 @@ cargo.crates \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
-    portable-atomic                  1.8.0  d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce \
+    portable-atomic                  1.9.0  cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
     precomputed-hash                 0.1.1  925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
@@ -444,7 +444,7 @@ cargo.crates \
     tabled                          0.16.0  77c9303ee60b9bedf722012ea29ae3711ba13a67c9b9ae28993838b63057cb1b \
     tabled_derive                    0.8.0  bf0fb8bfdc709786c154e24a66777493fb63ae97e3036d914c8666774c477069 \
     tar                             0.4.42  4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020 \
-    tempfile                        3.12.0  04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64 \
+    tempfile                        3.13.0  f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b \
     tendril                          0.4.3  d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0 \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
@@ -495,7 +495,7 @@ cargo.crates \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                        0.7.4  ef8f6a44b06866b37810400ecc3ee80dd0354448c870a60d424d6ab364c7e50b \
+    usage-lib                        0.8.3  f1ea55fc767a5cbeffacb5740c9e68aea2a78109820bf6ff83fa1b76948ea637 \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \


### PR DESCRIPTION
#### Description

mise: Update to 2024.9.12

##### Tested on

macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
