### PR TITLE
cpr: update to 1.11.0

### DIFF
--- a/devel/cpr/Portfile
+++ b/devel/cpr/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           openssl 1.0
 
-github.setup        libcpr cpr 1.10.5
+github.setup        libcpr cpr 1.11.0
 revision            0
 categories          devel net
 license             MIT
@@ -13,9 +13,9 @@ maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         C++ Requests: Curl for People
 long_description    C++ Requests is a simple wrapper around libcurl.
 homepage            https://docs.libcpr.org
-checksums           rmd160  70ec9559b978c5c23a97005577dcf859c2817efa \
-                    sha256  c8590568996cea918d7cf7ec6845d954b9b95ab2c4980b365f582a665dea08d8 \
-                    size    132280
+checksums           rmd160  f8fbde58f19b19e106bf872f307abe61348b06c5 \
+                    sha256  fdafa3e3a87448b5ddbd9c7a16e7276a78f28bbe84a3fc6edcfef85eca977784 \
+                    size    141318
 github.tarball_from archive
 
 depends_lib-append  port:curl \
@@ -34,10 +34,6 @@ configure.args-append \
                     -DCPR_USE_BOOST_FILESYSTEM=OFF \
                     -DCPR_USE_SYSTEM_CURL=ON \
                     -DCPR_USE_SYSTEM_GTEST=ON
-
-# https://github.com/libcpr/cpr/issues/1087
-configure.cxxflags-append \
-                    -Wno-error=overflow
 
 configure.pre_args-replace \
                     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
