### PR TITLE
sdl_sopwith: patch header include order, adopt

### DIFF
--- a/games/sdl_sopwith/Portfile
+++ b/games/sdl_sopwith/Portfile
@@ -8,7 +8,7 @@ name                sdl_sopwith
 version             2.5.0
 categories          games
 license             GPL-2+
-maintainers         nomaintainer
+maintainers         {samthompson.com:pubgithub @sambthompson} openmaintainer
 description         Classic biplane shooter
 long_description    This is a port of the classic computer game \"Sopwith\" \
                     to run on modern computers and operating systems.
@@ -23,16 +23,10 @@ checksums           md5     9527c13fd463731d0e189deb24eb39f8 \
                     sha256  afef3efb49994aec6a37185bde97af46d7231a7bf18dfbc6d3c87251f3f9dd46 \
                     size    1046380
 
-depends_build       port:pkgconfig \
-                    port:automake
+depends_build       port:pkgconfig
 depends_lib         port:libsdl2
 
 patchfiles          src_sdl_Makefile.in.patch
-
-post-patch {
-    file delete ${worksrcpath}/config.cache ${worksrcpath}/config.log \
-                ${worksrcpath}/config.status
-}
 
 app.name            Sopwith
 app.executable      sopwith

--- a/games/sdl_sopwith/Portfile
+++ b/games/sdl_sopwith/Portfile
@@ -23,10 +23,16 @@ checksums           md5     9527c13fd463731d0e189deb24eb39f8 \
                     sha256  afef3efb49994aec6a37185bde97af46d7231a7bf18dfbc6d3c87251f3f9dd46 \
                     size    1046380
 
-depends_build       port:pkgconfig
+depends_build       port:pkgconfig \
+                    port:automake
 depends_lib         port:libsdl2
 
-configure.args      --disable-sdltest
+patchfiles          src_sdl_Makefile.in.patch
+
+post-patch {
+    file delete ${worksrcpath}/config.cache ${worksrcpath}/config.log \
+                ${worksrcpath}/config.status
+}
 
 app.name            Sopwith
 app.executable      sopwith

--- a/games/sdl_sopwith/files/src_sdl_Makefile.in.patch
+++ b/games/sdl_sopwith/files/src_sdl_Makefile.in.patch
@@ -1,0 +1,11 @@
+--- src/sdl/Makefile.in.orig	2024-04-19 10:02:18.000000000 +1000
++++ src/sdl/Makefile.in	2024-10-15 14:28:17.000000000 +1100
+@@ -284,7 +284,7 @@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-AM_CFLAGS = @CFLAGS@ @SDL_CFLAGS@ -I$(srcdir)/..
++AM_CFLAGS = -I$(srcdir)/.. @CFLAGS@ @SDL_CFLAGS@
+ noinst_LIBRARIES = libsdlsopwith.a libsdlsopmain.a
+ libsdlsopwith_a_SOURCES = video.c pcsound.c timer.c
+ libsdlsopmain_a_SOURCES = main.c


### PR DESCRIPTION
#### Description
Per [comments from jmroot on previous PR](https://github.com/macports/macports-ports/commit/fbe25355e770c5a0748a6ac88e2b01fef93b7905#r147929525), added patch for CFLAGS include order in src/sdl/Makefile.in. This is a generated file, so a PR for upstream has already been reported and a fix landed in https://github.com/fragglet/sdl-sopwith/pull/45. 
This should be able to be discarded at next upstream release.

Also adopted port (was with nomaintainer, per guide 7.3.3, including openmaintainer as well).

###### Type(s)
- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
