### PR TITLE
wezterm: Update to sha 30345b36d8a00fed347e4df5dadd83915a7693fb

### DIFF
--- a/aqua/wezterm/Portfile
+++ b/aqua/wezterm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        wez wezterm 20240203-110809-5046fc22
+github.setup        wez wezterm 30345b36d8a00fed347e4df5dadd83915a7693fb
 revision            0
 
 homepage            https://wezfurlong.org/wezterm


### PR DESCRIPTION
#### Description

Update `wezterm` to a newer (not yet released) upstream version. Closes https://trac.macports.org/ticket/70833 .

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

`sudo port test` fails with a message that I do not understand. The error is
```
:info:build error: could not load Cargo configuration
:info:build Caused by:
:info:build   could not parse TOML configuration in `/opt/local/var/macports/build/_Users_eschnett_src_macports-ports_aqua_wezterm/wezterm/work/.home/.cargo/config.toml`
:info:build Caused by:
:info:build   TOML parse error at line 14, column 1
:info:build      |
:info:build   14 | [build]
:info:build      | ^
:info:build   invalid table header
:info:build   duplicate key `build` in document root
```
