### PR TITLE
gitleaks: Upgrade to 8.21.0

### DIFF
--- a/security/gitleaks/Portfile
+++ b/security/gitleaks/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/zricethezav/gitleaks 8.19.3 v
+go.setup            github.com/zricethezav/gitleaks 8.21.0 v
 go.package          github.com/zricethezav/gitleaks/v8
 go.offline_build    no
 github.tarball_from archive
@@ -25,9 +25,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  0f7ff52f9d5ec7fa20e01a3892a4e07c6faa3cab \
-                    sha256  80b986a3a650fa08b8e864f57b4dffccaa50e6f9623d46a6b7f47c8dbad5da99 \
-                    size    178763
+checksums           rmd160  cf1560dfdcabbf5803ccde26dc25c37854dc95d3 \
+                    sha256  e4c3009009e5789c2e9e18209fd93b5bd4e12831f442fe4b5ee1b2ed17bf5bbd \
+                    size    196416
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

gitleaks: Upgrade to 8.21.0

##### Tested on

macOS 14.7 23H124 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
