### PR TITLE
emacs-app-devel: update to 20241021

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -150,15 +150,14 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     depends_lib-delete  port:jansson
     configure.args-append   --with-native-compilation=no
 
-    # TODO: Put this somewhere better. See https://github.com/emacs-mirror/emacs/commit/4c6f45fa8eef1a15d5790c1f3d3e608b548015db#diff-731c852b7c27c6ee90c44c871e2988ecfc2d225bc720156d7a47c1d563c2683aR59
+    # Later-on this could potentially be a variant, given enough demand. See: https://github.com/emacs-mirror/emacs/commit/4c6f45fa8eef1a15d5790c1f3d3e608b548015db#diff-731c852b7c27c6ee90c44c871e2988ecfc2d225bc720156d7a47c1d563c2683aR59
     configure.args-append   --disable-gc-mark-trace
 
     if {[variant_isset nativecomp]} {
         notes "emacs devel subports don't always keep compatibility for native\
  compiled files. Better to cleanup your ~/.emacs.d/.local/cache/eln"
 
-        configure.args-delete   --with-native-compilation=no
-        configure.args-append   --with-native-compilation=aot
+        configure.args-replace  --with-native-compilation=no --with-native-compilation=aot
     }
 } else {
     livecheck.type  regex

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -40,7 +40,9 @@ subport emacs-app-devel {
     conflicts   emacs-app
 }
 
-depends_build-append port:autoconf port:automake port:libtool
+depends_build-append  port:autoconf \
+                      port:automake \
+                      port:libtool
 
 configure.args  --disable-silent-rules \
                 --without-ns \
@@ -75,7 +77,7 @@ depends_lib-append     port:gmp \
                        port:sqlite3 \
                        port:webp
 
-compiler.blacklist-append  *gcc-4.0 *gcc-4.2
+compiler.blacklist-append   *gcc-4.0 *gcc-4.2
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/emacs/${version}/leim
@@ -144,19 +146,19 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     livecheck.type none
 
     # Emacs 30 removes libjansson in favour of native JSON support.
-    configure.args-delete --with-json
-    depends_lib-delete port:jansson
-    configure.args-append --with-native-compilation=no
+    configure.args-delete   --with-json
+    depends_lib-delete  port:jansson
+    configure.args-append   --with-native-compilation=no
 
     # TODO: Put this somewhere better. See https://github.com/emacs-mirror/emacs/commit/4c6f45fa8eef1a15d5790c1f3d3e608b548015db#diff-731c852b7c27c6ee90c44c871e2988ecfc2d225bc720156d7a47c1d563c2683aR59
-    configure.args-append --disable-gc-mark-trace
+    configure.args-append   --disable-gc-mark-trace
 
     if {[variant_isset nativecomp]} {
         notes "emacs devel subports don't always keep compatibility for native\
  compiled files. Better to cleanup your ~/.emacs.d/.local/cache/eln"
 
-        configure.args-delete --with-native-compilation
-        configure.args-append --with-native-compilation=aot
+        configure.args-delete   --with-native-compilation=no
+        configure.args-append   --with-native-compilation=aot
     }
 } else {
     livecheck.type  regex
@@ -180,7 +182,7 @@ if {$subport eq $name || $subport eq "emacs-devel"} {
             --with-lcms2 \
             --without-rsvg \
             --with-xft
-        depends_lib-append      port:xorg-libXmu \
+        depends_lib-append  port:xorg-libXmu \
             port:xorg-libXaw \
             port:xpm \
             path:include/turbojpeg.h:libjpeg-turbo \

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -124,7 +124,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
     github.setup    emacs-mirror emacs a06a7209028363a1bb2f727ffaecdf4d02296b2e
-    epoch           1
+    epoch           6
     version         20240926
     revision        0
 

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -5,6 +5,7 @@ PortGroup       active_variants 1.1
 
 # Need openat()
 PortGroup       legacysupport 1.1
+
 legacysupport.newest_darwin_requires_legacy 13
 
 name            emacs
@@ -122,16 +123,16 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs f70a6ea0ea86ef461e40d20664a75a92d02679ea
-    epoch           5
-    version         20240804
+    github.setup    emacs-mirror emacs a06a7209028363a1bb2f727ffaecdf4d02296b2e
+    epoch           1
+    version         20240926
     revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  12a45be4572b1ab5bb4cd7983673742f984ca52b \
-                    sha256  de8ab5f6bd3f9a269626f3d5110da1a10db71bfade08b8e043643ee9d66e4986 \
-                    size    50643953
+    checksums       rmd160  1363618bfcc9baf1b014bf3434de88908f8df8d8 \
+                    sha256  d40a0e09255d53223485b132887e91b49f7e73a9b68fa5fa74a8a98f32406cee \
+                    size    51693911
 
     patchfiles-append \
                     patch-allow-powerpc-devel.diff
@@ -142,9 +143,20 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     livecheck.type none
 
+    # Emacs 30 removes libjansson in favour of native JSON support.
+    configure.args-delete --with-json
+    depends_lib-delete port:jansson
+    configure.args-append --with-native-compilation=no
+
+    # TODO: Put this somewhere better. See https://github.com/emacs-mirror/emacs/commit/4c6f45fa8eef1a15d5790c1f3d3e608b548015db#diff-731c852b7c27c6ee90c44c871e2988ecfc2d225bc720156d7a47c1d563c2683aR59
+    configure.args-append --disable-gc-mark-trace
+
     if {[variant_isset nativecomp]} {
         notes "emacs devel subports don't always keep compatibility for native\
  compiled files. Better to cleanup your ~/.emacs.d/.local/cache/eln"
+
+        configure.args-delete --with-native-compilation
+        configure.args-append --with-native-compilation=aot
     }
 } else {
     livecheck.type  regex

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -125,16 +125,16 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs a06a7209028363a1bb2f727ffaecdf4d02296b2e
-    epoch           6
-    version         20240926
+    github.setup    emacs-mirror emacs b3af195213518514f78ac6f66f9598e45befd1ec
+    epoch           5
+    version         20241021
     revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  1363618bfcc9baf1b014bf3434de88908f8df8d8 \
-                    sha256  d40a0e09255d53223485b132887e91b49f7e73a9b68fa5fa74a8a98f32406cee \
-                    size    51693911
+    checksums       rmd160  5cfa75f07bd15346f131ec7313939f7ada06251c \
+                    sha256  8ad85e7ee9eaaa193207919d51c1ce26966dde8fe2bc90fa5326ea149ffa4cc8 \
+                    size    51709184
 
     patchfiles-append \
                     patch-allow-powerpc-devel.diff


### PR DESCRIPTION
#### Description

This is a weird one I think since I have chosen to specifically only update emacs-app-devel which also has differing compilation flags (native compilation is now default for example).

As and when Emacs 30 gets released I imagine the Portfile will get simpler, I've been using this general structure since August rebuilding from Emacs' master every other week or so.

###### Tested on

macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
