### PR TITLE
openjdk11: update to 11.0.25

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -2,34 +2,35 @@
 
 PortSystem          1.0
 
-name                openjdk11
+set feature 11
+name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk11/ for the version and build number that matches the latest '-ga' version
-version             11.0.24
-set build 8
-revision            1
+version             ${feature}.0.25
+set build 9
+revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
 maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
-description         OpenJDK 11
-long_description    JDK 11 builds of OpenJDK, the Open-Source implementation \
+description         OpenJDK ${feature}
+long_description    JDK ${feature} builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
-homepage            https://openjdk.org/projects/jdk/11/
-master_sites        https://openjdk-sources.osci.io/openjdk11/
+homepage            https://openjdk.org/projects/jdk/${feature}/
+master_sites        https://openjdk-sources.osci.io/openjdk${feature}/
 distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  af111ef6eb5258d12d6e60abcb8ebd1f2786a773 \
-                    sha256  7a261e4140ee301dfa7c8cdbf0e09f1dc62c653723561ba3f9ca1851958ada81 \
-                    size    72182240
+checksums           rmd160  b0edf71371b1e0114ca6fe8de4b111e09b80ea48 \
+                    sha256  6eaf2248b50c1d46b6405d26018ba6fa975c60f7682a85909a9f466282e39ca2 \
+                    size    72344244
 
 depends_lib         port:freetype \
                     port:libiconv
 depends_build       port:autoconf \
                     port:gmake \
                     port:bash \
-                    port:openjdk11-bootstrap
+                    port:openjdk${feature}-bootstrap
 
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4
@@ -54,7 +55,7 @@ configure.args      --with-debug-level=release \
                     --with-extra-cflags="${configure.cflags}" \
                     --with-extra-cxxflags="${configure.cxxflags}" \
                     --with-extra-ldflags="${configure.ldflags}" \
-                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk11-bootstrap/Contents/Home \
+                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk${feature}-bootstrap/Contents/Home \
                     --with-freetype=system \
                     --with-freetype-include=${prefix}/include/freetype2 \
                     --with-freetype-lib=${prefix}/lib \
@@ -64,7 +65,7 @@ configure.args      --with-debug-level=release \
                     --with-vendor-url="https://www.macports.org" \
                     --with-vendor-bug-url="${bug_url}" \
                     --with-vendor-vm-bug-url="${bug_url}" \
-                    --with-conf-name=openjdk11
+                    --with-conf-name=openjdk${feature}
 
 if {[option configure.ccache]} {
     # replace MacPorts ccache integration into JDK
@@ -148,7 +149,7 @@ build.type          gnu
 build.target        images
 use_parallel_build  no
 set jdkn jdk-${version}.jdk
-set bundle_dir build/openjdk11/images/jdk-bundle/${jdkn}/Contents
+set bundle_dir build/openjdk${feature}/images/jdk-bundle/${jdkn}/Contents
 
 test.run            yes
 test.cmd            ${bundle_dir}/Home/bin/java
@@ -178,6 +179,6 @@ export JAVA_HOME=${jdk}/Contents/Home
 "
 
 livecheck.type      regex
-livecheck.url       https://openjdk-sources.osci.io/openjdk11/
+livecheck.url       https://openjdk-sources.osci.io/openjdk${feature}/
 livecheck.regex     openjdk-(\[0-9.\]+)-ga
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.25.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?