### PR TITLE
termscp: update to 0.16.0

### DIFF
--- a/sysutils/termscp/Portfile
+++ b/sysutils/termscp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        veeso termscp 0.13.0 v
+github.setup        veeso termscp 0.16.0 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {@sikmir disroot.org:sikmir} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b28bdaf52bbe64dff8c491e2858c042dd14c1844 \
-                    sha256  26167374d619ced9fad84382dbdffbec861a36a20224b4ecdc955e732881e367 \
-                    size    11864196
+                    rmd160  7c41992125138a1e20a95219c7c971239735bfb4 \
+                    sha256  58f3b4770c5d1c5d7998af88b6df8c6a53dee4409f2cf6ea676caccec79cdb7f \
+                    size    11915056
 
 destroot {
     xinstall -m 0755 \
@@ -30,77 +30,84 @@ destroot {
 }
 
 cargo.crates \
-    addr2line                       0.20.0  f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3 \
-    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    addr2line                       0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
+    adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
     aes                              0.7.5  9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8 \
-    ahash                            0.7.6  fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47 \
-    aho-corasick                     1.0.2  43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41 \
+    aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
+    allocator-api2                  0.2.18  5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    argh                            0.1.10  ab257697eb9496bf75526f0217b5ed64636a9cfafa78b8365c71bd283fcef93e \
-    argh_derive                     0.1.10  b382dbd3288e053331f03399e1db106c9fb0d8562ad62cb04859ae926f324fa6 \
-    argh_shared                     0.1.10  64cb94155d965e3d37ffbbe7cc5b82c3dd79dd33bd48e536f73d2cfb8d85506f \
-    async-broadcast                  0.5.1  7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b \
-    async-channel                    1.8.0  cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833 \
-    async-executor                   1.5.1  6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb \
-    async-fs                         1.6.0  279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06 \
-    async-io                        1.13.0  0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af \
-    async-lock                       2.7.0  fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7 \
-    async-process                    1.7.0  7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9 \
-    async-recursion                  1.0.4  0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba \
-    async-task                       4.4.0  ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae \
-    async-trait                     0.1.71  a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf \
-    atomic-waker                     1.1.1  1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3 \
+    anyhow                          1.0.89  86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6 \
+    arbitrary                        1.3.2  7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110 \
+    argh                            0.1.12  7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219 \
+    argh_derive                     0.1.12  56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a \
+    argh_shared                     0.1.12  5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531 \
+    async-trait                     0.1.83  721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd \
     attohttpc                       0.26.1  0f77d243921b0979fbbd728dd2d5162e68ac8252976797c24eb5b3a6af9090dc \
-    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     aws-creds                       0.36.0  390ad3b77f3e21e01a4a0355865853b681daf1988510b0b15e31c0c4ae7eb0f6 \
-    aws-region                      0.25.4  42fed2b9fca70f2908268d057a607f2a906f47edbf856ea8587de9038d264e22 \
-    backtrace                       0.3.68  4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12 \
-    base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
-    base64                          0.21.2  604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d \
+    aws-region                      0.25.5  e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b \
+    backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
+    base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
+    base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
+    base64ct                         1.6.0  8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                         2.4.2  ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf \
+    bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
     block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block-modes                      0.8.1  2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e \
     block-padding                    0.2.1  8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae \
-    blocking                         1.3.1  77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65 \
-    bumpalo                         3.13.0  a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1 \
-    byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
-    bytes                            1.5.0  a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223 \
-    bytesize                         1.2.0  38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5 \
+    bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
+    bytes                            1.7.2  428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3 \
+    bytesize                         1.3.0  a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc \
     bytestring                       1.3.1  74d80203ea6b29df88012294f62733de21cfeab47f17b41af3a38bc30a03ee72 \
+    camino                           1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
+    cargo-platform                   0.1.8  24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc \
+    cargo_metadata                  0.18.1  2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037 \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
-    cc                              1.0.79  50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
-    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    castaway                         0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
+    cc                              1.1.30  b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    cfg_aliases                      0.1.1  fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e \
-    cfg_aliases                      0.2.0  77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f \
-    chrono                          0.4.26  ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5 \
+    cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
+    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
     cipher                           0.3.0  7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7 \
-    concurrent-queue                 2.2.0  62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c \
-    console                         0.15.7  c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8 \
-    const-random                    0.1.17  5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a \
+    compact_str                      0.8.0  6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644 \
+    console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
+    const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
+    const-random                    0.1.18  87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359 \
     const-random-macro              0.1.16  f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e \
     content_inspector                0.2.4  b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38 \
-    core-foundation                  0.9.3  194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146 \
-    core-foundation-sys              0.8.4  e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa \
-    cpufeatures                      0.2.9  a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1 \
-    crc-any                          2.4.3  774646b687f63643eb0f4bf13dc263cb581c8c9e57973b6ddf78bda3994d88df \
-    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
-    crossbeam-utils                 0.8.16  5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294 \
-    crossterm                       0.25.0  e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67 \
-    crossterm                       0.27.0  f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df \
+    core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
+    core-foundation                 0.10.0  b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63 \
+    core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    cpufeatures                     0.2.14  608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0 \
+    crc-any                          2.5.0  a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73 \
+    crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
+    crossbeam-channel               0.5.13  33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2 \
+    crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
+    crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
+    crossterm                       0.28.1  829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6 \
     crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
-    ctor                            0.1.26  6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096 \
-    dashmap                          5.4.0  907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc \
+    curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
+    curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
+    darling                        0.20.10  6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989 \
+    darling_core                   0.20.10  95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5 \
+    darling_macro                  0.20.10  d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806 \
+    data-encoding                    2.6.0  e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2 \
     dbus                             0.9.7  1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b \
+    dbus-secret-service              4.0.3  b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b \
     debug-helper                    0.3.13  f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e \
+    der                              0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
-    derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
+    derive_arbitrary                 1.3.2  67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611 \
+    derive_builder                  0.20.2  507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947 \
+    derive_builder_core             0.20.2  2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8 \
+    derive_builder_macro            0.20.2  ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c \
     des                              0.7.0  ac41dd49fb554432020d52c875fc290e110113f864c6b1b525cd62c7e7747a5d \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
@@ -109,351 +116,394 @@ cargo.crates \
     dirs-next                        2.0.0  b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1 \
     dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
     dirs-sys-next                    0.1.2  4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d \
+    displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     dlv-list                         0.5.2  442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f \
-    edit                             0.1.4  c562aa71f7bc691fde4c6bf5f93ae5a5298b617c2eb44c76c87832299a17fbb4 \
-    either                           1.8.1  7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91 \
+    ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
+    ed25519-dalek                    2.1.1  4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871 \
+    edit                             0.1.5  f364860e764787163c8c8f58231003839be31276e821e2ad2092ddf496b1aa09 \
+    either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
     encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
-    encoding_rs                     0.8.32  071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394 \
-    enumflags2                       0.7.7  c041f5090df68b32bcd905365fd51769c8b9d553fe87fde0b683534f10c01bd2 \
-    enumflags2_derive                0.7.7  5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745 \
-    equivalent                       1.0.0  88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1 \
-    errno                            0.3.1  4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a \
-    errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
-    event-listener                   2.5.3  0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0 \
-    fastrand                         1.9.0  e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be \
-    filetime                        0.2.21  5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153 \
-    flate2                          1.0.26  3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743 \
+    encoding_rs                     0.8.34  b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59 \
+    equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+    errno                            0.3.9  534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba \
+    fastrand                         2.1.1  e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6 \
+    fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
+    filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
+    flate2                          1.0.34  a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foldhash                         0.1.3  f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
-    form_urlencoded                  1.2.0  a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652 \
-    fsevent                          0.4.0  5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6 \
-    fsevent-sys                      2.0.1  f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0 \
-    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
-    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-    futures                         0.3.28  23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40 \
-    futures-channel                 0.3.28  955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2 \
-    futures-core                    0.3.28  4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c \
-    futures-executor                0.3.28  ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0 \
-    futures-io                      0.3.28  4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964 \
-    futures-lite                    1.13.0  49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce \
-    futures-macro                   0.3.28  89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72 \
-    futures-sink                    0.3.28  f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e \
-    futures-task                    0.3.28  76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65 \
-    futures-util                    0.3.28  26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533 \
+    form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
+    fsevent-sys                      4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
+    futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
+    futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
+    futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
+    futures-executor                0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
+    futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
+    futures-lite                     2.3.0  52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5 \
+    futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
+    futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
+    futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
+    futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
-    getrandom                       0.2.10  be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427 \
-    gimli                           0.27.3  b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e \
-    h2                              0.3.20  97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049 \
-    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
+    gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
+    git2                            0.19.0  b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724 \
+    h2                              0.3.26  81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8 \
     hashbrown                       0.13.2  43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e \
-    hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
-    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
-    hermit-abi                       0.3.2  443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b \
+    hashbrown                       0.15.0  1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb \
+    headers                          0.4.0  322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9 \
+    headers-core                     0.3.0  54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4 \
+    heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
+    hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    hkdf                            0.12.3  791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437 \
     hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
-    hostname                         0.3.1  3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867 \
-    http                             0.2.9  bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482 \
-    http                             1.0.0  b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea \
-    http-body                        0.4.5  d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1 \
-    httparse                         1.8.0  d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
+    hostname                         0.4.0  f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba \
+    http                            0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
+    http                             1.1.0  21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258 \
+    http-body                        0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
+    http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
+    http-body-util                   0.1.2  793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f \
+    httparse                         1.9.5  7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    hyper                          0.14.27  ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468 \
-    hyper-rustls                    0.24.1  8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97 \
+    hyper                          0.14.30  a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9 \
+    hyper                            1.4.1  50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05 \
+    hyper-http-proxy                 1.0.0  5d06dbdfbacf34d996c6fb540a71a684a7aae9056c71951163af8a8a4c07b9a4 \
+    hyper-rustls                    0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
+    hyper-timeout                    0.5.1  3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793 \
     hyper-tls                        0.5.0  d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905 \
-    iana-time-zone                  0.1.57  2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613 \
+    hyper-util                       0.1.9  41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b \
+    iana-time-zone                  0.1.61  235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
-    idna                             0.4.0  7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c \
-    indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                         2.2.5  7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4 \
-    indicatif                       0.17.5  8ff8cc23a7393a397ed1d7f56e6365cba772aba9f9912ab968b03043c395d057 \
-    indoc                            2.0.4  1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
-    inotify                          0.7.1  4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f \
+    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
+    idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
+    indexmap                         2.6.0  707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da \
+    indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
+    inotify                          0.9.6  f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff \
     inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
-    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
-    io-lifetimes                    1.0.11  eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2 \
-    iovec                            0.1.4  b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e \
-    ipnet                            2.8.0  28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6 \
+    instability                      0.3.2  b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c \
+    instant                         0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
+    ipnet                           2.10.1  ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708 \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-wsl                           0.4.0  173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5 \
-    itertools                       0.11.0  b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57 \
-    itoa                             1.0.8  62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a \
-    js-sys                          0.3.64  c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a \
-    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
-    keyring                          2.0.4  04ac4b8b0884cdf23c4619d139acf43839eac4f0739b92980c2a6d460d9c84f5 \
-    lazy-regex                       2.5.0  ff63c423c68ea6814b7da9e88ce585f793c87ddd9e78f646970891769c8235d4 \
-    lazy-regex                       3.1.0  5d12be4595afdf58bd19e4a9f4e24187da2a66700786ff660a418e9059937a4c \
-    lazy-regex-proc_macros           2.4.1  8edfc11b8f56ce85e207e62ea21557cfa09bb24a8f6b04ae181b086ff8611c22 \
-    lazy-regex-proc_macros           3.1.0  44bcd58e6c97a7fcbaffcdc95728b393b8d98933bfadad49ed4097845b57ef0b \
-    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                           0.2.147  b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3 \
+    itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
+    itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
+    jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
+    js-sys                          0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
+    jsonpath-rust                    0.5.1  19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200 \
+    k8s-openapi                     0.22.0  19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755 \
+    keyring                          3.4.0  bd3d701d3de5b9c4b0d9d077f8c2c66f0388d75e96932ebbb7cdff8713d7f7c6 \
+    kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
+    kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
+    kube                            0.92.1  231c5a5392d9e2a9b0d923199760d3f1dd73b95288f2871d16c7c90ba4954506 \
+    kube-client                     0.92.1  8f4bf54135062ff60e2a0dfb3e7a9c8e931fc4a535b4d6bd561e0a1371321c61 \
+    kube-core                       0.92.1  40fb9bd8141cbc0fe6b0d9112d371679b4cb607b45c31dd68d92e40864a12975 \
+    lazy-regex                       3.3.0  8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda \
+    lazy-regex-proc_macros           3.3.0  76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163 \
+    lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
+    libc                           0.2.159  561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5 \
     libdbus-sys                      0.2.5  06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72 \
+    libgit2-sys                   0.17.0+1.8.1  10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224 \
+    libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
-    libz-sys                         1.1.9  56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db \
-    linux-keyutils                   0.2.3  3f27bb67f6dd1d0bb5ab582868e4f65052e58da6401188a08f0da09cf512b84b \
-    linux-raw-sys                    0.3.8  ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519 \
-    lock_api                        0.4.10  c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16 \
-    log                             0.4.19  b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4 \
-    mac-notification-sys             0.5.6  3e72d50edb17756489e79d52eb146927bec8eba9dd48faadf9ef08bca3791ad5 \
-    magic-crypt                     3.1.12  0196bd5c76f5f51d7d6563545f86262fef4c82d75466ba6f6d359c40a523318d \
+    libz-sys                        1.1.20  d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472 \
+    linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
+    lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
+    lockfree-object-pool             0.1.6  9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e \
+    log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
+    lru                             0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
+    mac-notification-sys             0.6.2  dce8f34f3717aa37177e723df6c1fc5fb02b2a1087374ea3fe0ea42316dc8f91 \
+    magic-crypt                     3.1.13  6c42f95f9d296f2dcb50665f507ed5a68a171453142663ce44d77a4eb217b053 \
     malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
-    match_cfg                        0.1.0  ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4 \
-    maybe-async                      0.2.7  0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305 \
+    maybe-async                     0.2.10  5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11 \
     md-5                             0.9.1  7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15 \
     md5                              0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
-    memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
-    memoffset                        0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
+    memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
-    miniz_oxide                      0.7.1  e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7 \
-    mio                             0.6.23  4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4 \
-    mio                              0.8.8  927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2 \
-    mio-extras                       2.0.6  52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19 \
-    miow                             0.2.2  ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d \
-    native-tls                      0.2.11  07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e \
-    net2                            0.2.39  b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac \
-    nix                             0.26.2  bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a \
+    miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
+    mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
+    mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
+    native-tls                      0.2.12  a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466 \
     nonempty                         0.9.0  995defdca0a589acfdd1bd2e8e3b896b4d4f7675a31fd14c32611440c7f608e6 \
-    notify                          4.0.17  ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257 \
-    notify-rust                      4.8.0  2bfa211d18e360f08e36c364308f394b5eb23a6629150690e109a916dc6f610e \
-    num                              0.4.0  43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606 \
-    num-bigint                       0.4.3  f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f \
-    num-complex                      0.4.3  02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d \
+    notify                           6.1.1  6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d \
+    notify-rust                     4.11.3  5134a72dc570b178bff81b01e81ab14a6fcc015391ed4b3b14853090658cd3a3 \
+    ntapi                            0.4.1  e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4 \
+    nucleo                           0.5.0  5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4 \
+    nucleo-matcher                   0.3.1  bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85 \
+    num                              0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
+    num-bigint                       0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
+    num-complex                      0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
     num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
-    num-integer                     0.1.45  225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9 \
-    num-iter                        0.1.43  7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252 \
-    num-rational                     0.4.1  0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0 \
-    num-traits                      0.2.15  578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd \
-    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
-    num_threads                      0.1.6  2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44 \
+    num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
+    num-iter                        0.1.45  1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
+    num-rational                     0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
+    num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
+    num_threads                      0.1.7  5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
     objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
     objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
-    object                          0.31.1  8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1 \
-    once_cell                       1.18.0  dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d \
-    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
-    open                             5.0.0  cfabf1927dce4d6fdf563d63328a0a506101ced3ec780ca2135747336c98cef8 \
-    openssl                        0.10.55  345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d \
+    object                          0.36.5  aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e \
+    once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
+    opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
+    open                             5.3.0  61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3 \
+    openssl                        0.10.66  9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1 \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
-    openssl-src                   111.26.0+1.1.1u  efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37 \
-    openssl-sys                     0.9.90  374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6 \
+    openssl-src                   300.3.2+3.3.2  a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b \
+    openssl-sys                    0.9.103  7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
+    ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     ordered-multimap                 0.6.0  4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e \
-    ordered-stream                   0.2.0  9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50 \
-    output_vt100                     0.1.3  628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66 \
-    parking                          2.1.0  14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e \
+    parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
-    parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
+    parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                 0.8.6  60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc \
-    parking_lot_core                 0.9.8  93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447 \
-    paste                           1.0.14  de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c \
+    parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
+    paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
     path-slash                       0.1.5  498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696 \
     path-slash                       0.2.1  1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42 \
-    pathdiff                         0.2.1  8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd \
-    pavao                            0.2.3  0bcafb8d680c0b6750c095fbd3c9263fc0b3c315e6055cd1867db038641c1757 \
-    percent-encoding                 2.3.0  9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94 \
-    pin-project-lite                0.2.10  4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57 \
+    pathdiff                         0.2.2  d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361 \
+    pavao                            0.2.7  e3bc0f9e07a0ef53a1004f67e01bc2fbf877ea9835dce2947e27fc7ac77b44db \
+    pem                              3.0.4  8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae \
+    percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    pest                            2.7.13  fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9 \
+    pest_derive                     2.7.13  4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0 \
+    pest_generator                  2.7.13  94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e \
+    pest_meta                       2.7.13  ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f \
+    pin-project                      1.1.6  baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec \
+    pin-project-internal             1.1.6  a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8 \
+    pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    pkg-config                      0.3.27  26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964 \
-    polling                          2.8.0  4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce \
-    portable-atomic                  1.3.3  767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794 \
+    pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
+    pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
+    portable-atomic                  1.9.0  cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
-    ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
-    pretty_assertions                1.3.0  a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755 \
-    proc-macro-crate                 1.3.1  7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919 \
-    proc-macro2                     1.0.78  e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae \
+    ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
+    pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
+    proc-macro2                     1.0.87  b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a \
     quick-xml                       0.23.1  11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea \
     quick-xml                       0.30.0  eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956 \
     quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
-    quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
+    quinn                           0.11.5  8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684 \
+    quinn-proto                     0.11.8  fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6 \
+    quinn-udp                        0.5.5  4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b \
+    quote                           1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
-    ratatui                         0.23.0  2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad \
+    ratatui                         0.28.1  fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d \
+    rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
+    rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
-    redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
-    redox_users                      0.4.3  b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b \
-    regex                            1.9.0  89089e897c013b3deb627116ae56a6955a72b8bed395c9526af31c9fe528b484 \
-    regex-automata                   0.3.0  fa250384981ea14565685dea16a9ccc4d1c541a13f82b9c168572264d1df8c56 \
-    regex-syntax                     0.7.3  2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846 \
-    remotefs                         0.2.0  e8df5d94ca7480505315216544f145f358b7609781beef33a9149ecd9be44a5b \
-    remotefs-aws-s3                  0.2.4  ff8527f19059c3246d85fa8e81be1b720eeae28099d9e6debe6d7d214875c2aa \
-    remotefs-ftp                     0.1.3  dd84067bd28eb9f17c906f59a6bfbd2c812a45397357f0c00325d420f0cff0e0 \
-    remotefs-smb                     0.2.0  27c4fb523b04b6bcd5dae95a33cbaee73cf7d6607862039b6d2bff310db6ed9f \
-    remotefs-ssh                     0.2.1  d3f30dd4a6510058d4717a012accccc6a2da8ea57387739169b058d2cee8dd7a \
-    remotefs-webdav                  0.1.1  e88503e1cd53067ab639150625718bb8d88e6bcd1e165205de0d941beca66bde \
-    reqwest                        0.11.18  cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55 \
-    ring                           0.16.20  3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc \
-    rpassword                        7.2.0  6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322 \
-    rtoolbox                         0.0.1  034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a \
+    redox_syscall                    0.5.7  9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f \
+    redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
+    regex                           1.11.0  38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8 \
+    regex-automata                   0.4.8  368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3 \
+    regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
+    remotefs                         0.3.0  b34c83859b73d72acd9a02090193ef379e669644cea9ab5260a7ad9a0342de30 \
+    remotefs-aws-s3                  0.3.1  db7009ceac2977be5919e8c09f14069fdd21a0ff6111a418898071159a578def \
+    remotefs-ftp                     0.2.1  87763db466371654509075793e3de3fd78ab295b46628d5b0a04de8bbd43e582 \
+    remotefs-kube                    0.4.0  a7ca6df262715fd3c88b58bcc9d219ed46ace67bf73e4216b9fa9b73eafd8426 \
+    remotefs-smb                     0.3.0  74686dd420fd460f123212a7ceb7e9850aa0b242f250f5e7119525f867acf94a \
+    remotefs-ssh                     0.4.1  b18f2efb0eb0d1c15a1c6be859646dc62124b33fed5b5a3839f09ded0ccfd3ae \
+    remotefs-webdav                  0.2.0  5d2b34f3ac2069b106c65b2d0c91b9b4b24a0b5fe9585b49f50fff4135f2cff8 \
+    reqwest                        0.11.27  dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62 \
+    reqwest                         0.12.8  f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b \
+    ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
+    rpassword                        7.3.1  80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f \
+    rtoolbox                         0.0.2  c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e \
     rust-ini                        0.19.0  7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091 \
-    rust-s3                       0.34.0-rc4  0533896b025761b23147ca1a168c436e1b87d14e460b1f19a6442882d2a3e07f \
-    rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
-    rustix                         0.37.23  4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06 \
-    rustls                          0.21.3  b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed \
-    rustls-pemfile                   1.0.3  2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2 \
-    rustls-webpki                  0.101.1  15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e \
-    rustversion                     1.0.14  7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4 \
+    rust-s3                         0.34.0  c6679da8efaf4c6f0c161de0961dfe95fb6e9049c398d6fbdada2639f053aedb \
+    rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
+    rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
+    rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
+    rustix                         0.38.37  8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811 \
+    rustls                         0.21.12  3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e \
+    rustls                         0.23.14  415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8 \
+    rustls-native-certs              0.7.3  e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5 \
+    rustls-native-certs              0.8.0  fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a \
+    rustls-pemfile                   1.0.4  1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c \
+    rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
+    rustls-pki-types                 1.9.0  0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55 \
+    rustls-webpki                  0.101.7  8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765 \
+    rustls-webpki                  0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
+    rustversion                     1.0.17  955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6 \
     rustydav                         0.1.3  bc4c86c47126ac8bfc573084610e93f4ca8726f3ae7bf6c64bd60476731b6e42 \
-    ryu                             1.0.14  fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9 \
+    ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    schannel                        0.1.22  0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88 \
-    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-    sct                              0.7.0  d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4 \
-    secret-service                   3.0.1  5da1a5ad4d28c03536f82f77d9f36603f5e37d8869ac98f0a750d5b5686d8d95 \
-    security-framework               2.9.1  1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8 \
-    security-framework-sys           2.9.0  f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7 \
-    self_update                     0.37.0  a667e18055120bcc9a658d55d36f2f6bfc82e07968cc479ee7774e3bfb501e14 \
-    semver                          1.0.17  bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed \
-    serde                          1.0.197  3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2 \
-    serde_derive                   1.0.197  7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b \
-    serde_json                     1.0.100  0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c \
-    serde_repr                      0.1.14  1d89a8107374290037607734c0b73a85db7ed80cae314b3c5791f192a496e731 \
-    serde_spanned                    0.6.5  eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1 \
+    scc                              2.2.1  553f8299af7450cda9a52d3a370199904e7a46b5ffd1bef187c4a6af3bb6db69 \
+    schannel                        0.1.26  01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1 \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    sct                              0.7.1  da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414 \
+    sdd                              3.0.4  49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95 \
+    secrecy                          0.8.0  9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e \
+    security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
+    security-framework               3.0.0  f9d0283c0a4a22a0f1b0e4edca251aa20b92fc96eaa09b84bec052f9415e9d71 \
+    security-framework-sys          2.12.0  ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6 \
+    self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
+    self_update                     0.41.0  469a3970061380c19852269f393e74c0fe607a4e23d85267382cf25486aa8de5 \
+    semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
+    serde                          1.0.210  c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a \
+    serde-value                      0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
+    serde_derive                   1.0.210  243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f \
+    serde_json                     1.0.128  6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8 \
+    serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serial_test                      3.0.0  953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d \
-    serial_test_derive               3.0.0  b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212 \
-    sha1                            0.10.5  f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3 \
+    serde_yaml                    0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
+    serial_test                      3.1.1  4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d \
+    serial_test_derive               3.1.1  82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67 \
+    sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha2                             0.9.9  4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800 \
-    sha2                            0.10.7  479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8 \
+    sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
+    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
-    signal-hook-mio                  0.2.3  29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af \
-    signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
-    simplelog                       0.12.1  acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369 \
-    slab                             0.4.8  6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d \
-    smallvec                        1.11.0  62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9 \
-    smawk                            0.3.1  f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043 \
-    socket2                          0.4.9  64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662 \
-    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    signal-hook-mio                  0.2.4  34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd \
+    signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
+    signature                        2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
+    simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \
+    simplelog                       0.12.2  16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0 \
+    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
+    smawk                            0.3.2  b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c \
+    socket2                          0.5.7  ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c \
+    spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
+    spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     ssh2                             0.9.4  e7fe461910559f6d5604c3731d00d2aafc4a83d1665922e280f42f9a168d5455 \
-    ssh2-config                      0.2.0  e31d9bb8e97972d6541ccf32ed51294e4e16feeef06a0e77a6272d041f0f5bc7 \
+    ssh2-config                      0.2.3  98150bad1e8fe53df07f38b53364f4d34e84a6cc2ee9f933e43629571060af65 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
-    strum                           0.25.0  290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125 \
-    strum_macros                    0.25.3  23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0 \
-    subtle                           2.4.1  6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601 \
-    suppaftp                         5.1.2  4c84c5cecf19018f5f85ca3f2c7e2c974dfe07e7e4a85cbea4330bb1e7c578df \
-    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.52  b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07 \
-    tar                             0.4.38  4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6 \
-    tauri-winrt-notification         0.1.2  4f5bff1d532fead7c43324a0fa33643b8621a47ce2944a633be4cb6c0240898f \
-    tempfile                         3.6.0  31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6 \
-    termcolor                        1.1.3  bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755 \
+    strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
+    strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
+    strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
+    subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
+    suppaftp                         6.0.1  3d5c3d37ce3092d7148494a30a0f5036f8722792a626b25662a87434d3683c33 \
+    syn                             2.0.79  89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590 \
+    sync_wrapper                     0.1.2  2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160 \
+    sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
+    sysinfo                         0.31.4  355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be \
+    system-configuration             0.5.1  ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7 \
+    system-configuration-sys         0.5.0  a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9 \
+    tar                             0.4.42  4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020 \
+    tauri-winrt-notification         0.2.1  f89f5fb70d6f62381f5d9b2ba9008196150b40b75f3068eb24faeddf1c686871 \
+    tempfile                        3.13.0  f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b \
+    termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     textwrap                        0.16.1  23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9 \
-    thiserror                       1.0.57  1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b \
-    thiserror-impl                  1.0.57  a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81 \
+    thiserror                       1.0.64  d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84 \
+    thiserror-impl                  1.0.64  08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3 \
     tiger                            0.1.0  443e531cbcf9de83258cfef70bcd56c91188de5819ebd4b19c85f589e0617005 \
-    time                            0.1.45  1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a \
-    time                            0.3.34  c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749 \
+    time                            0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
-    time-macros                     0.2.17  7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774 \
+    time-macros                     0.2.18  3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf \
     tiny-keccak                      2.0.2  2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237 \
-    tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+    tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.29.1  532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da \
+    tokio                           1.38.1  eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df \
+    tokio-macros                     2.3.0  5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
-    tokio-rustls                    0.24.1  c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081 \
-    tokio-util                       0.7.8  806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d \
-    toml                            0.8.10  9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290 \
-    toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
-    toml_edit                      0.19.12  c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78 \
-    toml_edit                       0.22.6  2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6 \
-    tower-service                    0.3.2  b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52 \
-    tracing                         0.1.37  8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8 \
-    tracing-attributes              0.1.26  5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab \
-    tracing-core                    0.1.31  0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a \
-    try-lock                         0.2.4  3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed \
-    tui                             0.19.0  ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1 \
-    tui-realm-stdlib                 1.3.1  a14fa5a0376ef64b93b484f811716b73422803df91c9ce7f83c50cc391230426 \
-    tuirealm                         1.9.1  412447298ad477c25ff50c4a894ff5077b6ee3e25b913d42db30021d81b1af53 \
-    tuirealm_derive                  1.0.0  e0adcdaf59881626555558eae08f8a53003c8a1961723b4d7a10c51599abbc81 \
-    typenum                         1.16.0  497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba \
-    uds_windows                      1.0.2  ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d \
-    unicode-bidi                    0.3.13  92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460 \
-    unicode-ident                   1.0.10  22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73 \
-    unicode-linebreak                0.1.4  c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137 \
-    unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
-    unicode-segmentation            1.10.1  1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36 \
-    unicode-width                   0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
-    untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
-    url                              2.4.0  50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb \
-    urlencoding                      2.1.2  e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9 \
-    users                           0.11.0  24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032 \
+    tokio-rustls                    0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
+    tokio-tungstenite               0.23.1  c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd \
+    tokio-util                      0.7.12  61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a \
+    toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
+    toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
+    toml_edit                      0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
+    tower                           0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
+    tower-http                       0.5.2  1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5 \
+    tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
+    tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
+    tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
+    tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
+    tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
+    try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
+    tui-realm-stdlib                 2.0.1  78a24d06b8403c57b32a3d3fdac795adf4ef8610e5f9650a3629efc8a9d6c0bb \
+    tuirealm                         2.0.3  0d3865c9f0e84c07c991c24c853f095bb764859fa3806fe6e00b559f40f1253f \
+    tuirealm_derive                  2.0.0  caa8b0560f4245acc0bbe0e1d76e1f6a308145dd6e107befce4cf29e7fe32662 \
+    tungstenite                     0.23.0  6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8 \
+    typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
+    ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
+    unicode-bidi                    0.3.17  5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893 \
+    unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
+    unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
+    unicode-normalization           0.1.24  5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956 \
+    unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
+    unicode-truncate                 1.1.0  b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf \
+    unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
+    unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
+    unsafe-libyaml                  0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
+    untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
+    url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
+    urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
+    utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
+    uzers                           0.12.1  4df81ff504e7d82ad53e95ed1ad5b72103c11253f39238bcc0235b90768a97dd \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
-    version-compare                  0.1.1  579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29 \
-    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
-    waker-fn                         1.1.0  9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca \
-    walkdir                          2.3.3  36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698 \
+    vergen                           9.0.1  349ed9e45296a581f455bc18039878f409992999bc1d5da12a6800eb18c8752f \
+    vergen-git2                      1.0.1  e771aff771c0d7c2f42e434e2766d304d917e29b40f0424e8faaaa936bbc3f29 \
+    vergen-lib                       0.1.4  229eaddb0050920816cf051e619affaf18caa3dd512de8de5839ccbc8e53abb0 \
+    version-compare                  0.2.0  852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b \
+    version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
+    walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
-    wasi                          0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
     wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.87  7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342 \
-    wasm-bindgen-backend            0.2.87  5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd \
-    wasm-bindgen-futures            0.4.37  c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03 \
-    wasm-bindgen-macro              0.2.87  dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d \
-    wasm-bindgen-macro-support      0.2.87  54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b \
-    wasm-bindgen-shared             0.2.87  ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1 \
-    web-sys                         0.3.64  9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b \
-    webpki                          0.22.0  f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd \
-    webpki-roots                    0.22.6  b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87 \
+    wasite                           0.1.0  b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b \
+    wasm-bindgen                    0.2.95  128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e \
+    wasm-bindgen-backend            0.2.95  cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358 \
+    wasm-bindgen-futures            0.4.45  cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b \
+    wasm-bindgen-macro              0.2.95  e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56 \
+    wasm-bindgen-macro-support      0.2.95  26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68 \
+    wasm-bindgen-shared             0.2.95  65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d \
+    web-sys                         0.3.72  f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112 \
     webpki-roots                    0.25.4  5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1 \
-    which                            4.4.0  2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269 \
-    whoami                           1.4.1  22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50 \
-    wildmatch                        2.1.1  ee583bdc5ff1cf9db20e9db5bb3ff4c3089a8f6b8b31aff265c9aba85812db86 \
-    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    webpki-roots                    0.26.6  841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958 \
+    which                            4.4.2  87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7 \
+    whoami                           1.5.2  372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d \
+    wildmatch                        2.4.0  68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
-    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows                         0.39.0  f1c4bd0a50ac6020f65184721f758dba47bb9fbc2133df715ec74a237b26794a \
-    windows                         0.48.0  e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f \
-    windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows                         0.52.0  e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be \
+    windows                         0.56.0  1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132 \
+    windows                         0.57.0  12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143 \
+    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
+    windows-core                    0.56.0  4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6 \
+    windows-core                    0.57.0  d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d \
+    windows-implement               0.56.0  f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b \
+    windows-implement               0.57.0  9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7 \
+    windows-interface               0.56.0  08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc \
+    windows-interface               0.57.0  29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7 \
+    windows-registry                 0.2.0  e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0 \
+    windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
+    windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
+    windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
-    windows-targets                 0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
-    windows-targets                 0.48.1  05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f \
-    windows-targets                 0.52.4  7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b \
-    windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
-    windows_aarch64_gnullvm         0.48.0  91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc \
-    windows_aarch64_gnullvm         0.52.4  bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9 \
-    windows_aarch64_msvc            0.39.0  ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2 \
-    windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
-    windows_aarch64_msvc            0.48.0  b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3 \
-    windows_aarch64_msvc            0.52.4  da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675 \
-    windows_i686_gnu                0.39.0  763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b \
-    windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
-    windows_i686_gnu                0.48.0  622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241 \
-    windows_i686_gnu                0.52.4  b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3 \
-    windows_i686_msvc               0.39.0  7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106 \
-    windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
-    windows_i686_msvc               0.48.0  4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00 \
-    windows_i686_msvc               0.52.4  1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02 \
-    windows_x86_64_gnu              0.39.0  6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65 \
-    windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
-    windows_x86_64_gnu              0.48.0  ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1 \
-    windows_x86_64_gnu              0.52.4  5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03 \
-    windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
-    windows_x86_64_gnullvm          0.48.0  7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953 \
-    windows_x86_64_gnullvm          0.52.4  77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177 \
-    windows_x86_64_msvc             0.39.0  5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809 \
-    windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
-    windows_x86_64_msvc             0.48.0  1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a \
-    windows_x86_64_msvc             0.52.4  32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8 \
-    winnow                           0.4.7  ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448 \
-    winnow                           0.6.5  dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8 \
-    winreg                          0.10.1  80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d \
-    ws2_32-sys                       0.2.1  d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e \
-    xattr                            0.2.3  6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc \
-    xdg-home                         1.0.0  2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd \
-    yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec \
-    zbus                            3.14.1  31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948 \
-    zbus_macros                     3.14.1  41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d \
-    zbus_names                       2.6.0  fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9 \
-    zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
-    zvariant                        3.15.0  44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c \
-    zvariant_derive                 3.15.0  934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd \
-    zvariant_utils                   1.0.1  7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200
+    windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-version                  0.1.1  6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515 \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
+    winnow                          0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
+    winreg                          0.50.0  524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1 \
+    xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
+    yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
+    zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
+    zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
+    zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
+    zip                              2.2.0  dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494 \
+    zipsign-api                      0.1.2  6413a546ada9dbcd0b9a3e0b0880581279e35047bce9797e523b3408e1df607c \
+    zopfli                           0.8.1  e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946


### PR DESCRIPTION
#### Description
https://github.com/veeso/termscp/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
