### PR TITLE
libmypaint,MyPaint: use Python 3.12

### DIFF
--- a/graphics/MyPaint/Portfile
+++ b/graphics/MyPaint/Portfile
@@ -6,7 +6,7 @@ PortGroup                   github 1.0
 PortGroup                   python 1.0
 
 github.setup                mypaint mypaint 2.0.1 v
-revision                    2
+revision                    3
 checksums                   rmd160  60718b6e9c4f26253f1887a527e0ba24554bcfac \
                             sha256  f3e437d7cdd5fd28ef6532e8ab6b4b05d842bcdd644f16a0162dad3d8e57bb16 \
                             size    7295048
@@ -32,7 +32,7 @@ use_xz                      yes
 compiler.cxx_standard       2011
 
 # Remember to update the python version in libmypaint too.
-python.versions             38
+python.versions             312
 
 # CRITICAL: mypaint: Installation layout: unknown!
 # RuntimeError: Unknown install type; could not determine paths
@@ -58,7 +58,8 @@ depends_lib-append          path:lib/pkgconfig/glib-2.0.pc:glib2 \
 
 depends_run-append          port:hicolor-icon-theme
 
-patchfiles                  _DARWIN_C_SOURCE.patch
+patchfiles                  _DARWIN_C_SOURCE.patch \
+                            compatibiliby-newer-Python-versions.diff
 
 configure.pkg_config_path-prepend \
                             ${frameworks_dir}/Python.framework/Versions/${python.branch}/lib/pkgconfig

--- a/graphics/MyPaint/Portfile
+++ b/graphics/MyPaint/Portfile
@@ -25,7 +25,7 @@ long_description            ${name} is ${description}. It lets you focus on the 
                             minimum distractions, bringing up the interface only \
                             when you need it.
 
-homepage                    http://mypaint.org
+homepage                    https://mypaint.app
 github.tarball_from         releases
 use_xz                      yes
 

--- a/graphics/MyPaint/files/compatibiliby-newer-Python-versions.diff
+++ b/graphics/MyPaint/files/compatibiliby-newer-Python-versions.diff
@@ -1,0 +1,91 @@
+python: fix for Python 3.11
+- python 3 always open in universal mode, U is default mode in 3.0,
+  and removed in 3.11
+- mypaint doesn't use ld?n?gettext, so bind_textdomain_codeset isn't
+  needed, that function is deprecated in 3.8 and is no-ops in 3.10 and
+  removed in 3.11
+
+See: https://github.com/mypaint/mypaint/commit/032a155b72f2b021f66a994050d83f07342d04af
+
+diff --git a/lib/gettext_setup.py b/lib/gettext_setup.py
+index d4ce60a20..72cfaeddc 100644
+--- lib/gettext_setup.py.orig
++++ lib/gettext_setup.py
+@@ -82,13 +82,11 @@ def init_gettext(localepath):
+     # yanked in over GI.
+     # https://bugzilla.gnome.org/show_bug.cgi?id=574520#c26
+     bindtextdomain = None
+-    bind_textdomain_codeset = None
+     textdomain = None
+
+     # Try the POSIX/Linux way first.
+     try:
+         bindtextdomain = locale.bindtextdomain
+-        bind_textdomain_codeset = locale.bind_textdomain_codeset
+         textdomain = locale.textdomain
+     except AttributeError:
+         logger.warning(
+@@ -117,12 +115,6 @@ def init_gettext(localepath):
+                         ctypes.c_char_p,
+                     )
+                     bindtextdomain.restype = ctypes.c_char_p
+-                    bind_textdomain_codeset = libintl.bind_textdomain_codeset
+-                    bind_textdomain_codeset.argtypes = (
+-                        ctypes.c_char_p,
+-                        ctypes.c_char_p,
+-                    )
+-                    bind_textdomain_codeset.restype = ctypes.c_char_p
+                     textdomain = libintl.textdomain
+                     textdomain.argtypes = (
+                         ctypes.c_char_p,
+@@ -177,35 +169,22 @@ def init_gettext(localepath):
+         # complete set from the same source.
+         # Required for translatable strings in GtkBuilder XML
+         # to be translated.
+-        if bindtextdomain and bind_textdomain_codeset and textdomain:
++        if bindtextdomain and textdomain:
+             assert os.path.exists(path)
+             assert os.path.isdir(path)
+             if sys.platform == 'win32':
+                 p = bindtextdomain(dom.encode('utf-8'), path.encode('utf-8'))
+-                c = bind_textdomain_codeset(
+-                    dom.encode('utf-8'), codeset.encode('utf-8')
+-                )
+             else:
+                 p = bindtextdomain(dom, path)
+-                c = bind_textdomain_codeset(dom, codeset)
+             logger.debug("C bindtextdomain(%r, %r): %r", dom, path, p)
+-            logger.debug(
+-                "C bind_textdomain_codeset(%r, %r): %r",
+-                dom, codeset, c,
+-            )
+         # Call the implementations in Python's standard gettext module
+         # too.  This has proper cross-platform support, but it only
+         # initializes the native Python "gettext" module.
+         # Required for marked strings in Python source to be translated.
+         # See http://docs.python.org/release/2.7/library/locale.html
+         p = gettext.bindtextdomain(dom, path)
+-        c = gettext.bind_textdomain_codeset(dom, codeset)
+         logger.debug("Python bindtextdomain(%r, %r): %r", dom, path, p)
+-        logger.debug(
+-            "Python bind_textdomain_codeset(%r, %r): %r",
+-            dom, codeset, c,
+-        )
+-    if bindtextdomain and bind_textdomain_codeset and textdomain:
++    if bindtextdomain and textdomain:
+         if sys.platform == 'win32':
+             d = textdomain(defaultdom.encode('utf-8'))
+         else:
+diff --git a/setup.py b/setup.py
+index 204236765..046db5880 100644
+--- setup.py.orig
++++ setup.py
+@@ -679,7 +679,7 @@ def _install_script(self, src, header):
+         self.announce("installing %s as %s" % (src, targ_basename), level=2)
+         if self.dry_run:
+             return []
+-        with open(src, "rU") as in_fp:
++        with open(src, "r") as in_fp:
+             with open(targ, "w") as out_fp:
+                 line = in_fp.readline().rstrip()
+                 if line.startswith("#!"):

--- a/graphics/libmypaint/Portfile
+++ b/graphics/libmypaint/Portfile
@@ -56,4 +56,7 @@ depends_build-append \
 
 configure.args      --with-glib
 
+test.run            yes
+test.target         check
+
 github.livecheck.regex  {(\d+(?:\.\d+)+)}

--- a/graphics/libmypaint/Portfile
+++ b/graphics/libmypaint/Portfile
@@ -27,12 +27,14 @@ use_xz              yes
 set python_branch   3.8
 set python_version  [string map {. {}} ${python_branch}]
 
-depends_build       port:intltool \
+depends_build       port:gettext \
+                    port:intltool \
                     port:pkgconfig \
                     port:python${python_version}
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    port:json-c
+                    port:json-c \
+                    port:gettext-runtime
 
 # reconfigure with our intltool.m4 using upstream autogen.sh
 post-extract {

--- a/graphics/libmypaint/Portfile
+++ b/graphics/libmypaint/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        mypaint libmypaint 1.6.1 v
-revision            0
+revision            1
 checksums           rmd160  1c09037ab87cadddb57345e5fc2057ba4fadfe23 \
                     sha256  741754f293f6b7668f941506da07cd7725629a793108bb31633fb6c3eae5315f \
                     size    519464
@@ -24,7 +24,7 @@ github.tarball_from releases
 use_xz              yes
 
 # Using the same python as MyPaint for consistency.
-set python_branch   3.8
+set python_branch   3.12
 set python_version  [string map {. {}} ${python_branch}]
 
 depends_build       port:gettext \


### PR DESCRIPTION
#### Description
- use Python 3.12 for both ports (want to remove the `py38-numpy` subport in preparation for an update that uses the new `meson` backend) and this is the only straggler.
- `libmypaint` is missing a build dependency on `gettext` - at least I cannot get it to configure without
- `MyPaint` needs a backport of an upstream patch to allow newer Python versions due to deprecations in the Python standard library  
- tests for `libmypaint`, enabled in this PR, pass and `MyPaint` starts up correctly and I can do some drawing
 
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.0.1 24A348 x86_64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? 
There are a few Trac tickets for older OSes which I cannot check whether or not that is resolved by this PR.
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
