### PR TITLE
QMPlay2: fix version threshold

### DIFF
--- a/multimedia/QMPlay2/Portfile
+++ b/multimedia/QMPlay2/Portfile
@@ -64,7 +64,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 15} {
 
     # Support for Qt5 < 5.10 has been dropped in 21.03.09:
     # https://github.com/zaps166/QMPlay2/commit/02684fec6217ac87a37dbd40d7b07683122e5997
-    if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    if {${os.platform} eq "darwin" && ${os.major} < 19} {
         github.setup    zaps166 QMPlay2 20.12.16
         revision        0
         checksums       rmd160  582ec7368e582b4b29280d6c76d4dc54d1fd0bb3 \


### PR DESCRIPTION
#### Description

Move version threshold in a hope it fixes some pre-Catalina OS. (Also current one is duplicate after https://github.com/macports/macports-ports/commit/613d55e83fe738b77320937cd443a62b6841d69e commit.)
Not tested, but the change only concerns systems which currently fail anyway.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
