### PR TITLE
openjdk17-temurin: fix checksum for arm64

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -36,9 +36,9 @@ if {${configure.build_arch} eq "x86_64"} {
                  size    179980449
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  d0bfb3664cbde6c1bdd322346e7bb473c5a39a94 \
-                 sha256  f89fdb3d6b8ad55127c2f6cc3e2c3df5d303e9cf0429c4533ff0995ff72e854d \
-                 size    185238298
+    checksums    rmd160  c73a11e0e2151f8ff5588d275d300d28fe4d2c8e \
+                 sha256  d8b2f77f755d06e81a540834c5be22ed86f3c8a51a20396606c074303f8f9e2d \
+                 size    185240495
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Fix checksum for arm64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?