### PR TITLE
ruby-build: Update to 20241030

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20241017 v
+github.setup        rbenv ruby-build 20241030 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  b67086b13026361ea3fcc903eae73189032f7714 \
-                    sha256  3e876c13dc6a5f6a24276d9da9d0126cef3c21354dd33499e6772eeb48692072 \
-                    size    92997
+checksums           rmd160  b2e328513361b83271333ae0b14db3132aa55f96 \
+                    sha256  21b95d0cd726914f6cd8c8271cbe293f5f7705256fa4ac89793f9f66cbc9a1d2 \
+                    size    93049
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20241030

##### Tested on

macOS 14.7 23H124 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
