### PR TITLE
squeak: unbreak build on old systems

### DIFF
--- a/lang/squeak/Portfile
+++ b/lang/squeak/Portfile
@@ -104,17 +104,9 @@ post-destroot {
     system "cd ${destroot}${datadir} && ln -s ${squeak_img_changes}.gz squeak.changes.gz"
 }
 
-# "quartz" support uses NSQuickDrawView
-if {${os.subplatform} eq "macosx" &&
-    ((!(${universal_possible} && [variant_isset universal]) && ![string match *64 ${configure.build_arch}]) ||
-     (${universal_possible} && [variant_isset universal] && ![string match *64* ${configure.universal_archs}]))
-} then {
-    variant quartz {
+variant quartz {
         configure.args-delete   --without-quartz
         configure.args-append   --with-quartz
-    }
-
-    default_variants    +quartz
 }
 
 variant x11 {
@@ -122,4 +114,8 @@ variant x11 {
                                 port:xorg-libsm
         configure.args-delete   --without-x
         configure.args-append   --with-x
+}
+
+if {![variant_isset quartz]} {
+    default_variants            +x11
 }

--- a/lang/squeak/Portfile
+++ b/lang/squeak/Portfile
@@ -104,15 +104,15 @@ post-destroot {
 }
 
 variant quartz {
-        configure.args-delete   --without-quartz
-        configure.args-append   --with-quartz
+        configure.args-replace  --without-quartz \
+                                --with-quartz
 }
 
 variant x11 {
         depends_lib-append      port:mesa \
                                 port:xorg-libsm
-        configure.args-delete   --without-x
-        configure.args-append   --with-x
+        configure.args-replace  --without-x \
+                                --with-x
 }
 
 if {![variant_isset quartz]} {

--- a/lang/squeak/Portfile
+++ b/lang/squeak/Portfile
@@ -71,20 +71,19 @@ destroot.destdir    ROOT=${destroot}
 post-destroot {
     set unzip "[binaryInPath "unzip"] -o"
     set gzip "[binaryInPath "gzip"] -f"
-    
-    set datadir ${prefix}/share/squeak
-    
+
+    set datadir ${prefix}/share/${name}
+
     # Have inisqueak look at the right place
     reinplace "s|MAJOR=3|MAJOR=${squeak_short_vrsn}|" ${worksrcpath}/build/inisqueak
     reinplace "s|imgdir=${prefix}/lib/squeak|imgdir=${datadir}|" ${worksrcpath}/build/inisqueak
 
     # Install inisqueak
     xinstall -m 755 ${worksrcpath}/build/inisqueak ${destroot}${prefix}/bin/
-    
+
     # fix bad doc install path (should use --docdir or --datarootdir during configure)
-    xinstall -d ${destroot}${datadir}
-    move ${destroot}${prefix}/doc ${destroot}${prefix}/share
-    
+    move ${destroot}${prefix}/doc/${name} ${destroot}${prefix}/share/doc/${name}
+
     # Recompress and install the default image
     system "cd ${worksrcpath} && ${unzip} ${distpath}/${squeak_img_src}"
     system "cd ${worksrcpath} && ${gzip} ${squeak_img_name}/${squeak_img}"

--- a/lang/squeak/Portfile
+++ b/lang/squeak/Portfile
@@ -23,7 +23,7 @@ long_description    Squeak is a full-featured implementation of the \
                     distributed freely with a liberal license.
 
 # https://trac.macports.org/ticket/36369
-known_fail          yes
+platforms           {darwin < 12}
 
 homepage            http://www.squeak.org
 


### PR DESCRIPTION
#### Description

1. Unbreak destroot.
2. Remove `known_fail`, replace with version threshold.
3. Default to X11: `quartz` is already used here only on 32-bit archs, and on `ppc` it does not work, no point to keep these ridiculous macros for the sake of `i386`. Just use X11 everywhere by default.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
