### PR TITLE
openjdk17-zulu: update to 17.54.21

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -2,7 +2,8 @@
 
 PortSystem       1.0
 
-name             openjdk17-zulu
+set feature 17
+name             openjdk${feature}-zulu
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        {darwin any}
@@ -14,12 +15,12 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.52.17
+version      ${feature}.54.21
 revision     0
 
-set openjdk_version 17.0.12
+set openjdk_version ${feature}.0.13
 
-description  Azul Zulu Community OpenJDK 17 (Long Term Support)
+description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
                  specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
                  verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
@@ -29,23 +30,23 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  44c021b44b5ce7043b7ccaa3b0c9653f343583e5 \
-                 sha256  f159461548429f7344d80e36c62ebd2b366abb446818e5756588fca1aa829d37 \
-                 size    194566320
+    checksums    rmd160  c558e9071619ff7feef483d707a4d7b5d15824e2 \
+                 sha256  0bfbf156542f6164e1d180bd1571982a644191dbf35389dda08d71aeb7f16f62 \
+                 size    193928655
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  d76ec32564931b9bd3f8e1d263b39ee250794dff \
-                 sha256  459de135040513eb294d3f651472e39a4a254a4a470e0d87beba3ac62eee370c \
-                 size    192418508
+    checksums    rmd160  e1f3d85bbae662c7b53ae4ea559b026493380685 \
+                 sha256  8ad9d79c16a97f274df11362a072bb166e6dd00cf667e626f78c3ed2d70f72cb \
+                 size    191841301
 }
 
-worksrcdir   ${distname}/zulu-17.jdk
+worksrcdir   ${distname}/zulu-${feature}.jdk
 
 homepage     https://www.azul.com/downloads/
 
 livecheck.type      regex
 livecheck.url       https://cdn.azul.com/zulu/bin/
-livecheck.regex     zulu(17\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
+livecheck.regex     zulu(${feature}\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.54.21 (OpenJDK 17.0.13).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?