### PR TITLE
ghidra: enable native file picker and menubar

### DIFF
--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -6,6 +6,7 @@ PortGroup           java 1.0
 PortGroup           app 1.0
 
 github.setup        NationalSecurityAgency ghidra 11.2 Ghidra_ _build
+revision            1
 checksums           rmd160  570f95ba37cae4180b815bc968dab1497803c005 \
                     sha256  1b893066b55ae58e2f7ca006b4665a2604f47ddbf5de4498f77e2673a1e84105 \
                     size    70354834
@@ -33,6 +34,8 @@ build.env-append    _JAVA_OPTIONS=-Duser.home=${worksrcpath}
 build.cmd           gradle
 build.target        buildGhidra
 
+patchfiles          launch.properties.diff
+
 set ghidra_copy_list \
 [list \
     Extensions \
@@ -52,6 +55,7 @@ destroot {
     foreach item ${ghidra_copy_list} {
         copy ${worksrcpath}/ghbuild/ghidra_${version}_DEV/${item} ${destroot}${javadest}/
     }
+    system "javac -d ${destroot}${javadest}/Ghidra/patch/ -cp \"\$(find ${destroot}${javadest}/ | egrep '.jar\$' | tr '\n' ':')\" ${filespath}/docking/widgets/filechooser/GhidraFileChooser.java"
 }
 
 # app settings

--- a/devel/ghidra/files/docking/widgets/filechooser/GhidraFileChooser.java
+++ b/devel/ghidra/files/docking/widgets/filechooser/GhidraFileChooser.java
@@ -1,0 +1,154 @@
+package docking.widgets.filechooser;
+
+import docking.DialogComponentProvider;
+import ghidra.util.filechooser.GhidraFileChooserModel;
+import ghidra.util.filechooser.GhidraFileFilter;
+import java.awt.Component;
+import java.awt.Dialog;
+import java.awt.FileDialog;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.Arrays;
+import java.util.List;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class GhidraFileChooser extends DialogComponentProvider {
+	private GhidraFileChooserModel model;
+	private GhidraFileFilter filter;
+	private FileDialog fileDialog;
+	private int mode = FILES_AND_DIRECTORIES;
+
+	public static final int FILES_ONLY = 0;
+	public static final int DIRECTORIES_ONLY = 1;
+	public static final int FILES_AND_DIRECTORIES = 2;
+
+	public GhidraFileChooser(Component parent) {
+		this(new LocalFileChooserModel(), parent);
+	}
+
+	GhidraFileChooser(GhidraFileChooserModel model, Component parent) {
+		super("File Chooser", true, true, true, false);
+		this.model = model;
+		Component root = SwingUtilities.getRoot(parent);
+		if (root instanceof Dialog) {
+			fileDialog = new FileDialog((Dialog)root);
+		} else {
+			fileDialog = new FileDialog((JFrame)root);
+		}
+	}
+
+	public void setShowDetails(boolean showDetails) {
+	}
+
+	public void setFileSelectionMode(int mode) {
+		this.mode = mode;
+	}
+
+	public void setFileSelectionMode(GhidraFileChooserMode mode) {
+		switch (mode) {
+		case FILES_ONLY:
+			this.mode = 0;
+			break;
+		case DIRECTORIES_ONLY:
+			this.mode = 1;
+			break;
+		case FILES_AND_DIRECTORIES:
+			this.mode = 2;
+			break;
+		}
+	}
+
+	public boolean isMultiSelectionEnabled() {
+		return fileDialog.isMultipleMode();
+	}
+
+	public void setMultiSelectionEnabled(boolean b) {
+		fileDialog.setMultipleMode(b);
+	}
+
+	public void setApproveButtonText(String buttonText) {
+	}
+
+	public void setApproveButtonToolTipText(String tooltipText) {
+	}
+
+	public void setLastDirectoryPreference(String newKey) {
+	}
+
+	public File getSelectedFile() {
+		show();
+		String path = fileDialog.getFile();
+		return path != null ? new File(fileDialog.getDirectory(), path) : null;
+	}
+
+	public List<File> getSelectedFiles() {
+		show();
+		return Arrays.asList(fileDialog.getFiles());
+	}
+
+	public File getSelectedFile(boolean show) {
+		return getSelectedFile();
+	}
+
+	public void setSelectedFile(File file) {
+		fileDialog.setFile(file != null ? file.getPath() : null);
+	}
+
+	public void show() {
+		fileDialog.setVisible(true);
+	}
+
+	public void close() {
+		fileDialog.setVisible(false);
+	}
+
+	public File getCurrentDirectory() {
+		return new File(fileDialog.getDirectory());
+	}
+
+	public void setCurrentDirectory(File directory) {
+		fileDialog.setDirectory(directory.getPath());
+	}
+
+	public void rescanCurrentDirectory() {
+	}
+
+	private class _FilenameFilter implements FilenameFilter {
+		@Override
+		public boolean accept(File dir, String name) {
+			File file = new File(dir, name);
+			switch (mode) {
+			case DIRECTORIES_ONLY:
+				if (file.isFile()) {
+					return false;
+				}
+				break;
+			case FILES_AND_DIRECTORIES:
+			default:
+				break;
+			}
+			return filter.accept(file, model);
+		}
+	}
+
+	public void addFileFilter(GhidraFileFilter f) {
+	}
+
+	public void setSelectedFileFilter(GhidraFileFilter filter) {
+		this.filter = filter;
+	}
+
+	public void setFileFilter(GhidraFileFilter filter) {
+		this.filter = filter;
+	}
+
+	public boolean wasCancelled() {
+		return fileDialog.getFile() == null;
+	}
+
+	@Override
+	public void setTitle(String title) {
+		fileDialog.setTitle(title);
+	}
+}

--- a/devel/ghidra/files/launch.properties.diff
+++ b/devel/ghidra/files/launch.properties.diff
@@ -1,0 +1,11 @@
+--- Ghidra/RuntimeScripts/Common/support/launch.properties.orig	2024-10-10 13:05:57
++++ Ghidra/RuntimeScripts/Common/support/launch.properties	2024-10-10 13:06:13
+@@ -71,7 +71,7 @@
+ VMARGS_MACOS=-Declipse.filelock.disable=true
+ 
+ # Where the menu bar is displayed on macOS
+-VMARGS_MACOS=-Dapple.laf.useScreenMenuBar=false
++VMARGS_MACOS=-Dapple.laf.useScreenMenuBar=true
+ 
+ # Make the title bar adaptable to macOS theme
+ VMARGS_MACOS=-Dapple.awt.application.appearance=system


### PR DESCRIPTION
#### Description

add variants `nativefilepicker` and `nativemenubar` to use native file picker widget, and native macos menubar.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
