### PR TITLE
tmux: enable sixel support

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -9,13 +9,13 @@ legacysupport.newest_darwin_requires_legacy 8
 
 github.setup    tmux tmux 3.5a
 if {${subport} eq ${name}} {
-    revision        0
+    revision        1
     conflicts       tmux-devel
 }
 subport tmux-devel {
     github.setup    tmux tmux 7c30056d96689cc8a66c748e7a18e180665b7d14
     version         20240927-[string range ${github.version} 0 6]
-    revision        0
+    revision        1
     conflicts       tmux
 }
 categories      sysutils
@@ -93,6 +93,12 @@ post-destroot {
     xinstall -m 0755 -d ${destroot}${prefix}/share/vim/vimfiles/ftdetect
     xinstall -m 0644 ${filespath}/ftdetect-tmux.vim ${destroot}${prefix}/share/vim/vimfiles/ftdetect/tmux.vim
 }
+
+variant sixel description {Support SIXEL graphics} {
+    configure.args-append   --enable-sixel
+}
+
+default_variants-append +sixel
 
 notes {
     On legacy systems, consider installing port tmux-pasteboard to\


### PR DESCRIPTION
#### Description

tmux added SIXEL support since 3.4, enable this feature during build.

https://github.com/tmux/tmux/blob/2df15ad08c9e4cf286cdb38cb645fc9066c3098d/CHANGES#L102

test method, build and open shell in tmux, install ImageMagick

```
convert /path/to/pic sixel:-
```

You should get a preview of the picture within tmux, if your terminal also support SIXEL images. (terminals including iTerm2, wezterm, etc)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7 21G816 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? (without -t trace mode, which is broken)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
