### PR TITLE
Packwiz: Update to 20240924

### DIFF
--- a/games/packwiz/Portfile
+++ b/games/packwiz/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/packwiz/packwiz 0bb89a4872d8dc2c45af251345ee780cab7ab9ad
+go.setup            github.com/packwiz/packwiz 811dbc6f908b2b34a41abeee1c39839a611dd701
 go.offline_build    no
 
-version             20240808
+version             20240924
 maintainers         {johnlindop.com:git @JLindop} openmaintainer
 revision            0
 
@@ -21,9 +21,9 @@ categories          games
 license             MIT
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  4d8784d0a7222a2933bbfae8601fafb2943d41e7 \
-                        sha256  3d26fb26762d8df1ed5fc3c509409c215f4f6ada41b9ff516ea1df2f3c48a0a5 \
-                        size    90028
+                        rmd160  51d2d17ee1affd2ba3783eb8fea5bf91ca31ea24 \
+                        sha256  82d1fe9da7166fe4c031abe935cfd4890d1f6659f9d55ba8fa0d7385d85357ee \
+                        size    90005
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update Packwiz to 20240924
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
