### PR TITLE
ghidra: update to 11.2

### DIFF
--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -5,10 +5,10 @@ PortGroup           github 1.0
 PortGroup           java 1.0
 PortGroup           app 1.0
 
-github.setup        NationalSecurityAgency ghidra 11.1.1 Ghidra_ _build
-checksums           rmd160  c67db1ba5175ff281d18f88c8b0710578c09f766 \
-                    sha256  e733a601cf4b8ac1482c07b1af827d2bcec7be6bd17c349cf8e049298bb5aa48 \
-                    size    70084743
+github.setup        NationalSecurityAgency ghidra 11.2 Ghidra_ _build
+checksums           rmd160  570f95ba37cae4180b815bc968dab1497803c005 \
+                    sha256  1b893066b55ae58e2f7ca006b4665a2604f47ddbf5de4498f77e2673a1e84105 \
+                    size    70354834
 
 categories          devel
 license             Apache
@@ -18,8 +18,8 @@ description         A software reverse engineering (SRE) suite of tools develope
 long_description    ${description}
 homepage            https://ghidra-sre.org/
 
-java.version        17
-java.fallback       openjdk17
+java.version        21
+java.fallback       openjdk21
 
 universal_variant   no
 depends_build-append    port:gradle
@@ -27,7 +27,7 @@ depends_build-append    port:gradle
 set javadest        ${prefix}/share/java/${name}-${version}
 configure.env-append    GRADLE_USER_HOME=${worksrcpath}
 configure.pre_args  ""
-configure.cmd       gradle -I gradle/support/fetchDependencies.gradle init
+configure.cmd       gradle -I gradle/support/fetchDependencies.gradle
 build.env-append    GRADLE_USER_HOME=${worksrcpath}
 build.env-append    _JAVA_OPTIONS=-Duser.home=${worksrcpath}
 build.cmd           gradle


### PR DESCRIPTION
update java dependency to JDK21

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
