### PR TITLE
symfony-cli: update to 5.10.4

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.10.3
+version             5.10.4
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  3a030783b9d2b0fcc3791658542c3d1c4e3c5aea \
-                        sha256  9a1aecf880d8dc11402f0d7d69c32cb598d1149a2fe26d253ff4e03d63328b4b \
-                        size    273061
+    checksums           rmd160  6b1ce6389f49f397cbeaa3395de74adffed33e48 \
+                        sha256  0b3dcf937d778ee4c0f804aaa175f39f1690c66cec76efe6f795b2cb24c255db \
+                        size    273395
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  22ef167cc1842cbf4d0a6419b7406733e62c421e \
-                        sha256  a41eff79dc9d83991e2c6af42c5f3fe1240cd17d1a380a626c6a61b31a1b3a4f \
-                        size    11671180
+    checksums           rmd160  c3de57dec3538fb43682e2f5892a04bd98ee52b6 \
+                        sha256  31ca20f167ca04ea06e9d7a41a1e34435314c91e2061dfe66a55a89af8b58d01 \
+                        size    11673049
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.10.4

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
