### PR TITLE
openjdk21-corretto: update minimum OS version

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -2,13 +2,15 @@
 
 PortSystem       1.0
 
-name             openjdk21-corretto
+set feature 21
+name             openjdk${feature}-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto
-# and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any} {darwin >= 21}
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11.0:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 20 }
 
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -19,10 +21,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      21.0.4.7.1
+version      ${feature}.0.4.7.1
 revision     0
 
-description  Amazon Corretto OpenJDK 21 (Long Term Support)
+description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
 
 master_sites https://corretto.aws/downloads/resources/${version}/
@@ -39,13 +41,13 @@ if {${configure.build_arch} eq "x86_64"} {
                  size    201257714
 }
 
-worksrcdir   amazon-corretto-21.jdk
+worksrcdir   amazon-corretto-${feature}.jdk
 
 homepage     https://aws.amazon.com/corretto/
 
 livecheck.type      regex
-livecheck.url       https://github.com/corretto/corretto-21/releases
-livecheck.regex     amazon-corretto-(21\.\[0-9\.\]+)-macosx-.*\.tar\.gz
+livecheck.url       https://github.com/corretto/corretto-${feature}/releases
+livecheck.regex     amazon-corretto-(${feature}\.\[0-9\.\]+)-macosx-.*\.tar\.gz
 
 use_configure    no
 build {}
@@ -79,7 +81,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-21-amazon-corretto.jdk
+set jdk ${jvms}/jdk-${feature}-amazon-corretto.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Correct the minimum OS version. Also see https://trac.macports.org/ticket/71045.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?