### PR TITLE
google-cloud-sdk: update to 495.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             494.0.0
+version             495.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  64b38fe11ef8c49ef7a6a548324a623c82cf1a6c \
-                    sha256  60d93661bed8abf2270dea3d2214b4d90a137a4a158a70ef1febd61d269bf1d7 \
-                    size    52190060
+    checksums       rmd160  78a81837b5a75bbfd5db7c81d40a99c68f5e1303 \
+                    sha256  f47b767124b519f2612978d51a2866f7e124bd99bd6754c2447760e64a7a7002 \
+                    size    52242752
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  2f6c4e4ff61ebaf6388ccd45f8093b35569bb034 \
-                    sha256  1f430d7a5e6a4921412a6af37e3e0cbdc936496dfd33c59b1d2d0b365641fe36 \
-                    size    53541729
+    checksums       rmd160  e1a5fed87fee459540e973fa3137ce2532174768 \
+                    sha256  3dfb7b0be76ea5668bb6f2c116254a155af6d5d69f61cefa62f0ff65e9874de5 \
+                    size    53596237
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  c174c0413aa622959b377482420b8320f63f3012 \
-                    sha256  39caeeee8104cf4d8e60005314151a59391479a362bd00e709195a02957ed808 \
-                    size    53489007
+    checksums       rmd160  924253f1d6632b3baa83684e4f845a58eaa566bf \
+                    sha256  153b04cda8ebbbf3ea352041329325ddfd3cc190d36eef2b8650adbb39d5eb0a \
+                    size    53543683
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 495.0.0.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?