### PR TITLE
openjdk21: update to 21.0.5

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -5,9 +5,9 @@ PortSystem          1.0
 set feature 21
 name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk21/ for the version and build number that matches the latest '-ga' version
-version             ${feature}.0.4
-set build 7
-revision            1
+version             ${feature}.0.5
+set build 11
+revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -26,9 +26,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  54dd5afc18c2b631b7d70e51d69cb69c8456d551 \
-                    sha256  d171ebc9bf386b597e5fbcc41729d64bfb4b309670e4dc22fc05ef7b56d45152 \
-                    size    69647724
+checksums           rmd160  3005b3b3dbd1c1fed06af9f9b60e03a53923fcaf \
+                    sha256  8a5d8be31d83edead93b02c7495960f969ddea38b59426a8d7b45aaadd82a960 \
+                    size    69823212
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.5.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?