### PR TITLE
jam: bugfix compatibility with ISO C99

### DIFF
--- a/devel/jam/Portfile
+++ b/devel/jam/Portfile
@@ -35,7 +35,9 @@ universal_variant   yes
 
 patchfiles          patch-Makefile.diff \
                     patch-make1.c.diff \
-                    patch-scan.h.diff
+                    patch-scan.h.diff \
+                    patch-jam.c.diff \
+                    patch-mkjambase.c.diff
 
 post-patch {
     # fix up reminder of Makefile, depending on variants

--- a/devel/jam/files/patch-jam.c.diff
+++ b/devel/jam/files/patch-jam.c.diff
@@ -1,0 +1,11 @@
+--- jam.c.old	2019-06-21 01:12:56
++++ jam.c	2024-09-29 09:52:11
+@@ -166,7 +166,7 @@
+ # endif
+ # endif
+ 
+-main( int argc, char **argv, char **arg_environ )
++int main( int argc, char **argv, char **arg_environ )
+ {
+ 	int		n;
+ 	const char	*s;

--- a/devel/jam/files/patch-mkjambase.c.diff
+++ b/devel/jam/files/patch-mkjambase.c.diff
@@ -1,0 +1,11 @@
+--- mkjambase.c.old	2019-06-21 01:12:56
++++ mkjambase.c	2024-09-29 09:59:25
+@@ -24,7 +24,7 @@
+ # include <stdio.h>
+ # include <string.h>
+ 
+-main( int argc, char **argv, char **envp )
++int main( int argc, char **argv, char **envp )
+ {
+ 	char buf[ 1024 ];
+ 	FILE *fin;


### PR DESCRIPTION
#### Description

building jam failes with quite recent XCode (at least 15 and 16) versions failed with message 
```
jam.c:169:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
mkjambase.c:27:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
```
so fixing these by adding the formerly used "int"  

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
