### PR TITLE
curl-ca-bundle: dump CA certs from Keychain

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -443,17 +443,17 @@ subport curl-ca-bundle {
     }
 
     notes "
-    curl-ca-bundle downloads CA certificates from Mozilla, merge them with
-    CA certs from Keychain, and save the result into
+    curl-ca-bundle downloads CA certificates from Mozilla, merges them with\
+    CA certs from Keychain, and saves the result into
 
       ${prefix}/share/curl/curl-ca-bundle.crt
 
-    Only certs installed as system CA in 'System Keychains -> System' will
-    be dumped into the bundle file.
-    To update the bundle after a new CA is installed into the Keychain,
-    reactivate the pkg manually
+    Only certs installed as system CA in 'System Keychains -> System' will\
+    be dumped into the bundle file.\
+    To update the bundle after a new CA is installed into the Keychain,\
+    reactivate the pkg manually:
 
-      sudo port deactivate curl-ca-bundle && sudo port activate curl-ca-bundle
+      sudo port -f deactivate curl-ca-bundle && sudo port activate curl-ca-bundle
     "
 
     livecheck.type              regexm

--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -276,7 +276,7 @@ if {${name} eq ${subport}} {
 
 subport curl-ca-bundle {
     # Also increase the revision of privoxy-pki-bundle whenever curl-ca-bundle contents change.
-    revision                    0
+    revision                    1
     categories                  net
     license                     {MPL-2 LGPL-2.1+}
     supported_archs             noarch
@@ -352,9 +352,109 @@ subport curl-ca-bundle {
         set ca_bundle_dir ${prefix}/share/curl
         set openssl_dir ${prefix}/etc/openssl
         xinstall -d ${destroot}${ca_bundle_dir} ${destroot}${openssl_dir}
-        xinstall -m 644 ${worksrcpath}/lib/ca-bundle.crt ${destroot}${ca_bundle_dir}/curl-ca-bundle.crt
+        foreach dst [list mozilla-ca-bundle.crt curl-ca-bundle.crt] {
+            xinstall -m 644 ${worksrcpath}/lib/ca-bundle.crt ${destroot}${ca_bundle_dir}/${dst}
+        }
         ln -s ${ca_bundle_dir}/curl-ca-bundle.crt ${destroot}${openssl_dir}/cert.pem
     }
+
+    post-activate {
+        ui_info "Regenerating CA certificate bundle from keychain, this may take a while..."
+
+        set keychains {
+            /Library/Keychains/System.keychain
+            /System/Library/Keychains/SystemRootCertificates.keychain
+        }
+
+        ui_debug "Fetch certificates from keychains"
+        set certs_list [exec /usr/bin/security find-certificate -a -p {*}$keychains]
+        set certs [regexp -inline -all -- {-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----} $certs_list]
+
+        ui_debug "Filter valid certificates: not expired, SSL root"
+        set checkend_cmd "/usr/bin/openssl x509 -inform pem -checkend 0 -noout"
+        set purpose_cmd "/usr/bin/openssl x509 -inform pem -purpose -noout"
+        set valid_certs {}
+        foreach cert $certs {
+            set status [catch {exec {*}$checkend_cmd << $cert} result]
+            if {$status != 0} {continue}
+            set status [catch {exec {*}$purpose_cmd << $cert} result]
+            if {$status != 0} {continue}
+            if {![string match "*SSL server CA : Yes*" $result]} {continue}
+            lappend valid_certs $cert
+        }
+
+        ui_debug "Filter certificates trusted in keychain"
+        file tempfile tmpfile_path /tmp/macports-${name}.txt
+        set verify_cmd "/usr/bin/security verify-cert -l -L -c $tmpfile_path -p ssl"
+        if {${os.major} >= 17} {append verify_cmd " -R offline"}  ;# high sierra
+        set trusted_certs {}
+        foreach cert $valid_certs {
+            set fobj [open $tmpfile_path w]
+            puts $fobj $cert
+            close $fobj
+            set status [catch {exec {*}$verify_cmd} result]
+            if {$status != 0} {continue}
+            lappend trusted_certs $cert
+        }
+        file delete $tmpfile_path
+
+        ui_debug "Get SHA256 fingerprints for all trusted certs"
+        set fingerprint_cmd "/usr/bin/openssl x509 -inform pem -fingerprint -sha256 -noout"
+        set fingerprints {}
+        foreach cert $trusted_certs {
+            set fingerprint [exec {*}$fingerprint_cmd << $cert]
+            lappend fingerprints $fingerprint
+        }
+
+        ui_debug "Found [llength $trusted_certs] CA certs from Keychain"
+        set print_cmd "/usr/bin/openssl x509 -inform pem -serial -issuer -startdate -enddate -subject -noout"
+        set i 0
+        foreach cert $trusted_certs {
+            incr i
+            set result [exec {*}$print_cmd << $cert]
+            ui_debug "No.${i}:\n${result}\n"
+        }
+
+        ui_debug "Process Mozilla certs downloaded from the package"
+        set pem_file [open "${prefix}/share/curl/mozilla-ca-bundle.crt" r]
+        set pem_certs_list [read $pem_file]
+        close $pem_file
+        set pem_certs [regexp -inline -all -- {-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----} $pem_certs_list]
+        ui_debug "Mozilla CA cert count: [llength $pem_certs]"
+
+        ui_debug "Append new certificates from downloaded"
+        set fingerprint_cmd "/usr/bin/openssl x509 -inform pem -fingerprint -sha256 -noout"
+        foreach cert $pem_certs {
+            set fingerprint [exec {*}$fingerprint_cmd << $cert]
+            if {[lsearch -exact $fingerprints $fingerprint] != -1} {
+                continue
+            }
+            lappend fingerprints $fingerprint
+            lappend trusted_certs $cert
+        }
+        ui_debug "Merged CA cert count: [llength $trusted_certs]"
+
+        set cert_file ${prefix}/share/curl/curl-ca-bundle.crt
+        ui_debug "Write the final trusted certificates"
+        file mkdir [file dirname $cert_file]
+        set cert_fobj [open $cert_file w]
+        puts $cert_fobj [join $trusted_certs "\n"]
+        close $cert_fobj
+    }
+
+    notes "
+    curl-ca-bundle downloads CA certificates from Mozilla, merge them with
+    CA certs from Keychain, and save the result into
+
+      ${prefix}/share/curl/curl-ca-bundle.crt
+
+    Only certs installed as system CA in 'System Keychains -> System' will
+    be dumped into the bundle file.
+    To update the bundle after a new CA is installed into the Keychain,
+    reactivate the pkg manually
+
+      sudo port deactivate curl-ca-bundle && sudo port activate curl-ca-bundle
+    "
 
     livecheck.type              regexm
     livecheck.url               https://hg.mozilla.org/mozilla-central/log/default/${certdata_path}


### PR DESCRIPTION
#### Description

~~Steal~~ Borrow the CA certs handling from [Homebrew's ca-certificates](https://github.com/Homebrew/homebrew-core/blob/master/Formula/c/ca-certificates.rb): download CA certs from Mozilla, dump CA certs (installed by user) from Keychain, and merge them together.

In the intranet of my worksplace, we have internal sites with self-signed certs, thru everyone download and trust a CA. Without change in this PR, i need to add the public key of intranet CA into `curl-ca-bundle.crt` every time it gets updated. And after some investigation, I found the solution from Homebrew and I think it perfect to my situation.

I noticed there is a `certsync` package, which sync CAs from Keychain. But it only uses CAs from the Keychain. While the `curl-ca-bundle` fetches CAs maintained by Mozilla, which is more up-to-update. 

Anyway, I think highly of this merge strategy and it deserves being mentioned, and made this PR.

The code is a line to line adaption from the ruby code from Homebrew ca-certificates, except the `ui_debug` msg I added and kept here.

BTW, since MacPorts is run by user `macports` during installation, only CA certs in "System Keychains -> System", those CA installed for all users on the computer will be dumped. While, Homebrew is run by current user, the certs get dumped may differ with MacPorts.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7 21G816 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? (no trace mode enabled)
- [x] tested basic functionality of all binary files? 
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
