### PR TITLE
openocd: add variant to enable Remote Bitbang jtag adapter

### DIFF
--- a/cross/openocd/Portfile
+++ b/cross/openocd/Portfile
@@ -165,6 +165,10 @@ variant cmsis description {Enable building support for the cmsis-dap} {
     depends_lib-append  port:hidapi
 }
 
+variant remote_bitbang description {Enable building support for the Remote Bitbang jtag driver} {
+    configure.args-append --enable-remote-bitbang
+}
+
 test.run            yes
 test.target         check
 


### PR DESCRIPTION
#### Description

Adds `remote_bitbang` variant to support building with Remote Bitbang JTAG driver.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
