### PR TITLE
openjdk21-sap: update to 21.0.5

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -2,10 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk21-sap
+set feature 21
+name             openjdk${feature}-sap
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 16 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,24 +20,24 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/21
-version      21.0.4
+version      ${feature}.0.5
 revision     0
 
-description  SAP Machine 21
-long_description An OpenJDK 21 release maintained and supported by SAP
+description  SAP Machine ${feature}
+long_description An OpenJDK ${feature} release maintained and supported by SAP
 
 master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  af5c18e8fe88b5582f28316877829e77e354acce \
-                 sha256  bf6f6ed13e8064da6a3ee0c799940ca66fd89a82699dc63f07601e8828b97e2e \
-                 size    203297114
+    checksums    rmd160  11187bd9102e719eaafa3eb5bc0188931949dcf2 \
+                 sha256  e344087aa42b1910c6191a7bc5d31d71a776e32e4c89292df0f9b6c4cb29140f \
+                 size    202511940
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  8d03af478b7c19b0d19984a0c9cdbf20368d2d12 \
-                 sha256  6fcf1c1b4adbfdfdb359e687b2707a16410e5b884eb2026f96e7356b195aa1eb \
-                 size    200958486
+    checksums    rmd160  d0a9ac3c98f2953c57667570834068e108f8a8da \
+                 sha256  dd0abf66425a0b299dbccae9b4b6006694c1393d011bb2e7c562363bfb96fe96 \
+                 size    200225682
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk
@@ -40,7 +46,7 @@ homepage     https://sap.github.io/SapMachine/
 
 livecheck.type      regex
 livecheck.url       https://github.com/SAP/SapMachine/releases
-livecheck.regex     sapmachine-jdk-(21\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
+livecheck.regex     sapmachine-jdk-(${feature}\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
 
 use_configure    no
 build {}
@@ -74,7 +80,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-21-sapmachine.jdk
+set jdk ${jvms}/jdk-${feature}-sapmachine.jdk
 
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Update to SapMachine 21.0.5 (OpenJDK 21.0.5).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?