### PR TITLE
ghc: fix livecheck

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -348,11 +348,9 @@ if {${name} eq ${subport}} {
 Copy/edit ${prefix}/etc/ghci.conf to your directory ~/.ghc
 for a user-specific startup configuration."
 
-    # livecheck broken on downloads.haskell.org
-    # See: https://lists.macports.org/pipermail/macports-dev/2019-December/041581.html
-    #livecheck.type      regex
-    #livecheck.url       https://downloads.haskell.org/~${name}
-    #livecheck.regex     (\\d+(?:\\.\\d+){1,3})
+    livecheck.url       ${homepage}/download.html
+    livecheck.type      regex
+    livecheck.regex     {<a href="download_ghc[_0-9]+.html">([0-9.]+)</a>}
 }
 
 subport ghc-prebuilt {


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
