### PR TITLE
dbeaver-community: Update to 2024.2.3 and add `all_arches` variant.

### DIFF
--- a/databases/dbeaver-community/Portfile
+++ b/databases/dbeaver-community/Portfile
@@ -29,18 +29,27 @@ homepage            https://dbeaver.io/
 
 use_dmg             yes
 
+variant all_arches description {Download files for all arches} { 
+    distfiles       dbeaver-ce-${version}-macos-x86_64${extract.suffix} \
+                    dbeaver-ce-${version}-macos-aarch64${extract.suffix}
+    }
+
+checksums           dbeaver-ce-${version}-macos-x86_64${extract.suffix} \
+                        rmd160  a2f74fb3308b9599eddb9fd7ed9e5cd55559d5f8 \
+                        sha256  fd8c8de5d69ea31ab4a228baa9846967c71be37bba9fc1ee55cd89a953a1af1b \
+                        size    123325756 \
+                    dbeaver-ce-${version}-macos-aarch64${extract.suffix} \
+                        rmd160  e5003687c9c975019e868228a99eea2d76995721 \
+                        sha256  1e6f76d7985ca0d11cfda99343d9815f6c25f79693085d7f4fee5cadcb5b69e0 \
+                        size    129368871
+                        
+
 switch ${build_arch} {
     x86_64 {
-        distfiles           dbeaver-ce-${version}-macos-x86_64${extract.suffix}
-        checksums           rmd160  3c278ba41874c541f9e0b4efd24c423876e3a5e0 \
-                            sha256  e2e66b9608c7273ef33a01a7ee64d1b73fea8e5bf30609570157237fb483982b \
-                            size    130591353
+        distfiles   dbeaver-ce-${version}-macos-x86_64${extract.suffix}
     }
     arm64 {
-        distfiles           dbeaver-ce-${version}-macos-aarch64${extract.suffix}
-        checksums           rmd160  e5003687c9c975019e868228a99eea2d76995721 \
-                            sha256  1e6f76d7985ca0d11cfda99343d9815f6c25f79693085d7f4fee5cadcb5b69e0 \
-                            size    129368871
+        distfiles   dbeaver-ce-${version}-macos-aarch64${extract.suffix}
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

The all_arches variant requests distfiles for both aarch64 and x86_64, regardless of the actual build arch. This allows commands like `port bump` to function correctly.
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.0.1 24A348 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
