### PR TITLE
neovim, -devel: update to 0.10.2 and 20240831

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -4,8 +4,8 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            neovim neovim 0.10.1 v
-revision                1
+github.setup            neovim neovim 0.10.2 v
+revision                0
 categories              editors
 maintainers             {raimue @raimue} \
                         {l2dy @l2dy} \
@@ -24,21 +24,19 @@ long_description \
 homepage                https://neovim.io
 
 github.tarball_from     archive
-checksums               rmd160  a49cf46d56f8c01362c349ac0d524d36f13d8d51 \
-                        sha256  edce96e79903adfcb3c41e9a8238511946325ea9568fde177a70a614501af689 \
-                        size    12796966
+checksums               rmd160  4d6f8395afad5763894c2cf60c56ada2a41ed2ad \
+                        sha256  546cb2da9fffbb7e913261344bbf4cf1622721f6c5a67aa77609e976e78b8e89 \
+                        size    12801272
 
 depends_build-append    port:pkgconfig
 
 depends_lib             port:gettext \
                         port:libuv \
                         port:libvterm \
-                        port:libtermkey \
                         port:unibilium \
                         port:msgpack \
                         path:lib/libluajit-5.1.2.dylib:luajit \
                         port:lua51-lpeg \
-                        port:lua51-mpack \
                         port:luv-luajit \
                         port:libiconv \
                         port:tree-sitter
@@ -56,16 +54,25 @@ post-patch {
 }
 
 subport neovim-devel {
-    github.setup    neovim neovim 0c2860d9e5ec5417a94db6e3edd237578b76d418
-    version         20240805-[string range ${github.version} 0 6]
+    # To progress past the 31 Aug 2024 nightly, there needs to be a new release
+    # of utf8proc.
+    #
+    # See: https://github.com/neovim/neovim/commit/26be6446e5ea1c5b22c50bfd9a0e5aa85927aff9
+    # See: https://github.com/JuliaStrings/utf8proc/issues/272
+    github.setup    neovim neovim 53af02adbad049f5fc24540cc0f38fa4f9aadf58
+    version         20240831-[string range ${github.version} 0 6]
     revision        0
 
     github.tarball_from tarball
-    checksums       rmd160  ba12caf9471df0abf6aa229e19ddf9761fefe17c \
-                    sha256  2cce952d8a08276687f9188f1f19ed3de4a6a337abb6769098556872c50114ac \
-                    size    12906200
+    checksums       rmd160  0baf764ccc3bb01d33983c295c03be5426ce0859 \
+                    sha256  ad0278f8dac15fcec59443ac99d42c6bf6ba4c40543889d0763cf2aa455ff690 \
+                    size    12950105
 
     conflicts       neovim
+
+    depends_lib-delete \
+                    port:libvterm \
+                    port:msgpack
 
     depends_lib-append \
                     port:libutf8proc


### PR DESCRIPTION
#### Description

`neovim`: update to 0.10.2:

- removed `lua51-mpack` as a dependency since it's [no longer required][0]
- removed `libtermkey` as a dependency since it's [no longer required][1]

[0]: https://github.com/neovim/neovim/pull/15566
[1]: https://github.com/neovim/neovim/pull/25870

`neovim-devel`: update to 20240831:

- removed `msgpack` as a dependency since it's [no longer required][2]
- removed `libvterm` as a dependency since it's [no longer required][3]

[2]: https://github.com/neovim/neovim/pull/29540
[3]: https://github.com/neovim/neovim/pull/30011

Also note that `neovim-devel` is not progressing past 2024-08-31 until `utf8proc` sees its next release. Versions after this date will fail with a compile error due to a type mismatch.

Fixes: https://trac.macports.org/ticket/70028

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
