### PR TITLE
openjdk11: fix build for clang 16

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -6,7 +6,7 @@ name                openjdk11
 # See https://openjdk-sources.osci.io/openjdk11/ for the version and build number that matches the latest '-ga' version
 version             11.0.24
 set build 8
-revision            0
+revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -36,6 +36,9 @@ pre-patch {
     reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
     reinplace "s|assert|vmassert|g" ${worksrcpath}/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
 }
+
+# Temporary workaround for clang 16: https://trac.macports.org/ticket/70819
+patchfiles          JDK-8340341-clang-16-workaround.patch
 
 set tpath ${prefix}/Library/Java
 use_configure    yes

--- a/java/openjdk11/files/JDK-8340341-clang-16-workaround.patch
+++ b/java/openjdk11/files/JDK-8340341-clang-16-workaround.patch
@@ -1,0 +1,14 @@
+--- make/hotspot/lib/JvmOverrideFiles.gmk.orig	2024-06-04 18:47:50
++++ make/hotspot/lib/JvmOverrideFiles.gmk	2024-09-22 23:45:41
+@@ -89,6 +89,11 @@
+     # for the clang bug was still needed.
+     BUILD_LIBJVM_loopTransform.cpp_CXXFLAGS := $(CXX_O_FLAG_NONE)
+ 
++    # See JDK-8340341
++    ifeq ($(firstword $(subst ., ,$(CXX_VERSION_NUMBER))), 16)
++      BUILD_LIBJVM_stackMapTable.cpp_CXXFLAGS := -O1
++    endif
++
+     # The following files are compiled at various optimization
+     # levels due to optimization issues encountered at the
+     # default level. The Clang compiler issues a compile


### PR DESCRIPTION
#### Description

Backport fix for https://trac.macports.org/ticket/70819 to OpenJDK 11.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?