### PR TITLE
openjdk11-corretto: update to 11.0.25.9.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -2,13 +2,15 @@
 
 PortSystem       1.0
 
-name             openjdk11-corretto
+set feature 11
+name             openjdk${feature}-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto
-# and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any} {darwin >= 21}
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 10 }
 
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -19,33 +21,33 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      11.0.24.8.1
+version      ${feature}.0.25.9.1
 revision     0
 
-description  Amazon Corretto OpenJDK 11 (Long Term Support)
+description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
 
 master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  4b95640f074d4c9ab08db82fa1f8fb62517fe5fa \
-                 sha256  e3d636242b60b5628b3f3078fe9616bdc312e41af5d628349bfd61e3233a2f39 \
-                 size    187851684
+    checksums    rmd160  52fc2f3f46165e5e99951e5266873676320bd547 \
+                 sha256  7eda66648dadf112e51c461c9bdd79f0bcaf79e5665b26d99b4ee92c13a8bf4b \
+                 size    187885510
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  044ffb419f6e8142e6d4fcf113b3686cfb1e1f7f \
-                 sha256  d3739f98b2573eaa0f6a8b2ee073c95ccb7fa80f34c2d6eff20db4f40ee4272d \
-                 size    185400257
+    checksums    rmd160  78ba4200ff695c2a5f80d2329db6ef8205790c97 \
+                 sha256  de89646c6232c288853c080013edfecc455982e9572a48d3c9dc442ba659e55a \
+                 size    185445776
 }
 
-worksrcdir   amazon-corretto-11.jdk
+worksrcdir   amazon-corretto-${feature}.jdk
 
 homepage     https://aws.amazon.com/corretto/
 
 livecheck.type      regex
-livecheck.url       https://github.com/corretto/corretto-11/releases
-livecheck.regex     amazon-corretto-(11\.\[0-9\.\]+)-macosx-.*\.tar\.gz
+livecheck.url       https://github.com/corretto/corretto-${feature}/releases
+livecheck.regex     amazon-corretto-(${feature}\.\[0-9\.\]+)-macosx-.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.25.9.1 (OpenJDK 11.0.25).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?