### PR TITLE
openjdk21-zulu: update minimum OS version

### DIFF
--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -2,10 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk21-zulu
+set feature 21
+name             openjdk${feature}-zulu
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11.00.00:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 20 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,12 +20,12 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk#zulu
-version      21.36.17
+version      ${feature}.36.17
 revision     0
 
-set openjdk_version 21.0.4
+set openjdk_version ${feature}.0.4
 
-description  Azul Zulu Community OpenJDK 21 (Long Term Support)
+description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
                  specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
                  verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
@@ -39,13 +45,13 @@ if {${configure.build_arch} eq "x86_64"} {
                  size    207089625
 }
 
-worksrcdir   ${distname}/zulu-21.jdk
+worksrcdir   ${distname}/zulu-${feature}.jdk
 
 homepage     https://www.azul.com/downloads/
 
 livecheck.type      regex
 livecheck.url       https://cdn.azul.com/zulu/bin/
-livecheck.regex     zulu(21\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
+livecheck.regex     zulu(${feature}\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
 
 use_configure    no
 build {}
@@ -79,7 +85,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-21-azul-zulu.jdk
+set jdk ${jvms}/jdk-${feature}-azul-zulu.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Correct the minimum OS version. Also see https://trac.macports.org/ticket/71045.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?