### PR TITLE
openjdk11-microsoft: update to 11.0.25

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -2,10 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk11-microsoft
+set feature 11
+name             openjdk${feature}-microsoft
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 16 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,11 +20,11 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.24
-set build    8
+version      ${feature}.0.25
+set build    9
 revision     0
 
-description  Microsoft Build of OpenJDK 11 (Long Term Support)
+description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
 long_description The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source \
     and available for free for anyone to deploy anywhere.
 
@@ -26,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  dd6654ededa5007dfe54c98e051d521e301dbf07 \
-                 sha256  21f6535dc01fb8915e2c485c2cd6cdd979021b79ba1a9afc747aa56a92fe90e4 \
-                 size    191482697
+    checksums    rmd160  9493aba024d41e37481f7d1ea9f8974d870618ab \
+                 sha256  8a8be7a59c7a9d44bffc8e96a6bbc5e3e7c2c743b277e991df1803326f10f051 \
+                 size    191541600
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  a5ea5089ee886ed6331a896912534361919ba9ce \
-                 sha256  cc93bbcddbbb1e9f2da2292829e10bd61ad5f582b48691a438394747e0cb5acc \
-                 size    185571276
+    checksums    rmd160  7d77b65a7ada748cab9a628513365803a99dd6d7 \
+                 sha256  652ed4f3d72337e88c569aeb6bef735d3809a4e60d7606d759a8a1883a72e750 \
+                 size    185634319
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -42,7 +48,7 @@ homepage     https://www.microsoft.com/openjdk
 
 livecheck.type      regex
 livecheck.url       https://docs.microsoft.com/en-us/java/openjdk/download
-livecheck.regex     microsoft-jdk-(11\.\[0-9\.\]+)-macOS-.*\.tar\.gz
+livecheck.regex     microsoft-jdk-(${feature}\.\[0-9\.\]+)-macOS-.*\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.25.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?