### PR TITLE
QMPlay2: revbump after dependencies update

### DIFF
--- a/multimedia/QMPlay2/Portfile
+++ b/multimedia/QMPlay2/Portfile
@@ -77,7 +77,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 15} {
                         1001-Fix-Qt-paths.patch
      } else {
         github.setup    zaps166 QMPlay2 24.06.16
-        revision        1
+        revision        2
         checksums       rmd160  b1851ab0fc52849471cc4f3a2d19a01d068fa864 \
                         sha256  7b06be4b95cb15064015934b24e76e583b85398136fc28b622dc1118d07c55b4 \
                         size    2042180


### PR DESCRIPTION
#### Description

At least on Sonoma pre-built app is broken: it fails to launch. Rebuilding fixes that.
Earlier versions may need to be revbumped, but I have no way to check it now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7
Xcode 15.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
