### PR TITLE
libimobiledevice-glue: fix build when AI_NUMERICSERV undefined

### DIFF
--- a/devel/libimobiledevice-glue/Portfile
+++ b/devel/libimobiledevice-glue/Portfile
@@ -60,6 +60,9 @@ subport libimobiledevice-glue-devel {
     livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
 }
 
+# https://github.com/libimobiledevice/libimobiledevice-glue/pull/46
+patchfiles-append   0001-socket.c-define-AI_NUMERICSERV-if-undefined.patch
+
 if {${subport} eq ${name}} {
     github.tarball_from     releases
     use_bzip2               yes

--- a/devel/libimobiledevice-glue/files/0001-socket.c-define-AI_NUMERICSERV-if-undefined.patch
+++ b/devel/libimobiledevice-glue/files/0001-socket.c-define-AI_NUMERICSERV-if-undefined.patch
@@ -1,0 +1,24 @@
+From 5140e4f2b9f85292954ada4662ac351935a179a4 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Tue, 29 Oct 2024 11:12:26 +0800
+Subject: [PATCH] socket.c: define AI_NUMERICSERV if undefined
+
+---
+ src/socket.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git src/socket.c src/socket.c
+index 100562c..1518954 100644
+--- src/socket.c
++++ src/socket.c
+@@ -83,6 +83,10 @@ static int wsa_init = 0;
+ #define ETIMEDOUT 138
+ #endif
+ 
++#ifndef AI_NUMERICSERV
++#define AI_NUMERICSERV 0
++#endif
++
+ static int verbose = 0;
+ 
+ void socket_set_verbose(int level)


### PR DESCRIPTION
#### Description

Fix build on legacy OS

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
