### PR TITLE
Various ports: Fix fish completion destination

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        astral-sh ruff 0.6.9
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://astral.sh/ruff
 
@@ -57,7 +57,7 @@ destroot {
     xinstall -d ${bash_comp_path}
     xinstall -m 0644 ${worksrcpath}/${name}.bash ${bash_comp_path}/${name}
 
-    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completion.d
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_comp_path}
     xinstall -m 0644 ${worksrcpath}/${name}.fish ${fish_comp_path}
 }

--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -6,7 +6,7 @@ PortGroup               github 1.0
 
 github.setup            astral-sh uv 0.4.20
 github.tarball_from     archive
-revision                0
+revision                1
 categories              devel python
 license                 {Apache-2 MIT}
 platforms               {darwin >= 17}
@@ -48,7 +48,7 @@ destroot {
     xinstall -d ${bash_comp_path}
     xinstall -m 0644 ${worksrcpath}/${name}.bash ${bash_comp_path}/${name}
 
-    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completion.d
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_comp_path}
     xinstall -m 0644 ${worksrcpath}/${name}.fish ${fish_comp_path}
 }

--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -5,7 +5,7 @@ PortGroup               golang 1.0
 
 go.setup                github.com/blacktop/ipsw 3.1.549 v
 github.tarball_from     archive
-revision                0
+revision                1
 categories              security devel
 license                 MIT
 platforms               {darwin >= 19}
@@ -60,9 +60,9 @@ destroot {
     xinstall -m 644 ${worksrcpath}/${name}.bash \
         ${destroot}${prefix}/share/bash-completion/completions/${name}
 
-    xinstall -d ${destroot}${prefix}/share/fish/vendor_completion.d
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -m 644 ${worksrcpath}/${name}.fish \
-        ${destroot}${prefix}/share/fish/vendor_completion.d
+        ${destroot}${prefix}/share/fish/vendor_completions.d
 
     xinstall -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 644 -W ${worksrcpath} LICENSE README.md \

--- a/sysutils/g-ls/Portfile
+++ b/sysutils/g-ls/Portfile
@@ -5,7 +5,7 @@ PortGroup               golang 1.0
 
 go.setup                github.com/Equationzhao/g 0.29.0 v
 name                    g-ls
-revision                0
+revision                1
 categories              sysutils
 license                 MIT
 platforms               {darwin >= 18}
@@ -38,7 +38,7 @@ destroot {
     xinstall -d ${bash_comp_path}
     xinstall -m 644 ${worksrcpath}/completions/bash/g-completion.bash ${bash_comp_path}/g
 
-    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completion.d
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_comp_path}
     xinstall -m 644 ${worksrcpath}/completions/fish/g.fish ${fish_comp_path}
 }

--- a/sysutils/ipatool/Portfile
+++ b/sysutils/ipatool/Portfile
@@ -5,7 +5,7 @@ PortGroup               golang 1.0
 
 go.setup                github.com/majd/ipatool 2.1.4 v
 github.tarball_from     archive
-revision                0
+revision                1
 categories              sysutils
 license                 MIT
 platforms               {darwin >= 19}
@@ -42,7 +42,7 @@ destroot {
     xinstall -d ${bash_comp_path}
     xinstall -m 0644 ${worksrcpath}/${name}.bash ${bash_comp_path}/${name}
 
-    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completion.d
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_comp_path}
     xinstall -m 0644 ${worksrcpath}/${name}.fish ${fish_comp_path}
 }


### PR DESCRIPTION
#### Description

Fix the fish completion destination for devel/ruff, devel/uv, security/ipsw, sysutils/g-ls, and sysutils/ipatool. Alll of these had been installing completions to `${destroot}${prefix}/share/fish/vendor_completion.d` but the correct destination is `${destroot}${prefix}/share/fish/vendor_completions.d`.

Tests had to be performed manually. I previously had `ruff` and `uv` installed and completions were not invoked. After installation with this change, completions were invoked. I do not use `ipsw`, `g-ls`, and `ipatool`, but have verified completions on them.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 14.7 23H124 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?