### PR TITLE
erlang: update to 27.1.2

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                erlang
-version             27.0
+version             27.1.2
 revision            0
 
 set doc_version     ${version}
@@ -46,17 +46,17 @@ distfiles           otp_src_${version}${extract.suffix}                    \
                     otp_doc_html_${doc_version}${extract.suffix}
 
 checksums           otp_src_${version}.tar.gz \
-                    rmd160  b3d8528389c497ee547bf94b0ad2c33cbb0290de \
-                    sha256  56412677466b756740fb2dbf4a8019e7c7cc38f01bd30c4cac5210214cafeef6 \
-                    size    101038198 \
+                    rmd160  81fd4dce5ef82df0e986a0299ce27c871cb211fe \
+                    sha256  1772e9fa07b2b020ed5911d6ce78b251dfb6ed8509ed7de9d372e96b87251d14 \
+                    size    101338359 \
                     otp_doc_man_${doc_version}.tar.gz \
-                    rmd160  14a6963ba477eabdd3e27324afa839686b07c364 \
-                    sha256  95a2ea0e22ea4b7d58e74df145b52e2c85b642434391c814300824204a107c38 \
-                    size    1764909 \
+                    rmd160  9bae6ac9e6cdb09e0f1e7de8acfa504513f7c271 \
+                    sha256  76f01e6833d841e614929a2b7426b0b08b32daae985ee3e81f2dedb17d367048 \
+                    size    45065 \
                     otp_doc_html_${doc_version}.tar.gz \
-                    rmd160  a769c4f2f72019e00978a60a1ac002cd993a81f7 \
-                    sha256  69c926bbf1b3fed93f361317a481910dae98f9700f58765b36c4875044bcc9d7 \
-                    size    29506649
+                    rmd160  a9c21d599f5de594a67b5005234c23c773634f7f \
+                    sha256  a46eea48eab01404eddd649f044bd30f5e4fb432df94be26345410590d1c3f53 \
+                    size    29910123
 
 worksrcdir          otp_src_${version}
 
@@ -83,9 +83,8 @@ post-destroot   {
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_html_${doc_version}${extract.suffix}]"
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf [shellescape ${distpath}/otp_doc_man_${doc_version}${extract.suffix}]"
 
-    set erts_dir            erts-12.2
-    set erl_interface_dir   erl_interface-5.1
-    set wx_dir              wx-2.1.1
+    set erts_dir            [glob -tails -directory ${destroot}${prefix}/lib/erlang/lib/ erts-*]
+    set erl_interface_dir   [glob -tails -directory ${destroot}${prefix}/lib/erlang/lib/ erl_interface-*]
 
     foreach x {dialyzer ear ecc elink epmd erl erlc escript run_erl start to_erl typer} {
         delete ${destroot}${prefix}/bin/${x}
@@ -120,6 +119,10 @@ platform darwin {
         # also "-framework Appkit"?
         configure.ldflags-append -framework CoreFoundation
     }
+
+    # asmjit fix for Sonoma annoying popup with JIT on amd64
+    # Upstream didn't want to include it yet
+    patchfiles-append           patch-asmjit-dualmap.diff
 }
 
 # FIXME: allow building with wxGTK on older systems.

--- a/lang/erlang/files/patch-asmjit-dualmap.diff
+++ b/lang/erlang/files/patch-asmjit-dualmap.diff
@@ -1,0 +1,457 @@
+diff --color=auto -ru erts/emulator/asmjit/core/globals.cpp asmjit.patched/core/globals.cpp
+--- erts/emulator/asmjit/core/globals.cpp	2024-10-17 10:41:53
++++ asmjit.patched/core/globals.cpp	2024-10-19 09:24:53
+@@ -87,6 +87,7 @@
+     "ExpressionOverflow\0"
+     "FailedToOpenAnonymousMemory\0"
+     "FailedToOpenFile\0"
++    "ProtectionFailure\0"
+     "<Unknown>\0";
+ 
+   static const uint16_t sErrorIndex[] = {
+@@ -94,7 +95,7 @@
+     247, 264, 283, 298, 314, 333, 352, 370, 392, 410, 429, 444, 460, 474, 488,
+     508, 533, 551, 573, 595, 612, 629, 645, 661, 677, 694, 709, 724, 744, 764,
+     784, 817, 837, 852, 869, 888, 909, 929, 943, 964, 978, 996, 1012, 1028, 1047,
+-    1073, 1088, 1104, 1119, 1134, 1164, 1188, 1207, 1235, 1252
++    1073, 1088, 1104, 1119, 1134, 1164, 1188, 1207, 1235, 1252, 1270
+   };
+   // @EnumStringEnd@
+ 
+diff --color=auto -ru erts/emulator/asmjit/core/globals.h asmjit.patched/core/globals.h
+--- erts/emulator/asmjit/core/globals.h	2024-10-17 10:41:53
++++ asmjit.patched/core/globals.h	2024-10-19 09:24:53
+@@ -330,6 +330,10 @@
+   //! \note This is a generic error that is used by internal filesystem API.
+   kErrorFailedToOpenFile,
+ 
++  //! Protection failure can be returned from a virtual memory allocator or when trying to change memory access
++  //! permissions.
++  kErrorProtectionFailure,
++
+   // @EnumValuesEnd@
+ 
+   //! Count of AsmJit error codes.
+diff --color=auto -ru erts/emulator/asmjit/core/virtmem.cpp asmjit.patched/core/virtmem.cpp
+--- erts/emulator/asmjit/core/virtmem.cpp	2024-10-17 10:41:53
++++ asmjit.patched/core/virtmem.cpp	2024-10-19 09:24:53
+@@ -76,8 +76,6 @@
+     #define MAP_ANONYMOUS MAP_ANON
+   #endif
+ 
+-  #define ASMJIT_ANONYMOUS_MEMORY_USE_FD
+-
+   // Android NDK doesn't provide `shm_open()` and `shm_unlink()`.
+   #if !defined(__BIONIC__) && !defined(ASMJIT_NO_SHM_OPEN)
+     #define ASMJIT_HAS_SHM_OPEN
+@@ -89,18 +87,60 @@
+     #define ASMJIT_VM_SHM_DETECT 1
+   #endif
+ 
+-  #if defined(__APPLE__) && TARGET_OS_OSX && ASMJIT_ARCH_ARM >= 64
+-    #define ASMJIT_HAS_PTHREAD_JIT_WRITE_PROTECT_NP
++  #if defined(__APPLE__) && TARGET_OS_OSX
++    #if ASMJIT_ARCH_X86 != 0
++      #define ASMJIT_ANONYMOUS_MEMORY_USE_MACH_VM_REMAP
++    #endif
++    #if ASMJIT_ARCH_ARM >= 64
++      #define ASMJIT_HAS_PTHREAD_JIT_WRITE_PROTECT_NP
++    #endif
+   #endif
+ 
++  #if defined(__APPLE__) && ASMJIT_ARCH_X86 == 0
++    #define ASMJIT_NO_DUAL_MAPPING
++  #endif
++
+   #if defined(__NetBSD__) && defined(MAP_REMAPDUP) && defined(PROT_MPROTECT)
+-    #undef ASMJIT_ANONYMOUS_MEMORY_USE_FD
+     #define ASMJIT_ANONYMOUS_MEMORY_USE_REMAPDUP
+   #endif
++
++  #if !defined(ASMJIT_ANONYMOUS_MEMORY_USE_REMAPDUP) && \
++      !defined(ASMJIT_ANONYMOUS_MEMORY_USE_MACH_VM_REMAP) && \
++      !defined(ASMJIT_NO_DUAL_MAPPING)
++    #define ASMJIT_ANONYMOUS_MEMORY_USE_FD
++  #endif
+ #endif
+ 
+ #include <atomic>
+ 
++#if defined(ASMJIT_ANONYMOUS_MEMORY_USE_MACH_VM_REMAP)
++#include <mach/mach.h>
++#include <mach/mach_time.h>
++
++extern "C" {
++
++#ifdef mig_external
++mig_external
++#else
++extern
++#endif
++kern_return_t mach_vm_remap(
++  vm_map_t target_task,
++  mach_vm_address_t *target_address,
++  mach_vm_size_t size,
++  mach_vm_offset_t mask,
++  int flags,
++  vm_map_t src_task,
++  mach_vm_address_t src_address,
++  boolean_t copy,
++  vm_prot_t *cur_protection,
++  vm_prot_t *max_protection,
++  vm_inherit_t inheritance
++);
++
++} // {extern "C"}
++#endif
++
+ ASMJIT_BEGIN_SUB_NAMESPACE(VirtMem)
+ 
+ // Virtual Memory Utilities
+@@ -141,6 +181,11 @@
+   return ::GetLargePageMinimum();
+ }
+ 
++static bool hasDualMappingSupport() noexcept {
++  // TODO: This assumption works on X86 platforms, this may not work on AArch64.
++  return true;
++}
++
+ // Returns windows-specific protectFlags from \ref MemoryFlags.
+ static DWORD protectFlagsFromMemoryFlags(MemoryFlags memoryFlags) noexcept {
+   DWORD protectFlags;
+@@ -165,7 +210,12 @@
+ }
+ 
+ static HardenedRuntimeFlags getHardenedRuntimeFlags() noexcept {
+-  return HardenedRuntimeFlags::kNone;
++  HardenedRuntimeFlags flags = HardenedRuntimeFlags::kNone;
++
++  if (hasDualMappingSupport())
++    flags |= HardenedRuntimeFlags::kDualMapping;
++
++  return flags;
+ }
+ 
+ Error alloc(void** p, size_t size, MemoryFlags memoryFlags) noexcept {
+@@ -703,8 +753,8 @@
+ 
+ // Detects whether MAP_JIT is available.
+ static inline bool hasMapJitSupport() noexcept {
+-#if defined(__APPLE__) && TARGET_OS_OSX && ASMJIT_ARCH_ARM >= 64
+-  // OSX on AArch64 always uses hardened runtime + MAP_JIT:
++#if defined(__APPLE__) && TARGET_OS_OSX && ASMJIT_ARCH_X86 == 0
++  // Apple platforms always use hardened runtime + MAP_JIT on non-x86 hardware:
+   //   - https://developer.apple.com/documentation/apple_silicon/porting_just-in-time_compilers_to_apple_silicon
+   return true;
+ #elif defined(__APPLE__) && TARGET_OS_OSX
+@@ -746,6 +796,14 @@
+ #endif
+ }
+ 
++static inline bool hasDualMappingSupport() noexcept {
++#if defined(ASMJIT_NO_DUAL_MAPPING)
++  return false;
++#else
++  return true;
++#endif
++}
++
+ static HardenedRuntimeFlags getHardenedRuntimeFlags() noexcept {
+   HardenedRuntimeFlags flags = HardenedRuntimeFlags::kNone;
+ 
+@@ -755,6 +813,9 @@
+   if (hasMapJitSupport())
+     flags |= HardenedRuntimeFlags::kMapJit;
+ 
++  if (hasDualMappingSupport())
++    flags |= HardenedRuntimeFlags::kDualMapping;
++
+   return flags;
+ }
+ 
+@@ -828,6 +889,7 @@
+ // Virtual Memory [Posix] - Dual Mapping
+ // =====================================
+ 
++#if !defined(ASMJIT_NO_DUAL_MAPPING)
+ static Error unmapDualMapping(DualMapping* dm, size_t size) noexcept {
+   Error err1 = unmapMemory(dm->rx, size);
+   Error err2 = kErrorOk;
+@@ -843,6 +905,7 @@
+   dm->rw = nullptr;
+   return kErrorOk;
+ }
++#endif // !ASMJIT_NO_DUAL_MAPPING
+ 
+ #if defined(ASMJIT_ANONYMOUS_MEMORY_USE_REMAPDUP)
+ static Error allocDualMappingUsingRemapdup(DualMapping* dmOut, size_t size, MemoryFlags memoryFlags) noexcept {
+@@ -875,16 +938,105 @@
+ }
+ #endif
+ 
+-Error allocDualMapping(DualMapping* dm, size_t size, MemoryFlags memoryFlags) noexcept {
+-  dm->rx = nullptr;
+-  dm->rw = nullptr;
++#if defined(ASMJIT_ANONYMOUS_MEMORY_USE_MACH_VM_REMAP)
++static Error asmjitErrorFromKernResult(kern_return_t result) noexcept {
++  switch (result) {
++    case KERN_PROTECTION_FAILURE:
++      return DebugUtils::errored(kErrorProtectionFailure);
++    case KERN_NO_SPACE:
++      return DebugUtils::errored(kErrorOutOfMemory);
++    case KERN_INVALID_ARGUMENT:
++      return DebugUtils::errored(kErrorInvalidArgument);
++    default:
++      return DebugUtils::errored(kErrorInvalidState);
++  }
++}
+ 
+-  if (off_t(size) <= 0)
+-    return DebugUtils::errored(size == 0 ? kErrorInvalidArgument : kErrorTooLarge);
++static Error allocDualMappingUsingMachVmRemap(DualMapping* dmOut, size_t size, MemoryFlags memoryFlags) noexcept {
++  DualMapping dm {};
+ 
+-#if defined(ASMJIT_ANONYMOUS_MEMORY_USE_REMAPDUP)
+-  return allocDualMappingUsingRemapdup(dm, size, memoryFlags);
+-#elif defined(ASMJIT_ANONYMOUS_MEMORY_USE_FD)
++  MemoryFlags mmapFlags = MemoryFlags::kAccessReadWrite | (memoryFlags & MemoryFlags::kMapShared);
++  ASMJIT_PROPAGATE(mapMemory(&dm.rx, size, mmapFlags));
++
++  vm_prot_t curProt;
++  vm_prot_t maxProt;
++
++  int rwProtectFlags = VM_PROT_READ | VM_PROT_WRITE;
++  int rxProtectFlags = VM_PROT_READ;
++
++  if (Support::test(memoryFlags, MemoryFlags::kAccessExecute))
++    rxProtectFlags |= VM_PROT_EXECUTE;
++
++  kern_return_t result {};
++  do {
++    vm_map_t task = mach_task_self();
++    mach_vm_address_t remappedAddr {};
++
++#if defined(VM_FLAGS_RANDOM_ADDR)
++    int remapFlags = VM_FLAGS_ANYWHERE | VM_FLAGS_RANDOM_ADDR;
++#else
++    int remapFlags = VM_FLAGS_ANYWHERE;
++#endif
++
++    // Try to remap the existing memory into a different address.
++    result = mach_vm_remap(
++      task,                       // target_task
++      &remappedAddr,              // target_address
++      size,                       // size
++      0,                          // mask
++      remapFlags,                 // flags
++      task,                       // src_task
++      (mach_vm_address_t)dm.rx,   // src_address
++      false,                      // copy
++      &curProt,                   // cur_protection
++      &maxProt,                   // max_protection
++      VM_INHERIT_DEFAULT);        // inheritance
++
++    if (result != KERN_SUCCESS)
++      break;
++
++    dm.rw = (void*)remappedAddr;
++
++    // Now, try to change permissions of both map regions into RW and RX. The vm_protect()
++    // API is used twice as we also want to set maximum permissions, so nobody would be
++    // allowed to change the RX region back to RW or RWX (if RWX is allowed).
++    uint32_t i;
++    for (i = 0; i < 2; i++) {
++      bool setMaximum = (i == 0);
++
++      result = vm_protect(
++        task,                       // target_task
++        (vm_address_t)dm.rx,        // address
++        size,                       // size
++        setMaximum,                 // set_maximum
++        rxProtectFlags);            // new_protection
++
++      if (result != KERN_SUCCESS)
++        break;
++
++      result = vm_protect(task,     // target_task
++        (vm_address_t)dm.rw,        // address
++        size,                       // size
++        setMaximum,                 // set_maximum
++        rwProtectFlags);            // new_protection
++
++      if (result != KERN_SUCCESS)
++        break;
++    }
++  } while (0);
++
++  if (result != KERN_SUCCESS) {
++    unmapDualMapping(&dm, size);
++    return DebugUtils::errored(asmjitErrorFromKernResult(result));
++  }
++
++  *dmOut = dm;
++  return kErrorOk;
++}
++#endif // ASMJIT_ANONYMOUS_MEMORY_USE_MACH_VM_REMAP
++
++#if defined(ASMJIT_ANONYMOUS_MEMORY_USE_FD)
++static Error allocDualMappingUsingFile(DualMapping* dm, size_t size, MemoryFlags memoryFlags) noexcept {
+   bool preferTmpOverDevShm = Support::test(memoryFlags, MemoryFlags::kMappingPreferTmp);
+   if (!preferTmpOverDevShm) {
+     AnonymousMemoryStrategy strategy;
+@@ -910,13 +1062,39 @@
+   dm->rx = ptr[0];
+   dm->rw = ptr[1];
+   return kErrorOk;
++}
++#endif // ASMJIT_ANONYMOUS_MEMORY_USE_FD
++
++Error allocDualMapping(DualMapping* dm, size_t size, MemoryFlags memoryFlags) noexcept {
++  dm->rx = nullptr;
++  dm->rw = nullptr;
++
++#if defined(ASMJIT_NO_DUAL_MAPPING)
++  DebugUtils::unused(size, memoryFlags);
++  return DebugUtils::errored(kErrorFeatureNotEnabled);
+ #else
+-  #error "[asmjit] VirtMem::allocDualMapping() doesn't have implementation for the target OS and compiler"
++  if (off_t(size) <= 0)
++    return DebugUtils::errored(size == 0 ? kErrorInvalidArgument : kErrorTooLarge);
++
++#if defined(ASMJIT_ANONYMOUS_MEMORY_USE_REMAPDUP)
++  return allocDualMappingUsingRemapdup(dm, size, memoryFlags);
++#elif defined(ASMJIT_ANONYMOUS_MEMORY_USE_MACH_VM_REMAP)
++  return allocDualMappingUsingMachVmRemap(dm, size, memoryFlags);
++#elif defined(ASMJIT_ANONYMOUS_MEMORY_USE_FD)
++  return allocDualMappingUsingFile(dm, size, memoryFlags);
++#else
++  #error "[asmjit] VirtMem::allocDualMapping() doesn't have implementation for the target OS or architecture"
+ #endif
++#endif // ASMJIT_NO_DUAL_MAPPING
+ }
+ 
+ Error releaseDualMapping(DualMapping* dm, size_t size) noexcept {
++#if defined(ASMJIT_NO_DUAL_MAPPING)
++  DebugUtils::unused(dm, size);
++  return DebugUtils::errored(kErrorFeatureNotEnabled);
++#else
+   return unmapDualMapping(dm, size);
++#endif // ASMJIT_NO_DUAL_MAPPING
+ }
+ #endif
+ 
+@@ -1017,8 +1195,9 @@
+ 
+   INFO("VirtMem::hardenedRuntimeInfo():");
+   INFO("  flags:");
+-  INFO("    kEnabled: %s", Support::test(hardenedFlags, VirtMem::HardenedRuntimeFlags::kEnabled) ? "true" : "false");
+-  INFO("    kMapJit: %s", Support::test(hardenedFlags, VirtMem::HardenedRuntimeFlags::kMapJit) ? "true" : "false");
++  INFO("    kEnabled: %s"    , Support::test(hardenedFlags, VirtMem::HardenedRuntimeFlags::kEnabled    ) ? "true" : "false");
++  INFO("    kMapJit: %s"     , Support::test(hardenedFlags, VirtMem::HardenedRuntimeFlags::kMapJit     ) ? "true" : "false");
++  INFO("    kDualMapping: %s", Support::test(hardenedFlags, VirtMem::HardenedRuntimeFlags::kDualMapping) ? "true" : "false");
+ }
+ 
+ ASMJIT_END_NAMESPACE
+diff --color=auto -ru erts/emulator/asmjit/core/virtmem.h asmjit.patched/core/virtmem.h
+--- erts/emulator/asmjit/core/virtmem.h	2024-10-17 10:41:53
++++ asmjit.patched/core/virtmem.h	2024-10-19 09:24:53
+@@ -10,6 +10,7 @@
+ #ifndef ASMJIT_NO_JIT
+ 
+ #include "../core/globals.h"
++#include "../core/support.h"
+ 
+ ASMJIT_BEGIN_NAMESPACE
+ 
+@@ -215,15 +216,31 @@
+   //! architecture.
+   kEnabled = 0x00000001u,
+ 
+-  //! Read+Write+Execute can only be allocated with MAP_JIT flag (Apple specific, only available on OSX).
+-  kMapJit = 0x00000002u
++  //! Read+Write+Execute can only be allocated with MAP_JIT flag (Apple specific, only available on Apple platforms).
++  kMapJit = 0x00000002u,
++
++  //! Read+Write+Execute can be allocated with dual mapping approach (one region with RW and the other with RX).
++  kDualMapping = 0x00000004u
+ };
+ ASMJIT_DEFINE_ENUM_FLAGS(HardenedRuntimeFlags)
+ 
+ //! Hardened runtime information.
+ struct HardenedRuntimeInfo {
++  //! \name Members
++  //! \{
++
+   //! Hardened runtime flags.
+   HardenedRuntimeFlags flags;
++
++  //! \}
++
++  //! \name Accessors
++  //! \{
++
++  //! Tests whether the hardened runtime `flag` is set.
++  ASMJIT_INLINE_NODEBUG bool hasFlag(HardenedRuntimeFlags flag) const noexcept { return Support::test(flags, flag); }
++
++  //! \}
+ };
+ 
+ //! Returns runtime features provided by the OS.
+diff --color=auto -ru erts/emulator/asmjit/x86/x86emitter.h asmjit.patched/x86/x86emitter.h
+--- erts/emulator/asmjit/x86/x86emitter.h	2024-10-17 10:41:53
++++ asmjit.patched/x86/x86emitter.h	2024-10-19 09:24:53
+@@ -2827,7 +2827,7 @@
+   ASMJIT_INST_3x(vpand, Vpand, Vec, Vec, Mem)                          // AVX+
+   ASMJIT_INST_3x(vpandd, Vpandd, Vec, Vec, Vec)                        //      AVX512_F{kz|b32}
+   ASMJIT_INST_3x(vpandd, Vpandd, Vec, Vec, Mem)                        //      AVX512_F{kz|b32}
+-  ASMJIT_INST_3x(vpandn, Vpandn, Vec, Vec, Vec)                        // AV+
++  ASMJIT_INST_3x(vpandn, Vpandn, Vec, Vec, Vec)                        // AVX+
+   ASMJIT_INST_3x(vpandn, Vpandn, Vec, Vec, Mem)                        // AVX+
+   ASMJIT_INST_3x(vpandnd, Vpandnd, Vec, Vec, Vec)                      //      AVX512_F{kz|b32}
+   ASMJIT_INST_3x(vpandnd, Vpandnd, Vec, Vec, Mem)                      //      AVX512_F{kz|b32}
+@@ -3186,7 +3186,7 @@
+   ASMJIT_INST_2x(vpopcntq, Vpopcntq, Vec, Mem)                         //      AVX512_VPOPCNTDQ{kz|b64}
+   ASMJIT_INST_2x(vpopcntw, Vpopcntw, Vec, Vec)                         //      AVX512_BITALG{kz|b32}
+   ASMJIT_INST_2x(vpopcntw, Vpopcntw, Vec, Mem)                         //      AVX512_BITALG{kz|b32}
+-  ASMJIT_INST_3x(vpor, Vpor, Vec, Vec, Vec)                            // AV+
++  ASMJIT_INST_3x(vpor, Vpor, Vec, Vec, Vec)                            // AVX+
+   ASMJIT_INST_3x(vpor, Vpor, Vec, Vec, Mem)                            // AVX+
+   ASMJIT_INST_3x(vpord, Vpord, Vec, Vec, Vec)                          //      AVX512_F{kz|b32}
+   ASMJIT_INST_3x(vpord, Vpord, Vec, Vec, Mem)                          //      AVX512_F{kz|b32}
+--- erts/configure	2024-10-19 20:50:46
++++ erts/configure	2024-10-19 20:51:39
+@@ -25482,32 +25482,7 @@
+ 
+    case "$ARCH" in
+         amd64)
+-           case "$OPSYS" in
+-              darwin)
+-                # macOS Sonoma introduced some very annoying popups when
+-                # dual-mapping memory through the documented APIs, and we did
+-                # not wish to start using undocumented functionality in a patch
+-                # release, so we have disabled the JIT by default on this
+-                # platform.
+-                #
+-                # The previous version, macOS Ventura, does not have the
+-                # annoying popups, so it is still possible to explicitly
+-                # enable the JIT.
+-                #
+-                # The ARM JIT is unaffected because it uses per-thread
+-                # permissions instead of dual-mapped memory.
+-                if test ${enable_jit} = yes; then
+-                  JIT_ARCH=x86
+-                else
+-                  enable_jit=no
+-                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: JIT disabled due to annoying popus on x86 Macs with Sononma" >&5
+-printf "%s\n" "$as_me: WARNING: JIT disabled due to annoying popus on x86 Macs with Sononma" >&2;}
+-                fi
+-                ;;
+-              *)
+-                JIT_ARCH=x86
+-                ;;
+-           esac
++           JIT_ARCH=x86
+            ;;
+         arm64)
+            case "$OPSYS" in


### PR DESCRIPTION
Also fix support for JIT which was disabled by default by upstream on macOS/amd64 because of an annoying popup starting from Sonoma. Fix was eventually provided by asmjit and this is backported here as a patch.

Also fix a bug where tools such as epmd were not properly symlinked.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
