### PR TITLE
openjdk22-temurin: fix livecheck

### DIFF
--- a/java/openjdk22-temurin/Portfile
+++ b/java/openjdk22-temurin/Portfile
@@ -19,7 +19,7 @@ version      ${feature}.0.2
 set build    9
 revision     0
 
-description  Eclipse Temurin, based on OpenJDK ${feature}
+description  Eclipse Temurin, based on OpenJDK ${feature} (Short Term Support until September 2024)
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, \
     production-ready Java runtimes.
 
@@ -42,8 +42,8 @@ worksrcdir   jdk-${version}+${build}
 homepage     https://adoptium.net
 
 livecheck.type      regex
-livecheck.url       https://github.com/adoptium/temurin${feature}-binaries/releases
-livecheck.regex     OpenJDK${feature}U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
+livecheck.url       https://github.com/adoptium/temurin${feature}-binaries
+livecheck.regex     jdk-(${feature}\[\.0-9\]+)\+
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Fix livecheck.

###### Tested on

macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?