### PR TITLE
flang-14: fix for macOS ≥ 14

### DIFF
--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -29,7 +29,7 @@ revision                0
 subport                 mlir-${llvm_version}  { revision 0 }
 subport                 clang-${llvm_version} { revision 3 }
 subport                 lldb-${llvm_version}  { revision 1 }
-subport                 flang-${llvm_version} { revision 0 }
+subport                 flang-${llvm_version} { revision 1 }
 
 checksums               rmd160  2b8b71bbb9fa5718c85f78924a0aa7e700cbd2ee \
                         sha256  8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a \
@@ -269,12 +269,17 @@ if { ${subport} eq "flang-${llvm_version}" } {
     # has to match mlir's archs
     supported_archs     arm64 x86_64
 
+    post-patch {
+        reinplace -E "1s|^#!.*$|#!${prefix}/bin/bash|" ${worksrcpath}/../flang/tools/f18/flang
+    }
+
     configure.args-append \
         -DLLVM_ENABLE_PROJECTS="clang\;flang\;compiler-rt\;mlir" \
         -DLIBCXX_ENABLE_SHARED=OFF          \
         -DLIBCXX_INSTALL_LIBRARY=OFF
 
     depends_lib-append  port:clang-${llvm_version} port:mlir-${llvm_version}
+    depends_run-append  port:bash
 
     destroot {
         # we have to run the destroot like this, because individual targets for each of the
@@ -344,6 +349,23 @@ if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_versio
         # avoid need for thread_local_storage
         configure.args-append    -DCLANG_ENABLE_CLANGD=OFF \
                                  -DLLVM_ENABLE_BACKTRACES=OFF
+    }
+
+    post-configure {
+        # -Wl,-syslibroot referencing the macOS SDK must not appear when linking
+        # runtime libraries for non-macOS platforms, which are cross-built and
+        # used for cross-platform support. The clang and flang builds will
+        # provide the proper -isysroot for the platform in these cases. Remove
+        # the macOS SDK.
+        foreach rtl_dir {asan lsan stats tsan/rtl ubsan ubsan_minimal} {
+            set rtl [lindex [split ${rtl_dir} /] 0]
+            foreach rtl_os {ios iossim} {
+                set link_txt_path "${workpath}/build/projects/compiler-rt/lib/${rtl_dir}/CMakeFiles/clang_rt.${rtl}_${rtl_os}_dynamic.dir/link.txt"
+                if {[file exists "${link_txt_path}"]} {
+                    reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" "${link_txt_path}"
+                }
+            }
+        }
     }
 }
 
@@ -543,23 +565,6 @@ if {${subport} eq "clang-${llvm_version}"} {
     }
     if { ${cxx_stdlib} eq "libstdc++" } {
         default_variants-append +libstdcxx
-    }
-
-    post-configure {
-	# -Wl,-syslibroot referencing the macOS SDK must not appear when linking
-	# runtime libraries for non-macOS platforms, which are cross-built and
-	# used for cross-platform support. The clang build will provide the
-	# proper -isysroot for the platform in these cases. Remove the macOS
-	# SDK.
-        foreach rtl_dir {asan lsan stats tsan/rtl ubsan ubsan_minimal} {
-            set rtl [lindex [split ${rtl_dir} /] 0]
-            foreach rtl_os {ios iossim} {
-                set link_txt_path "${workpath}/build/projects/compiler-rt/lib/${rtl_dir}/CMakeFiles/clang_rt.${rtl}_${rtl_os}_dynamic.dir/link.txt"
-                if {[file exists "${link_txt_path}"]} {
-                    reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" "${link_txt_path}"
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
93df94134805 (as fixed by c04f7bf1e4b0) must be made to apply to flang-14 in addition to clang-14, because the sanitizer runtimes are built for both.

flang-mp-14 delegates to a bash wrapper script that uses modern bash-isms not supported by bash-3.2 shipped by Apple in /bin. A run-time dependency on the bash port is added, and the wrapper script is patched to use MacPorts’ bash as its interpreter rather than whatever happens to be first in the PATH.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

macOS 14.7 23H124 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->