### PR TITLE
openjdk23: update to 23.0.1

### DIFF
--- a/java/openjdk23/Portfile
+++ b/java/openjdk23/Portfile
@@ -9,8 +9,8 @@ set boot_feature 22
 
 name                openjdk${feature}
 # See https://github.com/openjdk/jdk23u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             ${feature}
-set build 37
+version             ${feature}.0.1
+set build 11
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -24,9 +24,9 @@ master_sites        https://github.com/openjdk/jdk${feature}u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk${feature}u-${distname}
 
-checksums           rmd160  6efaf7f716e81d7e60ed53d997c1a5a74958c3c0 \
-                    sha256  02e2c3b356c00c3cc7efcca2fbd37723f55349677a1de483a9be8a43f327de76 \
-                    size    116630157
+checksums           rmd160  d415bdbf8fe2783dcf381c6009fb9dfb23a0d202 \
+                    sha256  0e058ae2956871aafc5be33960b6e0f8dd954d234d590d249bcb3b619b579a0a \
+                    size    116677478
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 23.0.1.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
