### PR TITLE
simplotask: update to 1.16.1

### DIFF
--- a/sysutils/simplotask/Portfile
+++ b/sysutils/simplotask/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/umputun/spot 1.16.0 v
+go.setup            github.com/umputun/spot 1.16.1 v
 name                simplotask
 revision            0
 categories          sysutils
@@ -19,9 +19,9 @@ build.pre_args-append \
                     REV=v${version}
 build.args          build
 
-checksums           rmd160  c0ba532c0d5e46f42c19f4e83eb719f733f92ca0 \
-                    sha256  8fc3b46e83b9dea18d6e52564b4b8bbc07b781542a5a74fa69b0267b4cadb615 \
-                    size    44184600
+checksums           rmd160  bbee67507691fbf421dc73f6eafc66fab2390d22 \
+                    sha256  3ad9a9f758b4328b1a5e31a167bf563d1895026186238a7b18e75cae24f3a7a9 \
+                    size    47628676
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/.bin/spot ${destroot}${prefix}/bin


### PR DESCRIPTION
#### Description
https://github.com/umputun/spot/releases/tag/v1.16.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
