### PR TITLE
tio: fix build on macOS Sequoia

### DIFF
--- a/comms/tio/Portfile
+++ b/comms/tio/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 github.setup            tio tio 3.7 v
 github.tarball_from     releases
-revision                0
+revision                1
 
 categories              comms
 installs_libs           no
@@ -36,6 +36,10 @@ depends_build-append    path:bin/pkg-config:pkgconfig
 depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2 \
                         port:inih   \
                         port:lua54
+
+# https://github.com/tio/tio/issues/278
+# remove this in the next release
+patchfiles-append       patch-replace-send.diff
 
 use_xz                  yes
 

--- a/comms/tio/files/patch-replace-send.diff
+++ b/comms/tio/files/patch-replace-send.diff
@@ -1,0 +1,24 @@
+From 9fec68911769736ab2595fda911a835e5c21633b Mon Sep 17 00:00:00 2001
+From: Martin Lund <martin.lund@keep-it-simple.com>
+Date: Sun, 15 Sep 2024 05:57:31 +0200
+Subject: [PATCH] Fix name declaration conflict with socket send()
+--- src/script.c
++++ src/script.c
+@@ -181,7 +181,7 @@ static int modem_send(lua_State *L)
+ }
+ 
+ // lua: send(string)
+-static int send(lua_State *L)
++static int send_(lua_State *L)
+ {
+     const char *string = lua_tostring(L, 1);
+     int ret;
+@@ -455,7 +455,7 @@ static const struct luaL_Reg tio_lib[] =
+     { "msleep", msleep},
+     { "line_set", line_set},
+     { "modem_send", modem_send},
+-    { "send", send},
++    { "send", send_},
+     { "read", read_string},
+     { "expect", expect},
+     { "exit", exit_},


### PR DESCRIPTION
#### Description

https://build.macports.org/builders/ports-15_x86_64-builder/builds/16687/steps/install-port/logs/stdio

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
