### PR TITLE
py-cliff: update to 4.7.0 and add missing dependency

### DIFF
--- a/python/py-autopage/Portfile
+++ b/python/py-autopage/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-autopage
+version             0.5.2
+maintainers         nomaintainer
+license             Apache-2
+supported_archs     noarch
+platforms           {darwin any}
+
+description         automatically display terminal output in a pager
+long_description    ${description}
+homepage            https://github.com/zaneb/autopage
+checksums           rmd160  03ed2cf74f3e59d9fc72eba08ba6d947ec13bced \
+                    sha256  826996d74c5aa9f4b6916195547312ac6384bac3810b8517063f293248257b72 \
+                    size    33031
+
+python.versions     38 39 310 311 312

--- a/python/py-cliff/Portfile
+++ b/python/py-cliff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cliff
-version             4.4.0
+version             4.7.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -16,21 +16,25 @@ long_description    cliff is a framework for building command line \
                     provide subcommands, output formatters, and other \
                     extensions.
 homepage            https://docs.openstack.org/cliff/latest/
-checksums           rmd160  6dbe1b37f6643b4ab38a45509e0e4d1db3c45b80 \
-                    sha256  aa8d404aa2d6b4d8639c61bd6dc47acb3656ebc3fc025b1b7bb07af2baef785f \
-                    size    83609
+checksums           rmd160  370f093748ab5b28e5f6776cadde5e23e717826b \
+                    sha256  6ca45f8df519bbc0722c61049de7b7e442a465fa7f3f552b96d735fa26fd5b26 \
+                    size    84250
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${subport} ne ${name}} {
     depends_build-append \
                     port:py${python.version}-pbr
 
+    if {${python.version} < 310} {
+        depends_lib-append  port:py${python.version}-importlib-metadata
+    }
+
     depends_run-append \
+                    port:py${python.version}-autopage \
                     port:py${python.version}-cmd2 \
                     port:py${python.version}-prettytable \
-                    port:py${python.version}-parsing \
-                    port:py${python.version}-six \
                     port:py${python.version}-stevedore \
                     port:py${python.version}-yaml
 }
+

--- a/python/py-cmd2/Portfile
+++ b/python/py-cmd2/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  ae288a0e0921eb5d23480d44259f35e176d6458b \
                     sha256  71873c11f72bd19e2b1db578214716f0d4f7c8fa250093c601265a9a717dee52 \
                     size    678661
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

`py-cliff` at its present version (4.4.0) misses the Python library Autopage. This PR adds the missing dependency (via the submission of the port `py-autopage`) and updates `py-cliff`.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
