### PR TITLE
vim, MacVim: update to vim version 9.1.0727

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # is because they both share the same set of configuration files and ensures
 # that the user's configuration files will always work with both.
 set vim_version     9.1
-set release         179
+set release         180
 github.setup        macvim-dev macvim ${release} release-
 revision            0
 name                MacVim
@@ -25,9 +25,9 @@ long_description \
 
 homepage            https://macvim.org
 
-checksums           rmd160  692664e7643b05385025b01bf32133c2651d8aff \
-                    sha256  1b58bfff65afb3cf448c7134afcaf156d16d982f28288f7595a41a458b00cd6c \
-                    size    25330222
+checksums           rmd160  fb34366d9059f09ef73a56dd215ff504951cad42 \
+                    sha256  bcc84a691ab2344942b18d2dbedd20aab4ecd4d6ac928ac8842f6d1b0c7d70f7 \
+                    size    25822029
 
 depends_lib-append  port:gettext \
                     port:libiconv \
@@ -130,7 +130,7 @@ variant perl description {Enable Perl scripting} {
     depends_lib-append      path:bin/perl:perl5
 }
 
-set pythons_suffixes {27 36 37 38 39 310 311}
+set pythons_suffixes {27 39 310 311 312 313}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {
@@ -158,57 +158,71 @@ foreach s ${pythons_suffixes} {
 }
 
 variant ruby requires ruby18 description {Compatibility variant, requires +ruby18} {}
-variant ruby18 conflicts ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby18 conflicts ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby1.8
     depends_lib-append      port:ruby
 }
-variant ruby19 conflicts ruby18 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby19 conflicts ruby18 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby1.9
     depends_lib-append      port:ruby19
 }
-variant ruby20 conflicts ruby18 ruby19 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby20 conflicts ruby18 ruby19 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.0
     depends_lib-append      port:ruby20
 }
-variant ruby21 conflicts ruby18 ruby19 ruby20 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby21 conflicts ruby18 ruby19 ruby20 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.1
     depends_lib-append      port:ruby21
 }
-variant ruby22 conflicts ruby18 ruby19 ruby20 ruby21 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby22 conflicts ruby18 ruby19 ruby20 ruby21 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.2
     depends_lib-append      port:ruby22
 }
-variant ruby23 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby23 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.3
     depends_lib-append      port:ruby23
 }
-variant ruby24 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby24 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.4
     depends_lib-append      port:ruby24
 }
-variant ruby25 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby25 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.5
     depends_lib-append      port:ruby25
 }
-variant ruby30 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby31 description {Enable Ruby scripting} {
+variant ruby30 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby3.0
     depends_lib-append      port:ruby30
 }
-variant ruby31 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 description {Enable Ruby scripting} {
+variant ruby31 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby3.1
     depends_lib-append      port:ruby31
     # Ruby itself uses a modern gcc or clang, so building this with old Xcode gcc fails:
     # /opt/local/include/ruby-3.1.4/ruby/defines.h:55:23: error: stdalign.h: No such file or directory
+    compiler.blacklist-append \
+                            *gcc-4.0 *gcc-4.2
+}
+variant ruby32 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby33 description {Enable Ruby scripting} {
+    configure.args-append   --enable-rubyinterp
+    configure.args-append   --with-ruby-command=${prefix}/bin/ruby3.2
+    depends_lib-append      port:ruby32
+    compiler.blacklist-append \
+                            *gcc-4.0 *gcc-4.2
+}
+variant ruby33 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 description {Enable Ruby scripting} {
+    configure.args-append   --enable-rubyinterp
+    configure.args-append   --with-ruby-command=${prefix}/bin/ruby3.3
+    depends_lib-append      port:ruby33
     compiler.blacklist-append \
                             *gcc-4.0 *gcc-4.2
 }

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 # is because they both share the same set of configuration files and ensures
 # that the user's configuration files will always work with both.
 set vim_version     9.1
-set vim_patchlevel  0000
+set vim_patchlevel  0727
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v
 revision            0
 categories          editors
@@ -22,9 +22,9 @@ long_description    Vim is an advanced text editor that seeks to provide \
 
 homepage            https://www.vim.org
 
-checksums           rmd160  aed3a40e2fb0a96fc22c554b2fd102fb3369d560 \
-                    sha256  f0cdc73963122d052a666d88f787ec5b295f75ebdc3dfa5aa5a48f8afa92d98f \
-                    size    17604158
+checksums           rmd160  862555466b868c9d99943f29d9384c440c67711e \
+                    sha256  dfc41f36c2415acc00d1faef5e50d053be3c5a50b0c569d8ac4c73820be7c731 \
+                    size    18094755
 
 depends_lib-append  port:gettext \
                     port:libiconv \
@@ -111,7 +111,7 @@ variant perl description {Enable Perl scripting} {
     depends_lib-append      path:bin/perl:perl5
 }
 
-set pythons_suffixes {27 36 37 38 39 310 311}
+set pythons_suffixes {27 39 310 311 312 313}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {
@@ -139,57 +139,71 @@ foreach s ${pythons_suffixes} {
 }
 
 variant ruby requires ruby18 description {Compatibility variant, requires +ruby18} {}
-variant ruby18 conflicts ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby18 conflicts ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby1.8
     depends_lib-append      port:ruby
 }
-variant ruby19 conflicts ruby18 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby19 conflicts ruby18 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby1.9
     depends_lib-append      port:ruby19
 }
-variant ruby20 conflicts ruby18 ruby19 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby20 conflicts ruby18 ruby19 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.0
     depends_lib-append      port:ruby20
 }
-variant ruby21 conflicts ruby18 ruby19 ruby20 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby21 conflicts ruby18 ruby19 ruby20 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.1
     depends_lib-append      port:ruby21
 }
-variant ruby22 conflicts ruby18 ruby19 ruby20 ruby21 ruby23 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby22 conflicts ruby18 ruby19 ruby20 ruby21 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.2
     depends_lib-append      port:ruby22
 }
-variant ruby23 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby24 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby23 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby24 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.3
     depends_lib-append      port:ruby23
 }
-variant ruby24 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby25 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby24 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby25 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.4
     depends_lib-append      port:ruby24
 }
-variant ruby25 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby30 ruby31 description {Enable Ruby scripting} {
+variant ruby25 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby30 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby2.5
     depends_lib-append      port:ruby25
 }
-variant ruby30 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby31 description {Enable Ruby scripting} {
+variant ruby30 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby31 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby3.0
     depends_lib-append      port:ruby30
 }
-variant ruby31 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 description {Enable Ruby scripting} {
+variant ruby31 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby32 ruby33 description {Enable Ruby scripting} {
     configure.args-append   --enable-rubyinterp
     configure.args-append   --with-ruby-command=${prefix}/bin/ruby3.1
     depends_lib-append      port:ruby31
     # Ruby itself uses a modern gcc or clang, so building this with old Xcode gcc fails:
     # /opt/local/include/ruby-3.1.4/ruby/defines.h:55:23: error: stdalign.h: No such file or directory
+    compiler.blacklist-append \
+                            *gcc-4.0 *gcc-4.2
+}
+variant ruby32 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby33 description {Enable Ruby scripting} {
+    configure.args-append   --enable-rubyinterp
+    configure.args-append   --with-ruby-command=${prefix}/bin/ruby3.2
+    depends_lib-append      port:ruby32
+    compiler.blacklist-append \
+                            *gcc-4.0 *gcc-4.2
+}
+variant ruby33 conflicts ruby18 ruby19 ruby20 ruby21 ruby22 ruby23 ruby24 ruby25 ruby30 ruby31 ruby32 description {Enable Ruby scripting} {
+    configure.args-append   --enable-rubyinterp
+    configure.args-append   --with-ruby-command=${prefix}/bin/ruby3.3
+    depends_lib-append      port:ruby33
     compiler.blacklist-append \
                             *gcc-4.0 *gcc-4.2
 }


### PR DESCRIPTION
#### Description

* update Vim to v9.1.0727
* update MacVim to release-180
* add python312, python313, ruby32, and ruby33 variants for Vim and MacVim
* remove variants python36, python37, and python38 corresponding to EOL Python versions from Vim and MacVim

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
   - n/a 
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
  - Unable to run with trace-mode due to [#66356](https://trac.macports.org/ticket/66358)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
  - Tested functionality of Vim with +cscope, +huge, +python312, +python313, +tcl
  - Tested build of Vim with +python27, +python39, +python310, python311, +ruby32, and +ruby33
  - Tested functionality with MacVim with +cscope, +huge, +python312, +python313, +tcl
  - Tested build of MacVim with +python27, +python39, +python310, python311, +ruby32, and +ruby33

###### Notes
- Vim patch  `patch-python.diff` and `patch-tcl.diff` apply cleanly without changes. 
- MacVim patches `patch-python.diff`, `patch-remove-updater.diff`, `patch-remove-Homebrew-python.diff`, and `patch-tcl.diff` apply cleanly without changes.