### PR TITLE
openjdk17: update to 17.0.13

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -2,31 +2,32 @@
 
 PortSystem          1.0
 
-name                openjdk17
+set feature 17
+name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk17/ for the version and build number that matches the latest '-ga' version
-version             17.0.12
-set build 7
-revision            1
+version             ${feature}.0.13
+set build 11
+revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
 maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
-description         OpenJDK 17
-long_description    JDK 17 builds of OpenJDK, the Open-Source implementation \
+description         OpenJDK ${feature}
+long_description    JDK ${feature} builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
-homepage            https://openjdk.org/projects/jdk/17/
-master_sites        https://openjdk-sources.osci.io/openjdk17/
+homepage            https://openjdk.org/projects/jdk/${feature}/
+master_sites        https://openjdk-sources.osci.io/openjdk${feature}/
 distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  411ea9d5a7d8b87317a8945e04fcc4c14cdb5086 \
-                    sha256  efeb07211d69b8b2abf2b8930b6fce359c0917def5646e78f95bd33e9cb425b2 \
-                    size    65821300
+checksums           rmd160  61878ca56c7b0b395b545c43b1350e80616c0418 \
+                    sha256  bb53c87cea4e1d145d2bef567f003f50e47f10495bbaac43c1d50874aa89c694 \
+                    size    66424164
 
 depends_lib         port:freetype \
                     port:libiconv
-depends_build       port:openjdk17-bootstrap \
+depends_build       port:openjdk${feature}-bootstrap \
                     port:autoconf \
                     port:gmake \
                     port:bash
@@ -55,7 +56,7 @@ configure.args      --with-debug-level=release \
                     --with-extra-cflags="${configure.cflags}" \
                     --with-extra-cxxflags="${configure.cxxflags}" \
                     --with-extra-ldflags="${configure.ldflags}" \
-                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk17-bootstrap/Contents/Home \
+                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk${feature}-bootstrap/Contents/Home \
                     --with-freetype=system \
                     --with-freetype-include=${prefix}/include/freetype2 \
                     --with-freetype-lib=${prefix}/lib \
@@ -170,5 +171,5 @@ export JAVA_HOME=${jdk}/Contents/Home
 "
     
 livecheck.type      regex
-livecheck.url       https://openjdk-sources.osci.io/openjdk17/
-livecheck.regex     openjdk-(17\.\[0-9.\]+)-ga
+livecheck.url       https://openjdk-sources.osci.io/openjdk${feature}/
+livecheck.regex     openjdk-(${feature}\.\[0-9.\]+)-ga


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.13.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?