### PR TITLE
fastfetch: update to 2.26.1

### DIFF
--- a/sysutils/fastfetch/Portfile
+++ b/sysutils/fastfetch/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        fastfetch-cli fastfetch 2.25.0
+github.setup        fastfetch-cli fastfetch 2.26.1
 github.tarball_from archive
 revision            0
 
@@ -24,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  07bad93f79c5715f5487544d4c4b335147e82fc1 \
-                    sha256  17ea39fd062d5bccc9c608e868f593a665d569646bc9b447111b3a608b648783 \
-                    size    1110619
+checksums           rmd160  2775411be3aa5d53a18dd55c3c1c61fd8337e348 \
+                    sha256  4320d1c304df6880e8c944e6a36340d12a3340477be40b2ead42be308a7fcdaf \
+                    size    1120664
 
 set py_version      312
 


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
