### PR TITLE
svt-av1: disable AVX512 support by default, revbump

### DIFF
--- a/multimedia/svt-av1/Portfile
+++ b/multimedia/svt-av1/Portfile
@@ -8,7 +8,7 @@ PortGroup               legacysupport 1.1
 
 gitlab.setup            AOMediaCodec SVT-AV1 2.3.0 v
 name                    svt-av1
-revision                0
+revision                1
 categories              multimedia
 license                 BSD
 maintainers             {i0ntempest @i0ntempest} openmaintainer
@@ -42,9 +42,18 @@ if {${os.arch} ne "powerpc"} {
 patchfiles              patch-no-dispatch-on-old-OS.diff \
                         patch-fix-native.diff
 
+# never enable AVX512 by default
+configure.args-append   -DENABLE_AVX512=OFF
+
 post-destroot {
     ln -s SvtAv1EncApp ${destroot}${prefix}/bin/svtav1enc
     ln -s SvtAv1DecApp ${destroot}${prefix}/bin/svtav1dec
+}
+
+variant avx512 description "Build with AVX-512 asm files" {
+    configure.args-replace \
+                        -DENABLE_AVX512=OFF \
+                        -DENABLE_AVX512=ON
 }
 
 variant native description "Optimize for CPU" {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
