### PR TITLE
carthage: Update to 0.40.0

### DIFF
--- a/devel/carthage/Portfile
+++ b/devel/carthage/Portfile
@@ -8,7 +8,6 @@ use_xcode           yes
 github.setup        Carthage Carthage 0.39.1
 name                carthage
 categories          devel
-platforms           darwin
 
 universal_variant   no
 license             MIT

--- a/devel/carthage/Portfile
+++ b/devel/carthage/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
 use_xcode           yes
-github.setup        Carthage Carthage 0.39.1
+github.setup        Carthage Carthage 0.40.0
 name                carthage
 categories          devel
 


### PR DESCRIPTION
#### Description

Updates carthage to [0.40.0](https://github.com/Carthage/Carthage/releases/tag/0.40.0).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7 23H124 x86_64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] ~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?~ (N/A) <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
