### PR TITLE
flang-{15–18}: depend on and use bash

### DIFF
--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -29,7 +29,7 @@ revision                1
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 3 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
-subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
+subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
 checksums               rmd160  a6d22eab24e3143461505c05786015b6f9769f31 \
                         sha256  8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6 \
@@ -281,12 +281,17 @@ if { ${subport} eq "flang-${llvm_version}" } {
     # has to match mlir's archs
     supported_archs     arm64 x86_64
 
+    post-patch {
+        reinplace -E "1s|^#!.*$|#!${prefix}/bin/bash|" ${worksrcpath}/../flang/tools/f18/flang-to-external-fc.in
+    }
+
     configure.args-append \
         -DLLVM_ENABLE_PROJECTS="clang\;flang\;compiler-rt\;mlir" \
         -DLIBCXX_ENABLE_SHARED=OFF          \
         -DLIBCXX_INSTALL_LIBRARY=OFF
 
     depends_lib-append  port:clang-${llvm_version} port:mlir-${llvm_version}
+    depends_run-append  port:bash
 
     destroot {
         # we have to run the destroot like this, because individual targets for each of the

--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -29,7 +29,7 @@ revision                1
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 5 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
-subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
+subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
 checksums               rmd160  b86eeac2e1dd052a182022109374372844934cfc \
                         sha256  ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e \
@@ -313,12 +313,17 @@ if { ${subport} eq "flang-${llvm_version}" } {
     # CMakeLists.txt: flang isn't supported on 32 bit CPUs
     supported_archs     arm64 x86_64
 
+    post-patch {
+        reinplace -E "1s|^#!.*$|#!${prefix}/bin/bash|" ${worksrcpath}/../flang/tools/f18/flang-to-external-fc.in
+    }
+
     configure.args-append \
         -DLLVM_ENABLE_PROJECTS="clang\;flang\;compiler-rt\;mlir" \
         -DLIBCXX_ENABLE_SHARED=OFF          \
         -DLIBCXX_INSTALL_LIBRARY=OFF
 
     depends_lib-append  port:clang-${llvm_version} port:mlir-${llvm_version}
+    depends_run-append  port:bash
 
     destroot {
         # we have to run the destroot like this, because individual targets for each of the

--- a/lang/llvm-17/Portfile
+++ b/lang/llvm-17/Portfile
@@ -31,7 +31,7 @@ revision                1
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 2 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
+subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
 checksums               rmd160  10f44d5a8e3d0d5fc1a1961a8adaac945733ec07 \
                         sha256  58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813 \
@@ -309,12 +309,17 @@ if { ${subport} eq "flang-${llvm_version}" } {
     # CMakeLists.txt: flang isn't supported on 32 bit CPUs
     supported_archs     arm64 x86_64
 
+    post-patch {
+        reinplace -E "1s|^#!.*$|#!${prefix}/bin/bash|" ${worksrcpath}/../flang/tools/f18/flang-to-external-fc.in
+    }
+
     configure.args-append \
         -DLLVM_ENABLE_PROJECTS="clang\;flang\;compiler-rt\;mlir" \
         -DLIBCXX_ENABLE_SHARED=OFF          \
         -DLIBCXX_INSTALL_LIBRARY=OFF
 
     depends_lib-append  port:clang-${llvm_version} port:mlir-${llvm_version}
+    depends_run-append  port:bash
 }
 
 if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_version}" } {

--- a/lang/llvm-18/Portfile
+++ b/lang/llvm-18/Portfile
@@ -31,7 +31,7 @@ revision                0
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 2 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
+subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
 checksums               rmd160  7f2aa95a10e79cd79b52933f0702d70185d7b862 \
                         sha256  0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a \
@@ -266,12 +266,17 @@ if { ${subport} eq "flang-${llvm_version}" } {
     # CMakeLists.txt: flang isn't supported on 32 bit CPUs
     supported_archs     arm64 x86_64
 
+    post-patch {
+        reinplace -E "1s|^#!.*$|#!${prefix}/bin/bash|" ${worksrcpath}/../flang/tools/f18/flang-to-external-fc.in
+    }
+
     configure.args-append \
         -DLLVM_ENABLE_PROJECTS="clang\;flang\;compiler-rt\;mlir" \
         -DLIBCXX_ENABLE_SHARED=OFF          \
         -DLIBCXX_INSTALL_LIBRARY=OFF
 
     depends_lib-append  port:clang-${llvm_version} port:mlir-${llvm_version}
+    depends_run-append  port:bash
 }
 
 if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_version}" } {


### PR DESCRIPTION
#### Description

flang-to-external-fc-mp-{15–18} delegates to a bash wrapper script that uses modern bash-isms not supported by bash-3.2 shipped by Apple in /bin. A run-time dependency on the bash port is added, and the wrapper script is patched to use MacPorts’ bash as its interpreter rather than whatever happens to be first in the PATH.

flang-14 is being handled in #26039, and flang-13 was handled in c8ea54857743.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->