### PR TITLE
openjdk21-zulu: update to 21.38.21

### DIFF
--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk#zulu
-version      ${feature}.36.17
+version      ${feature}.38.21
 revision     0
 
-set openjdk_version ${feature}.0.4
+set openjdk_version ${feature}.0.5
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -35,14 +35,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  70edc2c8d6937707028c37ad13945b9538575854 \
-                 sha256  5ce75a6a247c7029b74c4ca7cf6f60fd2b2d68ce1e8956fb448d2984316b5fea \
-                 size    209377702
+    checksums    rmd160  ae5bd466f38eb649fcb2e6cd31805889f7b48f0d \
+                 sha256  cd74e5eb738c91459d4b8e5e10eac918ae2a05d21a9fc7ca5dc2da64e65bcebd \
+                 size    208365257
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  43b3edec1cfb1db971cc2ecf30633541a5e3917f \
-                 sha256  bc2750f81a166cc6e9c30ae8aaba54f253a8c8ec9d8cfc04a555fe20712c7bff \
-                 size    207089625
+    checksums    rmd160  13eba9368fdc8a1fee007b93060738ecf9a59eaa \
+                 sha256  80ffc25df79b95565318dbfc8309c515726ff42e9bdb533061edc7ad26f13df2 \
+                 size    206147293
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 21.38.21 (OpenJDK 21.0.5).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?