### PR TITLE
py-meson: Default FrameworkPath not found when using -std=C++<ver> or std=gnu++<ver>

### DIFF
--- a/python/py-meson/Portfile
+++ b/python/py-meson/Portfile
@@ -8,7 +8,7 @@ name                py-meson
 # update version and revision also in the meson port
 github.setup        mesonbuild meson 1.6.0
 github.tarball_from releases
-revision            0
+revision            1
 
 checksums           rmd160  b3376a06163a378f4188a75d412d92f4cafcf1d8 \
                     sha256  999b65f21c03541cf11365489c1fad22e2418bb0c3d50ca61139f2eec09d5496 \

--- a/python/py-meson/files/patch-meson-gcc-appleframeworks.diff
+++ b/python/py-meson/files/patch-meson-gcc-appleframeworks.diff
@@ -1,6 +1,6 @@
---- mesonbuild/compilers/mixins/clike.py.orig	2022-01-03 04:12:32.000000000 +0800
-+++ mesonbuild/compilers/mixins/clike.py	2022-04-06 05:50:19.000000000 +0800
-@@ -1123,9 +1123,6 @@
+--- mesonbuild/compilers/mixins/clike.py.orig	2024-10-20 20:20:25.000000000 +0200
++++ mesonbuild/compilers/mixins/clike.py	2024-10-25 10:29:11.000000000 +0200
+@@ -1185,14 +1185,12 @@
          unless you select a particular macOS SDK with the -isysroot flag.
          You can also add to this by setting -F in CFLAGS.
          '''
@@ -8,5 +8,12 @@
 -        if self.id != 'clang':
 -            raise mesonlib.MesonException('Cannot find framework path with non-clang compiler')
          # Construct the compiler command-line
-         commands = self.get_exelist() + ['-v', '-E', '-']
+         commands = self.get_exelist(ccache=False) + ['-v', '-E', '-']
          commands += self.get_always_args()
+         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS from the env
+-        commands += env.coredata.get_external_args(self.for_machine, self.language)
++        # 'std=c++<ver>','std=gnu++<ver>' are valid for C++/ObjC++ but not for 'C'
++        commands += [x for x in env.coredata.get_external_args(self.for_machine, self.language) if '-std=c++' not in x and '-std=gnu++' not in x]
+         mlog.debug('Finding framework path by running: ', ' '.join(commands), '\n')
+         os_env = os.environ.copy()
+         os_env['LC_ALL'] = 'C'


### PR DESCRIPTION
#### Description
  Closes: https://trac.macports.org/ticket/71165

  Modifies the patch-meson-gcc-appleframeworks.diff patch file.
  Bumps py-meson Portfile to revision 1
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15
Xcode 11.5 / Command Line Tools 11.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
