### PR TITLE
starship: update to 1.21.1

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo   1.0
 PortGroup           github  1.0
 PortGroup           openssl 1.0
 
-github.setup        starship starship 1.20.1 v
+github.setup        starship starship 1.21.1 v
 github.tarball_from archive
 revision            0
 
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  24e7dd6e8431fb43c4d6f4890f30a153f18612f1 \
-                    sha256  851d84be69f9171f10890e3b58b8c5ec6057dd873dc83bfe0bdf965f9844b5dc \
-                    size    9414001
+                    rmd160  a9df04b2eb6d1ce45440083ca0eea8a9d29d3c80 \
+                    sha256  f543dfa3229441ca2a55b8a625ce4bad5756a896378b019f4d0f0e00cf34dcc8 \
+                    size    9435990
 
 # crate:openssl-sys requires pkgconfig & libssl.dylib
 depends_build-append \
@@ -45,36 +45,34 @@ destroot {
 }
 
 cargo.crates \
-    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
     ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     allocator-api2                  0.2.18  5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anstream                         0.6.7  4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba \
-    anstream                        0.6.14  418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b \
-    anstyle                          1.0.7  038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b \
-    anstyle-parse                    0.2.4  c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4 \
-    anstyle-query                    1.1.0  ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391 \
-    anstyle-wincon                   3.0.3  61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19 \
-    anyhow                          1.0.86  b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da \
+    anstream                        0.6.15  64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526 \
+    anstyle                          1.0.8  1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1 \
+    anstyle-parse                    0.2.5  eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb \
+    anstyle-query                    1.1.1  6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a \
+    anstyle-wincon                   3.0.4  5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8 \
+    anyhow                          1.0.89  86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arraydeque                       0.5.1  7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236 \
-    arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
+    arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     async-broadcast                  0.7.1  20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e \
     async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
-    async-executor                  1.13.0  d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7 \
+    async-executor                  1.13.1  30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec \
     async-fs                         2.1.2  ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a \
-    async-io                         2.3.3  0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964 \
-    async-lock                       2.8.0  287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b \
+    async-io                         2.3.4  444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8 \
     async-lock                       3.4.0  ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18 \
-    async-process                    2.2.3  f7eda79bbd84e29c2b308d1dc099d7de8dcc7035e48f4bf5dc4a531a44ff5e2a \
+    async-process                    2.3.0  63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb \
     async-recursion                  1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
-    async-signal                     0.2.9  dfb3634b73397aa844481f814fad23bbf07fdb0eabec10f2eb95e58944b1ec32 \
+    async-signal                    0.2.10  637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3 \
     async-task                       4.7.1  8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de \
-    async-trait                     0.1.81  6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107 \
+    async-trait                     0.1.83  721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    autocfg                          1.3.0  0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0 \
+    autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
@@ -83,41 +81,39 @@ cargo.crates \
     block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     blocking                         1.6.1  703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea \
-    bstr                             1.9.1  05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706 \
+    bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytesize                         1.3.0  a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc \
-    cc                               1.1.6  2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f \
+    cc                              1.1.30  b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
-    clap                            4.5.11  35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3 \
-    clap_builder                    4.5.11  49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa \
-    clap_complete                   4.5.11  c6ae69fbb0833c6fcd5a8d4b8609f108c7ad95fc11e248d853ff2c42a90df26a \
-    clap_derive                     4.5.11  5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e \
-    clap_lex                         0.7.1  4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70 \
+    clap                            4.5.20  b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8 \
+    clap_builder                    4.5.20  19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54 \
+    clap_complete                   4.5.33  9646e2e245bf62f45d39a0f3f36f1171ad1ea0d6967fd114bca72cb02a8fcdfb \
+    clap_derive                     4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
+    clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
     clru                             0.6.2  cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59 \
-    cmake                           0.1.50  a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130 \
-    colorchoice                      1.0.1  0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422 \
+    cmake                           0.1.51  fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a \
+    colorchoice                      1.0.2  d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0 \
     concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     const-random                    0.1.18  87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359 \
     const-random-macro              0.1.16  f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e \
-    const_format                    0.2.32  e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673 \
-    const_format_proc_macros        0.2.32  c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500 \
-    core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
-    core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
-    cpufeatures                     0.2.12  53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504 \
+    const_format                    0.2.33  50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b \
+    const_format_proc_macros        0.2.33  eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1 \
+    core-foundation                 0.10.0  b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63 \
+    core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    cpufeatures                     0.2.14  608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
-    crossbeam                        0.8.4  1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8 \
     crossbeam-channel               0.5.13  33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2 \
     crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-queue                 0.3.11  df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35 \
     crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     deelevate                        0.2.0  1c7397f8c48906dd9b5afc75001368c979418e5dff5575998a831eb2319b424e \
     deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
-    derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
     digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     dirs                             4.0.0  ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059 \
@@ -128,7 +124,7 @@ cargo.crates \
     dirs-sys-next                    0.1.2  4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d \
     dlv-list                         0.5.2  442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f \
     downcast                        0.11.0  1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1 \
-    dunce                            1.0.4  56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b \
+    dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.17  0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125 \
     either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
     encoding_rs                     0.8.34  b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59 \
@@ -139,107 +135,105 @@ cargo.crates \
     errno                            0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
     errno                            0.3.9  534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba \
     errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
-    event-listener                   2.5.3  0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0 \
-    event-listener                   4.0.1  84f2cdcf274580f2d63697192d744727b3198894b1bf02923643bf59e2c26712 \
     event-listener                   5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
-    event-listener-strategy          0.4.0  958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3 \
     event-listener-strategy          0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
     faster-hex                       0.9.0  a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183 \
-    fastrand                         2.1.0  9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a \
+    fastrand                         2.1.1  e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6 \
     filedescriptor                   0.8.2  7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e \
-    filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
-    flate2                          1.0.30  5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae \
+    filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
+    flate2                          1.0.34  a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fragile                          2.0.0  6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa \
-    futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
-    futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
+    futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
+    futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
     futures-lite                     2.3.0  52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5 \
-    futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
-    futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
-    futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
+    futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
+    futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
+    futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
-    gethostname                      0.5.0  dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30 \
     getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
-    gix                             0.64.0  d78414d29fcc82329080166077e0f7689f4016551fdb334d787c3d040fe2634f \
-    gix-actor                       0.31.5  a0e454357e34b833cc3a00b6efbbd3dd4d18b24b9fb0c023876ec2645e8aa3f2 \
+    gix                             0.66.0  9048b8d1ae2104f045cb37e5c450fc49d5d8af22609386bfc739c11ba88995eb \
+    gix-actor                       0.32.0  fc19e312cd45c4a66cd003f909163dc2f8e1623e30a0c0c6df3776e89b308665 \
     gix-bitmap                      0.2.11  a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae \
     gix-chunk                        0.4.8  45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52 \
     gix-commitgraph                 0.24.3  133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78 \
-    gix-config                      0.38.0  28f53fd03d1bf09ebcc2c8654f08969439c4556e644ca925f27cf033bc43e658 \
-    gix-config-value                0.14.7  b328997d74dd15dc71b2773b162cb4af9a25c424105e4876e6d0686ab41c383e \
-    gix-date                         0.8.7  9eed6931f21491ee0aeb922751bd7ec97b4b2fe8fbfedcb678e2a2dce5f3b8c0 \
-    gix-diff                        0.44.1  1996d5c8a305b59709467d80617c9fde48d9d75fd1f4179ea970912630886c9d \
-    gix-discover                    0.33.0  67662731cec3cb31ba3ed2463809493f76d8e5d6c6d245de8b0560438c13450e \
+    gix-config                      0.40.0  78e797487e6ca3552491de1131b4f72202f282fb33f198b1c34406d765b42bb0 \
+    gix-config-value                0.14.8  03f76169faa0dec598eac60f83d7fcdd739ec16596eca8fb144c88973dbe6f8c \
+    gix-date                         0.9.0  35c84b7af01e68daf7a6bb8bb909c1ff5edb3ce4326f1f43063a5a96d3c3c8a5 \
+    gix-diff                        0.46.0  92c9afd80fff00f8b38b1c1928442feb4cd6d2232a6ed806b6b193151a3d336c \
+    gix-discover                    0.35.0  0577366b9567376bc26e815fd74451ebd0e6218814e242f8e5b7072c58d956d2 \
     gix-features                    0.38.2  ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69 \
-    gix-fs                          0.11.2  6adf99c27cdf17b1c4d77680c917e0d94d8783d4e1c73d3be0d1d63107163d7a \
-    gix-glob                        0.16.4  fa7df15afa265cc8abe92813cd354d522f1ac06b29ec6dfa163ad320575cb447 \
+    gix-fs                          0.11.3  f2bfe6249cfea6d0c0e0990d5226a4cb36f030444ba9e35e0639275db8f98575 \
+    gix-glob                        0.16.5  74908b4bbc0a0a40852737e5d7889f676f081e340d5451a16e5b4c50d592f111 \
     gix-hash                        0.14.2  f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e \
     gix-hashtable                    0.5.2  7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242 \
-    gix-index                       0.33.1  9a9a44eb55bd84bb48f8a44980e951968ced21e171b22d115d1cdcef82a7d73f \
+    gix-index                       0.35.0  0cd4203244444017682176e65fd0180be9298e58ed90bd4a8489a357795ed22d \
     gix-lock                        14.0.0  e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d \
-    gix-macros                       0.1.5  999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17 \
-    gix-object                      0.42.3  25da2f46b4e7c2fa7b413ce4dffb87f69eaf89c2057e386491f4c55cadbfe386 \
-    gix-odb                         0.61.1  20d384fe541d93d8a3bb7d5d5ef210780d6df4f50c4e684ccba32665a5e3bc9b \
-    gix-pack                        0.51.1  3e0594491fffe55df94ba1c111a6566b7f56b3f8d2e1efc750e77d572f5f5229 \
-    gix-path                        0.10.9  8d23d5bbda31344d8abc8de7c075b3cf26e5873feba7c4a15d916bce67382bd9 \
+    gix-object                      0.44.0  2f5b801834f1de7640731820c2df6ba88d95480dc4ab166a5882f8ff12b88efa \
+    gix-odb                         0.63.0  a3158068701c17df54f0ab2adda527f5a6aca38fd5fd80ceb7e3c0a2717ec747 \
+    gix-pack                        0.53.0  3223aa342eee21e1e0e403cad8ae9caf9edca55ef84c347738d10681676fd954 \
+    gix-path                       0.10.11  ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af \
     gix-quote                       0.4.12  cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff \
-    gix-ref                         0.45.0  636e96a0a5562715153fee098c217110c33a6f8218f08f4687ff99afde159bb5 \
-    gix-refspec                     0.23.1  6868f8cd2e62555d1f7c78b784bece43ace40dd2a462daf3b588d5416e603f37 \
-    gix-revision                    0.27.2  01b13e43c2118c4b0537ddac7d0821ae0dfa90b7b8dbf20c711e153fb749adce \
-    gix-revwalk                     0.13.2  1b030ccaab71af141f537e0225f19b9e74f25fefdba0372246b844491cab43e0 \
-    gix-sec                         0.10.7  1547d26fa5693a7f34f05b4a3b59a90890972922172653bcb891ab3f09f436df \
-    gix-tempfile                    14.0.1  006acf5a613e0b5cf095d8e4b3f48c12a60d9062aa2b2dd105afaf8344a5600c \
-    gix-trace                        0.1.9  f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e \
-    gix-traverse                    0.39.2  e499a18c511e71cf4a20413b743b9f5bcf64b3d9e81e9c3c6cd399eae55a8840 \
-    gix-url                         0.27.4  e2eb9b35bba92ea8f0b5ab406fad3cf6b87f7929aa677ff10aa042c6da621156 \
+    gix-ref                         0.47.0  ae0d8406ebf9aaa91f55a57f053c5a1ad1a39f60fdf0303142b7be7ea44311e5 \
+    gix-refspec                     0.25.0  ebb005f82341ba67615ffdd9f7742c87787544441c88090878393d0682869ca6 \
+    gix-revision                    0.29.0  ba4621b219ac0cdb9256883030c3d56a6c64a6deaa829a92da73b9a576825e1e \
+    gix-revwalk                     0.15.0  b41e72544b93084ee682ef3d5b31b1ba4d8fa27a017482900e5e044d5b1b3984 \
+    gix-sec                         0.10.8  0fe4d52f30a737bbece5276fab5d3a8b276dc2650df963e293d0673be34e7a5f \
+    gix-tempfile                    14.0.2  046b4927969fa816a150a0cda2e62c80016fe11fb3c3184e4dddf4e542f108aa \
+    gix-trace                       0.1.10  6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b \
+    gix-traverse                    0.41.0  030da39af94e4df35472e9318228f36530989327906f38e27807df305fccb780 \
+    gix-url                         0.27.5  fd280c5e84fb22e128ed2a053a0daeacb6379469be6a85e3d518a0636e160c89 \
     gix-utils                       0.1.12  35192df7fd0fa112263bad8021e2df7167df4cc2a6e6d15892e1e55621d3d4dc \
-    gix-validate                     0.8.5  82c27dd34a49b1addf193c92070bcbf3beaf6e10f16a78544de6372e146a0acf \
-    guess_host_triple                0.1.3  b35a8ce923c7490629d84e12fa2f75e1733f1ec692a47c264f9b7fd632855afc \
+    gix-validate                     0.9.0  81f2badbb64e57b404593ee26b752c26991910fd0d81fe6f9a71c1a8309b6c86 \
+    guess_host_triple                0.1.4  5dd62763349a2c83ed2ce9ce5429158085fa43e0cdd8c60011a7843765d04e18 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashlink                         0.8.4  e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7 \
+    hashbrown                       0.15.0  1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb \
+    hashlink                         0.9.1  6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
-    iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
+    iana-time-zone                  0.1.61  235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                         2.2.6  168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26 \
+    indexmap                         2.6.0  707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-wsl                           0.4.0  173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5 \
     is_debug                         1.0.1  06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89 \
-    is_terminal_polyfill            1.70.0  f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800 \
+    is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
-    js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
-    jwalk                            0.8.1  2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56 \
+    jiff                            0.1.13  8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb \
+    jiff-tzdb                        0.1.1  91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653 \
+    jiff-tzdb-platform               0.1.1  9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329 \
+    js-sys                          0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                           0.2.155  97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c \
+    libc                           0.2.159  561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    libz-ng-sys                     1.1.15  c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5 \
-    libz-sys                        1.1.18  c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e \
+    libz-ng-sys                     1.1.16  4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438 \
+    libz-sys                        1.1.20  d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472 \
     linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
     log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
-    mac-notification-sys             0.6.1  51fca4d74ff9dbaac16a01b924bc3693fa2bba0862c2c633abc73f9a8ea21f64 \
+    mac-notification-sys             0.6.2  dce8f34f3717aa37177e723df6c1fc5fb02b2a1087374ea3fe0ea42316dc8f91 \
     mach2                            0.4.2  19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709 \
     malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
-    memmap2                          0.9.4  fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322 \
+    memmap2                          0.9.5  fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f \
     memmem                           0.1.1  a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15 \
     memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
-    miniz_oxide                      0.7.4  b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08 \
+    miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
     mockall                         0.13.0  d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a \
     mockall_derive                  0.13.0  341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020 \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              5.1.3  08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
-    notify-rust                     4.11.0  5312f837191c317644f313f7b2b39f9cb1496570c74f7c17152dd3961219551f \
+    notify-rust                     4.11.3  5134a72dc570b178bff81b01e81ab14a6fcc015391ed4b3b14853090658cd3a3 \
     nu-ansi-term                    0.50.1  d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399 \
     num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
     num-derive                       0.3.3  876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d \
@@ -248,7 +242,7 @@ cargo.crates \
     objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
     objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
     objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
-    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
+    once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
     opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
     open                             5.3.0  61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
@@ -256,53 +250,52 @@ cargo.crates \
     ordered-multimap                 0.7.3  49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79 \
     ordered-stream                   0.2.0  9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50 \
     os_info                          3.8.2  ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092 \
-    parking                          2.2.0  bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae \
+    parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     path-slash                       0.2.1  1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42 \
-    pathdiff                         0.2.1  8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd \
+    pathdiff                         0.2.2  d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361 \
     pathsearch                       0.2.0  da983bc5e582ab17179c190b4b66c7d76c5943a69c6d34df2a2b6bf8a2977b05 \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    pest                            2.7.11  cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95 \
-    pest_derive                     2.7.11  2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a \
-    pest_generator                  2.7.11  3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183 \
-    pest_meta                       2.7.11  a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f \
+    pest                            2.7.14  879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442 \
+    pest_derive                     2.7.14  d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd \
+    pest_generator                  2.7.14  eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e \
+    pest_meta                       2.7.14  b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d \
     phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
     phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
     phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
     phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
     pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    piper                            0.2.3  ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391 \
-    pkg-config                      0.3.30  d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec \
+    piper                            0.2.4  96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066 \
+    pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
     plist                            1.7.0  42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016 \
-    polling                          3.7.2  a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b \
+    polling                          3.7.3  cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
-    ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
-    predicates                       3.1.0  68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8 \
-    predicates-core                  1.0.6  b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174 \
-    predicates-tree                  1.0.9  368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf \
-    proc-macro-crate                 3.1.0  6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284 \
-    proc-macro2                     1.0.86  5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77 \
-    process_control                  4.1.0  4d18334c4a4b2770ee894e63cf466d5a9ea449cf29e321101b0b135a747afb6f \
+    ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
+    predicates                       3.1.2  7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97 \
+    predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
+    predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
+    proc-macro-crate                 3.2.0  8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b \
+    proc-macro2                     1.0.87  b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a \
+    process_control                  5.0.0  f32c4eb5a227708adf07971a8b0da3d7c8f7fb3e54de64aaaedc9bef72f70b62 \
     prodash                         28.0.0  744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79 \
     quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
     quick-xml                       0.32.0  1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2 \
-    quick-xml                       0.36.1  96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc \
-    quote                           1.0.36  0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7 \
+    quick-xml                       0.36.2  f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe \
+    quote                           1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
-    redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
-    redox_syscall                    0.5.3  2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4 \
-    redox_users                      0.4.5  bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891 \
-    regex                           1.10.5  b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f \
-    regex-automata                   0.4.7  38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df \
-    regex-syntax                     0.8.4  7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b \
-    rust-ini                        0.21.0  0d625ed57d8f49af6cfa514c42e1a71fadcff60eb0b1c517ff82fe41aa025b41 \
-    rustix                         0.38.34  70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f \
+    redox_syscall                    0.5.7  9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f \
+    redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
+    regex                           1.11.0  38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8 \
+    regex-automata                   0.4.8  368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3 \
+    regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
+    rust-ini                        0.21.1  4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f \
+    rustix                         0.38.37  8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811 \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schemars                        0.8.21  09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92 \
@@ -311,41 +304,42 @@ cargo.crates \
     semver                          0.11.0  f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6 \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
     semver-parser                   0.10.2  00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7 \
-    serde                          1.0.204  bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12 \
-    serde_derive                   1.0.204  e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222 \
+    serde                          1.0.210  c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a \
+    serde_derive                   1.0.210  243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                     1.0.120  4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5 \
+    serde_json                     1.0.129  6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2 \
     serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
-    serde_spanned                    0.6.7  eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d \
+    serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha1-asm                         0.5.3  286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b \
     sha1_smol                        1.0.1  bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d \
     sha2                             0.9.9  4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800 \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
-    shadow-rs                       0.30.0  d253e54681d4be0161e965db57974ae642a0b6aaeb18a999424c4dab062be8c5 \
+    shadow-rs                       0.35.1  2311e39772c00391875f40e34d43efef247b23930143a70ca5fbec9505937420 \
     shared_library                   0.1.9  5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11 \
     shell-words                      1.1.0  24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde \
+    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                     0.1.17  7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729 \
     signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
     signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
     siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
-    starship-battery                 0.9.1  da7915746794358b8f649d3032c8ce150f55b7a0cd41951f170162e82e6cf43f \
+    starship-battery                0.10.0  9017a937879cf3db80807fa7c28f09eafd4981c998265233028ee7b75f898ed2 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.72  dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af \
+    syn                             2.0.79  89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590 \
     systemstat                       0.2.3  a24aec24a9312c83999a28e3ef9db7e2afd5c64bf47725b758cdc1cafd5b0bd2 \
     tauri-winrt-notification         0.2.1  f89f5fb70d6f62381f5d9b2ba9008196150b40b75f3068eb24faeddf1c686871 \
-    tempfile                        3.10.1  85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1 \
-    terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
+    tempfile                        3.13.0  f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b \
+    terminal_size                    0.4.0  4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef \
     terminfo                         0.7.5  da31aef70da0f6352dbcb462683eb4dd2bfad01cf3fc96cf204547b9a839a585 \
     termios                          0.3.3  411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b \
     termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
     termwiz                         0.15.0  31ef6892cc0348a9b3b8c377addba91e0f6365863d92354bf27559dca81ee8c5 \
-    thiserror                       1.0.63  c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724 \
-    thiserror-impl                  1.0.63  a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261 \
+    thiserror                       1.0.64  d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84 \
+    thiserror-impl                  1.0.64  08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3 \
     time                            0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
     time-macros                     0.2.18  3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf \
@@ -353,45 +347,46 @@ cargo.crates \
     tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
-    toml                            0.8.16  81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c \
-    toml_datetime                    0.6.7  f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db \
-    toml_edit                       0.21.1  6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1 \
-    toml_edit                      0.22.17  8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16 \
+    toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
+    toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
+    toml_edit                      0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
     tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
     tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
     tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
     trim-in-place                    0.1.7  343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
-    ucd-trie                         0.1.6  ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9 \
+    ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     uds_windows                      1.1.0  89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9 \
     uluru                            3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
     unicase                          2.7.0  f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89 \
-    unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
+    unicode-bidi                    0.3.17  5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893 \
     unicode-bom                      2.0.3  7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217 \
-    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
-    unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
-    unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
-    unicode-width                   0.1.13  0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d \
-    unicode-xid                      0.2.4  f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c \
+    unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
+    unicode-normalization           0.1.24  5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956 \
+    unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
+    unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
+    unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     uom                             0.36.0  ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c \
     url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
-    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
-    versions                         6.3.0  5fc28d1172a20e32754969ea1a873c2c6e68e36c449c6056aa3e2ee5fe69a794 \
+    version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
+    versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
     vtparse                          0.6.2  6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
-    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.92  4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8 \
-    wasm-bindgen-backend            0.2.92  614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da \
-    wasm-bindgen-macro              0.2.92  a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726 \
-    wasm-bindgen-macro-support      0.2.92  e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7 \
-    wasm-bindgen-shared             0.2.92  af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96 \
-    which                            6.0.1  8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7 \
+    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasite                           0.1.0  b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b \
+    wasm-bindgen                    0.2.95  128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e \
+    wasm-bindgen-backend            0.2.95  cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358 \
+    wasm-bindgen-macro              0.2.95  e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56 \
+    wasm-bindgen-macro-support      0.2.95  26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68 \
+    wasm-bindgen-shared             0.2.95  65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d \
+    which                            6.0.3  b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f \
+    whoami                           1.5.2  372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.8  4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b \
+    winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     windows                         0.56.0  1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132 \
     windows                         0.58.0  dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6 \
@@ -407,6 +402,7 @@ cargo.crates \
     windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
     windows-version                  0.1.1  6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515 \
@@ -425,12 +421,11 @@ cargo.crates \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                          0.5.40  f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876 \
-    winnow                          0.6.15  557404e450152cd6795bb558bca69e43c585055f4606e3bcae5894fc6dac9ba0 \
+    winnow                          0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
     winres                          0.1.12  b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
-    xdg-home                         1.2.0  ca91dcf8f93db085f3a0a29358cd0b9d670915468f4290e8b85d118a34211ab8 \
-    yaml-rust2                       0.8.1  8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8 \
+    xdg-home                         1.3.0  ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6 \
+    yaml-rust2                       0.9.0  2a1a1c0bc9823338a3bdf8c61f994f23ac004c6fa32c08cd152984499b445e8d \
     zbus                             4.4.0  bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725 \
     zbus_macros                      4.4.0  267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e \
     zbus_names                       3.0.0  4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c \


### PR DESCRIPTION
#### Description

Update to Starship 1.21.1.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?