### PR TITLE
timescaledb: fix conflict with subport

### DIFF
--- a/databases/timescaledb/Portfile
+++ b/databases/timescaledb/Portfile
@@ -82,18 +82,30 @@ configure.args          -DAPACHE_ONLY=1 \
 
 build.dir               ${worksrcpath}/build
 
+# @holymonson 2024-10-30: for smooth upgrade from legacy, kill this hack sometime later.
+# https://trac.macports.org/wiki/PortfileRecipes#deactivatehack
+pre-activate {
+    if {![catch {lindex [registry_active timescaledb] 0} installed]} {
+        set _version [lindex $installed 1]
+        if {[vercmp $_version 2.16.1] < 0} {
+            registry_deactivate_composite timescaledb "" [list ports_nodepcheck 1]
+        }
+    }
+}
+
 github.livecheck.regex  {([0-9.]+)}
 
 variant timescale_license description {Enable Timescale License code, license will be Timescale License} {
     configure.args-delete   -DAPACHE_ONLY=1
-    license                 {Timescale License}
+    license                 Timescale-License
 }
 
 if {${name} eq ${subport}} {
-    PortGroup       stub 1.0
+    PortGroup       obsolete 1.0
+    revision        1
 
     supported_archs noarch
 
-    # set this stub port depends on its latest subport for legacy
-    depends_lib     port:pg[lindex ${postgresql_branches} end]-${name}
+    set latest_branch [lindex ${postgresql_branches} end]
+    replaced_by     pg${latest_branch}-${name}
 }


### PR DESCRIPTION
* fix conflict with subport
* fix license

Closes: https://trac.macports.org/ticket/71189

cc @barracuda156 @ryandesign 

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Command Line Tools 14.2.0.0.1.1668646533
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
