### PR TITLE
webarchiver: update to 0.12

### DIFF
--- a/www/webarchiver/Portfile
+++ b/www/webarchiver/Portfile
@@ -4,8 +4,9 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       xcode 1.0
 
-github.setup    newzealandpaul webarchiver 0.10
-epoch           0
+github.setup    newzealandpaul webarchiver 0.12
+revision        0
+epoch           1
 categories      www
 maintainers     {khindenburg @kurthindenburg} openmaintainer
 license         none
@@ -16,9 +17,31 @@ long_description \
     webarchives (.webarchive) from the command line.\
     webarchiver is compatible with Mac OS X 10.4 (Safari 2.0).
 
-checksums           rmd160  d1651236d5e7d7c6865ab77a4770cb3a791d88b6 \
-                    sha256  36be3cb61df9bbb117766113e4676bb90eb159e436499945147a9d4511f4978d \
-                    size    14399
+checksums           rmd160  d4a837dc229ddf4567384cec56ced764c2f36f9d \
+                    sha256  a2528bb2d208dbd3c9d09fe75b3347ccb516108f7a723986e62914b7af066c87 \
+                    size    26974
+
+xcode.scheme            ${name}
+xcode.configuration     "Release"
+
+# See root6 portfile
+if {${os.platform} eq "darwin" && ${os.major} >= 20} {
+    configure.sdk_version
+}
+
+if {${os.major} >= 22} {
+    xcode.build.settings-append \
+        CODE_SIGN_IDENTITY=-
+} else {
+    xcode.build.settings-append \
+        CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO
+}
+
+# This should be removed if/when dealt with in the xcode portgroup; see:
+# https://trac.macports.org/ticket/57137
+if {[vercmp ${xcodeversion} 12.0] >= 0} {
+    build.pre_args  -derivedDataPath ./DerivedData
+}
 
 destroot {
     xinstall ${worksrcpath}/build/Release/webarchiver ${destroot}${prefix}/bin

--- a/www/webarchiver/Portfile
+++ b/www/webarchiver/Portfile
@@ -29,7 +29,7 @@ if {${os.platform} eq "darwin" && ${os.major} >= 20} {
     configure.sdk_version
 }
 
-if {${os.major} >= 22} {
+if {${os.major} >= 21} {
     xcode.build.settings-append \
         CODE_SIGN_IDENTITY=-
 } else {


### PR DESCRIPTION
In 2020, I inadvertly changed the epoch to 0; set it back to 1

I had to add a large amount of code to get this to compile on a newer
system.   All of them were taken from tickets or other portfiles.


