### PR TITLE
libcanberra: move pulseaudio to a variant

### DIFF
--- a/audio/libcanberra/Portfile
+++ b/audio/libcanberra/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                libcanberra
 version             0.30
-revision            10
+revision            11
 
 categories          audio devel
 license             LGPL-2.1+
@@ -27,8 +27,7 @@ depends_build-append \
                     path:bin/pkg-config:pkgconfig
 
 depends_lib-append \
-                    port:libvorbis \
-                    port:pulseaudio
+                    port:libvorbis
 
 depends_run-append \
                     port:sound-theme-freedesktop
@@ -48,6 +47,7 @@ configure.args-append \
                     --disable-lynx \
                     --disable-null \
                     --disable-oss \
+                    --disable-pulse \
                     --disable-silent-rules \
                     --disable-tdb \
                     --disable-udev
@@ -86,7 +86,20 @@ variant x11 conflicts quartz {
                     port:xorg-libX11
 }
 
+variant pulse description {Enable pulseaudio support} {
+    depends_lib-append \
+                    port:pulseaudio
+    configure.args-delete \
+                    --disable-pulse
+}
+
 default_variants    +gtk2 +gtk3
+
+if {${os.platform} ne "darwin" || ${os.major} > 9} {
+    # pulseaudio does not build on 10.5 at the moment.
+    default_variants-append \
+                    +pulse
+}
 
 if {[variant_isset gtk2] || [variant_isset gtk3]} {
     if {![variant_isset quartz]} {


### PR DESCRIPTION
#### Description

Do not force users build pulseaudio, rather move it to a variant and make a default on 10.6+ (reportedly it fails on 10.5.8).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
