### PR TITLE
gobject-introspection*: use legacysupport to fix malloc errors

### DIFF
--- a/gnome/gobject-introspection-devel/Portfile
+++ b/gnome/gobject-introspection-devel/Portfile
@@ -1,8 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           meson 1.0
 PortGroup           active_variants 1.1
+PortGroup           meson 1.0
 
 name                gobject-introspection-devel
 conflicts           gobject-introspection
@@ -40,7 +40,7 @@ set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build-append \
                     port:bison \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     port:python${py_ver_nodot} \
                     port:py${py_ver_nodot}-cython
 

--- a/gnome/gobject-introspection-devel/Portfile
+++ b/gnome/gobject-introspection-devel/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           active_variants 1.1
+PortGroup           legacysupport 1.1
 PortGroup           meson 1.0
 
 name                gobject-introspection-devel
@@ -9,7 +10,7 @@ conflicts           gobject-introspection
 set my_name         gobject-introspection
 
 version             1.78.1
-revision            2
+revision            3
 epoch               1
 
 categories          gnome
@@ -34,6 +35,10 @@ checksums           rmd160  3fda7e7ac0eb288335a4db69551fdf356fcc03b1 \
 
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload
+
+# https://trac.macports.org/ticket/71191
+legacysupport.newest_darwin_requires_legacy 0
+legacysupport.redirect_bins g-ir-compiler g-ir-generate g-ir-inspect g-ir-scanner
 
 set py_ver          3.12
 set py_ver_nodot    [string map {. {}} ${py_ver}]

--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           active_variants 1.1
+PortGroup           legacysupport 1.1
 PortGroup           meson 1.0
 
 name                gobject-introspection
@@ -9,7 +10,7 @@ conflicts           gobject-introspection-devel
 set my_name         gobject-introspection
 
 version             1.78.1
-revision            3
+revision            4
 epoch               1
 
 categories          gnome
@@ -34,6 +35,10 @@ checksums           rmd160  3fda7e7ac0eb288335a4db69551fdf356fcc03b1 \
 
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload
+
+# https://trac.macports.org/ticket/71191
+legacysupport.newest_darwin_requires_legacy 0
+legacysupport.redirect_bins g-ir-compiler g-ir-generate g-ir-inspect g-ir-scanner
 
 set py_ver          3.12
 set py_ver_nodot    [string map {. {}} ${py_ver}]

--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -1,8 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           meson 1.0
 PortGroup           active_variants 1.1
+PortGroup           meson 1.0
 
 name                gobject-introspection
 conflicts           gobject-introspection-devel
@@ -40,7 +40,7 @@ set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build-append \
                     port:bison \
-                    port:pkgconfig \
+                    path:bin/pkg-config:pkgconfig \
                     port:python${py_ver_nodot} \
                     port:py${py_ver_nodot}-cython
 


### PR DESCRIPTION
#### Description

Verified to fix `malloc` errors with two dependents: gexiv2 and libcmatrix.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@kencu @mascguy Please take a look.