### PR TITLE
jdk21: update to 21.0.5

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -2,7 +2,8 @@
 
 PortSystem       1.0
 
-name             jdk21
+set feature 21
+name             jdk${feature}
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
@@ -14,26 +15,26 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      21.0.4
+version      ${feature}.0.5
 revision     0
 
-description  Oracle Java SE Development Kit 21
+description  Oracle Java SE Development Kit ${feature}
 long_description Java Platform, Standard Edition Development Kit (JDK). \
     The JDK is a development environment for building applications and components using the Java programming language. \
     This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense).
 
-master_sites https://download.oracle.com/java/21/archive/
+master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  db61c69287582fad46bf8ed2487072d24e3e3ef7 \
-                 sha256  b4818ec569fe91372bdd8c68409d391b048217642a6cd15c2f56c1bcde4f00a3 \
-                 size    193407206
+    checksums    rmd160  a43c8166eb36fae0491b1a7f3715ad0c9610bba1 \
+                 sha256  6e5afb736b47fd49d81545fee8b6453f67e92a6b35f9b5b77426dc66cf5488b8 \
+                 size    193475240
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  437909c42a6578d1ac9faaeab66a3c4729ca88b6 \
-                 sha256  70aae35540e8d450bf00502f6bb40867142058ef8307e2e987048ac5b97aa4c2 \
-                 size    191050003
+    checksums    rmd160  225235978e0e7013283c7294a1b1f8e5edd4aff5 \
+                 sha256  13cb8d754069fc76a2ff6eee96273cc1a96cb47ecf3afa7820407635c386dd37 \
+                 size    191126741
 }
 
 worksrcdir   jdk-${version}.jdk
@@ -42,7 +43,7 @@ homepage     https://www.oracle.com/java/
 
 livecheck.type      regex
 livecheck.url       https://www.oracle.com/java/technologies/downloads/
-livecheck.regex     Java SE Development Kit (21\.\[0-9\.\]+)
+livecheck.regex     Java SE Development Kit (${feature}\.\[0-9\.\]+)
 
 use_configure    no
 build {}
@@ -76,7 +77,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-21-oracle-java-se.jdk
+set jdk ${jvms}/jdk-${feature}-oracle-java-se.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Update to JDK 21.0.5.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?