### PR TITLE
openjdk21-temurin: update to 21.0.5

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.4
-set build    7
+version      ${feature}.0.5
+set build    11
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature}
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  80c32d2faf305235166539047a0e5bc429e684f8 \
-                 sha256  e368e5de7111aa88e6bbabeff6f4c040772b57fb279cc4e197b51654085bbc18 \
-                 size    194603417
+    checksums    rmd160  e9ac00f5c86c885fecc2b9be6f7820baf9892b3b \
+                 sha256  b9b46f396ab5f3658fa5569af963896167c7f735cfec816359c04101fae38bdf \
+                 size    193852232
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  5c2b2789ac884083614a599767c4777a55080269 \
-                 sha256  dcf69a21601d9b1b25454bbad4f0f32784bb42cdbe4063492e15a851b74cb61e \
-                 size    192096746
+    checksums    rmd160  d90bc6a7d0d5ecc341b59b6f22b574d1b25c0c05 \
+                 sha256  dc6db7347907d23743d13af935d3c10e8b3490acdf542115f578838227da0dab \
+                 size    199597948
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 21.0.5 (OpenJDK 21.0.5).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?