### PR TITLE
colima: update to 0.7.6

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.7.5 v
+go.setup            github.com/abiosoft/colima 0.7.6 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  80cd54fece7acd198e7e7f9ff79329284986b571 \
-                    sha256  88e37091e64d632ec44e5284665e5adc6506000acb13102fa2bbc67790770a3d \
-                    size    613692
+checksums           rmd160  6c5057fb9edb33de4734692e917f5c7f698aa2a8 \
+                    sha256  97a3130023e00b5e1a73a24167e958e7135f69a742ab555993a0d6033f31b60e \
+                    size    615586
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

Update to Colima 0.7.6.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?