### PR TITLE
micronaut: update to 4.6.3

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.6.2 v
+github.setup    micronaut-projects micronaut-starter 4.6.3 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  51b21a4164c23b78d006e92f036e7ca7d723c0f4 \
-                 sha256  9824806be6df9be9c265f2c778f3e3535c199b88194afa73cb24f8aeef65e43c \
-                 size    25508107
+    checksums    rmd160  feeff8d66b20af6b83da1324abd6e2e29d3a9e8b \
+                 sha256  6c442cacde5e6606d2f34384a03fe35b27421903e4dd826e4383e29b94b286df \
+                 size    25505190
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  6340e75533fe4c8f388b7acbc6d03dfbbec22439 \
-                 sha256  461edcdb44fd68973186b599aa2ab5a5ce0c0af30b483788e0e32b17dedddf48 \
-                 size    25311055
+    checksums    rmd160  020cce77f55d1e66607f98dbf80c9515c2296a0f \
+                 sha256  4e9b7ceb8039653337f51151b1a8659118b89901d16df5508b36a11e989f2abf \
+                 size    25311323
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.6.3.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?