### PR TITLE
LyX: update to 2.3.8

### DIFF
--- a/aqua/LyX/Portfile
+++ b/aqua/LyX/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 name                LyX
 conflicts           LyX1
-version             2.3.7
+version             2.3.8
 revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          aqua
@@ -29,8 +29,7 @@ depends_lib-append      port:enchant \
                         port:aspell
 
 use_xz              yes
-# not sure why they added this "-1"
-distname            lyx-${version}-1
+distname            lyx-${version}
 worksrcdir          lyx-${version}
 
 master_sites        http://lyx.cybermirror.org/stable/${branch}.x/ \
@@ -38,9 +37,9 @@ master_sites        http://lyx.cybermirror.org/stable/${branch}.x/ \
                     ftp://ftp.ntua.gr/pub/X11/LyX/stable/${branch}.x/ \
                     ftp://ftp.lyx.org/pub/lyx/stable/${branch}.x/
 
-checksums           rmd160  54a5b4cf90e1903516de3ea9da720fc9b3aed567 \
-                    sha256  39be8864fb86b34e88310e70fb80e5e9e296601f0856cf161aa094171718d8ed \
-                    size    16158416
+checksums           rmd160  80b2c53d12b04dd64a6326b4b1ea505dcb352120 \
+                    sha256  7e8f56d148cb459eb00abbe9c6371744e4ff077b842c0024153a3f094b10d4ad \
+                    size    16412700
 
 configure.args      --disable-silent-rules
 


### PR DESCRIPTION
This is the last version in 2.3.x.  In 2.4 there are a lot of changes that are not trival to get it to build ATM.

See: https://trac.macports.org/ticket/70162

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
