### PR TITLE
openjdk17-microsoft: update to 17.0.13

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -2,10 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk17-microsoft
+set feature 17
+name             openjdk${feature}-microsoft
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 16 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,11 +20,11 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      17.0.12
-set build    7
+version      ${feature}.0.13
+set build    11
 revision     0
 
-description  Microsoft Build of OpenJDK 17 (Long Term Support)
+description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
 long_description The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source \
     and available for free for anyone to deploy anywhere.
 
@@ -26,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  957821bf76b3ddea6d8f80198c16ad7aab1ee209 \
-                 sha256  c4a44fbbf4c17282662856c44e97ec0ff0ebff44a7fc90a857204ccb8528d30c \
-                 size    188291485
+    checksums    rmd160  4f0ea55bf011d4a90338041083e3983c7c7c7559 \
+                 sha256  ce87d4110d61922ae3ee6d61d4c0ee48d7a98dcda38cffb8abc8299c47b5a730 \
+                 size    187631798
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  c3502d2928a3a24233081a58211c4129b851fc65 \
-                 sha256  070aafe1b417a95f70daa5ac3c9febff223fb71192b7359dc7c4667e2dd57904 \
-                 size    186047485
+    checksums    rmd160  0be73092714b48fe455da45c9dbc6184f70be8aa \
+                 sha256  095372e6d1a44890c52d0c8650c09ae26f740f5b740f1e6559398a492555a573 \
+                 size    185460735
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -42,7 +48,7 @@ homepage     https://www.microsoft.com/openjdk
 
 livecheck.type      regex
 livecheck.url       https://docs.microsoft.com/en-us/java/openjdk/download
-livecheck.regex     microsoft-jdk-(17\.\[0-9\.\]+)-macOS-.*\.tar\.gz
+livecheck.regex     microsoft-jdk-(${feature}\.\[0-9\.\]+)-macOS-.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.13.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?