### PR TITLE
ffmpeg*: Enable webp

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -18,7 +18,7 @@ set my_name         ffmpeg
 conflicts           ffmpeg7
 
 version             7.0.2
-revision            0
+revision            1
 epoch               2
 
 license             LGPL-2.1+
@@ -95,6 +95,7 @@ depends_lib-append \
                     port:openjpeg \
                     port:soxr \
                     path:lib/libspeex.dylib:speex \
+                    port:webp \
                     port:xz \
                     port:zimg \
                     port:zlib \
@@ -174,7 +175,6 @@ configure.args-append \
                     --disable-libopencore-amrwb \
                     --disable-libplacebo \
                     --disable-libvmaf \
-                    --disable-libwebp \
                     --disable-libxcb \
                     --disable-libxcb-shm \
                     --disable-libxcb-xfixes \
@@ -204,6 +204,7 @@ configure.args-append \
                     --enable-libtheora \
                     --enable-libvorbis \
                     --enable-libvpx \
+                    --enable-libwebp \
                     --enable-libzimg \
                     --enable-libzvbi \
                     --enable-lzma \

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -18,7 +18,7 @@ set my_name         ffmpeg
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            9
+revision            10
 epoch               1
 
 license             LGPL-2.1+
@@ -90,9 +90,11 @@ depends_lib-append \
                     port:libtheora \
                     port:libvorbis \
                     path:lib/pkgconfig/vpx.pc:libvpx \
+                    port:lzo2 \
                     port:openjpeg \
                     port:soxr \
                     path:lib/libspeex.dylib:speex \
+                    port:webp \
                     port:xz \
                     port:zimg \
                     port:zlib \
@@ -195,6 +197,7 @@ configure.args-append \
                     --enable-libtheora \
                     --enable-libvorbis \
                     --enable-libvpx \
+                    --enable-libwebp \
                     --enable-libzimg \
                     --enable-libzvbi \
                     --enable-lzma \

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -17,7 +17,7 @@ name                ffmpeg6
 set my_name         ffmpeg
 
 version             6.1.1
-revision            5
+revision            6
 epoch               0
 
 license             LGPL-2.1+
@@ -93,6 +93,7 @@ depends_lib-append \
                     port:openjpeg \
                     port:soxr \
                     path:lib/libspeex.dylib:speex \
+                    port:webp \
                     port:xz \
                     port:zimg \
                     port:zlib \
@@ -198,6 +199,7 @@ configure.args-append \
                     --enable-libtheora \
                     --enable-libvorbis \
                     --enable-libvpx \
+                    --enable-libwebp \
                     --enable-libzimg \
                     --enable-libzvbi \
                     --enable-lzma \

--- a/multimedia/ffmpeg7/Portfile
+++ b/multimedia/ffmpeg7/Portfile
@@ -13,7 +13,7 @@ set my_name         ffmpeg
 conflicts           ffmpeg-devel
 
 version             7.0.2
-revision            1
+revision            2
 
 license             LGPL-2.1+
 categories          multimedia
@@ -90,6 +90,7 @@ depends_lib-append \
                     port:openjpeg \
                     port:soxr \
                     path:lib/libspeex.dylib:speex \
+                    port:webp \
                     port:xz \
                     port:zimg \
                     port:zlib \
@@ -169,7 +170,6 @@ configure.args-append \
                     --disable-libopencore-amrwb \
                     --disable-libplacebo \
                     --disable-libvmaf \
-                    --disable-libwebp \
                     --disable-libxcb \
                     --disable-libxcb-shm \
                     --disable-libxcb-xfixes \
@@ -199,6 +199,7 @@ configure.args-append \
                     --enable-libtheora \
                     --enable-libvorbis \
                     --enable-libvpx \
+                    --enable-libwebp \
                     --enable-libzimg \
                     --enable-libzvbi \
                     --enable-lzma \


### PR DESCRIPTION
#### Description

ffmpeg-devel: Enable webp 

ffmpeg7: Enable webp 

ffmpeg6: Enable webp 

ffmpeg: Enable webp and lzo2 

Closes: https://trac.macports.org/ticket/70958

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
