### PR TITLE
ruby-build: Upgrade to 20241017

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20241007 v
+github.setup        rbenv ruby-build 20241017 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  61de595497971866bfb4fdc8c20d8512eb3a7691 \
-                    sha256  3670ae797e03f54365bf7bf07194b19a666c2ad15847a505b16023d66a6de1df \
-                    size    92517
+checksums           rmd160  b67086b13026361ea3fcc903eae73189032f7714 \
+                    sha256  3e876c13dc6a5f6a24276d9da9d0126cef3c21354dd33499e6772eeb48692072 \
+                    size    92997
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Upgrade to 20241017

##### Tested on

macOS 14.7 23H124 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
