### PR TITLE
go: fix for mismatch rmd160/size

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -139,9 +139,9 @@ if {$subport eq "${name}-devel"} {
                     sha256  d87031194fe3e01abdcaf3c7302148ade97a7add6eac3fec26765bcb3207b80f \
                     size    71637661 \
                     ${go_amdbin_dist} \
-                    rmd160  d87031194fe3e01abdcaf3c7302148ade97a7add6eac3fec26765bcb3207b80f \
+                    rmd160  8a5197a3afffd1f63b289d256764f0544fc6c339 \
                     sha256  445c0ef19d8692283f4c3a92052cc0568f5a048f4e546105f58e991d4aea54f5 \
-                    size    71637661
+                    size    74975218
     }
 
     livecheck.regex {go([0-9.]+)\.src\.tar\.gz}


### PR DESCRIPTION
#### Description

During the last go [go version update](https://github.com/macports/macports-ports/commit/1978d33dc665858eb67ce79024ac671f3a9434fd), there's mismatch of rmd160 & file size checksums.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
