### PR TITLE
rebase nodejs14->nodejs21 from my own branch

### DIFF
--- a/devel/nodejs14/Portfile
+++ b/devel/nodejs14/Portfile
@@ -14,9 +14,6 @@ deprecated.eol_version  yes
 openssl.branch          1.1
 openssl.configure       pkgconfig build_flags
 
-# on macOS nodejs only builds against libc++
-# this force is OK as node does not link against any other c++ libs
-depends_lib-append      port:libcxx
 configure.cxx_stdlib    libc++
 compiler.cxx_standard   2014
 
@@ -86,8 +83,34 @@ post-patch {
 
 # use the system libuv instead of the bundled version, as it is fixed for older systems
 if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # on macOS nodejs only builds against libc++
+    # this force is OK as node does not link against any other c++ libs
+    # per @kencu, libcxx is only for 10.5 and 10.6 as a prerequisite for an even-newer libcxx (macports-libcxx)
+    depends_lib-append      port:libcxx
     depends_lib-append    path:lib/libuv.dylib:libuv
     configure.args-append --shared-libuv
+}
+
+#apparently even macos14 needs the flags that i originally included for older macs.
+#so i am going to make the 'ignore warnings as errors' applicable for all targets
+configure.cppflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cflags-append     -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cxxflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+
+if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
+    # macports-libcxx is required for all platforms below 10.13, i think.
+    # set it to brosemite and lower (14). increase to 18 if it indeed is up to high sierra.
+    depends_lib-append          port:macports-libcxx
+    depends_build-append        port:macports-libcxx
+    configure.ldflags-append    -L/opt/local/lib/libcxx
+    # as @kencu has stated on the mailing-list, it is preferred to simply add the line 
+    # 
+    # legacysupport.use_mp_libcxx   yes 
+    #
+    # however the stock compiler for 10.7 etc is too old
+    # unless @kencu wants to fix the clash between macports-libcxx headers
+    # and each mp-clang, this will be the solution. i don't see it as problematic.
+
 }
 
 pre-configure {

--- a/devel/nodejs15/Portfile
+++ b/devel/nodejs15/Portfile
@@ -9,9 +9,6 @@ PortGroup               deprecated 1.0
 # https://github.com/nodejs/Release
 deprecated.eol_version  yes
 
-# on macOS nodejs only builds against libc++
-# this force is OK as node does not link against any other c++ libs
-depends_lib-append      port:libcxx
 configure.cxx_stdlib    libc++
 compiler.cxx_standard   2014
 
@@ -51,22 +48,42 @@ depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
 
 use_xcode               yes
 
-# error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
-set min_darwin 13
-if { ${os.major} < ${min_darwin} } {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} requires OSX 10.[expr ${min_darwin} - 4] or newer."
-        return -code error "Unsupported OSX version"
-    }
-}
-
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
         lappend files {*}[rec_glob $dir $pattern]
     }
     return $files
+}
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # on macOS nodejs only builds against libc++
+    # this force is OK as node does not link against any other c++ libs
+    # per @kencu, libcxx is only for 10.5 and 10.6 as a prerequisite for an even-newer libcxx (macports-libcxx)
+    depends_lib-append      port:libcxx
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
+}
+
+#apparently even macos14 needs the flags that i originally included for older macs.
+#so i am going to make the 'ignore warnings as errors' applicable for all targets
+configure.cppflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cflags-append     -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cxxflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+
+if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
+    # macports-libcxx is required for all platforms below 10.13, i think.
+    # set it to brosemite and lower (14). increase to 18 if it indeed is up to high sierra.
+    depends_lib-append          port:macports-libcxx
+    depends_build-append        port:macports-libcxx
+    configure.ldflags-append    -L/opt/local/lib/libcxx
+    # as @kencu has stated on the mailing-list, it is preferred to simply add the line
+    #
+    # legacysupport.use_mp_libcxx   yes
+    #
+    # however the stock compiler for 10.7 etc is too old
+    # unless @kencu wants to fix the clash between macports-libcxx headers
+    # and each mp-clang, this will be the solution. i don't see it as problematic.
 }
 
 configure.python ${prefix}/bin/python3.9

--- a/devel/nodejs16/Portfile
+++ b/devel/nodejs16/Portfile
@@ -10,9 +10,6 @@ PortGroup               deprecated 1.0
 # https://github.com/nodejs/Release
 deprecated.eol_version  yes
 
-# on macOS nodejs only builds against libc++
-# this force is OK as node does not link against any other c++ libs
-depends_lib-append      port:libcxx
 configure.cxx_stdlib    libc++
 compiler.cxx_standard   2014
 
@@ -56,14 +53,35 @@ if {![variant_isset openssl3]} {
     openssl.branch          1.1
 }
 
-# error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
-set min_darwin 13
-if { ${os.major} < ${min_darwin} } {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} requires OSX 10.[expr ${min_darwin} - 4] or newer."
-        return -code error "Unsupported OSX version"
-    }
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # on macOS nodejs only builds against libc++
+    # this force is OK as node does not link against any other c++ libs
+    # per @kencu, libcxx is only for 10.5 and 10.6 as a prerequisite for an even-newer libcxx (macports-libcxx)
+    depends_lib-append      port:libcxx
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
+}
+
+#apparently even macos14 needs the flags that i originally included for older macs.
+#so i am going to make the 'ignore warnings as errors' applicable for all targets
+configure.cppflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cflags-append     -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cxxflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+
+if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
+    # macports-libcxx is required for all platforms below 10.13, i think.
+    # set it to brosemite and lower (14). increase to 18 if it indeed is up to high sierra.
+    depends_lib-append          port:macports-libcxx
+    depends_build-append        port:macports-libcxx
+    configure.ldflags-append    -L/opt/local/lib/libcxx
+    # as @kencu has stated on the mailing-list, it is preferred to simply add the line
+    #
+    # legacysupport.use_mp_libcxx   yes
+    #
+    # however the stock compiler for 10.7 etc is too old
+    # unless @kencu wants to fix the clash between macports-libcxx headers
+    # and each mp-clang, this will be the solution. i don't see it as problematic.
 }
 
 proc rec_glob {basedir pattern} {

--- a/devel/nodejs17/Portfile
+++ b/devel/nodejs17/Portfile
@@ -9,9 +9,6 @@ PortGroup               deprecated 1.0
 # https://github.com/nodejs/Release
 deprecated.eol_version  yes
 
-# on macOS nodejs only builds against libc++
-# this force is OK as node does not link against any other c++ libs
-depends_lib-append      port:libcxx
 configure.cxx_stdlib    libc++
 compiler.cxx_standard   2014
 
@@ -51,14 +48,35 @@ depends_build-append    port:pkgconfig \
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
                         port:zlib
 
-# error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
-set min_darwin 13
-if { ${os.major} < ${min_darwin} } {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} requires OSX 10.[expr ${min_darwin} - 4] or newer."
-        return -code error "Unsupported OSX version"
-    }
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # on macOS nodejs only builds against libc++
+    # this force is OK as node does not link against any other c++ libs
+    # per @kencu, libcxx is only for 10.5 and 10.6 as a prerequisite for an even-newer libcxx (macports-libcxx)
+    depends_lib-append      port:libcxx
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
+}
+
+#apparently even macos14 needs the flags that i originally included for older macs.
+#so i am going to make the 'ignore warnings as errors' applicable for all targets
+configure.cppflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cflags-append     -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cxxflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+
+if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
+    # macports-libcxx is required for all platforms below 10.13, i think.
+    # set it to brosemite and lower (14). increase to 18 if it indeed is up to high sierra.
+    depends_lib-append          port:macports-libcxx
+    depends_build-append        port:macports-libcxx
+    configure.ldflags-append    -L/opt/local/lib/libcxx
+    # as @kencu has stated on the mailing-list, it is preferred to simply add the line
+    #
+    # legacysupport.use_mp_libcxx   yes
+    #
+    # however the stock compiler for 10.7 etc is too old
+    # unless @kencu wants to fix the clash between macports-libcxx headers
+    # and each mp-clang, this will be the solution. i don't see it as problematic.
 }
 
 proc rec_glob {basedir pattern} {

--- a/devel/nodejs18/Portfile
+++ b/devel/nodejs18/Portfile
@@ -4,9 +4,6 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               legacysupport 1.1
 
-# on macOS nodejs only builds against libc++
-# this force is OK as node does not link against any other c++ libs
-depends_lib-append      port:libcxx
 configure.cxx_stdlib    libc++
 compiler.cxx_standard   2014
 
@@ -46,15 +43,37 @@ depends_build-append    port:pkgconfig \
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
                         port:zlib
 
-# error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
-set min_darwin 13
-if { ${os.major} < ${min_darwin} } {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} requires OSX 10.[expr ${min_darwin} - 4] or newer."
-        return -code error "Unsupported OSX version"
-    }
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # on macOS nodejs only builds against libc++
+    # this force is OK as node does not link against any other c++ libs
+    # per @kencu, libcxx is only for 10.5 and 10.6 as a prerequisite for an even-newer libcxx (macports-libcxx)
+    depends_lib-append      port:libcxx
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
 }
+
+#apparently even macos14 needs the flags that i originally included for older macs.
+#so i am going to make the 'ignore warnings as errors' applicable for all targets
+configure.cppflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cflags-append     -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cxxflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+
+if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
+    # macports-libcxx is required for all platforms below 10.13, i think.
+    # set it to brosemite and lower (14). increase to 18 if it indeed is up to high sierra.
+    depends_lib-append          port:macports-libcxx
+    depends_build-append        port:macports-libcxx
+    configure.ldflags-append    -L/opt/local/lib/libcxx
+    # as @kencu has stated on the mailing-list, it is preferred to simply add the line
+    #
+    # legacysupport.use_mp_libcxx   yes
+    #
+    # however the stock compiler for 10.7 etc is too old
+    # unless @kencu wants to fix the clash between macports-libcxx headers
+    # and each mp-clang, this will be the solution. i don't see it as problematic.
+}
+
 
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]

--- a/devel/nodejs19/Portfile
+++ b/devel/nodejs19/Portfile
@@ -9,9 +9,6 @@ PortGroup               deprecated 1.0
 # https://github.com/nodejs/Release
 deprecated.eol_version  yes
 
-# on macOS nodejs only builds against libc++
-# this force is OK as node does not link against any other c++ libs
-depends_lib-append      port:libcxx
 configure.cxx_stdlib    libc++
 compiler.cxx_standard   2014
 
@@ -51,15 +48,37 @@ depends_build-append    port:pkgconfig \
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
                         port:zlib
 
-# error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
-set min_darwin 13
-if { ${os.major} < ${min_darwin} } {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} requires OSX 10.[expr ${min_darwin} - 4] or newer."
-        return -code error "Unsupported OSX version"
-    }
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # on macOS nodejs only builds against libc++
+    # this force is OK as node does not link against any other c++ libs
+    # per @kencu, libcxx is only for 10.5 and 10.6 as a prerequisite for an even-newer libcxx (macports-libcxx)
+    depends_lib-append      port:libcxx
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
 }
+
+#apparently even macos14 needs the flags that i originally included for older macs.
+#so i am going to make the 'ignore warnings as errors' applicable for all targets
+configure.cppflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cflags-append     -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cxxflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+
+if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
+    # macports-libcxx is required for all platforms below 10.13, i think.
+    # set it to brosemite and lower (14). increase to 18 if it indeed is up to high sierra.
+    depends_lib-append          port:macports-libcxx
+    depends_build-append        port:macports-libcxx
+    configure.ldflags-append    -L/opt/local/lib/libcxx
+    # as @kencu has stated on the mailing-list, it is preferred to simply add the line
+    #
+    # legacysupport.use_mp_libcxx   yes
+    #
+    # however the stock compiler for 10.7 etc is too old
+    # unless @kencu wants to fix the clash between macports-libcxx headers
+    # and each mp-clang, this will be the solution. i don't see it as problematic.
+}
+
 
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]

--- a/devel/nodejs20/Portfile
+++ b/devel/nodejs20/Portfile
@@ -4,9 +4,6 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               legacysupport 1.1
 
-# on macOS nodejs only builds against libc++
-# this force is OK as node does not link against any other c++ libs
-depends_lib-append      port:libcxx
 configure.cxx_stdlib    libc++
 compiler.cxx_standard   2014
 
@@ -46,14 +43,35 @@ depends_build-append    port:pkgconfig \
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
                         port:zlib
 
-# error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
-set min_darwin 13
-if { ${os.major} < ${min_darwin} } {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} requires OSX 10.[expr ${min_darwin} - 4] or newer."
-        return -code error "Unsupported OSX version"
-    }
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # on macOS nodejs only builds against libc++
+    # this force is OK as node does not link against any other c++ libs
+    # per @kencu, libcxx is only for 10.5 and 10.6 as a prerequisite for an even-newer libcxx (macports-libcxx)
+    depends_lib-append      port:libcxx
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
+}
+
+#apparently even macos14 needs the flags that i originally included for older macs.
+#so i am going to make the 'ignore warnings as errors' applicable for all targets
+configure.cppflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cflags-append     -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cxxflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+
+if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
+    # macports-libcxx is required for all platforms below 10.13, i think.
+    # set it to brosemite and lower (14). increase to 18 if it indeed is up to high sierra.
+    depends_lib-append          port:macports-libcxx
+    depends_build-append        port:macports-libcxx
+    configure.ldflags-append    -L/opt/local/lib/libcxx
+    # as @kencu has stated on the mailing-list, it is preferred to simply add the line
+    #
+    # legacysupport.use_mp_libcxx   yes
+    #
+    # however the stock compiler for 10.7 etc is too old
+    # unless @kencu wants to fix the clash between macports-libcxx headers
+    # and each mp-clang, this will be the solution. i don't see it as problematic.
 }
 
 proc rec_glob {basedir pattern} {

--- a/devel/nodejs21/Portfile
+++ b/devel/nodejs21/Portfile
@@ -4,9 +4,6 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               legacysupport 1.1
 
-# on macOS nodejs only builds against libc++
-# this force is OK as node does not link against any other c++ libs
-depends_lib-append      port:libcxx
 configure.cxx_stdlib    libc++
 compiler.cxx_standard   2014
 
@@ -46,14 +43,42 @@ depends_build-append    port:pkgconfig \
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
                         port:zlib
 
-# error: 'atomic_load<v8::internal::OwnedVector<const unsigned char> >' is unavailable: introduced in macOS 10.9
-set min_darwin 13
-if { ${os.major} < ${min_darwin} } {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} requires OSX 10.[expr ${min_darwin} - 4] or newer."
-        return -code error "Unsupported OSX version"
-    }
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    # on macOS nodejs only builds against libc++
+    # this force is OK as node does not link against any other c++ libs
+    # per @kencu, libcxx is only for 10.5 and 10.6 as a prerequisite for an even-newer libcxx (macports-libcxx)
+    depends_lib-append      port:libcxx
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
+}
+
+#apparently even macos14 needs the flags that i originally included for older macs.
+#so i am going to make the 'ignore warnings as errors' applicable for all targets
+configure.cppflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cflags-append     -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+configure.cxxflags-append   -Wno-incompatible-function-pointer-types -Wno-enum-constexpr-conversion
+
+if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
+    # macports-libcxx is required for all platforms below 10.13, i think.
+    # set it to brosemite and lower (14). increase to 18 if it indeed is up to high sierra.
+    depends_lib-append          port:macports-libcxx
+    depends_build-append        port:macports-libcxx
+    configure.ldflags-append    -L/opt/local/lib/libcxx
+    # as @kencu has stated on the mailing-list, it is preferred to simply add the line
+    #
+    # legacysupport.use_mp_libcxx   yes
+    #
+    # however the stock compiler for 10.7 etc is too old
+    # unless @kencu wants to fix the clash between macports-libcxx headers
+    # and each mp-clang, this will be the solution. i don't see it as problematic.
+
+    #OSes lower than BROSEMITE need a small patch to avoid the pthread qos API
+    patchfiles nodejs21_plus_pthread_qos_api_guard.patch
+    
+    #if BROSEMITE or newer end up falling in this conditional, uncomment the following
+    #line!
+    #configure.cppflags-append -DON_BROSEMITE_OR_LATER=1
 }
 
 proc rec_glob {basedir pattern} {

--- a/devel/nodejs21/files/nodejs21_plus_pthread_qos_api_guard.patch
+++ b/devel/nodejs21/files/nodejs21_plus_pthread_qos_api_guard.patch
@@ -1,0 +1,36 @@
+--- ./deps/v8/src/base/platform/platform-posix.cc	2024-04-10 05:46:12.000000000 -0700
++++ ./deps/v8/src/base/platform/platform-posix.cc	2024-09-30 19:49:47.000000000 -0700
+@@ -1135,6 +1135,7 @@
+   SetThreadName(thread->name());
+ #if V8_OS_DARWIN
+   switch (thread->priority()) {
++#ifdef ON_BROSEMITE_OR_LATER
+     case Thread::Priority::kBestEffort:
+       pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
+       break;
+@@ -1144,6 +1145,7 @@
+     case Thread::Priority::kUserBlocking:
+       pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0);
+       break;
++#endif
+     case Thread::Priority::kDefault:
+       break;
+   }
+--- ./deps/v8/src/d8/d8.cc	2024-04-10 05:46:13.000000000 -0700
++++ ./deps/v8/src/d8/d8.cc	2024-09-30 19:51:11.000000000 -0700
+@@ -5696,6 +5696,7 @@
+ 
+   v8::V8::InitializeICUDefaultLocation(argv[0], options.icu_data_file);
+ 
++#ifdef ON_BROSEMITE_OR_LATER
+ #ifdef V8_OS_DARWIN
+   if (options.apply_priority) {
+     struct task_category_policy category = {.role =
+@@ -5705,6 +5706,7 @@
+     pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+   }
+ #endif
++#endif
+ 
+ #ifdef V8_INTL_SUPPORT
+   if (options.icu_locale != nullptr) {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
