### PR TITLE
icmake: Fix building icm-exec and exit if an error occurs

### DIFF
--- a/devel/icmake/Portfile
+++ b/devel/icmake/Portfile
@@ -33,7 +33,8 @@ patchfiles          0001-Use-strictly-compliant-POSIX-BREs-in-build.patch \
                     0003-Index-common-symbols-in-static-archives-in-Mac-build.patch \
                     0004-Correct-some-minor-documentation-errors.patch \
                     0005-Build-verbosely.patch \
-                    0006-Use-MacPorts-install-locations.patch
+                    0006-Use-MacPorts-install-locations.patch \
+                    exit.patch
 patch.pre_args-replace  -p0 -p2
 post-patch {
     reinplace -W ${worksrcpath} s|__MACPORTS__|${prefix}|g \

--- a/devel/icmake/Portfile
+++ b/devel/icmake/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           gitlab 1.0
 
 gitlab.setup        fbb-git icmake 9.03.01
+revision            1
 categories          devel
-platforms           darwin
 license             GPL-3
 maintainers         {larryv @larryv}
 
@@ -62,7 +62,7 @@ configure.cmd       ./icm_prepare
 configure.pre_args  ${prefix}
 # contains.c: error: ‘for’ loop initial declaration used outside C99 mode
 configure.cflags-append \
-                    -std=c99
+                    -std=gnu99
 
 build.env           CC=${configure.cc} \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \

--- a/devel/icmake/files/exit.patch
+++ b/devel/icmake/files/exit.patch
@@ -1,0 +1,13 @@
+Exit if an error occurs while building.
+This fix is already in icmake 10.00.00.
+--- a/icmake/icm_bootstrap.orig	2024-09-30 02:27:52.000000000 -0500
++++ b/icmake/icm_bootstrap	2024-09-30 02:28:58.000000000 -0500
+@@ -28,7 +28,7 @@
+ for target in rss icmake un pp comp exec dep icmbuild
+ do
+     cd $target
+-    ./icm_bootstrap
++    ./icm_bootstrap || exit 1
+     cd ..
+ done
+ 


### PR DESCRIPTION
#### Description

icmake: Fix building icm-exec and exit if an error occurs

Closes: https://trac.macports.org/ticket/70874

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
