### PR TITLE
openjdk11-sap: update to 11.0.25

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -2,10 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk11-sap
+set feature 11
+name             openjdk${feature}-sap
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 16 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,24 +20,24 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.24
+version      ${feature}.0.25
 revision     0
 
-description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
+description  OpenJDK ${feature} builds (Long Term Support) maintained and supported by SAP
 long_description Sap builds of OpenJDK for everyone who wish to use OpenJDK to run their applications.
 
 master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  a1f46617f263ce95368da25d20c91fceaf762d2e \
-                 sha256  2022ece5381172f94cbfd1e1da26f4e39b1859b7adabe3f0cede312f9e78f83c \
-                 size    187783143
+    checksums    rmd160  2c0eba663c0d038ee6f990b7f65aef9f14c0de1a \
+                 sha256  f35dfcd983371dd6ad007ae7ba8f4aca9c9df9b3b030f2d79f4199fa071a7339 \
+                 size    187899279
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  c008c1a5361cccf564b96d5666c1733b3271ae28 \
-                 sha256  ec3a2c845930f622497a222896cc74e2852b3fa37c78b2a8857434f8fc97ca9c \
-                 size    185912902
+    checksums    rmd160  d3f245f5425cc5e096b12e641488c7c7c0aef5d2 \
+                 sha256  8778711f61976d65b63a73cdd8601b080c0f164428a21fd05b2812fe03e0e31c \
+                 size    186016720
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk
@@ -40,7 +46,7 @@ homepage     https://sapmachine.io
 
 livecheck.type      regex
 livecheck.url       https://github.com/SAP/SapMachine/releases
-livecheck.regex     sapmachine-jdk-(11\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
+livecheck.regex     sapmachine-jdk-(${feature}\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.25 (OpenJDK 11.0.25).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?