### PR TITLE
openjdk21: update patches

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -50,7 +50,7 @@ pre-patch {
 # Temporary workaround for clang 16: https://trac.macports.org/ticket/70819
 # Temporary workaround for undeclared enum in < 11.00: https://trac.macports.org/ticket/71049
 patchfiles          JDK-8340341-clang-16-workaround.patch \
-                    JDK-8266242-undecl-ident-nsbun-arm64-workaround.patch
+                    JDK-8342071-undecl-ident-nsbun-arm64-workaround.patch
 
 set tpath ${prefix}/Library/Java
 use_xcode           yes

--- a/java/openjdk21/files/JDK-8340341-clang-16-workaround.patch
+++ b/java/openjdk21/files/JDK-8340341-clang-16-workaround.patch
@@ -4,7 +4,7 @@
      # for the clang bug was still needed.
      BUILD_LIBJVM_loopTransform.cpp_CXXFLAGS := $(CXX_O_FLAG_NONE)
  
-+    # See JDK-8340341
++    # See https://bugs.openjdk.org/browse/JDK-8340341
 +    ifeq ($(firstword $(subst ., ,$(CXX_VERSION_NUMBER))), 16)
 +      BUILD_LIBJVM_stackMapTable.cpp_CXXFLAGS := -O1
 +    endif

--- a/java/openjdk21/files/JDK-8342071-undecl-ident-nsbun-arm64-workaround.patch
+++ b/java/openjdk21/files/JDK-8342071-undecl-ident-nsbun-arm64-workaround.patch
@@ -5,7 +5,7 @@
  
  static BOOL isValidDisplayMode(CGDisplayModeRef mode) {
 +    // https://trac.macports.org/ticket/71049: temporary additional guard for undef'd NSBun..ARM64
-+    // Should be reported/fixed upstream at openjdk.org.
++    // https://bugs.java.com/bugdatabase/view_bug?bug_id=JDK-8342071
 +#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
      // Workaround for apple bug FB13261205, since it only affects arm based macs
      // and arm support started with macOS 11 ignore the workaround for previous versions


### PR DESCRIPTION
#### Description

Update patch comments with assigned bug ID's.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?