### PR TITLE
botan: Update to version 3.5.0.; Bugfix

### DIFF
--- a/security/botan/Portfile
+++ b/security/botan/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 name                botan
-version             2.19.5
+version             3.5.0
 revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          security devel
@@ -26,9 +26,9 @@ master_sites        ${homepage}/releases/
 distname            Botan-${version}
 use_xz              yes
 
-checksums           rmd160  b82daea6a81d29aeb425bfceeb80826ff1ee1fb3 \
-                    sha256  dfeea0e0a6f26d6724c4af01da9a7b88487adb2d81ba7c72fcaf52db522c9ad4 \
-                    size    6140148
+checksums           rmd160  174d07e4ffdc193871665b69b18a76f7df8878a0 \
+                    sha256  67e8dae1ca2468d90de4e601c87d5f31ff492b38e8ab8bcbd02ddf7104ed8a9f \
+                    size    7256492
 
 depends_build       port:python312
 depends_lib         port:bzip2 \
@@ -48,6 +48,16 @@ post-patch {
 compiler.cxx_standard   2011
 # botan uses thread_local, which is not supported in Xcode < 8
 compiler.thread_local_storage   yes
+
+# CLT clang build issues, including:
+# https://github.com/randombit/botan/issues/4348
+set os_major_version_clang_issue_arm64  23
+set os_major_version_clang_issue        21
+if {${build_arch} eq {arm64}
+    && ${os.major} >= ${os_major_version_clang_issue_arm64}
+    || ${os.major} == ${os_major_version_clang_issue}} {
+    compiler.blacklist      clang
+}
 
 if {[tbool configure.ccache]} {
     configure.args-append   --cc-bin="${prefix}/bin/ccache ${configure.cxx}"


### PR DESCRIPTION
* Fixes: https://github.com/randombit/botan/issues/4348

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
