### PR TITLE
R: disable ccache, since R bakes in compiler value

### DIFF
--- a/_resources/port1.0/group/R-1.0.tcl
+++ b/_resources/port1.0/group/R-1.0.tcl
@@ -132,6 +132,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
     }
 }
 
+# R bakes in the compiler, so if it is built with ccache,
+# then it will require ccache to build R packages.
+# Disable it to avoid an unnecessary dependency.
+configure.ccache            no
+
 port::register_callback R.add_dependencies
 
 proc R.add_dependencies {} {

--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -9,7 +9,7 @@ name                        R
 # Remember to set revision to 0 when bumping version
 # And also to update Rversion in R PortGroup
 version                     4.4.1
-revision                    3
+revision                    4
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science
@@ -76,6 +76,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
 # as the primary compiler: -Wno-error=incompatible-pointer-types
 # devQuartz.c:3049:35: error: passing argument 2 of 'CGContextSetFont'
 # from incompatible pointer type [-Wincompatible-pointer-types]
+
+# R bakes in the compiler, so if it is built with ccache,
+# then it will require ccache to build R packages.
+# Disable it to avoid an unnecessary dependency.
+configure.ccache            no
 
 compilers.choose            fc f77
 compilers.setup             require_fortran


### PR DESCRIPTION
#### Description

If `R` is built with ccache enabled, then it will require ccache to build all its packages which have compilable code.
Avoid introducing this unwanted dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
