### PR TITLE
PNPM: Update to 9.12.0

### DIFF
--- a/devel/pnpm/Portfile
+++ b/devel/pnpm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pnpm
-version             9.11.0
+version             9.12.0
 revision            0
 
 categories          devel
@@ -18,6 +18,6 @@ long_description    pnpm is a fast, disk space efficient package manager, \
 
 homepage            https://pnpm.io
 
-checksums           rmd160  b9c85f37cae28cdb0660cce4a06782220042c0df \
-                    sha256  1c0e33f70e5df9eede84a357bdfa0b1f9dba6e58194628d48a1055756f553754 \
-                    size    4541843
+checksums           rmd160  1f2838623f1c65d5b28ab678ccf26aa6a7e2bc9a \
+                    sha256  a61b67ff6cc97af864564f4442556c22a04f2e5a7714fbee76a1011361d9b726 \
+                    size    4542556


### PR DESCRIPTION
#### Description
Update PNPM to 9.12.0

Mach-o files for x86 files are present, but all distributions of pnpm include mach-o files for all architechtures. It can't be marked as universal because it depends on node, which doesn't have a universal varient.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0 24A335 arm64
Xcode 16.0 16A242d
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
