### PR TITLE
lldb-13, mlir-13, flang-13: enable on macOS ≥ 14

### DIFF
--- a/lang/llvm-13/Portfile
+++ b/lang/llvm-13/Portfile
@@ -28,7 +28,7 @@ revision                2
 subport                 mlir-${llvm_version}  { revision 0 }
 subport                 clang-${llvm_version} { revision 4 }
 subport                 lldb-${llvm_version}  { revision 2 }
-subport                 flang-${llvm_version} { revision 0 }
+subport                 flang-${llvm_version} { revision 1 }
 
 checksums               rmd160  ae542658ad0e97b4bf088b1cfba66fa10b9b52d8 \
                         sha256  326335a830f2e32d06d0a36393b5455d17dc73e0bd1211065227ee014f92cbf8 \
@@ -263,12 +263,17 @@ if { ${subport} eq "flang-${llvm_version}" } {
     # has to match mlir's archs
     supported_archs     arm64 x86_64
 
+    post-patch {
+        reinplace -E "1s|^#!.*$|#!${prefix}/bin/bash|" ${worksrcpath}/../flang/tools/f18/flang.in
+    }
+
     configure.args-append \
         -DLLVM_ENABLE_PROJECTS="clang\;flang\;compiler-rt\;mlir" \
         -DLIBCXX_ENABLE_SHARED=OFF          \
         -DLIBCXX_INSTALL_LIBRARY=OFF
 
     depends_lib-append  port:clang-${llvm_version} port:mlir-${llvm_version}
+    depends_run-append  port:bash
 
     destroot {
         # we have to run the destroot like this, because individual targets for each of the
@@ -288,7 +293,7 @@ if { ${subport} eq "flang-${llvm_version}" } {
 if { ${subport} eq "mlir-${llvm_version}" ||
      ${subport} eq "flang-${llvm_version}" } {
     # temporarily restrict to newer systems until older systems can be rigorously vetted
-    platforms {darwin >= 10} {darwin < 23}
+    platforms {darwin >= 10}
 }
 
 if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_version}" } {
@@ -339,6 +344,22 @@ if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_versio
         configure.args-append    -DCLANG_ENABLE_CLANGD=OFF \
                                  -DLLVM_ENABLE_BACKTRACES=OFF
     }
+
+    post-configure {
+        # -Wl,-syslibroot referencing the macOS SDK must not appear when linking
+        # runtime libraries for non-macOS platforms, which are cross-built and
+        # used for cross-platform support. The clang/flang build will provide
+        # the proper -isysroot for the platform in these cases. Remove the macOS
+        # SDK.
+        foreach rtl {asan lsan stats tsan ubsan ubsan_minimal} {
+            foreach rtl_os {ios iossim} {
+                set link_txt_path "${workpath}/build/projects/compiler-rt/lib/${rtl}/CMakeFiles/clang_rt.${rtl}_${rtl_os}_dynamic.dir/link.txt"
+                if {[file exists "${link_txt_path}"]} {
+                    reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" "${link_txt_path}"
+                }
+            }
+        }
+    }
 }
 
 if {${subport} eq "lldb-${llvm_version}"} {
@@ -356,7 +377,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     select.file         ${filespath}/mp-${subport}
 
     # error: use of undeclared identifier 'CPU_SUBTYPE_ARM64E
-    platforms {darwin >= 18} {darwin < 23}
+    platforms {darwin >= 18}
 
     configure.args-append \
         -DLLDB_CODESIGN_IDENTITY=- \
@@ -537,22 +558,6 @@ if {${subport} eq "clang-${llvm_version}"} {
     }
     if { ${cxx_stdlib} eq "libstdc++" } {
         default_variants-append +libstdcxx
-    }
-
-    post-configure {
-        # -Wl,-syslibroot referencing the macOS SDK must not appear when linking
-        # runtime libraries for non-macOS platforms, which are cross-built and
-        # used for cross-platform support. The clang build will provide the
-        # proper -isysroot for the platform in these cases. Remove the macOS
-        # SDK.
-        foreach rtl {asan lsan stats tsan ubsan ubsan_minimal} {
-            foreach rtl_os {ios iossim} {
-                set link_txt_path "${workpath}/build/projects/compiler-rt/lib/${rtl}/CMakeFiles/clang_rt.${rtl}_${rtl_os}_dynamic.dir/link.txt"
-                if {[file exists "${link_txt_path}"]} {
-                    reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" "${link_txt_path}"
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
93df94134805 (as fixed by c04f7bf1e4b0) must be made to apply to flang-13 in addition to clang-13, because the sanitizer runtimes are built for both.

flang-mp-13 delegates to a bash wrapper script that uses modern bash-isms not supported by bash-3.2 shipped by Apple in /bin. A run-time dependency on the bash port is added, and the wrapper script is patched to use MacPorts’ bash as its interpreter rather than whatever happens to be first in the PATH.

#### Description

@jmroot @ryandesign

This was requested by https://github.com/macports/macports-ports/commit/9e855c03657030f7cc3c85a41a89e09ae453be67#r147430250.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

macOS 14.7 23H124 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
