### PR TITLE
openjdk8-temurin: fix livecheck

### DIFF
--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -38,8 +38,8 @@ checksums    rmd160  5f8860f55c3cc25de4e5a348aa8c946c7d646255 \
 homepage     https://adoptium.net
 
 livecheck.type      regex
-livecheck.url       https://github.com/adoptium/temurin${feature}-binaries/releases
-livecheck.regex     OpenJDK${feature}U-jdk_x64_mac_hotspot_(${feature}u\[0-9\]+)b\[0-9\]+\.tar\.gz
+livecheck.url       https://github.com/adoptium/temurin${feature}-binaries
+livecheck.regex     jdk(${feature}u\[0-9\]+)-b
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Fix livecheck.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?