### PR TITLE
dagger: update to 0.13.5

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.12.2 v
+github.setup        dagger dagger 0.13.5 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  21728a030dcfcf6e13908a729a681759cb9d2c2e \
-                            sha256  7255ea25af4de506328f2c48ddc90ad5cf37bf66c5b652a8b1d5417570a5a6ad \
-                            size    10088619
+        checksums           rmd160  eb54a5a3dfbf06909b4943401e4290e5149e8bf6 \
+                            sha256  8ecea918a4a27ee98f75114b9fff89c558e1cc5bff7c6375940d5607e259b47b \
+                            size    10275206
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  6575e6d5d80c4b703a167de9ff80fa7f3587b339 \
-                            sha256  baf301780f58d3d4982c2fe1592cc8b88493bdd730431d57810408ed0945fa67 \
-                            size    9531091
+        checksums           rmd160  ef6830e2a8bc0fe4a40e7d7bdcfa31646244fea4 \
+                            sha256  7f8328025ad62cb31ad74253ee855b799dd7f7e78c2c27299fa332357d80e3dd \
+                            size    9684356
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Update to current version

###### Tested on
macOS 14.6.1 23G93 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
