### PR TITLE
openjdk8-temurin: update to 8u432

### DIFF
--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -2,11 +2,16 @@
 
 PortSystem       1.0
 
-name             openjdk8-temurin
+set feature 8
+name             openjdk${feature}-temurin
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-# See https://adoptium.net/supported_platforms.html
-platforms        {darwin any} {darwin >= 16}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 10 }
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -15,26 +20,26 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64
 
-version      8u422
-set build    05
+version      ${feature}u432
+set build    06
 revision     0
 
-description  Eclipse Temurin, based on OpenJDK 8
+description  Eclipse Temurin, based on OpenJDK ${feature}
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
 
-master_sites https://github.com/adoptium/temurin8-binaries/releases/download/jdk${version}-b${build}/
-distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
+master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk${version}-b${build}/
+distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}b${build}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  a6d88d162a337659857c9c648eb08e70fed2d95d \
-             sha256  b5924def481e682e6af8c2a0c1d9cf45808d35a16f276159705fcbdd92574e4d \
-             size    109522911
+checksums    rmd160  5f8860f55c3cc25de4e5a348aa8c946c7d646255 \
+             sha256  e5cc78b704cf96f7a6c4ad677048f79331f38cd37fbef6c86dce75e1bfe28895 \
+             size    109538778
 
 homepage     https://adoptium.net
 
 livecheck.type      regex
-livecheck.url       https://github.com/adoptium/temurin8-binaries/releases
-livecheck.regex     OpenJDK8U-jdk_x64_mac_hotspot_(8u\[0-9\]+)b\[0-9\]+\.tar\.gz
+livecheck.url       https://github.com/adoptium/temurin${feature}-binaries/releases
+livecheck.regex     OpenJDK${feature}U-jdk_x64_mac_hotspot_(${feature}u\[0-9\]+)b\[0-9\]+\.tar\.gz
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u432 (OpenJDK 8u432).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?