### PR TITLE
openjdk11-graalvm: no longer supported

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem       1.0
 
-name             openjdk11-graalvm
+set feature 11
+name             openjdk${feature}-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      nomaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -33,26 +34,27 @@ use_configure    no
 build {}
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/openjdk11-graalvm
+set jdk ${jvms}/openjdk${feature}-graalvm
 
 if {${subport} eq ${name}} {
-    description  GraalVM Community Edition based on OpenJDK 11
+    description  GraalVM Community Edition based on OpenJDK ${feature}
     long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
-                     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
+                     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.\
+                     Version ${feature} of GraalVM Community Edition is no longer getting updates, so consider upgrading to a maintained version.
 
     if {${configure.build_arch} eq "x86_64"} {
-        distname     graalvm-ce-java11-darwin-amd64-${version}
+        distname     graalvm-ce-java${feature}-darwin-amd64-${version}
         checksums    rmd160  e596dc7f73ca0f602ae60ca5c1bc4247373ec158 \
                      sha256  cab6a1436626adc28ec0f72791772315678e7c758e2fbae2cb6758a38f27c56a \
                      size    254523003
     } elseif {${configure.build_arch} eq "arm64"} {
-        distname     graalvm-ce-java11-darwin-aarch64-${version}
+        distname     graalvm-ce-java${feature}-darwin-aarch64-${version}
         checksums    rmd160  3421d1754a491b0cfa44d09df798ff5053fcefc8 \
                      sha256  c59f32289d92671bea46a34f4227fef484a4aa9eeece159e59a486205aaa6c31 \
                      size    249144742
     }
 
-    worksrcdir   graalvm-ce-java11-${version}
+    worksrcdir   graalvm-ce-java${feature}-${version}
 
     variant Applets \
         description { Advertise the JVM capability "Applets".} {}
@@ -111,13 +113,13 @@ subport ${name}-native-image {
     long_description   ${description}
 
     if {${configure.build_arch} eq "x86_64"} {
-        set jar_file native-image-installable-svm-java11-darwin-amd64-${version}.jar
+        set jar_file native-image-installable-svm-java${feature}-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  373bfe27fe1acd74596411b52d4506cdbd5260d0 \
                      sha256  56ddaf1f1d7e69efb88d8e391a4071f3a237723bdcee67794be1c56a03f56536 \
                      size    28688654
     } elseif {${configure.build_arch} eq "arm64"} {
-        set jar_file native-image-installable-svm-java11-darwin-aarch64-${version}.jar
+        set jar_file native-image-installable-svm-java${feature}-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  65a84d8dd894be0830673ffdf7e77a0ca19cf1ac \
                      sha256  df923df186826dcb7cb0eac0f5e93c3e215584f0377bad0c76310e09d7dc58cd \


### PR DESCRIPTION
#### Description

Note that GraalVM Community Edition 11 is no longer receiving upstream updates. Switching to `nomaintainer`.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?