### PR TITLE
openjdk17-temurin: update to 17.0.13

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -2,10 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk17-temurin
+set feature 17
+name             openjdk${feature}-temurin
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 16 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,25 +20,25 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.12
-set build    7
+version      ${feature}.0.13
+set build    11
 revision     0
 
-description  Eclipse Temurin, based on OpenJDK 17
+description  Eclipse Temurin, based on OpenJDK ${feature}
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
 
-master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${version}%2B${build}/
+master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk-${version}%2B${build}/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  62505c5826d20b169a0ceff8289f496121b0a0ae \
-                 sha256  d5230eeec88739aa7133e4c8635bbd4ab226708c12deaafa13cf26b02bc8e8c4 \
-                 size    180640890
+    distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
+    checksums    rmd160  61bf3a3347b7a8ae59937201df8dc1a5e1136d5c \
+                 sha256  840535070200a944a6b582d258ee84608bd25c9f2b5d1cdddb58dfadb019675a \
+                 size    179980449
 } elseif {${configure.build_arch} eq "arm64"} {
-    distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  47a7408b4716a3f757845cce2bb339eae29bf0e1 \
-                 sha256  d7910b1acaeb290c5c5da21811d2b2b8635f806612a2d6e8d1953b2f77580f78 \
-                 size    178427485
+    distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
+    checksums    rmd160  d0bfb3664cbde6c1bdd322346e7bb473c5a39a94 \
+                 sha256  f89fdb3d6b8ad55127c2f6cc3e2c3df5d303e9cf0429c4533ff0995ff72e854d \
+                 size    185238298
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -40,8 +46,8 @@ worksrcdir   jdk-${version}+${build}
 homepage     https://adoptium.net
 
 livecheck.type      regex
-livecheck.url       https://github.com/adoptium/temurin17-binaries/releases
-livecheck.regex     OpenJDK17U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
+livecheck.url       https://github.com/adoptium/temurin${feature}-binaries/releases
+livecheck.regex     OpenJDK${feature}U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.13 (OpenJDK 17.0.13).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?