### PR TITLE
symfony-cli: update to 5.10.3

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.10.2
+version             5.10.3
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  0a3619526259dc3348bc650f997a4d0339e1bfd9 \
-                        sha256  631d7c781f6d8ba51b7043dcdb0be6a8f3162c4d98981e94bbf119d56d9823f2 \
-                        size    273136
+    checksums           rmd160  3a030783b9d2b0fcc3791658542c3d1c4e3c5aea \
+                        sha256  9a1aecf880d8dc11402f0d7d69c32cb598d1149a2fe26d253ff4e03d63328b4b \
+                        size    273061
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  1f0d2226f5909977deb9ecd845601b3d2526de83 \
-                        sha256  a1d6e6dafe4b83152657af12509191e5126964affae3c0b1362b75815f62cc71 \
-                        size    11530854
+    checksums           rmd160  22ef167cc1842cbf4d0a6419b7406733e62c421e \
+                        sha256  a41eff79dc9d83991e2c6af42c5f3fe1240cd17d1a380a626c6a61b31a1b3a4f \
+                        size    11671180
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.10.3

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
