### PR TITLE
google-cloud-sdk: update to 497.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             496.0.0
+version             497.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  09633b7c0c34390ddab633409eefde3a7e031d00 \
-                    sha256  8d93e2fca6dc07b94518206a73b0a770f4ddbb26d653320cab8791f52e92f9f0 \
-                    size    52336140
+    checksums       rmd160  1794fcafc6e12d5c7151f1389556ccfca804573f \
+                    sha256  c2bf4ee475785644a63ab88e367189fdb98bde7700cc7173faafac1d64f2bd10 \
+                    size    52285945
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  135885c008382518b3b7c4694aa88c96d7a90068 \
-                    sha256  11c72013000dc33173431276f07419b4e6e4e49cc02cfd8bde374bf119f75850 \
-                    size    53689152
+    checksums       rmd160  65bde5bfe5cf562b5f32e08457de6a8e08487612 \
+                    sha256  261c5ada9571aa0c0fe8ad06f863c5c2f6c61714a5d94379ddd833df67441e17 \
+                    size    53636087
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  9f63713e6078bf21ac54c11b179ffd9bed691872 \
-                    sha256  82bafbed2f387399665e95ce8518627e44ead695ff094edea65597156a4d727e \
-                    size    53636574
+    checksums       rmd160  f2c16597a27b309721e7dbffde1c935765b72be3 \
+                    sha256  0584bd1642e01d5195f75c92fbceb045464a9197cff48d71df2cf0ac51e5d1a4 \
+                    size    53583662
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 497.0.0.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?