### PR TITLE
LyX: update to 2.4.2 for Qt5; pin Qt4 at 2.3.8

### DIFF
--- a/aqua/LyX/Portfile
+++ b/aqua/LyX/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 name                LyX
 conflicts           LyX1
-version             2.3.8
+version             2.4.2
 revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          aqua
@@ -37,9 +37,9 @@ master_sites        http://lyx.cybermirror.org/stable/${branch}.x/ \
                     ftp://ftp.ntua.gr/pub/X11/LyX/stable/${branch}.x/ \
                     ftp://ftp.lyx.org/pub/lyx/stable/${branch}.x/
 
-checksums           rmd160  80b2c53d12b04dd64a6326b4b1ea505dcb352120 \
-                    sha256  7e8f56d148cb459eb00abbe9c6371744e4ff077b842c0024153a3f094b10d4ad \
-                    size    16412700
+checksums           rmd160  686630c5fe6d98bb29625e0818d9ad027bdb3814 \
+                    sha256  0d5a75dec9a169ab23bfa47da53ec65c62432de57014de315023d620ebccfe68 \
+                    size    17871168
 
 configure.args      --disable-silent-rules
 
@@ -55,6 +55,7 @@ post-configure {
         ${worksrcpath}/development/MacOSX/Makefile
 }
 
+# 2.4.x has expermintal support for Qt6 - we are ignoring ATM
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     default_variants +qt4
 } elseif {![variant_isset qt4]} {
@@ -62,27 +63,45 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 }
 
 # Make the default match boost's default.
-if {![variant_isset python38] && ![variant_isset python39]} {
-    default_variants-append +python310
+if {![variant_isset python38] && ![variant_isset python39] &&
+    ![variant_isset python310] && ![variant_isset python311]} {
+    default_variants-append +python312
 }
 
-variant python38 conflicts python39 python310 description {Use python38} {
+# TODO: use loops like other ports do
+variant python38 conflicts python39 python310 python311 python312 description {Use python38} {
     depends_build-append    port:python38
     configure.python        ${prefix}/bin/python3.8
 }
 
-variant python39 conflicts python38 python310 description {Use python39} {
+variant python39 conflicts python38 python310 python311 python312 description {Use python39} {
     depends_build-append    port:python39
     configure.python        ${prefix}/bin/python3.9
 }
 
-variant python310 conflicts python38 python39 description {Use python310} {
+variant python310 conflicts python38 python39 python311 python312 description {Use python310} {
     depends_build-append    port:python310
     configure.python        ${prefix}/bin/python3.10
 }
 
+variant python311 conflicts python38 python39 python310 python312 description {Use python311} {
+    depends_build-append    port:python311
+    configure.python        ${prefix}/bin/python3.11
+}
+
+variant python312 conflicts python38 python39 python310 python311 description {Use python312} {
+    depends_build-append    port:python312
+    configure.python        ${prefix}/bin/python3.12
+}
+
 variant qt4 conflicts qt5 description {Use Qt4} {
     PortGroup qt4 1.0
+
+    version     2.3.8
+    revision    0
+    checksums           rmd160  80b2c53d12b04dd64a6326b4b1ea505dcb352120 \
+                        sha256  7e8f56d148cb459eb00abbe9c6371744e4ff077b842c0024153a3f094b10d4ad \
+                        size    16412700
 
     configure.pre_args  --prefix=${applications_dir}/LyX.app
     configure.args-append \


### PR DESCRIPTION
We are ignoring expermental Qt6 ATM. Add other python versions.

Closes: https://trac.macports.org/ticket/70162

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
