### PR TITLE
jdk21-graalvm: update to 21.0.5

### DIFF
--- a/java/jdk21-graalvm/Portfile
+++ b/java/jdk21-graalvm/Portfile
@@ -21,8 +21,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava21-mac
 supported_archs  x86_64 arm64
 
-version     ${feature}.0.4
-set build 8
+version     ${feature}.0.5
+set build 9
 revision    0
 
 master_sites https://download.oracle.com/graalvm/${feature}/archive/
@@ -40,14 +40,14 @@ long_description Oracle GraalVM for JDK ${feature} compiles your Java applicatio
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  8caf50183e31942bdf0b7da6017721699ce7c912 \
-                 sha256  4cfe4037fbb4190c27899e13ebdee8a034309f7a96e9e20f73fc94b28783a98d \
-                 size    313581138
+    checksums    rmd160  0ea2d934cbb915c46fcf5ed1d1859265df553ace \
+                 sha256  2d9b09e28bc1bb6ff219bf62eacc4626c7740b4f1829ede9ea4450f33e9c0826 \
+                 size    314358647
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  88e8a4ec1ad1865e7ae65358bb7b0cd8480d7e38 \
-                 sha256  1a38609765bb7f985783b438c0488dca1a03ee2d418c2d94a1aaabd6ea9960be \
-                 size    326407555
+    checksums    rmd160  fa29e4657a1dedd98beeaa43902bbe2f52e5b05c \
+                 sha256  cb68cb2c796f42f37a56fcd1385d8b86cca12e0b46c5618a5ed3ec7dd2260f6f \
+                 size    327124226
 }
 
 worksrcdir   graalvm-jdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 21.0.5.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?