### PR TITLE
asmotor: update to 1.3.2

### DIFF
--- a/devel/asmotor/Portfile
+++ b/devel/asmotor/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 # Verify the correct util commit for each asmotor version update.
-github.setup        asmotor asmotor 1.3.1 release-
+github.setup        asmotor asmotor 1.3.2 release-
 set util_commit     9eda7afa576ee9b691f6389eaaef1c715174b32d
 revision            0
 
@@ -39,9 +39,9 @@ distfiles           ${main_distfile}:main \
                     ${util_distfile}:util
 
 checksums           ${main_distfile} \
-                    rmd160  b92dcbd789b47340c1c907c3815b1b85820af655 \
-                    sha256  edd6fea6129881d741f179ccdce6d5eaa135792062af83dc2f37dcd4ddbda7e8 \
-                    size    274915 \
+                    rmd160  07fe83a855a75ea37fa7fd9baa9541759ad4c422 \
+                    sha256  ecc371521471d3fbddb736414659b0b74f24b180042d16ef1dd081d2fbfeec11 \
+                    size    275955 \
                     ${util_distfile} \
                     rmd160  bf16d79447e27b77f503d3a27b87cbb53cbae063 \
                     sha256  514da08b74d123b8b6b0935003d8aac48be448ea5d1c24555c705e4820d01379 \


### PR DESCRIPTION
#### Description

Update `asmotor` to the latest released version 1.3.2.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
macOS 14.7 23H124 x86_64
Command Line Tools 15.3.0.0.1.1708487402

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
