### PR TITLE
jdk23: update to 23.0.1

### DIFF
--- a/java/jdk23/Portfile
+++ b/java/jdk23/Portfile
@@ -2,7 +2,8 @@
 
 PortSystem       1.0
 
-name             jdk23
+set feature 23
+name             jdk${feature}
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
@@ -14,8 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk23-mac
-set feature 23
-version      ${feature}
+version      ${feature}.0.1
 revision     0
 
 description  Oracle Java SE Development Kit ${feature} (Short Term Support until March 2025)
@@ -27,14 +27,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  61d37f069d915a46fce2127707c75ab84247c086 \
-                 sha256  924de84fd5a5978ddcf1ce5176ff1b5f3c75460ab0215b29954bce95bb065a24 \
-                 size    240066832
+    checksums    rmd160  a74944abf0cb70a7fc67b950d7cdd4493286a1f5 \
+                 sha256  deee028d44aa76c506624bc21886543bd1948283234237f7a40d4b8a8fb73bd2 \
+                 size    239982938
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  b8ba2bea5c345090f041d3c9ca1996bcda7b992d \
-                 sha256  c3f370000b5c96cca426a3a82e51ef580dc0a7f81ad0328d77a7c3376b95533b \
-                 size    237178559
+    checksums    rmd160  33f973656845914b6c721ab5f7e8c4cc6d4db614 \
+                 sha256  e5595d2bceae027a604cd3a2a5c6709ff57a2d3695bd173074716b95a617cee2 \
+                 size    237296293
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to JDK 23.0.1.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?