### PR TITLE
openjdk23-zulu: update to 23.30.13

### DIFF
--- a/java/openjdk23-zulu/Portfile
+++ b/java/openjdk23-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-23-lts&os=macos&package=jdk#zulu
-version      23.28.85
+version      23.30.13
 revision     0
 
-set openjdk_version 23.0.0
+set openjdk_version 23.0.1
 
 description  Azul Zulu Community OpenJDK 23 (Short Term Support until March 2025)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  a89d321297a2c7bcb07a54b3af35de4387acd842 \
-                 sha256  ac4afc337285f59f79815f2c1ea8b99500f64498edb2c671f10f20a32e9d6a7c \
-                 size    215259844
+    checksums    rmd160  5625a607334b65adf6c7ed74e223c9d64c2e84a7 \
+                 sha256  698c9fd522901a03b9c0f6fe7c17c9835f6cfaa515987bde9a1eb10f05d0b697 \
+                 size    215289637
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  23f17446b50d35714e2a36009a472711118a44a4 \
-                 sha256  805bdf24bd1142020e0132d331d7daf9f4ad502add1d80b7af1cb48f978d5437 \
-                 size    212899556
+    checksums    rmd160  a0083293bdb9b4deb2d139cf07893b8eb22b945e \
+                 sha256  3885df560c7a8a9c77b802c22dc1946cd2ee129d9dfcd74558a8ff9e9459e6cf \
+                 size    212937165
 }
 
 worksrcdir   ${distname}/zulu-23.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 23.30.13 (OpenJDK 23.0.1).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?