### PR TITLE
openjdk21-temurin: update minimum OS version

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -2,10 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk21-temurin
+set feature 21
+name             openjdk${feature}-temurin
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11.00.00:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 20 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,22 +20,22 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      21.0.4
+version      ${feature}.0.4
 set build    7
 revision     0
 
-description  Eclipse Temurin, based on OpenJDK 21
+description  Eclipse Temurin, based on OpenJDK ${feature}
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
 
-master_sites https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${version}%2B${build}/
+master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk-${version}%2B${build}/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     OpenJDK21U-jdk_x64_mac_hotspot_${version}_${build}
+    distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
     checksums    rmd160  80c32d2faf305235166539047a0e5bc429e684f8 \
                  sha256  e368e5de7111aa88e6bbabeff6f4c040772b57fb279cc4e197b51654085bbc18 \
                  size    194603417
 } elseif {${configure.build_arch} eq "arm64"} {
-    distname     OpenJDK21U-jdk_aarch64_mac_hotspot_${version}_${build}
+    distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
     checksums    rmd160  5c2b2789ac884083614a599767c4777a55080269 \
                  sha256  dcf69a21601d9b1b25454bbad4f0f32784bb42cdbe4063492e15a851b74cb61e \
                  size    192096746
@@ -40,8 +46,8 @@ worksrcdir   jdk-${version}+${build}
 homepage     https://adoptium.net
 
 livecheck.type      regex
-livecheck.url       https://github.com/adoptium/temurin21-binaries/releases
-livecheck.regex     OpenJDK21U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
+livecheck.url       https://github.com/adoptium/temurin${feature}-binaries/releases
+livecheck.regex     OpenJDK${feature}U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
 
 use_configure    no
 build {}
@@ -69,7 +75,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-21-eclipse-temurin.jdk
+set jdk ${jvms}/jdk-${feature}-eclipse-temurin.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Correct the minimum OS version. Also see https://trac.macports.org/ticket/71045.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?