### PR TITLE
jdk23-graalvm: update to 23.0.1

### DIFF
--- a/java/jdk23-graalvm/Portfile
+++ b/java/jdk23-graalvm/Portfile
@@ -16,8 +16,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava23-mac
 supported_archs  x86_64 arm64
 
-version     ${feature}
-set build 37
+version     ${feature}.0.1
+set build 11
 revision    0
 
 master_sites https://download.oracle.com/graalvm/${feature}/archive/
@@ -35,14 +35,14 @@ long_description Oracle GraalVM for JDK ${feature} compiles your Java applicatio
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  c826b3f79204c09dfaae8b3ba3263012afa03ed5 \
-                 sha256  d516ea854e361a821c7679d127ff7126c254b8c43c99e571e203df218df2764b \
-                 size    336258583
+    checksums    rmd160  4b4a4c326110a51e7b0bc03361d44c6899a83de1 \
+                 sha256  539699d8ff4979623bc7bdf8282ac6f76cd2560f47d14ec5438bada24f136f96 \
+                 size    336189146
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  765bb038039e8a5c5cd9b2526b35e78b762fea4d \
-                 sha256  63290bf6242836ac46ca4c8c4ad048e4482fdb3f8276b9689088f059be430687 \
-                 size    350455170
+    checksums    rmd160  1c24bce8638a9d43cf55ab0ff40f6e3045c8680b \
+                 sha256  c00a7a62ce453aa026bff65e5a18c63464f725c01e5a71771856226928ba5b0f \
+                 size    350643130
 }
 
 worksrcdir   graalvm-jdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 23.0.1.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?