### PR TITLE
libssh2: update to 1.11.1 (CVE-2023-48795)

### DIFF
--- a/devel/libssh2/Portfile
+++ b/devel/libssh2/Portfile
@@ -5,7 +5,7 @@ PortGroup           github      1.0
 PortGroup           muniversal  1.0
 PortGroup           openssl     1.0
 
-github.setup        libssh2 libssh2 1.11.0 libssh2-
+github.setup        libssh2 libssh2 1.11.1 libssh2-
 github.tarball_from releases
 revision            0
 
@@ -23,18 +23,20 @@ long_description    libssh2 is a library implementing the SSH2 protocol as \
 
 license             BSD
 
-checksums           rmd160  de0e85ddd91d1962decfe1e3efefa0ce6d3e9200 \
-                    sha256  3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461 \
-                    size    1053562
+checksums           rmd160  52fe2f3426d24da14fd2ad7a442b536f32c701f1 \
+                    sha256  d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7 \
+                    size    1093012
 
 if {[string match *gcc-4.* ${configure.compiler}]} {
 # Remove errant pragmas inside functions not supported on older gcc versions.
     patchfiles-append patch-libssh2-pragmas-older-gcc.diff
 }
 
+depends_build-append \
+                    bin:gawk:gawk
 depends_lib-append  port:zlib
 
-configure.args      ac_cv_prog_AWK=/usr/bin/awk
+configure.args      ac_cv_prog_AWK=${prefix}/bin/gawk
 
 configure.checks.implicit_function_declaration.whitelist-append strchr
 


### PR DESCRIPTION
- switch to using MacPorts' gawk

CVE: CVE-2023-48795

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with ~`port lint --nitpick`~ `sudo port -d destroot`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
