### PR TITLE
hugo: update to 0.136.0

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,14 +3,14 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.134.2 v
+go.setup            github.com/gohugoio/hugo 0.136.0 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  18a59fe0417fb8b7c396f5b7b40ee4a605f937c8 \
-                    sha256  6052a0c059e6ef1ab867c8316988b260ce422138a7550829159b23d2296376e0 \
-                    size    21223040
+checksums           rmd160  f04e0d28218fee0b682a3ee4293838ae84140d7d \
+                    sha256  0c488f10b53d20930e2132089caa3727283bf3c2b07a2d3211e94fe553168339 \
+                    size    21226224
 
 categories          www
 installs_libs       no


### PR DESCRIPTION
#### Description
hugo: update to 0.136.0

###### Tested on
macOS 12.7.6 21H1320 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
