### PR TITLE
py-imagecodecs: remove \r in patch header

### DIFF
--- a/python/py-imagecodecs/files/patch-setup.py.diff
+++ b/python/py-imagecodecs/files/patch-setup.py.diff
@@ -1,5 +1,5 @@
---- setup.py.orig	2024-09-21 00:14:09
-+++ setup.py	2024-09-22 20:10:24
+--- setup.py.orig
++++ setup.py
 @@ -594,7 +594,7 @@
      del EXTENSIONS['zlibng']
  


### PR DESCRIPTION
#### Description

While the patch appears to be correct, it seems that `patch` fails to apply it on macOS 12 and older. The file to be patched (`setup.py`) has CRLF line endings, and so does the patch. However, it seems that older versions of patch require that the header lines end with a simple LF. Adjusting the patch file format like that allowed this port to build on my 10.9.5 system.

Git does mess up the line endings sometimes, so I am not 100 % sure that this will work. However, I did try to add a hex printout to the CI log (using `xxd`) to see if the line endings had been touched. The output looks as it should, with `0a` after the three first lines and `0d 0a` after the rest.

This is a vulnerable patch, so I considered other options:
* Use LF only and convert `setup.py` from CRLF to LF before patching it. I would have to use a `sed` since Mac OS X does not have `dos2unix`, or `tr` with a temporary file. That did not feel like a very elegant solution. 
* Use `reinplace` directly in the Portfile. However, the line in question appears more than once, so I would have had to replace the comment line before it instead (for example). That too felt a little too dirty.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
