### PR TITLE
xvega and friends: set cxx_standard 2017, remove the unnecessary dependency on xtl

### DIFF
--- a/devel/xeus-zmq/Portfile
+++ b/devel/xeus-zmq/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           openssl 1.0
 
 github.setup        jupyter-xeus xeus-zmq 3.1.0
-revision            0
+revision            1
 categories          devel science
 license             BSD
 maintainers         {mps @Schamschula} openmaintainer
@@ -26,7 +26,6 @@ depends_lib-append  port:cppzmq \
                     path:lib/libssl.dylib:openssl \
                     port:xeus \
                     port:xproperty \
-                    port:xtl \
                     port:zmq
 
 # https://trac.macports.org/ticket/66817

--- a/devel/xeus/Portfile
+++ b/devel/xeus/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 github.setup            jupyter-xeus xeus 5.1.1
-revision                0
+revision                1
 categories              devel science
 license                 BSD
 maintainers             {mps @Schamschula} openmaintainer
@@ -25,8 +25,6 @@ compiler.cxx_standard   2017
 depends_build-append    port:pkgconfig \
                         port:cctools
 
-depends_lib-append      port:nlohmann-json \
-                        port:xtl
+depends_lib-append      port:nlohmann-json
 
-configure.args-append   -DCMAKE_PREFIX_PATH=${prefix}/lib/cmake/xtl/xtlConfig.cmake \
-                        -DXEUS_DISABLE_ARCH_NATIVE=ON
+configure.args-append   -DXEUS_DISABLE_ARCH_NATIVE=ON

--- a/devel/xproperty/Portfile
+++ b/devel/xproperty/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        jupyter-xeus xproperty 0.12.0
-revision            0
+revision            1
 categories          devel
 license             Boost
 maintainers         {mps @Schamschula} openmaintainer
@@ -19,5 +19,3 @@ platforms           {darwin any}
 checksums           rmd160  d68113e53b3c8a2677516f9c64f5fe9d1c3ac8e4 \
                     sha256  003c4fde1ba6c47e8709d1f0fc8f542adbacef269ca836ac6423c840b0929f9b \
                     size    42053
-
-depends_lib-append  port:xtl

--- a/graphics/xvega/Portfile
+++ b/graphics/xvega/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        QuantStack xvega 0.1.1
-revision            0
+revision            1
 categories          graphics
 license             BSD
 maintainers         {mps @Schamschula} openmaintainer
@@ -17,11 +17,11 @@ checksums           rmd160  99ee5429db35a4601f95077d12092ae6d00df761 \
                     size    53602
 
 depends_lib-append  port:nlohmann-json \
-                    port:xproperty \
-                    port:xtl
+                    port:xproperty
 
+# title.hpp:10:10: fatal error: 'optional' file not found
 compiler.cxx_standard \
-                    2014
+                    2017
 
 configure.args      -DXVEGA_DISABLE_OPT_NATIVE=ON
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
