### PR TITLE
jdk17-graalvm: update minimum OS version

### DIFF
--- a/java/jdk17-graalvm/Portfile
+++ b/java/jdk17-graalvm/Portfile
@@ -7,9 +7,9 @@ name             jdk${feature}-graalvm
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12.0 for x86_64:
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any >= 20 }
+platforms        {darwin any >= 16 }
 
 # GraalVM Free Terms and Conditions: https://www.oracle.com/downloads/licenses/graal-free-license.html
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries


### PR DESCRIPTION
#### Description

Correct minimum OS version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?