### PR TITLE
jdk17: note that version 17.0.13+ is not available via MacPorts

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem       1.0
 
-name             jdk17
+set feature 17
+name             jdk${feature}
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      nomaintainer
 platforms        darwin
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          NFTC NoMirror
@@ -14,15 +15,17 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.12
+version      ${feature}.0.12
 revision     0
 
-description  Oracle Java SE Development Kit 17
+description  Oracle Java SE Development Kit ${feature}
 long_description Java Platform, Standard Edition Development Kit (JDK). \
     The JDK is a development environment for building applications and components using the Java programming language. \
-    This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense).
+    This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense). \
+    Oracle JDK ${feature}.0.13 and later are only available under the OTN license and therefore cannot be made available via MacPorts. \
+    If you require an up-to-date JDK ${feature}, consider installing the 'openjdk${feature}' or another openjdk${feature}-* port instead.
 
-master_sites https://download.oracle.com/java/17/archive/
+master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
@@ -42,7 +45,7 @@ homepage     https://www.oracle.com/java/
 
 livecheck.type      regex
 livecheck.url       https://www.oracle.com/java/technologies/downloads/
-livecheck.regex     Java SE Development Kit (17\.\[0-9\.\]+)
+livecheck.regex     JDK Development Kit (${feature}\.\[0-9\.\]+) downloads
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Oracle changed the license for Oracle JDK 17.0.13 and later in October 2024 and doesn't offer direct downloads for these versions, so this port cannot be updated anymore.

Noting in the description that users may want to use a different JDK 17 port instead.

I'm also switching this port to `nomaintainer`.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?