### PR TITLE
Add python 3.13 subports for several packages

### DIFF
--- a/python/py-fastjsonschema/Portfile
+++ b/python/py-fastjsonschema/Portfile
@@ -22,4 +22,4 @@ checksums           rmd160  c07814a11997ba031d7a0683c64e621a100fed5f \
                     sha256  3d48fc5300ee96f5d116f10fe6f28d938e6008f59a6a025c2649475b87f76a23 \
                     size    373056
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313

--- a/python/py-filelock/Portfile
+++ b/python/py-filelock/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  145d8cfd7f09944e7d518d2cd4ae13aed1612b1c \
 
 # keep versions for Python < 3.4, these are (indirect) dependencies of py-virtualenv
 # See: <https://trac.macports.org/wiki/Python#VersionPolicy>
-python.versions     27 37 38 39 310 311 312
+python.versions     27 37 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     if {${python.version} >= 37} {

--- a/python/py-pkginfo/Portfile
+++ b/python/py-pkginfo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pkginfo
-version             1.11.1
+version             1.11.2
 revision            0
 
 license             MIT
@@ -20,8 +20,8 @@ long_description \
 
 homepage            https://pypi.python.org/pypi/pkginfo
 
-checksums           rmd160  8e87ed7f632bd5f395466d72b70a2d2affbd30fe \
-                    sha256  2e0dca1cf4c8e39644eed32408ea9966ee15e0d324c62ba899a393b3c6b467aa \
-                    size    376911
+checksums           rmd160  2b2f25fa0f12b0df61f2c64ea0a289d6640f650e \
+                    sha256  c6bc916b8298d159e31f2c216e35ee5b86da7da18874f879798d0a1983537c86 \
+                    size    450821
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313

--- a/python/py-platformdirs/Portfile
+++ b/python/py-platformdirs/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  ab9c718c8dc4d8aa46fd31c87e8a3b482f879b92 \
 
 # keep th Python 2.7 subport as it is a dependency of py-virtualenv
 # See <https://trac.macports.org/wiki/Python#VersionPolicy>
-python.versions     27 38 39 310 311 312
+python.versions     27 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-requests-toolbelt/Portfile
+++ b/python/py-requests-toolbelt/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  bc8306044dbad82b948fbbe47f763f61173a8412 \
                     sha256  5743439930e6072034f441eabf2bef93a21961aee8ab8f6291a860fa04d530b4 \
                     size    199298
 
-python.versions     27 38 39 310 311 312
+python.versions     27 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-shellingham/Portfile
+++ b/python/py-shellingham/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 license             ISC
 supported_archs     noarch
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 

--- a/python/py-xattr/Portfile
+++ b/python/py-xattr/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  560915916b2e80414f7172dae9cf04506f9ee49a \
                     sha256  fecbf3b05043ed3487a28190dec3e4c4d879b2fcec0e30bafd8ec5d4b6043630 \
                     size    16634
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

For testing, I just did an `import foo` from the interpreter. That being said, I did review changelogs etc and this is all low risk.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 x86_64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
