### PR TITLE
openjdk23-corretto: update to 23.0.1.8.1

### DIFF
--- a/java/openjdk23-corretto/Portfile
+++ b/java/openjdk23-corretto/Portfile
@@ -2,13 +2,15 @@
 
 PortSystem       1.0
 
-name             openjdk23-corretto
+set feature 23
+name             openjdk${feature}-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto
-# and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any} {darwin >= 21}
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 16 }
 
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -19,33 +21,33 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-23/releases
-version      23.0.0.37.1
+version      ${feature}.0.1.8.1
 revision     0
 
-description  Amazon Corretto OpenJDK 23 (Short Term Support until March 2025)
+description  Amazon Corretto OpenJDK ${feature} (Short Term Support until March 2025)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
 
 master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  cecab8386904156f7e266bbdbdd1615f9820997b \
-                 sha256  a01c65e3e5284d9a591d7ae7ce62917b0e3a10d8eaa05e1f7ca10d430fc9df20 \
-                 size    210028401
+    checksums    rmd160  0a4d6f96bf4b53599afebeb41eb899d5be12d68d \
+                 sha256  2d5ee2fb3cdcb080e009d2cfb3531961acf9d77cb4a2f45cb6976451bcf47dd3 \
+                 size    210053162
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  2a3acd2bd7bc81473bd7f7fe26a9a90aed884837 \
-                 sha256  68849fd895c6a647031322da5e81ded1209755f2dddd31331a46e88899380eaf \
-                 size    207753443
+    checksums    rmd160  65a5f9569f38112fdc039686f387b75a79d70b65 \
+                 sha256  4d56e723ac321f0d9de7297abc2c680f82957cbdf95aebfff512672a1b1103cd \
+                 size    207788843
 }
 
-worksrcdir   amazon-corretto-23.jdk
+worksrcdir   amazon-corretto-${feature}.jdk
 
 homepage     https://aws.amazon.com/corretto/
 
 livecheck.type      regex
-livecheck.url       https://github.com/corretto/corretto-23/releases
-livecheck.regex     amazon-corretto-(23\.\[0-9\.\]+)-macosx-.*\.tar\.gz
+livecheck.url       https://github.com/corretto/corretto-${feature}/releases
+livecheck.regex     amazon-corretto-(${feature}\.\[0-9\.\]+)-macosx-.*\.tar\.gz
 
 use_configure    no
 build {}
@@ -79,7 +81,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-23-amazon-corretto.jdk
+set jdk ${jvms}/jdk-${feature}-amazon-corretto.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 23.0.1.8.1 (OpenJDK 23.0.1).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?