### PR TITLE
nco: update to 5.2.9

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.2.8
+github.setup        nco nco 5.2.9
 revision            0
-platforms           darwin
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
                     openmaintainer
@@ -21,9 +20,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  d4b78ad5383becff29d46677b5e58fd1a4904cae \
-                    sha256  da29dad0313c457e2cfd4e614da13545bb1a142cca57a57d2b865c7778e14762 \
-                    size    6835842
+checksums           rmd160  c8f3c750d9bc26814868993aeaab40a5667c9104 \
+                    sha256  a7ba0b5cf328c6a4a8d6c8edf5bfc04629109580fc56b80baa86c0dec82cd021 \
+                    size    6840905
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Simple upgrade to upstream version 5.2.9
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.0.1 24A348 x86_64
Command Line Tools 16.0.0.0.1.1724870825

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
