### PR TITLE
openjdk11-temurin: use feature variable and fix platform

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -2,34 +2,40 @@
 
 PortSystem       1.0
 
-name             openjdk11-temurin
+set feature 11
+name             openjdk${feature}-temurin
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 16 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
 universal_variant no
 
-# https://adoptium.net/temurin/releases/
+# https://adoptium.net/temurin/releases/?os=mac&version=11
 supported_archs  x86_64 arm64
 
-version      11.0.24
+version      ${feature}.0.24
 set build    8
 revision     0
 
-description  Eclipse Temurin, based on OpenJDK 11
+description  Eclipse Temurin, based on OpenJDK ${feature}
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
 
-master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${version}%2B${build}/
+master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk-${version}%2B${build}/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
+    distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
     checksums    rmd160  d9223baa629fe84d82bbe9a1a811784f3cc7dde2 \
                  sha256  07a1be21f45f0951db05516e57602c414295c51a920f7e9b6ddeaa325d619b28 \
                  size    187710109
 } elseif {${configure.build_arch} eq "arm64"} {
-    distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
+    distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
     checksums    rmd160  651a5dda4c260e6d0574e973264fbb2c91a3cfc2 \
                  sha256  8bcbb98e293fb3c4d5cae3539f240ed478fae85962311fccd4c628ebad3a90e4 \
                  size    185018067
@@ -40,8 +46,8 @@ worksrcdir   jdk-${version}+${build}
 homepage     https://adoptium.net
 
 livecheck.type      regex
-livecheck.url       https://github.com/adoptium/temurin11-binaries/releases
-livecheck.regex     OpenJDK11U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
+livecheck.url       https://github.com/adoptium/temurin${feature}-binaries/releases
+livecheck.regex     OpenJDK${feature}U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Refactor portfile and fix the platform.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?