### PR TITLE
openjdk17-corretto: update to 17.0.13.11.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -2,13 +2,15 @@
 
 PortSystem       1.0
 
-name             openjdk17-corretto
+set feature 17
+name             openjdk${feature}-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto
-# and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any} {darwin >= 21}
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 10 }
 
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -19,33 +21,33 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.12.7.1
+version      ${feature}.0.13.11.1
 revision     0
 
-description  Amazon Corretto OpenJDK 17 (Long Term Support)
+description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
 
 master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  c350f80ae93a83263e83fe633092b0a484273b7f \
-                 sha256  11d8732af8a184db085411cd8153a73b6e535324ff115c175504a7233b858961 \
-                 size    188713291
+    checksums    rmd160  81b438712730ef5f1ae3c411e718e9cb8ea9f718 \
+                 sha256  17fb370f6b6e4f79e6fb6ee720631d2c3fd39d90f37d079352327aef4d834689 \
+                 size    188055151
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  e9cb4c8c868666060d2b7ac3e023c447ed023c75 \
-                 sha256  0c0b2b7dabc2b55bd9c1a71d18f375c3570d507613633e861daea3958bd1bf75 \
-                 size    186817195
+    checksums    rmd160  6c6e79216889d9c43feb59ede8ac78629d4a19d8 \
+                 sha256  33b40aee3ae3db7d298bea0bd34574e755beb2f017ce4eb323f8e28960f0324d \
+                 size    186193229
 }
 
-worksrcdir   amazon-corretto-17.jdk
+worksrcdir   amazon-corretto-${feature}.jdk
 
 homepage     https://aws.amazon.com/corretto/
 
 livecheck.type      regex
-livecheck.url       https://github.com/corretto/corretto-17/releases
-livecheck.regex     amazon-corretto-(17\.\[0-9\.\]+)-macosx-.*\.tar\.gz
+livecheck.url       https://github.com/corretto/corretto-${feature}/releases
+livecheck.regex     amazon-corretto-(${feature}\.\[0-9\.\]+)-macosx-.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.13.11.1 (OpenJDK 17.0.13).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?