### PR TITLE
Erlang: Fix incorrect symlink target for erts directory

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -83,7 +83,7 @@ post-destroot   {
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_html_${doc_version}${extract.suffix}]"
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_man_${doc_version}${extract.suffix}]"
 
-    set erts_dir            erts-12.2
+    set erts_dir            erts-15.0
     set erl_interface_dir   erl_interface-5.1
     set wx_dir              wx-2.1.1
 


### PR DESCRIPTION
erts 12.2 doesn't exist, version 15.0 is the one included with Erlang 27. This doesn't resolve the presence of an erts-10.7.2.1 directory - it exists but its purpose is unclear.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0
Xcode 16.1 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
