### PR TITLE
openjdk21: builds on macOS 11+

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -13,10 +13,9 @@ supported_archs     x86_64 arm64
 license             GPL-2+
 maintainers         {breun.nl:nils @breun} openmaintainer
 
-# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11.00.00:
-# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Builds successfully on macOS 11+
 # Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any >= 20 }
+platforms           { darwin >= 20 }
 
 description         OpenJDK ${feature} (Long Term Support)
 long_description    JDK ${feature} builds of OpenJDK, the Open-Source implementation \


### PR DESCRIPTION
#### Description

Correct minimum OS version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?