### PR TITLE
py-pyobjc: fix Quartz module on macOS 15

### DIFF
--- a/python/py-pyobjc/Portfile
+++ b/python/py-pyobjc/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        ronaldoussoren pyobjc 10.1 v
-revision            0
+revision            1
 
 checksums           rmd160  4ed3e4de68817e52920dc72bc9d2a3e667c56b80 \
                     sha256  079c59f41c75c36fbbbc9b72f49b6afdaeedbc503f6263c9c8d7542303d93c89 \
@@ -55,6 +55,12 @@ if {${name} ne ${subport}} {
 
     use_xcode                  yes
     compiler.blacklist-append  {clang < 900}
+
+    # Quartz module uses CGWindowListCreateImageFromArray which is no longer available on macOS 15
+    # See https://trac.macports.org/ticket/71103
+    if {${os.platform} eq "darwin" && [vercmp ${macosx_deployment_target} >= 15.0]} {
+        macosx_deployment_target 14.0
+    }
 
     post-patch {
         reinplace \


### PR DESCRIPTION
#### Description

Fix build of Quartz module by setting deployment target to macOS 14 (see [Sequoia Problems](https://trac.macports.org/wiki/SequoiaProblems)), because `CGWindowListCreateImageFromArray` is no longer available on macOS 15.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?