### PR TITLE
yabai: update to 7.1.4

### DIFF
--- a/sysutils/yabai/Portfile
+++ b/sysutils/yabai/Portfile
@@ -4,19 +4,18 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               makefile 1.0
 
-github.setup            koekeishiya yabai 7.1.1 v
+github.setup            koekeishiya yabai 7.1.4 v
 github.tarball_from     archive
 
 categories              sysutils
-platforms               darwin
 maintainers             {@TheKevJames thekev.in:macports} openmaintainer
 license                 MIT
 description             A tiling window manager for macOS based on binary space partitioning
 long_description        yabai is a window management utility that is designed to work as an extension to the built-in window manager of macOS.
 
-checksums               rmd160  0f93af971652a3373372d612d94627f6b3800d9a \
-                        sha256  a1845ce2a7c0e40abb89958925ab45c2ffba0bf81a59a01fa16956868e91c9b6 \
-                        size    1565680
+checksums               rmd160  c1a88dcb28d0e49a22ed49d90dd02eb8918918fa \
+                        sha256  25ea51fd6d9fa90473f34d4e9742b2bc4823f43dbb3293ecccdb87bf386854b8 \
+                        size    1567797
 
 use_parallel_build      no
 

--- a/sysutils/yabai/Portfile
+++ b/sysutils/yabai/Portfile
@@ -19,6 +19,8 @@ checksums               rmd160  c1a88dcb28d0e49a22ed49d90dd02eb8918918fa \
 
 use_parallel_build      no
 
+compiler.c_standard     2011
+
 destroot {
     # Copy binary
     xinstall -m 755 ${worksrcpath}/bin/yabai ${destroot}${prefix}/bin/yabai

--- a/sysutils/yabai/files/patch-makefile.diff
+++ b/sysutils/yabai/files/patch-makefile.diff
@@ -1,19 +1,19 @@
---- makefile.orig	2022-09-26 10:06:45.000000000 +0200
-+++ makefile	2022-09-26 10:19:48.000000000 +0200
+--- makefile	2024-09-30 00:05:50
++++ makefile.orig	2024-09-30 01:16:00
 @@ -1,7 +1,7 @@
  FRAMEWORK_PATH = -F/System/Library/PrivateFrameworks
  FRAMEWORK      = -framework Carbon -framework Cocoa -framework CoreServices -framework CoreVideo -framework SkyLight
  CLI_FLAGS      =
--BUILD_FLAGS    = -std=c99 -Wall -g -O0 -fvisibility=hidden -mmacosx-version-min=11.0 -fno-objc-arc -arch x86_64 -arch arm64 -sectcreate __TEXT __info_plist $(INFO_PLIST)
-+CFLAGS         += -std=c99 -Wall -DNDEBUG -O3 -fvisibility=hidden -fno-objc-arc -arch x86_64 -arch arm64 -sectcreate __TEXT __info_plist $(INFO_PLIST)
+-BUILD_FLAGS    = -std=c11 -Wall -Wextra -g -O0 -fvisibility=hidden -mmacosx-version-min=11.0 -fno-objc-arc -arch x86_64 -arch arm64 -sectcreate __TEXT __info_plist $(INFO_PLIST)
++CFLAGS         += -std=c11 -Wall -Wextra -DNDEBUG -O3 -fvisibility=hidden -fno-objc-arc -arch x86_64 -arch arm64 -sectcreate __TEXT __info_plist $(INFO_PLIST)
  BUILD_PATH     = ./bin
  DOC_PATH       = ./doc
  SCRIPT_PATH    = ./scripts
 @@ -24,12 +24,12 @@
+ tsan: BUILD_FLAGS=-std=c11 -Wall -Wextra -g -O0 -fvisibility=hidden -fsanitize=thread,undefined -mmacosx-version-min=11.0 -fno-objc-arc -arch x86_64 -arch arm64 -sectcreate __TEXT __info_plist $(INFO_PLIST)
+ tsan: clean-build $(BINS)
  
- all: clean-build $(BINS)
- 
--install: BUILD_FLAGS=-std=c99 -Wall -DNDEBUG -O3 -fvisibility=hidden -mmacosx-version-min=11.0 -fno-objc-arc -arch x86_64 -arch arm64 -sectcreate __TEXT __info_plist $(INFO_PLIST)
+-install: BUILD_FLAGS=-std=c11 -Wall -Wextra -DNDEBUG -O3 -fvisibility=hidden -mmacosx-version-min=11.0 -fno-objc-arc -arch x86_64 -arch arm64 -sectcreate __TEXT __info_plist $(INFO_PLIST)
  install: clean-build $(BINS)
 +	cp $(BINS) $(DESTDIR)/$(PREFIX)/$(BINS)
  


### PR DESCRIPTION
#### Description

update `yabai` to latest release.

###### Tested on

macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
