### PR TITLE
pandoc: fixed x86 and arm64 checksums

### DIFF
--- a/textproc/pandoc/Portfile
+++ b/textproc/pandoc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        jgm pandoc 3.4
-revision            0
+revision            1
 categories          textproc haskell
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer
@@ -134,14 +134,14 @@ if {(${os.platform} eq {darwin}
     # run `sudo port clean --all pandoc` afterwards
     switch ${build_arch} {
         arm64 {
-            checksums       rmd160  35b4e308078541b184be314e5933028792003a99 \
-                            sha256  7c67ba6e481a27bcd1dbed3f4de982f2efff6a781c706aee27002e46dee95cce \
-                            size    34709166
+            checksums       rmd160  7788802a963a696e37ca7f6b128579d9466d1557 \
+                            sha256  2bc48ef152d5404cc7d5b98ee01f11af8bd91e503a6e888d2537bd261a578d02 \
+                            size    35849240
         }
         x86_64 {
-            checksums       rmd160  f11004ef5b6b7c7ec0157d79f703ff1374d4063d \
-                            sha256  84cc09fbb8b072076cba829a482ec5a8b46229b80dd9217ea87dcb2166e38245 \
-                            size    21724047
+            checksums       rmd160  05ac3649d76cbb17577e1f6c29aabeb291634c4d \
+                            sha256  fb342213ce16af4a81565f1f106a808574f993900ac914a5737649ba8cedb2b3 \
+                            size    21926889
         }
         default {
             known_fail  yes


### PR DESCRIPTION
#### Description

fixes: https://trac.macports.org/ticket/71002

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?