### PR TITLE
py-makelive: update to 0.6.2

### DIFF
--- a/python/py-makelive/Portfile
+++ b/python/py-makelive/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-makelive
-version             0.6.1
+version             0.6.2
 revision            0
 
 supported_archs     noarch
@@ -27,9 +27,9 @@ long_description    {*}${description} \
 
 homepage            https://pypi.org/project/makelive/
 
-checksums           rmd160  93af83a1dbe563fb03c07a370ce659bdb0d60b14 \
-                    sha256  06371ff4ea6a6046894632f62264c6563559733044c09707685feb4526954eb6 \
-                    size    18549
+checksums           rmd160  12440ba7928fed3d1da24d5986cdfc305eb06ba0 \
+                    sha256  df02b715116e462a3e7316517eb91b8f9a1dbad1d6d41352fd562f44a168e858 \
+                    size    18723
 
 python.versions     312
 


### PR DESCRIPTION
#### Description

Update to MakeLive 0.6.2.

###### Tested on

macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?