### PR TITLE
ctpv: fix build on Leopard and Snow Leopard

### DIFF
--- a/graphics/ctpv/Portfile
+++ b/graphics/ctpv/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           github   1.0
 PortGroup           makefile 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        NikitaIvanovV ctpv 1.1 v
 github.tarball_from archive
@@ -25,5 +24,6 @@ depends_lib-append  path:lib/libcrypto.dylib:openssl \
                     port:libmagic
 
 destroot.post_args  ${destroot.destdir} PREFIX=${prefix}
-compiler.blacklist-append \
-                    {clang < 1400} *gcc-4.*
+
+# https://trac.macports.org/ticket/70170
+compiler.cxx_standard 2020


### PR DESCRIPTION
#### Description

ctpv fails to build on Leopard and Snow Leopard as the compiler blacklist does not cause MacPorts to use an appropriate compiler on these systems. Defining the C language standard required for building the port resolves the issue. #25798 previously attempted to address this.

Closes: https://trac.macports.org/ticket/70170

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.6.8 10K549 i386
Xcode 3.2.6 10M2518

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
