### PR TITLE
clang-13, llvm-13, lldb-13: fix for macOS ≥ 14

### DIFF
--- a/lang/llvm-13/Portfile
+++ b/lang/llvm-13/Portfile
@@ -20,15 +20,13 @@ categories              lang
 license                 NCSA
 maintainers             nomaintainer
 
-platforms               {darwin < 23}
-
 set llvm_version        13
 version                 ${llvm_version}.0.1
 
 name                    llvm-${llvm_version}
 revision                2
 subport                 mlir-${llvm_version}  { revision 0 }
-subport                 clang-${llvm_version} { revision 3 }
+subport                 clang-${llvm_version} { revision 4 }
 subport                 lldb-${llvm_version}  { revision 2 }
 subport                 flang-${llvm_version} { revision 0 }
 
@@ -61,15 +59,14 @@ cmake.build_type        Release
 cmake.install_rpath
 
 configure.pre_args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib
+    -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib"
 
 configure.pre_args-replace \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
 configure.pre_args-replace \
-    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr" \
+    -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;${cmake.install_prefix}\;/usr" \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \
@@ -130,9 +127,13 @@ patchfiles-append \
     0015-Fixup-libstdc-header-search-paths-for-older-versions.patch \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
     0025-lldb-add-defines-needed-for-older-SDKs.patch \
+    0028-lldb-Add-cstdio-include-to-fix-a595b931f1f91897317a4.patch \
+    0029-xray-Use-L-instead-of-.L-for-Mach-O.patch \
+    0030-builtins-Move-cfi-start-s-after-the-symbol-name-NFC.patch \
     SyntheticSections.cpp-types.patch \
     patch-lldb-stdc-macros-134877.diff \
-    patch-lldb-fix-swig-lvalue-2128646.diff
+    patch-lldb-fix-swig-lvalue-2128646.diff \
+    patch-xcode-15.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     patchfiles-append \
@@ -442,6 +443,16 @@ post-destroot {
             macos-setup-codesign.sh \
             ${lldb_scripts_destdir}
     }
+
+    if {${subport} eq "clang-${llvm_version}"} {
+        # move libc++ libraries out of default location to prevent accidental linkage
+        set libcxx_dir ${destroot}${sub_prefix}/lib/libc++
+        xinstall -d ${libcxx_dir}
+        foreach f [glob -nocomplain ${destroot}${sub_prefix}/lib/libc++*.*] {
+            ui_debug "Moving ${f} to ${libcxx_dir}"
+            move ${f} ${libcxx_dir}
+        }
+    }
 }
 
 if {${subport} eq "clang-${llvm_version}"} {
@@ -526,6 +537,22 @@ if {${subport} eq "clang-${llvm_version}"} {
     }
     if { ${cxx_stdlib} eq "libstdc++" } {
         default_variants-append +libstdcxx
+    }
+
+    post-configure {
+        # -Wl,-syslibroot referencing the macOS SDK must not appear when linking
+        # runtime libraries for non-macOS platforms, which are cross-built and
+        # used for cross-platform support. The clang build will provide the
+        # proper -isysroot for the platform in these cases. Remove the macOS
+        # SDK.
+        foreach rtl {asan lsan stats tsan ubsan ubsan_minimal} {
+            foreach rtl_os {ios iossim} {
+                set link_txt_path "${workpath}/build/projects/compiler-rt/lib/${rtl}/CMakeFiles/clang_rt.${rtl}_${rtl_os}_dynamic.dir/link.txt"
+                if {[file exists "${link_txt_path}"]} {
+                    reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" "${link_txt_path}"
+                }
+            }
+        }
     }
 }
 

--- a/lang/llvm-13/files/0028-lldb-Add-cstdio-include-to-fix-a595b931f1f91897317a4.patch
+++ b/lang/llvm-13/files/0028-lldb-Add-cstdio-include-to-fix-a595b931f1f91897317a4.patch
@@ -1,0 +1,26 @@
+From 73e15b5edb4fa4a77e68c299a6e3b21e610d351f Mon Sep 17 00:00:00 2001
+From: Dmitry Chernenkov <dmitryc@google.com>
+Date: Tue, 2 May 2023 12:45:28 +0000
+Subject: [PATCH] [lldb] Add cstdio include to fix
+ a595b931f1f91897317a4257df313bddfeb029a6
+
+---
+ lldb/include/lldb/API/SBFile.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lldb/include/lldb/API/SBFile.h b/lldb/include/lldb/API/SBFile.h
+index d8b348b25c81..ebdc5607b794 100644
+--- a/lldb/include/lldb/API/SBFile.h
++++ b/lldb/include/lldb/API/SBFile.h
+@@ -11,6 +11,8 @@
+ 
+ #include "lldb/API/SBDefines.h"
+ 
++#include <cstdio>
++
+ namespace lldb {
+ 
+ class LLDB_API SBFile {
+-- 
+2.46.1
+

--- a/lang/llvm-13/files/0029-xray-Use-L-instead-of-.L-for-Mach-O.patch
+++ b/lang/llvm-13/files/0029-xray-Use-L-instead-of-.L-for-Mach-O.patch
@@ -1,0 +1,121 @@
+From c57c7b7c99605021123b54c02e57943923874cbe Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Fri, 16 Jun 2023 12:04:28 -0700
+Subject: [PATCH] [xray] Use L* instead of .L* for Mach-O
+
+Note: Mach-O support is not yet done and check-xray is not allowed yet.
+---
+ compiler-rt/lib/xray/xray_trampoline_x86_64.S | 28 +++++++++----------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/compiler-rt/lib/xray/xray_trampoline_x86_64.S b/compiler-rt/lib/xray/xray_trampoline_x86_64.S
+index 02cf69f766c4..0f00bcc41508 100644
+--- a/compiler-rt/lib/xray/xray_trampoline_x86_64.S
++++ b/compiler-rt/lib/xray/xray_trampoline_x86_64.S
+@@ -124,14 +124,14 @@ ASM_SYMBOL(__xray_FunctionEntry):
+ 	// On x86/amd64, a simple (type-aligned) MOV instruction is enough.
+ 	movq	ASM_SYMBOL(_ZN6__xray19XRayPatchedFunctionE)(%rip), %rax
+ 	testq	%rax, %rax
+-	je	.Ltmp0
++	je	LOCAL_LABEL(tmp0)
+ 
+ 	// The patched function prologue puts its xray_instr_map index into %r10d.
+ 	movl	%r10d, %edi
+ 	xor	%esi,%esi
+ 	callq	*%rax
+ 
+-.Ltmp0:
++LOCAL_LABEL(tmp0):
+ 	RESTORE_REGISTERS
+ 	RESTORE_STACK_ALIGNMENT
+ 	retq
+@@ -162,13 +162,13 @@ ASM_SYMBOL(__xray_FunctionExit):
+ 	movq	%rdx, 0(%rsp)
+ 	movq	ASM_SYMBOL(_ZN6__xray19XRayPatchedFunctionE)(%rip), %rax
+ 	testq %rax,%rax
+-	je	.Ltmp2
++	je	LOCAL_LABEL(tmp2)
+ 
+ 	movl	%r10d, %edi
+ 	movl	$1, %esi
+ 	callq	*%rax
+ 
+-.Ltmp2:
++LOCAL_LABEL(tmp2):
+ 	// Restore the important registers.
+ 	movq  48(%rsp), %rbp
+ 	movupd	32(%rsp), %xmm0
+@@ -198,13 +198,13 @@ ASM_SYMBOL(__xray_FunctionTailExit):
+ 
+ 	movq	ASM_SYMBOL(_ZN6__xray19XRayPatchedFunctionE)(%rip), %rax
+ 	testq %rax,%rax
+-	je	.Ltmp4
++	je	LOCAL_LABEL(tmp4)
+ 
+ 	movl	%r10d, %edi
+ 	movl	$2, %esi
+ 	callq	*%rax
+ 
+-.Ltmp4:
++LOCAL_LABEL(tmp4):
+ 	RESTORE_REGISTERS
+ 	RESTORE_STACK_ALIGNMENT
+ 	retq
+@@ -227,14 +227,14 @@ ASM_SYMBOL(__xray_ArgLoggerEntry):
+ 	// Again, these function pointer loads must be atomic; MOV is fine.
+ 	movq	ASM_SYMBOL(_ZN6__xray13XRayArgLoggerE)(%rip), %rax
+ 	testq	%rax, %rax
+-	jne	.Larg1entryLog
++	jne	LOCAL_LABEL(arg1entryLog)
+ 
+ 	// If [arg1 logging handler] not set, defer to no-arg logging.
+ 	movq	ASM_SYMBOL(_ZN6__xray19XRayPatchedFunctionE)(%rip), %rax
+ 	testq	%rax, %rax
+-	je	.Larg1entryFail
++	je	LOCAL_LABEL(arg1entryFail)
+ 
+-.Larg1entryLog:
++LOCAL_LABEL(arg1entryLog):
+ 
+ 	// First argument will become the third
+ 	movq	%rdi, %rdx
+@@ -247,7 +247,7 @@ ASM_SYMBOL(__xray_ArgLoggerEntry):
+ 
+ 	callq	*%rax
+ 
+-.Larg1entryFail:
++LOCAL_LABEL(arg1entryFail):
+ 	RESTORE_REGISTERS
+ 	RESTORE_STACK_ALIGNMENT
+ 	retq
+@@ -270,11 +270,11 @@ ASM_SYMBOL(__xray_CustomEvent):
+ 	// already.
+ 	movq ASM_SYMBOL(_ZN6__xray22XRayPatchedCustomEventE)(%rip), %rax
+ 	testq %rax,%rax
+-	je .LcustomEventCleanup
++	je LOCAL_LABEL(customEventCleanup)
+ 
+ 	callq	*%rax
+ 
+-.LcustomEventCleanup:
++LOCAL_LABEL(customEventCleanup):
+ 	RESTORE_REGISTERS
+ 	retq
+ # LLVM-MCA-END
+@@ -296,11 +296,11 @@ ASM_SYMBOL(__xray_TypedEvent):
+ 	// and rdx without our intervention.
+ 	movq ASM_SYMBOL(_ZN6__xray21XRayPatchedTypedEventE)(%rip), %rax
+ 	testq %rax,%rax
+-	je .LtypedEventCleanup
++	je LOCAL_LABEL(typedEventCleanup)
+ 
+ 	callq	*%rax
+ 
+-.LtypedEventCleanup:
++LOCAL_LABEL(typedEventCleanup):
+ 	RESTORE_REGISTERS
+ 	retq
+ # LLVM-MCA-END
+-- 
+2.46.1
+

--- a/lang/llvm-13/files/0030-builtins-Move-cfi-start-s-after-the-symbol-name-NFC.patch
+++ b/lang/llvm-13/files/0030-builtins-Move-cfi-start-s-after-the-symbol-name-NFC.patch
@@ -1,0 +1,32 @@
+From 7939ce39dac0078fef7183d6198598b99c652c88 Mon Sep 17 00:00:00 2001
+From: Jon Roelofs <jonathan_roelofs@apple.com>
+Date: Fri, 17 Nov 2023 14:21:57 -0800
+Subject: [PATCH] [builtins] Move cfi start's after the symbol name [NFC]
+
+... in preparation for diagnosing improperly nested .cfi regions.
+
+See https://reviews.llvm.org/D155245
+---
+ compiler-rt/lib/builtins/assembly.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/compiler-rt/lib/builtins/assembly.h b/compiler-rt/lib/builtins/assembly.h
+index 169d49683f50..8c42fc773483 100644
+--- a/compiler-rt/lib/builtins/assembly.h
++++ b/compiler-rt/lib/builtins/assembly.h
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
+-  CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  name:                                                                        \
++  SEPARATOR CFI_START                                                          \
++  SEPARATOR BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \
+-- 
+2.46.1
+

--- a/lang/llvm-13/files/patch-xcode-15.diff
+++ b/lang/llvm-13/files/patch-xcode-15.diff
@@ -1,0 +1,47 @@
+From 786c10cd82a78c210379700b72cf18a018e1e1f7 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Thu, 28 Sep 2023 11:18:41 -0400
+Subject: [PATCH] [sanitizer] Use consistent checks for XDR
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is a backport of 28800c2e18972935cd4f942aa428c5e6cc4c1670
+(https://reviews.llvm.org/D130060), which is in llvm-15, to llvm-14,
+however it’s been adapted to be
+pre-8246b2e156568c31e71e16cbaf4c14d316e7c06e
+(https://reviews.llvm.org/D126263), which renamed SANITIZER_MAC (the
+macro in llvm-14) to SANITIZER_APPLE (the macro in llvm-15 and later).
+
+The original change’s description:
+
+> sanitizer_platform_limits_posix.h defines `__sanitizer_XDR ` if
+> `SANITIZER_LINUX && !SANITIZER_ANDROID`, but
+> sanitizer_platform_limits_posix.cpp tries to check it if
+> `HAVE_RPC_XDR_H`. This coincidentally works because macOS has a broken
+> <rpc/xdr.h> which causes `HAVE_RPC_XDR_H` to be 0, but if <rpc/xdr.h>
+> is fixed then clang fails to compile on macOS. Restore the platform
+> checks so that <rpc/xdr.h> can be fixed on macOS.
+
+This has become important with Xcode 15, which contains the macOS 14
+SDK, which does have a fixed <rpc/xdr.h>.
+---
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.cpp    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 32b8f47ed633..6cefef3f3327 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -1250,7 +1250,7 @@ CHECK_SIZE_AND_OFFSET(group, gr_passwd);
+ CHECK_SIZE_AND_OFFSET(group, gr_gid);
+ CHECK_SIZE_AND_OFFSET(group, gr_mem);
+ 
+-#if HAVE_RPC_XDR_H
++#if HAVE_RPC_XDR_H && !SANITIZER_MAC
+ CHECK_TYPE_SIZE(XDR);
+ CHECK_SIZE_AND_OFFSET(XDR, x_op);
+ CHECK_SIZE_AND_OFFSET(XDR, x_ops);
+-- 
+2.42.0
+


### PR DESCRIPTION
This rolls up backports of the following fixes for later llvm versions to llvm-13:

93df94134805 clang-14: Fix build under Xcode 15
2605e66ff779 lldb-14: fix build with macOS ≥ 14 SDK (Xcode ≥ 15)
aa0bc47391a7 clang-14: Move libc++*.* libraries to libc++ sub-dir, fix install names
49df5ce7f1f6 clang-14, llvm-14: restore functionality on macOS 15 (Xcode 16)

References: https://trac.macports.org/ticket/68257
References: https://trac.macports.org/ticket/70779

#### Description

This is mostly being done for aa0bc47391a7, which fixes a latent bug on any OS version. The easiest way for me to develop and test that fix was on macOS 15, hence the rest of the change.

@cjones051073

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
