### PR TITLE
eza: update to 0.20.5

### DIFF
--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        eza-community eza 0.20.3 v
+github.setup        eza-community eza 0.20.5 v
 github.tarball_from archive
 revision            0
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  649a0702bf98f424be8af8bf6577d8c8d4e608aa \
-                    sha256  51a61bba14d1e4043981cabc5cf3d14352bf6a4ca0e308f437d0c8d00f42c2f7 \
-                    size    1416238
+                    rmd160  8d4d76e07d7f4bf0e9111208a0ed9a5457eec599 \
+                    sha256  3455907abddd72ab405613588f82e2b5f6771facf215e5bcd92bca1a82520819 \
+                    size    1415403
 
 depends_lib-append  port:libiconv \
                     path:lib/pkgconfig/libgit2.pc:libgit2 \
@@ -124,7 +124,7 @@ cargo.crates \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     cc                              1.0.79  50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chrono                          0.4.34  5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b \
+    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
     ciborium                         0.2.1  effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926 \
     ciborium-io                      0.2.1  cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656 \
     ciborium-ll                      0.2.1  defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b \
@@ -170,7 +170,7 @@ cargo.crates \
     itoa                             1.0.9  af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38 \
     jobserver                       0.1.22  972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd \
     js-sys                          0.3.64  c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a \
-    libc                           0.2.159  561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5 \
+    libc                           0.2.161  8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1 \
     libgit2-sys               0.17.0+1.8.1  10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224 \
     libredox                         0.0.1  85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8 \
     libz-sys                         1.1.2  602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655 \


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
