### PR TITLE
osxphotos: update to 0.68.6

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.68.5
+version                 0.68.6
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  97eb477d3ce5544e6f12d2c591a2e6af64d2592f \
-                        sha256  505eb5f2ef162b3edfd2373b7ba8388cece9a6a6f23c5eb382246934f075ef06 \
-                        size    2169009
+checksums               rmd160  980a7e9a7031c7c0ded012956c048fe0d25ba1a0 \
+                        sha256  2b501749e209398f2c0b7a9d2be6538822dd359539dd90f37db56f24c879282c \
+                        size    2185193
 
 python.default_version  312
 
@@ -73,3 +73,4 @@ test.run    yes
 test.cmd    osxphotos
 test.target
 test.args   version
+


### PR DESCRIPTION
#### Description

Update to osxphotos 0.68.6.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?