### PR TITLE
openjdk21-microsoft: update to 21.0.5

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.4
-set build    7
+version      ${feature}.0.5
+set build    11
 revision     0
 
 description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  5ee1a5eb33847e69b0860044d9fa9306fd565886 \
-                 sha256  8bf2a7b24746af5a802bafd29adee6dccd1337a03d508776fa847c0b2d998bf3 \
-                 size    203051213
+    checksums    rmd160  e2c00a519b9d78f6e0f3efc90e542a6bffa39c2e \
+                 sha256  3e2317348141b28203fac39eaa60c14a1b3f1fdb9cfdbcb793eaa4dd5828da6e \
+                 size    202026107
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  40e7529f7bc2b2094301bbdddae7409428f40454 \
-                 sha256  65c7585a1bd2dd9cba99a43efd51d830b2714dfade80591b883ce9ef3300d50c \
-                 size    200536590
+    checksums    rmd160  6c703010f5c0f950c25338b9710f650f934a38a4 \
+                 sha256  78aa915475b426c03059cc51e9c12596a5138457bd7ebb9b90daad119551662d \
+                 size    199572433
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 21.0.5.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?