### PR TITLE
openjdk8-corretto: update to 8.432.06.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -2,13 +2,15 @@
 
 PortSystem       1.0
 
-name             openjdk8-corretto
+set feature 8
+name             openjdk${feature}-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto for minimum supported OS version
-# macOS 12 → Darwin 21 (https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version)
-platforms        {darwin any} {darwin >= 21}
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 10 }
 
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -19,33 +21,33 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.422.05.1
+version      ${feature}.432.06.1
 revision     0
 
-description  Amazon Corretto OpenJDK 8 (Long Term Support)
+description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
 
 master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  fd1623f5887cfe1ca2f1150a2f77ccef8ced9613 \
-                 sha256  5aaca055544ddcbae999a06729ca37e936ba672d8d35ae14a4dbace00e093ba7 \
-                 size    118471283
+    checksums    rmd160  949cfd5fcbef029217c235d17f4d84a8d4396a50 \
+                 sha256  b698659d8ac0dc816e1e971f43894f0d829a6c552887a89a78fa20e0b4e95090 \
+                 size    118482930
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  e17fe590bc03be1bcd9871f2e27e6867851af27e \
-                 sha256  1286deb303cbe3c49c670728eacfd03cfd088e7f81c7d2090f82dc4f51385793 \
-                 size    102898821
+    checksums    rmd160  442353162169b9055fc68ec72360d3bb136b6aeb \
+                 sha256  fe937f047efc3cb5e0f7102a81c7c03b9c82403f8a9baec79c6a3ac38751c3be \
+                 size    102915982
 }
 
-worksrcdir   amazon-corretto-8.jdk
+worksrcdir   amazon-corretto-${feature}.jdk
 
 homepage     https://aws.amazon.com/corretto/
 
 livecheck.type      regex
-livecheck.url       https://github.com/corretto/corretto-8/releases
-livecheck.regex     amazon-corretto-(8\.\[0-9\.\]+)-macosx-.*\.tar\.gz
+livecheck.url       https://github.com/corretto/corretto-${feature}/releases
+livecheck.regex     amazon-corretto-(${feature}\.\[0-9\.\]+)-macosx-.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.432.06.1 (OpenJDK 8u432).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?