### PR TITLE
snownews: fix build on darwin < 16

### DIFF
--- a/net/snownews/Portfile
+++ b/net/snownews/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 
 # clock_gettime()
 legacysupport.newest_darwin_requires_legacy 15
@@ -24,7 +24,7 @@ checksums           rmd160  e9fd727aa4fca5bb83def07a5ac19ff1d70acd7c \
                     size    144174
 
 depends_build-append \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     port:gettext
 
 depends_lib         port:gettext-runtime \
@@ -32,6 +32,11 @@ depends_lib         port:gettext-runtime \
                     port:libxml2 \
                     port:ncurses \
                     port:zlib
+
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    patchfiles-append \
+                    patch-legacy.diff
+}
 
 compiler.c_standard 2011
 # Work around MacPorts base C11 compiler selection bug.

--- a/net/snownews/files/patch-legacy.diff
+++ b/net/snownews/files/patch-legacy.diff
@@ -1,0 +1,11 @@
+--- Makefile	2023-04-13 07:38:01.000000000 +0800
++++ Makefile	2024-09-30 14:16:26.000000000 +0800
+@@ -21,7 +21,7 @@
+ 
+ ${exe}:	${objs}
+ 	@echo "Linking $@ ..."
+-	@${CC} ${ldflags} -o $@ $^ ${libs}
++	@${CC} ${ldflags} -o $@ $^ ${libs} -lMacportsLegacySupport
+ 
+ $O%.o:	%.c
+ 	@echo "    Compiling $< ..."


### PR DESCRIPTION
#### Description

It fails to pass ldflag to legacy-support. Do it manually.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
