### PR TITLE
openjdk17-sap: update to 17.0.13

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -2,10 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk17-sap
+set feature 17
+name             openjdk${feature}-sap
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 16 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,24 +20,24 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.12
+version      ${feature}.0.13
 revision     0
 
-description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
+description  OpenJDK ${feature} builds (Long Term Support) maintained and supported by SAP
 long_description Sap builds of OpenJDK for everyone who wish to use OpenJDK to run their applications.
 
 master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  ecdde02b8827db1624aff5a786e709d7c2945f92 \
-                 sha256  7879d4b1304793c25d7363d15068f6a8d81613b1abab89e48f5c26618c1f71ca \
-                 size    188626763
+    checksums    rmd160  81c0f2434a1cec2853ad72c61b008eed731d2d9c \
+                 sha256  db43604a994ec4835c01d03fb7e4e7461d1c9a41b3fc5e3dcc7c0b2a763b044a \
+                 size    188211641
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  69bdd22e0fb6b5fbd24361d9e559febf61395e35 \
-                 sha256  27d7a62448f4dc95506a8a33e14accbd1ff0562fc24ed33644d0f64f13e01027 \
-                 size    186499707
+    checksums    rmd160  8256fd9b8533290ef00a3d45e564c3b711cf4370 \
+                 sha256  e3a9a204362a90d31d56c9c120b2f842c2dca837111ad8090ea50c49824f9678 \
+                 size    186144050
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 
@@ -39,7 +45,7 @@ homepage     https://sapmachine.io
 
 livecheck.type      regex
 livecheck.url       https://github.com/SAP/SapMachine/releases
-livecheck.regex     sapmachine-jdk-(17\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
+livecheck.regex     sapmachine-jdk-(${feature}\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.13 (OpenJDK 17.0.13).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?