### PR TITLE
timescaledb: convert variants to subports

### DIFF
--- a/databases/timescaledb/Portfile
+++ b/databases/timescaledb/Portfile
@@ -5,14 +5,13 @@ PortGroup       compiler_blacklist_versions 1.0
 PortGroup       github    1.0
 PortGroup       perl5     1.0
 
-github.setup    timescale timescaledb 2.16.0
+github.setup    timescale timescaledb 2.16.1
 revision        0
 license         Apache-2
-description     A time-series database that integrates with PostreSQL.
+description     A time-series database that integrates with PostgreSQL.
 maintainers     {blair @blair} openmaintainer
 categories      databases
 conflicts       timescaledb1
-platforms       darwin
 homepage        https://www.timescaledb.com/
 
 long_description \
@@ -23,24 +22,26 @@ long_description \
                 as well as full SQL support. TimescaleDB is packaged \
                 as a PostgreSQL extension.
 
-checksums       rmd160  99ee6705c07bfa82f82c1341f55c19bc149180dc \
-                sha256  5cceccf506a585ad9f78c546eda73fe1a5b8ca8e2d264f62cad958ca9a0af213 \
-                size    7449831
+checksums           rmd160  f657bb86924d61c007522355f45c815e1f60fdc6 \
+                    sha256  a4804e6b5d07465f599b369e3bb0cf8460811d42d2e3a158e41244a7951e86bc \
+                    size    7449735
 
 depends_build   path:bin/cmake:cmake \
                 port:perl${perl5.major} \
                 port:p${perl5.major}-ipc-run
 
-variant postgresql11 conflicts postgresql12 postgresql13 postgresql14 postgresql15 postgresql16 description {Support for PostgreSQL 11.x} {
-    known_fail              yes
-    ui_error                "+postgresql11 variant is not supported in TimescaleDB 2.4.0 or greater"
-    return -code error      "Unsupported variant +postgresql11"
+set postgresql_branches {12 13 14 15 16}
+
+foreach branch ${postgresql_branches} {
+    subport pg${branch}-${name} {
+        set pg postgresql${branch}
+        depends_lib-append      port:${pg}
+        configure.env-append    PATH=${prefix}/lib/${pg}/bin:$::env(PATH)
+    }
 }
 
-variant postgresql12 conflicts postgresql11 postgresql13 postgresql14 postgresql15 postgresql16 description {Support for PostgreSQL 12.x} {
-    depends_lib-append      port:postgresql12
-    configure.env-append    PATH=${prefix}/lib/postgresql12/bin:$::env(PATH)
-
+# End of support branches
+subport pg12-${name} {
     # 2.11.2 is the last version supported for PostgreSQL 12.x.
     # https://github.com/timescale/timescaledb/releases/tag/2.12.0
     github.setup    timescale timescaledb 2.11.2
@@ -50,10 +51,7 @@ variant postgresql12 conflicts postgresql11 postgresql13 postgresql14 postgresql
                     size    7729279
 }
 
-variant postgresql13 conflicts postgresql11 postgresql12 postgresql14 postgresql15 postgresql16 description {Support for PostgreSQL 13.x} {
-    depends_lib-append      port:postgresql13
-    configure.env-append    PATH=${prefix}/lib/postgresql13/bin:$::env(PATH)
-
+subport pg13-${name} {
     # 2.15.3 is the last version supported for PostgreSQL 13.x.
     # https://github.com/timescale/timescaledb/releases/tag/2.16.0
     github.setup    timescale timescaledb 2.15.3
@@ -61,30 +59,6 @@ variant postgresql13 conflicts postgresql11 postgresql12 postgresql14 postgresql
     checksums       rmd160  b94f13ddf31c7e2a79e95d3d1b30ef23ffc4de5c \
                     sha256  70b7aa63558323f60e063c870456fa604d8b89fba8e6dab94aa26c9472b99942 \
                     size    7441397
-}
-
-variant postgresql14 conflicts postgresql11 postgresql12 postgresql13 postgresql15 postgresql16 description {Support for PostgreSQL 14.x} {
-    depends_lib-append      port:postgresql14
-    configure.env-append    PATH=${prefix}/lib/postgresql14/bin:$::env(PATH)
-}
-
-variant postgresql15 conflicts postgresql11 postgresql12 postgresql13 postgresql14 postgresql16 description {Support for PostgreSQL 15.x} {
-    depends_lib-append      port:postgresql15
-    configure.env-append    PATH=${prefix}/lib/postgresql15/bin:$::env(PATH)
-}
-
-variant postgresql16 conflicts postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 description {Support for PostgreSQL 16.x} {
-    depends_lib-append      port:postgresql16
-    configure.env-append    PATH=${prefix}/lib/postgresql16/bin:$::env(PATH)
-}
-
-if {![variant_isset postgresql11] && \
-    ![variant_isset postgresql12] && \
-    ![variant_isset postgresql13] && \
-    ![variant_isset postgresql14] && \
-    ![variant_isset postgresql15] && \
-    ![variant_isset postgresql16] } {
-    default_variants +postgresql16
 }
 
 compiler.c_standard     2011
@@ -113,4 +87,13 @@ github.livecheck.regex  {([0-9.]+)}
 variant timescale_license description {Enable Timescale License code, license will be Timescale License} {
     configure.args-delete   -DAPACHE_ONLY=1
     license                 {Timescale License}
+}
+
+if {${name} eq ${subport}} {
+    PortGroup       stub 1.0
+
+    supported_archs noarch
+
+    # set this stub port depends on its latest subport for legacy
+    depends_lib     port:pg[lindex ${postgresql_branches} end]-${name}
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
* convert variants to subports
* update to 2.16.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Command Line Tools 14.2.0.0.1.1668646533


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
