### PR TITLE
openjdk17-graalvm: no longer supported

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem       1.0
 
-name             openjdk17-graalvm
+set feature 17
+name             openjdk${feature}-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      nomaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -14,7 +15,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version     17.0.9
+version     ${feature}.0.9
 set build 9
 revision    0
 epoch       1
@@ -32,9 +33,10 @@ set jvms /Library/Java/JavaVirtualMachines
 set jdk ${jvms}/${name}
 
 if {${subport} eq ${name}} {
-    description  GraalVM Community Edition based on OpenJDK 17
+    description  GraalVM Community Edition based on OpenJDK ${feature}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
-                     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
+                     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.\
+                     Version ${feature} of GraalVM Community Edition is no longer getting updates, so consider upgrading to a maintained version.
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     graalvm-community-jdk-${version}_macos-x64_bin


### PR DESCRIPTION
#### Description

Note that GraalVM Community Edition 17 is no longer receiving upstream updates. Switching to `nomaintainer`.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?