### PR TITLE
uv: Update to 0.4.26

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.4.25
+github.setup            astral-sh uv 0.4.26
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  4747d797586ff9f3261c3e3080e16ad7f25c8db3 \
-                        sha256  b3bd159eb8a40ad29e8c5dc4bec84c03a5bcfef04ad75e0665777c21d886b56c \
-                        size    2766139
+                        rmd160  6b45712d518082ec127819130c12b665f04bd4cb \
+                        sha256  a85767a9a230216774a9b57b8b29f09a255074ad3216e9502090a4a03cd2a494 \
+                        size    2772725
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -28,11 +28,18 @@ cargo.offline_cmd
 build.args-append       --no-default-features
 
 post-build {
-    # Generate shell completions for supported shells
+    # Generate uv shell completions for supported shells
     set uv_bin ${worksrcpath}/target/[cargo.rust_platform]/release/${name}
     foreach shell {zsh bash fish} {
         system -W ${worksrcpath} \
             "${uv_bin} generate-shell-completion ${shell} > uv.${shell}"
+    }
+
+    # Generate uvx shell completions for supported shells
+    set uvx_bin ${worksrcpath}/target/[cargo.rust_platform]/release/${name}x
+    foreach shell {zsh bash fish} {
+        system -W ${worksrcpath} \
+            "${uvx_bin} --generate-shell-completion ${shell} > uvx.${shell}"
     }
 }
 
@@ -43,14 +50,17 @@ destroot {
     set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
     xinstall -d ${zsh_comp_path}
     xinstall -m 0644 ${worksrcpath}/${name}.zsh ${zsh_comp_path}/_${name}
+    xinstall -m 0644 ${worksrcpath}/${name}x.zsh ${zsh_comp_path}/_${name}x
 
     set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
     xinstall -d ${bash_comp_path}
     xinstall -m 0644 ${worksrcpath}/${name}.bash ${bash_comp_path}/${name}
+    xinstall -m 0644 ${worksrcpath}/${name}x.bash ${bash_comp_path}/${name}x
 
     set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_comp_path}
     xinstall -m 0644 ${worksrcpath}/${name}.fish ${fish_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}x.fish ${fish_comp_path}
 }
 
 cargo.crates \
@@ -78,7 +88,7 @@ cargo.crates \
     axoasset                         1.0.0  45e7b7ac1c1cd4fdcaa2f9e704defa9defd996039083d85e17efa5e8eefb3bd2 \
     axoprocess                       0.2.0  4de46920588aef95658797996130bacd542436aee090084646521260a74bda7d \
     axotag                           0.2.0  d888fac0b73e64cbdf36a743fc5a25af5ae955c357535cb420b389bf1e1a6c54 \
-    axoupdater                       0.7.2  fa6f92ef9ab41a352f403f709ef0f09cda1f461795de52085cd46ed831ead02e \
+    axoupdater                       0.7.3  6fe17874ee40fb66fe1d2cb7871b14de4d298fbf77ea29a6cedb8027365e1a33 \
     backoff                          0.4.0  b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1 \
     backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
@@ -148,6 +158,7 @@ cargo.crates \
     difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     directories                      5.0.1  9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35 \
+    dirs                             5.0.1  44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225 \
     dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
@@ -279,6 +290,7 @@ cargo.crates \
     oorandom                        11.1.4  b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
+    os_str_bytes                     6.6.1  e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     owo-colors                       4.1.0  fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56 \
     parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
@@ -351,6 +363,7 @@ cargo.crates \
     rosvgtree                        0.1.0  bdc23d1ace03d6b8153c7d16f0708cd80b61ee8e80304954803354e67e40d150 \
     roxmltree                       0.18.1  862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302 \
     roxmltree                       0.20.0  6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97 \
+    rust-netrc                       0.1.2  7e98097f62769f92dbf95fb51f71c0a68ec18a4ee2e70e0d3e4f47ac005d63e9 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
     rustix                         0.38.37  8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811 \
@@ -371,6 +384,7 @@ cargo.crates \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework-sys          2.12.0  ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6 \
+    self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
     serde                          1.0.210  c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a \
     serde-untagged                   0.1.6  2676ba99bd82f75cae5cbd2c8eda6fa0b8760f18978ea840e980dd5567b5c5b6 \
@@ -382,6 +396,7 @@ cargo.crates \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
+    shellexpand                      3.1.0  da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
     simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.4.26

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
