### PR TITLE
openjdk8-zulu: update to 8.82.0.21

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -2,10 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk8-zulu
+set feature 8
+name             openjdk${feature}-zulu
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        { darwin any >= 10 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,12 +20,12 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      8.80.0.17
+version      ${feature}.82.0.21
 revision     0
 
-set openjdk_version 8.0.422
+set openjdk_version ${feature}.0.432
 
-description  Azul Zulu Community OpenJDK 8 (Long Term Support)
+description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
                  specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
                  verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
@@ -29,35 +35,25 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  00d2f4eae53352d82528bcf075edc931eecf0e81 \
-                 sha256  bf207515ea67a70b22f4a8f0163105f986e20a09aa65c8ab66ed33991029f0f0 \
-                 size    106718712
+    checksums    rmd160  ab09bbdf3558c75ab4d3ed767b27b4041e1eb37f \
+                 sha256  a5a4bb4e95415d2a0ba719f76662ef87adeb1c8cf739c7ab14c0a2f1b3e62885 \
+                 size    106755351
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  45b480242fe9f758043f07f5d5c5bc861b41565b \
-                 sha256  43f854d88095c2625e86b5e60029b8fd7e3c50b4ea33a592739e490d582406f3 \
-                 size    104540856
+    checksums    rmd160  de8804b1115f3818b8edded23dd2495b7eab6568 \
+                 sha256  1036ce501972464c8e30ea2e0e2dc1c6c82e364edf99d13b9418286f61995f16 \
+                 size    104561942
 }
 
-worksrcdir   ${distname}/zulu-8.jdk
+worksrcdir   ${distname}/zulu-${feature}.jdk
 
 configure.cxx_stdlib libstdc++
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 18} {
-    # See https://www.azul.com/downloads/?os=macos&package=jdk
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.14 Mojave or later."
-        return -code error
-    }
-}
 
 homepage     https://www.azul.com/downloads/
 
 livecheck.type      regex
 livecheck.url       https://cdn.azul.com/zulu/bin/
-livecheck.regex     zulu(8\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
+livecheck.regex     zulu(${feature}\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.82.0.21 (OpenJDK 8u432).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?