### PR TITLE
mat2: bump python from 3.11 to 3.12

### DIFF
--- a/multimedia/mat2/Portfile
+++ b/multimedia/mat2/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                mat2
 version             0.13.4
-revision            0
+revision            1
 categories-prepend  multimedia
 license             LGPL-3
 supported_archs     noarch
@@ -22,7 +22,7 @@ checksums           rmd160  2b44330ae69d37ecb916fc35614365dfbc4fe67f \
                     sha256  744aeee924c9898a397fe930593b803c540389bf39cd24553b99a89acc2f5901 \
                     size    47947
 
-python.default_version 311
+python.default_version 312
 
 depends_lib-append  port:py${python.version}-cairo \
                     port:py${python.version}-mutagen \


### PR DESCRIPTION
#### Description

bump mat2 default python version to 3.12

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
