### PR TITLE
jdk17-graalvm: update minimum OS version

### DIFF
--- a/java/jdk17-graalvm/Portfile
+++ b/java/jdk17-graalvm/Portfile
@@ -2,10 +2,15 @@
 
 PortSystem       1.0
 
-name             jdk17-graalvm
+set feature 17
+name             jdk${feature}-graalvm
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11
+# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 20 }
+
 # GraalVM Free Terms and Conditions: https://www.oracle.com/downloads/licenses/graal-free-license.html
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GFTC NoMirror
@@ -15,11 +20,11 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava17-mac
 supported_archs  x86_64 arm64
 
-version     17.0.12
+version     ${feature}.0.12
 set build 8
 revision    0
 
-master_sites https://download.oracle.com/graalvm/17/archive/
+master_sites https://download.oracle.com/graalvm/${feature}/archive/
 
 homepage     https://www.oracle.com/java/graalvm/
 
@@ -28,8 +33,8 @@ livecheck.type  none
 use_configure    no
 build {}
 
-description  Oracle GraalVM for JDK 17
-long_description Oracle GraalVM for JDK 17 compiles your Java applications ahead of time into standalone \
+description  Oracle GraalVM for JDK ${feature}
+long_description Oracle GraalVM for JDK ${feature} compiles your Java applications ahead of time into standalone \
     binaries that start instantly, provide peak performance with no warmup, and use fewer cloud resources.
 
 if {${configure.build_arch} eq "x86_64"} {
@@ -75,7 +80,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-17-oracle-graalvm.jdk
+set jdk ${jvms}/jdk-${feature}-oracle-graalvm.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Correct the minimum OS version. Also see https://trac.macports.org/ticket/71045.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?