### PR TITLE
py-sniffio: Add missing build dep (setuptools_scm)

### DIFF
--- a/python/py-sniffio/Portfile
+++ b/python/py-sniffio/Portfile
@@ -26,4 +26,5 @@ checksums           rmd160  7ed50a618aea4898d388add3e4bb0ebb411e8c2c \
 
 if {${name} ne ${subport}} {
     python.pep517   yes
+    depends_build-append    port:py${python.version}-setuptools_scm
 }


### PR DESCRIPTION
Bugfix: [fails](https://build.macports.org/builders/ports-13_x86_64-builder/builds/80286) to build without setuptools_scm:

```
[build-system]
  requires = [
      "setuptools >= 64",
      "setuptools_scm >= 6.4"
  ]
```