### PR TITLE
ruff: Update to 0.7.0

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.6.9
+github.setup        astral-sh ruff 0.7.0
 github.tarball_from archive
-revision            1
+revision            0
 
 homepage            https://astral.sh/ruff
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  866ca7fb1bf8fe23ffd3ba8a4d77a711fa88d0ae \
-                    sha256  502811ee2607cb09e3e05f4c3d60ed164a5e5a24aeb87fe00200b8d508a0b0c4 \
-                    size    5156760
+                    rmd160  1485503b8b4e29df31a39057f55e2ee9b682e7ca \
+                    sha256  1bb27c8b7da3d2d2a676c677692f9a527d5fa5697a52c0515f9662f735449293 \
+                    size    5215016
 
 cargo.offline_cmd
 
@@ -67,7 +67,6 @@ cargo.crates \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
     ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
-    allocator-api2                  0.2.16  0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5 \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
@@ -106,8 +105,8 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.18  b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3 \
-    clap_builder                    4.5.18  4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b \
+    clap                            4.5.20  b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8 \
+    clap_builder                    4.5.20  19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54 \
     clap_complete                    4.5.2  dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.2  1accf1b463dee0d3ab2be72591dccdab8bef314958340447c882c4c72acfe2a3 \
@@ -175,6 +174,7 @@ cargo.crates \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
+    hashbrown                       0.15.0  1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb \
     hashlink                         0.9.1  6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
@@ -204,12 +204,12 @@ cargo.crates \
     itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jod-thread                       0.1.2  8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae \
-    js-sys                          0.3.70  1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a \
+    js-sys                          0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
     kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
     kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     libc                           0.2.159  561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5 \
-    libcst                           1.4.0  10293a04a48e8b0cb2cc825a93b83090e527bffd3c897a0255ad7bc96079e920 \
+    libcst                           1.5.0  1586dd7a857d8a61a577afde1a24cc9573ff549eff092d5ce968b1ec93cc61b6 \
     libcst_derive                    1.4.0  a2ae40017ac09cd2c6a53504cb3c871c7f2b41466eac5bc66ba63f39073b467b \
     libmimalloc-sys                 0.1.39  23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
@@ -237,7 +237,7 @@ cargo.crates \
     nu-ansi-term                    0.50.1  d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399 \
     num-traits                      0.2.18  da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
-    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
+    once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
     oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordermap                         0.5.3  31f2bd7b03bf2c767e1bb7b91505dbe022833776e60480275e6f2fb0db0c7503 \
@@ -245,14 +245,14 @@ cargo.crates \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
-    paste                           1.0.14  de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c \
+    paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
     path-absolutize                  3.1.1  e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5 \
     path-dedot                       3.1.1  07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397 \
     path-slash                       0.2.1  1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42 \
-    pathdiff                         0.2.1  8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd \
-    peg                              0.8.2  400bcab7d219c38abf8bd7cc2054eb9bbbd4312d66f6a5557d572a203f646f61 \
-    peg-macros                       0.8.2  46e61cce859b76d19090f62da50a9fe92bab7c2a5f09e183763559a2ac392c90 \
-    peg-runtime                      0.8.2  36bae92c60fa2398ce4678b98b2c4b5a7c61099961ca1fa305aec04a9ad28922 \
+    pathdiff                         0.2.2  d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361 \
+    peg                              0.8.4  295283b02df346d1ef66052a757869b2876ac29a6bb0ac3f5f7cd44aebe40e8f \
+    peg-macros                       0.8.4  bdad6a1d9cf116a059582ce415d5f5566aabcd4008646779dab7fdc2a9a9d426 \
+    peg-runtime                      0.8.3  e3aeb8f54c078314c2065ee649a7241f46b9d8e418e1a9581ba0546657d7aa3a \
     pep440_rs                        0.4.0  e0c29f9c43de378b4e4e0cd7dbcce0e5cfb80443de8c05620368b2948bc936a1 \
     pep440_rs                        0.6.6  466eada3179c2e069ca897b99006cbb33f816290eaeec62464eea907e22ae385 \
     pep508_rs                        0.3.0  910c513bea0f4f833122321c0f20e8c704e01de98692f6989c2ec21f43d88b1e \
@@ -273,7 +273,7 @@ cargo.crates \
     predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
     predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
-    proc-macro2                     1.0.86  5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77 \
+    proc-macro2                     1.0.87  b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a \
     pyproject-toml                   0.9.0  95c3dd745f99aa3c554b7bb00859f7d18c2f1d6afd749ccc86d60b61e702abd9 \
     quick-junit                      0.5.0  62ffd2f9a162cfae131bed6d9d1ed60adced33be340a94f96952897d7cb0c240 \
     quick-xml                       0.36.1  96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc \
@@ -291,10 +291,14 @@ cargo.crates \
     regex-automata                   0.4.8  368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3 \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
+    relative-path                    1.9.3  ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
     ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
+    rstest                          0.22.0  7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936 \
+    rstest_macros                   0.22.0  c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42 \
     rust-stemmers                    1.2.0  e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54 \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
+    rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.37  8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811 \
     rustls                         0.23.10  05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402 \
     rustls-pki-types                 1.7.0  976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d \
@@ -307,6 +311,7 @@ cargo.crates \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
+    semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
     serde                          1.0.210  c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a \
     serde-wasm-bindgen               0.6.5  8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b \
     serde_derive                   1.0.210  243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f \
@@ -315,8 +320,8 @@ cargo.crates \
     serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
     serde_spanned                    0.6.7  eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d \
     serde_test                     1.0.177  7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed \
-    serde_with                       3.9.0  69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857 \
-    serde_with_macros                3.9.0  a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350 \
+    serde_with                      3.11.0  8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817 \
+    serde_with_macros               3.11.0  9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shellexpand                      3.1.0  da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b \
@@ -334,7 +339,7 @@ cargo.crates \
     syn                             2.0.79  89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     tempfile                        3.13.0  f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b \
-    terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
+    terminal_size                    0.4.0  4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef \
     terminfo                         0.8.0  666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f \
     termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
     test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
@@ -387,14 +392,14 @@ cargo.crates \
     vte_generate_state_changes       0.1.1  d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.93  a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5 \
-    wasm-bindgen-backend            0.2.93  9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b \
-    wasm-bindgen-futures            0.4.43  61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed \
-    wasm-bindgen-macro              0.2.93  585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf \
-    wasm-bindgen-macro-support      0.2.93  afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836 \
-    wasm-bindgen-shared             0.2.93  c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484 \
-    wasm-bindgen-test               0.3.43  68497a05fb21143a08a7d24fc81763384a3072ee43c44e86aad1744d6adef9d9 \
-    wasm-bindgen-test-macro         0.3.43  4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021 \
+    wasm-bindgen                    0.2.95  128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e \
+    wasm-bindgen-backend            0.2.95  cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358 \
+    wasm-bindgen-futures            0.4.45  cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b \
+    wasm-bindgen-macro              0.2.95  e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56 \
+    wasm-bindgen-macro-support      0.2.95  26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68 \
+    wasm-bindgen-shared             0.2.95  65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d \
+    wasm-bindgen-test               0.3.45  d381749acb0943d357dcbd8f0b100640679883fcdeeef04def49daf8d33a5426 \
+    wasm-bindgen-test-macro         0.3.45  c97b2ef2c8d627381e51c071c2ab328eac606d3f69dd82bcbca20a9e389d95f0 \
     web-sys                         0.3.69  77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                    0.26.1  b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009 \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.7.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
