### PR TITLE
py-param: remove unneeded build dependencies

### DIFF
--- a/python/py-param/Portfile
+++ b/python/py-param/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-param
 version             2.1.1
-revision            0
+revision            1
 license             BSD
 maintainers         {mps @Schamschula} openmaintainer
 description         Param is a library providing Parameters.
@@ -22,14 +22,9 @@ checksums           rmd160  69bf3acc7bb57c892df4a121b79afd90b6411b8b \
                     size    174619
 
 python.versions     38 39 310 311 312
+python.pep517_backend hatch
 
 if {${name} ne ${subport}} {
-    python.pep517   yes
-    python.pep517_backend \
-                    hatch
-
     depends_build-append \
-                    port:py${python.version}-hatch-vcs \
-                    port:py${python.version}-numpy \
-                    port:py${python.version}-pyobjc
+                    port:py${python.version}-hatch-vcs
 }


### PR DESCRIPTION
#### Description
Upstream does not mention/use `py-numpy` and/or `py-pyobjc` as build dependencies.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.0.1 24A348 x86_64
Xcode 16.0 16A242d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
