### PR TITLE
lerc, tiff: build libLerc.a as subport and let tiff depend on it

### DIFF
--- a/gis/lerc/Portfile
+++ b/gis/lerc/Portfile
@@ -1,19 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+
+name                lerc
+version             4.0.0
 PortGroup           github  1.0
 PortGroup           cmake   1.1
 
 github.setup        Esri lerc 4.0.0 v
 github.tarball_from archive
-revision            1
+revision            2
 
 checksums           rmd160  4db543ea71fe126c94bce3ae8559107b483a4668 \
                     sha256  91431c2b16d0e3de6cbaea188603359f87caed08259a645fd5a3805784ee30a0 \
                     size    4710408
 
 categories          gis
-platforms           darwin
 maintainers         {vince @Veence} openmaintainer
 license             Apache-2
 
@@ -26,3 +28,16 @@ patchfiles          patch-include.diff
 
 
 compiler.cxx_standard 2011
+
+subport ${name}-static {
+    description-append         " (static library only)"
+    depends_lib-append        port:lerc
+    configure.args-append     -DBUILD_SHARED_LIBS=OFF
+
+    # Files are identical from dependent shared library port, so delete them
+    post-destroot {
+        delete ${destroot}${prefix}/include/Lerc_c_api.h
+        delete ${destroot}${prefix}/include/Lerc_types.h
+        delete ${destroot}${prefix}/lib/pkgconfig/Lerc.pc
+    }
+}

--- a/graphics/tiff/Portfile
+++ b/graphics/tiff/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 
 name                tiff
 version             4.7.0
-revision            0
+revision            1
 checksums           rmd160  f307a4810e45a522bd62ff51b314335b08e886cd \
                     sha256  67160e3457365ab96c5b3286a0903aa6e78bdc44c4bc737d2e486bcecb6ba976 \
                     size    3896583
@@ -35,6 +35,7 @@ master_sites        https://download.osgeo.org/libtiff/ \
                     freebsd
 
 depends_lib-append  port:lerc \
+                    port:lerc-static \
                     port:libdeflate \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:xz \


### PR DESCRIPTION
#### Description

Add subport with static version of `lerc` and allow `tiff` port to depend on it. Without `libLerc.a`, the existing `libtiff.a` cannot be used without mixing in a `dylib`.

Closes: https://trac.macports.org/ticket/70727

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7 23H124 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
