### PR TITLE
google-cloud-sdk: update to 498.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             497.0.0
+version             498.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1794fcafc6e12d5c7151f1389556ccfca804573f \
-                    sha256  c2bf4ee475785644a63ab88e367189fdb98bde7700cc7173faafac1d64f2bd10 \
-                    size    52285945
+    checksums       rmd160  6e344a174bf11e4122ed2b03306c69659e23f52b \
+                    sha256  34aa006071612f678154cc3411033f0336e4638310d76106ea043dae02812b45 \
+                    size    52361444
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  65bde5bfe5cf562b5f32e08457de6a8e08487612 \
-                    sha256  261c5ada9571aa0c0fe8ad06f863c5c2f6c61714a5d94379ddd833df67441e17 \
-                    size    53636087
+    checksums       rmd160  3346c7a27573362c3529da2fe2a3e709319537a5 \
+                    sha256  3ad3d16495ac80848e8e7980277cb27c93ec12e9d36ade394e5833f57ee68193 \
+                    size    53715411
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  f2c16597a27b309721e7dbffde1c935765b72be3 \
-                    sha256  0584bd1642e01d5195f75c92fbceb045464a9197cff48d71df2cf0ac51e5d1a4 \
-                    size    53583662
+    checksums       rmd160  ec9068cfde2fe5597aee05b31b9facc6f46d49f7 \
+                    sha256  c880c809f4201cb354a4f40959803866283cb2b3aa07a736e129826aa64fb377 \
+                    size    53663104
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -42,7 +42,8 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 worksrcdir          ${name}
 
 # Most recent supported Python version according to https://cloud.google.com/sdk/docs/install#mac
-python.default_version 312
+# Exception: gsutil is not compatible with Python 3.12 yet
+python.default_version 311
 
 post-patch {
     # Default to the MacPorts Python binary


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 498.0.0. Also downgraded Python dependency to 3.11, because `gsutil` is not compatible with Python 3.12 yet.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?