### PR TITLE
openjdk23: update patch syntax

### DIFF
--- a/java/openjdk23/files/JDK-8340341-clang-16-workaround.patch
+++ b/java/openjdk23/files/JDK-8340341-clang-16-workaround.patch
@@ -5,8 +5,8 @@
      BUILD_LIBJVM_loopTransform.cpp_CXXFLAGS := $(CXX_O_FLAG_NONE)
  
 +    # See JDK-8340341
-+    ifeq "$(firstword $(subst ., ,$(CXX_VERSION_NUMBER)))" "16"
-+      BUILD_LIBJVM_stackMapTable.cpp_CXXFLAGS := "-O1"
++    ifeq ($(firstword $(subst ., ,$(CXX_VERSION_NUMBER))), 16)
++      BUILD_LIBJVM_stackMapTable.cpp_CXXFLAGS := -O1
 +    endif
 +
      # The following files are compiled at various optimization


### PR DESCRIPTION
#### Description

Update syntax of patch.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?