### PR TITLE
google-cloud-sdk: update to 499.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             498.0.0
+version             499.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  6e344a174bf11e4122ed2b03306c69659e23f52b \
-                    sha256  34aa006071612f678154cc3411033f0336e4638310d76106ea043dae02812b45 \
-                    size    52361444
+    checksums       rmd160  44c562a2ac148a06c3a4716411e1948a9bebbe38 \
+                    sha256  6d1f381211e8803db0f12340f2965f899b0a4338cf4139063c133b2c852475b7 \
+                    size    52389033
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3346c7a27573362c3529da2fe2a3e709319537a5 \
-                    sha256  3ad3d16495ac80848e8e7980277cb27c93ec12e9d36ade394e5833f57ee68193 \
-                    size    53715411
+    checksums       rmd160  e95f450931ea2cd291870dc50679ce7af212a50b \
+                    sha256  6e3f576bedc046350b3e83f7e1872fd7ddf5145151705144aeaa4d508152fa22 \
+                    size    53738968
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  ec9068cfde2fe5597aee05b31b9facc6f46d49f7 \
-                    sha256  c880c809f4201cb354a4f40959803866283cb2b3aa07a736e129826aa64fb377 \
-                    size    53663104
+    checksums       rmd160  968ef18ffef670759ac3a7e32dd65983fc53b21b \
+                    sha256  00cfaa70af5963c5556dcfd004d47ef6e917cf571721181067308ad7a01aa2b7 \
+                    size    53686797
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 499.0.0.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?