### PR TITLE
openjdk{17,21}: workaround for regression in JDK-8266242

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -37,7 +37,9 @@ pre-patch {
 }
 
 # Temporary workaround for clang 16: https://trac.macports.org/ticket/70819
-patchfiles          JDK-8340341-clang-16-workaround.patch
+# Temporary workaround for undeclared enum in < 11.00: https://trac.macports.org/ticket/71049
+patchfiles          JDK-8340341-clang-16-workaround.patch \
+                    JDK-8266242-undecl-ident-nsbun-arm64-workaround.patch
 
 set tpath ${prefix}/Library/Java
 use_xcode           yes

--- a/java/openjdk17/files/JDK-8266242-undecl-ident-nsbun-arm64-workaround.patch
+++ b/java/openjdk17/files/JDK-8266242-undecl-ident-nsbun-arm64-workaround.patch
@@ -1,0 +1,20 @@
+--- src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m.orig	2024-10-08 18:09:38.000000000 +1100
++++ src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m	2024-10-08 18:09:16.000000000 +1100
+@@ -60,6 +60,9 @@
+ }
+ 
+ static BOOL isValidDisplayMode(CGDisplayModeRef mode) {
++    // https://trac.macports.org/ticket/71049: temporary additional guard for undef'd NSBun..ARM64
++    // Should be reported/fixed upstream at openjdk.org.
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+     // Workaround for apple bug FB13261205, since it only affects arm based macs
+     // and arm support started with macOS 11 ignore the workaround for previous versions
+     if (@available(macOS 11, *)) {
+@@ -70,6 +73,7 @@
+             return (CGDisplayModeGetPixelWidth(mode) >= 800);
+         }
+     }
++#endif
+     return (1 < CGDisplayModeGetWidth(mode) && 1 < CGDisplayModeGetHeight(mode));
+ }
+ 

--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -48,7 +48,9 @@ pre-patch {
 }
 
 # Temporary workaround for clang 16: https://trac.macports.org/ticket/70819
-patchfiles          JDK-8340341-clang-16-workaround.patch
+# Temporary workaround for undeclared enum in < 11.00: https://trac.macports.org/ticket/71049
+patchfiles          JDK-8340341-clang-16-workaround.patch \
+                    JDK-8266242-undecl-ident-nsbun-arm64-workaround.patch
 
 set tpath ${prefix}/Library/Java
 use_xcode           yes

--- a/java/openjdk21/files/JDK-8266242-undecl-ident-nsbun-arm64-workaround.patch
+++ b/java/openjdk21/files/JDK-8266242-undecl-ident-nsbun-arm64-workaround.patch
@@ -1,0 +1,20 @@
+--- src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m.orig	2024-07-09 18:07:16.000000000 +1000
++++ src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m	2024-10-08 18:34:39.000000000 +1100
+@@ -60,6 +60,9 @@
+ }
+ 
+ static BOOL isValidDisplayMode(CGDisplayModeRef mode) {
++    // https://trac.macports.org/ticket/71049: temporary additional guard for undef'd NSBun..ARM64
++    // Should be reported/fixed upstream at openjdk.org.
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+     // Workaround for apple bug FB13261205, since it only affects arm based macs
+     // and arm support started with macOS 11 ignore the workaround for previous versions
+     if (@available(macOS 11, *)) {
+@@ -70,6 +73,7 @@
+             return (CGDisplayModeGetPixelWidth(mode) >= 800);
+         }
+     }
++#endif
+     return (1 < CGDisplayModeGetWidth(mode) && 1 < CGDisplayModeGetHeight(mode));
+ }
+ 


### PR DESCRIPTION
Adds temporary patch to CGraphicsDevice.m to guard use of undeclared architecture enum referencing ARM64 unknown to macOS SDKs before macOS 11.

openjdk versions before 22 support build on 10.12 - 10.15, but when backporting the fix for 22 to 17 and 21, this support was broken. This patch should be removed once upstream regression is addressed.

See: https://trac.macports.org/ticket/71049

#### Description
Per maintainer request, providing temporary patches to re-enable building on macOS versions < 11.00, which regressed when openjdk project backported fix from [this issue with openjdk22](https://bugs.openjdk.org/browse/JDK-8266242) to openjdk17 and openjdk21. The regression has been reported upstream and the trac ticket will be updated once an ID is issued for this report.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`sudo port test` reports failure, but it appears to be a test error as the files claimed as missing as an actual `install` appears to work normally (`sudo port -vst install` works). Tested some core binaries; not sure what variants are considered important outside the defaults (which were used).