### PR TITLE
google-cloud-sdk: update to 496.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             495.0.0
+version             496.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  78a81837b5a75bbfd5db7c81d40a99c68f5e1303 \
-                    sha256  f47b767124b519f2612978d51a2866f7e124bd99bd6754c2447760e64a7a7002 \
-                    size    52242752
+    checksums       rmd160  09633b7c0c34390ddab633409eefde3a7e031d00 \
+                    sha256  8d93e2fca6dc07b94518206a73b0a770f4ddbb26d653320cab8791f52e92f9f0 \
+                    size    52336140
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  e1a5fed87fee459540e973fa3137ce2532174768 \
-                    sha256  3dfb7b0be76ea5668bb6f2c116254a155af6d5d69f61cefa62f0ff65e9874de5 \
-                    size    53596237
+    checksums       rmd160  135885c008382518b3b7c4694aa88c96d7a90068 \
+                    sha256  11c72013000dc33173431276f07419b4e6e4e49cc02cfd8bde374bf119f75850 \
+                    size    53689152
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  924253f1d6632b3baa83684e4f845a58eaa566bf \
-                    sha256  153b04cda8ebbbf3ea352041329325ddfd3cc190d36eef2b8650adbb39d5eb0a \
-                    size    53543683
+    checksums       rmd160  9f63713e6078bf21ac54c11b179ffd9bed691872 \
+                    sha256  82bafbed2f387399665e95ce8518627e44ead695ff094edea65597156a4d727e \
+                    size    53636574
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 496.0.0.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?