### PR TITLE
marble: depend on shapelib, revbump

### DIFF
--- a/kde/marble/Portfile
+++ b/kde/marble/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                marble
 version             4.14.3
-revision            5
+revision            6
 categories          kde kde4
 maintainers         nomaintainer
 license             LGPL-2.1+ GFDL-1.2
@@ -13,16 +13,16 @@ description         Virtual Globe
 long_description    KDE virtual globe and world atlas
 homepage            https://www.kde.org
 
-platforms           darwin
-
 master_sites        kde:stable/${version}/src/
 use_xz              yes
 
 checksums           rmd160  13f10ab9fc4d0e963eb258854102172ade68bc91 \
-                    sha256  4d6667cf67ae9976e4c1efc306be222d13f2ee5927483325411ae0e9631dc0f0
+                    sha256  4d6667cf67ae9976e4c1efc306be222d13f2ee5927483325411ae0e9631dc0f0 \
+                    size    19709200
 
 depends_lib-append  port:libkdeedu \
-                    port:gpsd
+                    port:gpsd \
+                    port:shapelib
 
 patchfiles-append   patch-GpsdSymbols.diff \
                     patch-interfaces.diff \


### PR DESCRIPTION
[skip ci]

#### Description

@reneeotten @herbygillot Skipping CI, since all KDE4 stuff broken on CI due to `raptor2` (nothing changed here).

This is needed, however, since it opportunistically links to `shapelib`, which was updated now, and that broke `marble`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
