### PR TITLE
aha: new port

### DIFF
--- a/textproc/aha/Portfile
+++ b/textproc/aha/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        theZiz aha 0.5.1
+revision            0
+
+categories          textproc
+license             GPL-2
+maintainers         nomaintainer
+
+description         aha converts ANSI escape sequences to HTML code
+long_description \
+    aha (Ansi HTML Adapter) is a program which converts ANSI escape \
+    sequences of a UNIX terminal to HTML code.
+
+checksums           rmd160  89228baddbf9b7b34fa73eba4e9a5a5547ef7778 \
+                    sha256  e7352989a09e462088af1d1f301ab3789331768662898227dc9a0d2005eb490c \
+                    size    394430
+
+use_configure       no
+
+destroot.args       PREFIX=${prefix}


### PR DESCRIPTION
#### Description

Adding new port for aha (Ansi HTML Adapter), which is a utility for converting ANSI escape sequences to HTML code. See more at https://github.com/theZiz/aha

Note: this is the first time I submit a new Portfile. While I have done my best to do it correctly and the file passes `port lint --nitpick`, it is probably a good idea to take an extra look at it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
