### PR TITLE
cubeb: a few fixes to the port

### DIFF
--- a/audio/cubeb/Portfile
+++ b/audio/cubeb/Portfile
@@ -27,5 +27,8 @@ post-fetch {
     system -W ${worksrcpath} "git submodule update --init --recursive"
 }
 
+# https://trac.macports.org/ticket/71027
+compiler.cxx_standard   2017
+
 configure.args-append \
                     -DBUILD_TESTS=OFF

--- a/audio/cubeb/Portfile
+++ b/audio/cubeb/Portfile
@@ -31,4 +31,14 @@ post-fetch {
 compiler.cxx_standard   2017
 
 configure.args-append \
-                    -DBUILD_TESTS=OFF
+                    -DBUILD_TESTS=OFF \
+                    -DUSE_AUDIOUNIT=OFF
+
+# AudioUnit configure check is wrong: it only verifies the header,
+# but the code requires libdispatch and support for blocks.
+# https://github.com/mozilla/cubeb/issues/804
+if {(${os.platform} eq "darwin" && ${os.major} > 9) \
+    && [string match *clang* ${configure.compiler}]} {
+    configure.args-replace \
+                    -DUSE_AUDIOUNIT=OFF -DUSE_AUDIOUNIT=ON
+}

--- a/audio/cubeb/Portfile
+++ b/audio/cubeb/Portfile
@@ -20,7 +20,7 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 fetch.type          git
 
 depends_build-append \
-                    port:doxygen \
+                    path:bin/doxygen:doxygen \
                     port:python312
 
 post-fetch {


### PR DESCRIPTION
#### Description

See commits.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
