### PR TITLE
gtk3: partially revert d0aca00

### DIFF
--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -282,8 +282,8 @@ variant demos description {Build demos and examples} {
 variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo quartz
     require_active_variants path:lib/pkgconfig/pango.pc:pango quartz
-    require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 quartz
-    require_active_variants libepoxy quartz
+    # +x11 may require glib2 +x11, but that doesn't imply that +quartz requires glib2 +quartz, too
+    # likewise with libepoxy
 
     configure.args-append \
                             -Dx11_backend=false \

--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -282,8 +282,8 @@ variant demos description {Build demos and examples} {
 variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo quartz
     require_active_variants path:lib/pkgconfig/pango.pc:pango quartz
-    require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 quartz
-    require_active_variants libepoxy quartz
+    # +x11 may require glib2 +x11, but that doesn't imply that +quartz requires glib2 +quartz, too
+    # likewise with libepoxy
 
     configure.args-append \
                             -Dx11_backend=false \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/70274

#### Description
PR #23864 added 2 active variants checks to gtk3 on glib2, but really only one of them was needed. This PR removes the unnecessary one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`? (it mentions "`Warning: Unnecessary platforms line as darwin is the default`" in the output, but I don't think that I should fix that here, as that seems off-topic, and it was already there)
- [ ] tried existing tests with `sudo port test`? (it looks like I'll need to review the libepoxy active variants check, too...)
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
