### PR TITLE
Toucan: New Port

### DIFF
--- a/www/toucan/Portfile
+++ b/www/toucan/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem         1.0
+PortGroup github   1.0
+
+github.setup       toucansites toucan 1.0.0-alpha.1
+
+maintainers        {johnlindop.com:git @JLindop} openmaintainer
+revision           0
+
+description        Static site generator written in Swift.
+long_description   Toucan is a Markdown-based Static Site Generator (SSG) written in Swift.
+
+categories         www
+license             MIT
+
+checksums          rmd160 91e312dc7c8f6744f6d663c37cb66ce26155a1c0 \
+                   sha256 cffe800ac8a712146b3a15cbb91a9b57ef955a8be40bf034f70fc8decffc7bd5 \
+                   size 34440
+                   
+
+platforms           {darwin >= 23}
+
+use_configure       no
+
+build.cmd          swift
+build.target       build
+build.args         --configuration release --disable-sandbox
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/.build/release/${name}-cli ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description
Toucan is a Markdown-based static site generator written in Swift. It uses Swift 5.10 and so can only be built on macOS 14 and newer.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
