### PR TITLE
ncurses: Portfile update for Linux hosts

### DIFF
--- a/devel/ncurses/Portfile
+++ b/devel/ncurses/Portfile
@@ -64,13 +64,35 @@ post-destroot {
         ln -s lib${f}.${major}.dylib ${destroot}${prefix}/lib/lib${f}w.${major}.dylib
         ln -s lib${f}.a ${destroot}${prefix}/lib/lib${f}w.a
         ln -s ${f}.pc ${destroot}${prefix}/lib/pkgconfig/${f}w.pc
-        reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" ${destroot}${prefix}/lib/pkgconfig/${f}.pc
-        reinplace "s|${archflags}||" ${destroot}${prefix}/lib/pkgconfig/${f}.pc
+        
+        # Check if configure.sdkroot is set and not null
+        if {![info exists configure.sdkroot] || ${configure.sdkroot} eq ""} {
+        } else {
+            reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" ${destroot}${prefix}/lib/pkgconfig/${f}.pc
+        }
+        
+        # Check if archflags is set and not null
+        if {![info exists archflags] || ${archflags} eq ""} {
+        } else {
+            reinplace "s|${archflags}||" ${destroot}${prefix}/lib/pkgconfig/${f}.pc
+        }
     }
+    
     ln -s libncurses.${major}.dylib ${destroot}${prefix}/lib/libtermcap.dylib
     ln -s ncurses6-config ${destroot}${prefix}/bin/ncursesw6-config
-    reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" ${destroot}${prefix}/bin/ncurses6-config
-    reinplace "s|${archflags}||" ${destroot}${prefix}/bin/ncurses6-config
+
+    # Check if configure.sdkroot is set and not null for ncurses6-config
+    if {![info exists configure.sdkroot] || ${configure.sdkroot} eq ""} {
+    } else {
+        reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" ${destroot}${prefix}/bin/ncurses6-config
+    }
+    
+    # Check if archflags is set and not null for ncurses6-config
+    if {![info exists archflags] || ${archflags} eq ""} {
+    } else {
+        reinplace "s|${archflags}||" ${destroot}${prefix}/bin/ncurses6-config
+    }
 }
+
 
 livecheck.regex ${name}-(\[\\d.-\]+)${extract.suffix}


### PR DESCRIPTION
* Updatated the tcl so that sed does not fail when {archflags} or {configure.sdkroot} are empty

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.7 22H123 x86_64
Xcode 14.3.1 14E300c
AND
Linux 6.1.0-22-amd64
Debian clang version 14.0.6
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
