### PR TITLE
openjdk23-sap: update to 23.0.1

### DIFF
--- a/java/openjdk23-sap/Portfile
+++ b/java/openjdk23-sap/Portfile
@@ -6,7 +6,12 @@ set feature 23
 name             openjdk${feature}-sap
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 16 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -15,7 +20,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/23
-version      ${feature}
+version      ${feature}.0.1
 revision     0
 
 description  SAP Machine ${feature} (Short Term Support until March 2025)
@@ -25,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  d96ddf0e2ffbbd5d544c2e396ec9faf817f8ebdf \
-                 sha256  2125eb7250d331fa18521375d954fdd9efed611308eb72cf732c8c8fd5a877af \
-                 size    209948000
+    checksums    rmd160  609b1bdcd9642ca169f6b8049a77f0df1491ca27 \
+                 sha256  c3c9602fbf9c022792bf31459aceddf0b6510a7ee0126b82344eafb9797aa0f2 \
+                 size    210232199
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  b559c2c8a44ad316f60c46abd00b1edab5a87f3e \
-                 sha256  8c5414b627e9c2616a77f614363b276dca9ac814bffd769eb4aebd9e9fddbafe \
-                 size    207500677
+    checksums    rmd160  1083cb9638488387b8aeda6fd2d54c5caebee34d \
+                 sha256  0af67f212e33ed965cdba44cd0a0cabce41fc7df1224436dfa36b56ce358b088 \
+                 size    207776811
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 23.0.1 (OpenJDK 23.0.1).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?