### PR TITLE
lagrange: update to 1.18.3

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.18.0 v
+gitea.setup         gemini lagrange 1.18.3 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  f3eb60734b82c2b8ba5403d508aa9c6319e01431 \
-                    sha256  9137dcdba01dd52a316a3ff21ad847469a6944770a0bdbae2600a73f911c07b7 \
-                    size    7780416
+checksums           rmd160  ca2c96d3ad9b78b0b99380c0e2c6ae439211db1f \
+                    sha256  0b476be2bf8dd577cd88082e7ad1cbfde195e083f53a59093d2a6cfc27436bbe \
+                    size    7798444
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://github.com/skyjake/lagrange/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
