### PR TITLE
openjdk21: should build on macOS 10.12.0+

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -13,9 +13,9 @@ supported_archs     x86_64 arm64
 license             GPL-2+
 maintainers         {breun.nl:nils @breun} openmaintainer
 
-# Builds successfully on macOS 11+
+# Builds on macOS 10.12.0+
 # Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms           { darwin >= 20 }
+platforms           { darwin >= 16 }
 
 description         OpenJDK ${feature} (Long Term Support)
 long_description    JDK ${feature} builds of OpenJDK, the Open-Source implementation \


### PR DESCRIPTION
#### Description

After https://github.com/macports/macports-ports/pull/26116 was merged `openjdk21` should now build on macOS 10.12.0 and later.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement