### PR TITLE
c-ares: Use cmake-bootstrap instead of cmake

### DIFF
--- a/net/c-ares/Portfile
+++ b/net/c-ares/Portfile
@@ -29,7 +29,12 @@ checksums           rmd160  12a83eebd1543ac2ce6255d868b154e6847f6d41 \
                     sha256  7e846f1742ab5998aced36d170408557de5292b92ec404fb0f7422f946d60103 \
                     size    1008224
 
+depends_build-replace \
+                    path:bin/cmake:cmake port:cmake-bootstrap
+
 patchfiles          patch-dnsinfo.h-availability.diff
+
+configure.cmd       ${prefix}/libexec/cmake-bootstrap/bin/cmake
 
 configure.args-append \
                     -DCARES_SHARED:BOOL=ON


### PR DESCRIPTION
#### Description

Resolves dependency cycle when curl is installed with +ares variant.

Closes: https://trac.macports.org/ticket/70910

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
