### PR TITLE
sketchybar: update to 2.21.0

### DIFF
--- a/sysutils/sketchybar/Portfile
+++ b/sysutils/sketchybar/Portfile
@@ -7,7 +7,7 @@ PortGroup               xcodeversion 1.0
 
 minimum_xcodeversions   {19 12.0}
 
-github.setup            FelixKratz SketchyBar 2.13.2 v
+github.setup            FelixKratz SketchyBar 2.21.0 v
 github.tarball_from     archive
 
 categories              sysutils
@@ -20,9 +20,9 @@ long_description        This bar project aims to create a highly flexible, \
                         customizable, fast and powerful status bar replacement \
                         for people that like playing with shell scripts.
 
-checksums               rmd160  c74923251f1d55e4798c5ca1f85ae94aab2ff3bd \
-                        sha256  2b6773f956dcd062f831e80da8445c90473d1a33f1629b4907e9a357ecf23949 \
-                        size    1499784
+checksums               rmd160  31c36e7a2cc2880b00d89a34f4907b1cc9bee5b4 \
+                        sha256  7a35b4079467d7b52edfa103ae33deb0be4133291c32ca4157ba38a9a0742f2a \
+                        size    1666781
 
 post-extract {
     file copy ${filespath}/org.macports.${name}.plist ${worksrcpath}/org.macports.${name}.plist

--- a/sysutils/sketchybar/Portfile
+++ b/sysutils/sketchybar/Portfile
@@ -15,6 +15,7 @@ maintainers             {@bashu gmail.com:bashu.was.here} openmaintainer
 license                 GPL-3
 name                    sketchybar
 revision                0
+supported_archs         x86_64 arm64
 description             Custom macOS statusbar with shell plugin, interaction and graph support
 long_description        This bar project aims to create a highly flexible, \
                         customizable, fast and powerful status bar replacement \
@@ -31,6 +32,15 @@ post-extract {
 post-patch {
     reinplace "s|@NAME@|${name}|g" ${worksrcpath}/org.macports.${name}.plist
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/org.macports.${name}.plist
+}
+
+
+if {${configure.build_arch} == "x86_64"} {
+    build.target "x86"
+} elseif {${configure.build_arch} == "arm64"} {
+    build.target "arm64"
+} elseif {${universal_possible}} {
+    build.target "universal"
 }
 
 destroot {


### PR DESCRIPTION
#### Description

update `sketchybar` to latest release.

###### Tested on

macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
