### PR TITLE
openjdk11-zulu: update to 11.76.21

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -2,7 +2,8 @@
 
 PortSystem       1.0
 
-name             openjdk11-zulu
+set feature 11
+name             openjdk${feature}-zulu
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        {darwin any}
@@ -14,12 +15,12 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.74.15
+version      ${feature}.76.21
 revision     0
 
-set openjdk_version 11.0.24
+set openjdk_version ${feature}.0.25
 
-description  Azul Zulu Community OpenJDK 11 (Long Term Support)
+description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
                  specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
                  verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
@@ -29,23 +30,23 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  79c3b26a31948ae8b5e27767acd1642fe20d9250 \
-                 sha256  087ea956e8b43c89c732df8024e1344f686b02611c2c5449be6478299b9a9dac \
-                 size    194770067
+    checksums    rmd160  de9d2b92bbd086b9250efde0214e7bf3cd14d2df \
+                 sha256  134fd0738cb3b204f89f137a989a55b3ed1795751eb38f4e4b01d900b6b6d9bd \
+                 size    194831156
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  a0af7f89624f7ae5c5fa03efa2e8efc5a68a3fce \
-                 sha256  f8ac458076c10f13753b7342033aaa073b715ef798023acf155ba814bff67514 \
-                 size    192746319
+    checksums    rmd160  1f130ba6333f53347bc78f6cb0f59e67e7ec4ba2 \
+                 sha256  e62bdbbaa97d631933554e59a842f0e94b2355fcf6bf8341dd6f2d040653a1f6 \
+                 size    192808746
 }
 
-worksrcdir   ${distname}/zulu-11.jdk
+worksrcdir   ${distname}/zulu-${feature}.jdk
 
 homepage     https://www.azul.com/downloads/
 
 livecheck.type      regex
 livecheck.url       https://cdn.azul.com/zulu/bin/
-livecheck.regex     zulu(11\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
+livecheck.regex     zulu(${feature}\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Open to Azul Zulu 11.76.21 (OpenJDK 11.0.25).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken
