### PR TITLE
py-bcrypt: Revert to older version on Tiger where Rust unavailable

### DIFF
--- a/python/py-bcrypt/Portfile
+++ b/python/py-bcrypt/Portfile
@@ -37,7 +37,7 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-setuptools
         depends_lib-append  port:py${python.version}-cffi \
                             port:py${python.version}-six
-    } elseif {${configure.build_arch} in [list ppc ppc64]} {
+    } elseif {${configure.build_arch} in [list ppc ppc64] || (${os.platform} eq "darwin" && ${os.major} < 9)} {
         version             3.2.2
         revision            0
         checksums           rmd160  3546659be12b634314e21e4a6b0b4c580efbd314 \


### PR DESCRIPTION


#### Description
We don't have Rust on Darwin 8. We've already carved out an older version of py-bcrypt for PPC machines- this adds anything Darwin 8 to this group. 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.4.11 8S2167 i386
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
