### PR TITLE
jdk17-graalvm: note that version 17.0.13+ is not available via MacPorts

### DIFF
--- a/java/jdk17-graalvm/Portfile
+++ b/java/jdk17-graalvm/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 17
 name             jdk${feature}-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      nomaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
@@ -36,7 +36,11 @@ build {}
 
 description  Oracle GraalVM for JDK ${feature}
 long_description Oracle GraalVM for JDK ${feature} compiles your Java applications ahead of time into standalone \
-    binaries that start instantly, provide peak performance with no warmup, and use fewer cloud resources.
+    binaries that start instantly, provide peak performance with no warmup, and use fewer cloud resources. \
+    This software is provided under the GraalVM Free Terms and Conditions (GFTC) license. \
+    Oracle GraalVM for JDK ${feature}.0.13 and later are only available under the GraalVM Oracle Technology \
+    Network (GOTN) license and therefore cannot be made available via MacPorts. \
+    If you require an up-to-date GraalVM for JDK, consider upgrading to a more recent feature version instead.
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin


### PR DESCRIPTION
#### Description

Oracle changed the license for Oracle GraalVM for JDK 17.0.13 and later in October 2024 and doesn't offer direct downloads for these versions, so this port cannot be updated anymore.

Noting in the description that users may want to use a later GraalVM for JDK port instead.

I'm also switching this port to `nomaintainer`.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?