### PR TITLE
openjdk11-temurin: update to 11.0.25

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?os=mac&version=11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.24
-set build    8
+version      ${feature}.0.25
+set build    9
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature}
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  d9223baa629fe84d82bbe9a1a811784f3cc7dde2 \
-                 sha256  07a1be21f45f0951db05516e57602c414295c51a920f7e9b6ddeaa325d619b28 \
-                 size    187710109
+    checksums    rmd160  abd97d0101aa81f517fe555a5982e25ff1638303 \
+                 sha256  fa6f88ebd8c3d2b4f5146cd45e4ef875cb2d073b6e95b60de86a1ce0bfdb463a \
+                 size    187793518
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  651a5dda4c260e6d0574e973264fbb2c91a3cfc2 \
-                 sha256  8bcbb98e293fb3c4d5cae3539f240ed478fae85962311fccd4c628ebad3a90e4 \
-                 size    185018067
+    checksums    rmd160  162514abbfb3a876b4f8d1a603ba2f1242ddd2a0 \
+                 sha256  658f73050ab168109862d4e25eefeedb587063cc01128a78ea4081e8ec62edcf \
+                 size    185072722
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.25 (OpenJDK 11.0.25).

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?