### PR TITLE
openjdk23-temurin: update to 23.0.1

### DIFF
--- a/java/openjdk23-temurin/Portfile
+++ b/java/openjdk23-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}
-set build    37
+version      ${feature}.0.1
+set build    11
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Short Term Support until March 2025)
@@ -27,14 +27,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  94da6f8f4f4c156bc6b4fbca00140a0f0595d289 \
-                 sha256  0b4b14f7cb44cab89083fb72beafa6d4f12ee6722bf682e5dd026dab12cc8d23 \
-                 size    200977435
+    checksums    rmd160  e8cffdb310089ca2afbb0f41b3e30fe185353ec8 \
+                 sha256  055a5b9c27991ad955c8207a20b549ac3254d479aa8a4fc199b6b02d56b1875e \
+                 size    201014412
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  a1f39d6a96a47ec46500170cb5ff97145b0371d0 \
-                 sha256  411934ca9ede95671afc1e7e1d9c8912c43247c7e4fba97730f20c0875287d44 \
-                 size    207118905
+    checksums    rmd160  1051c6ef12de12758b193e4a6ff2b80f635cb88e \
+                 sha256  9e69810a50c8183e01429243d0bb112e381a122c6e7be936b7c13c3cfe7b29a0 \
+                 size    207156358
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 23.0.1 (OpenJDK 23.0.1).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?