### PR TITLE
gwyddion: update to 2.66

### DIFF
--- a/science/gwyddion/Portfile
+++ b/science/gwyddion/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gwyddion
-version             2.63
+version             2.66
 revision            0
 categories          science x11
 platforms           darwin
@@ -20,9 +20,9 @@ master_sites        sourceforge:project/gwyddion/gwyddion/${version}
 use_xz              yes
 use_parallel_build  yes
 
-checksums           sha256  152b3f0db9ebd6c844c3f5b9d4385414f6fad6d33ed1ab5ceb0c58f351224dd3 \
-                    rmd160  5293607528e81ffe1f428bfd6da7e583a6603302 \
-                    size    5324664
+checksums           sha256  377bedcd2b0d8d133a329686da9f5f91807ff1d47937f9991195f1e863792d52 \
+                    rmd160  9dda736b0717d682560d847241b6a86ad48faf6a \
+                    size    5390884
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description

Update of gwyddion to the actual version

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61 / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
