### PR TITLE
py-dulwich: build pure version on legacy systems with no rust

### DIFF
--- a/python/py-dulwich/Portfile
+++ b/python/py-dulwich/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           rust 1.0
 
 name                py-dulwich
 version             0.22.3
@@ -24,6 +23,8 @@ checksums           ${distname}${extract.suffix} \
 
 python.versions     38 39 310 311 312 313
 
+set dulwich_darwin_min_ver 11
+
 if {${name} ne ${subport}} {
     if {${python.version} < 310} {
         depends_build-append \
@@ -32,11 +33,24 @@ if {${name} ne ${subport}} {
 
     patchfiles      patch-archflags.diff
 
+    # Backport of a fix from upstream.
+    # Drop with next release.
+    patchfiles-append \
+                    eb6e78f01a44d738ca3c801d777785910aab5000.patch
+
     depends_lib-append \
-                    port:py${python.version}-setuptools-rust \
                     port:py${python.version}-urllib3
 
-    cargo.crates \
+    if {${os.platform} eq "darwin" && ${os.major} < ${dulwich_darwin_min_ver}} {
+        build.env-append \
+                    PURE=1
+    } else {
+        PortGroup   rust 1.0
+
+        depends_build-append \
+                    port:py${python.version}-setuptools-rust
+
+        cargo.crates \
         autocfg 1.4.0 ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
         cfg-if 1.0.0 baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
         heck 0.5.0 2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
@@ -57,4 +71,5 @@ if {${name} ne ${subport}} {
         target-lexicon 0.12.16 61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
         unicode-ident 1.0.13 e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
         unindent 0.2.3 c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce
+    }
 }

--- a/python/py-dulwich/files/eb6e78f01a44d738ca3c801d777785910aab5000.patch
+++ b/python/py-dulwich/files/eb6e78f01a44d738ca3c801d777785910aab5000.patch
@@ -1,0 +1,108 @@
+From 9fea5e31722b35ee66c564538fb84c96f10eee40 Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz93@gmail.com>
+Date: Tue, 5 Nov 2024 12:01:47 -0500
+Subject: [PATCH] build: respect the "pure" argument at metadata generation
+ time
+
+When a pure build is requested, no compiled extensions are produced. The
+setuptools_rust dependency ends up imported-but-not-used. Teach
+setuptools to avoid build-requiring it in this case.
+
+Closes: https://github.com/jelmer/dulwich/issues/1405
+---
+ pyproject.toml |  2 +-
+ setup.py       | 58 ++++++++++++++++++++++++++++----------------------
+ 2 files changed, 33 insertions(+), 27 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 2f7c59681..aaa873223 100644
+--- pyproject.toml
++++ pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["setuptools>=61.2", "setuptools-rust"]
++requires = ["setuptools>=61.2"]
+ build-backend = "setuptools.build_meta"
+ 
+ [project]
+diff --git a/setup.py b/setup.py
+index 6eada1487..07381eee8 100755
+--- setup.py
++++ setup.py
+@@ -6,7 +6,6 @@
+ import sys
+ 
+ from setuptools import setup
+-from setuptools_rust import Binding, RustExtension
+ 
+ 
+ tests_require = ["fastimport"]
+@@ -18,35 +17,45 @@
+ 
+ optional = os.environ.get("CIBUILDWHEEL", "0") != "1"
+ 
+-rust_extensions = [
+-    RustExtension(
+-        "dulwich._objects",
+-        "crates/objects/Cargo.toml",
+-        binding=Binding.PyO3,
+-        optional=optional,
+-    ),
+-    RustExtension(
+-        "dulwich._pack",
+-        "crates/pack/Cargo.toml",
+-        binding=Binding.PyO3,
+-        optional=optional,
+-    ),
+-    RustExtension(
+-        "dulwich._diff_tree",
+-        "crates/diff-tree/Cargo.toml",
+-        binding=Binding.PyO3,
+-        optional=optional,
+-    ),
+-]
+-
+ # Ideally, setuptools would just provide a way to do this
+-if "--pure" in sys.argv:
+-    sys.argv.remove("--pure")
++if "PURE" in os.environ or "--pure" in sys.argv:
++    if "--pure" in sys.argv:
++        sys.argv.remove("--pure")
++    setup_requires = []
+     rust_extensions = []
++else:
++    setup_requires = ["setuptools_rust"]
++    # We check for egg_info since that indicates we are running prepare_metadata_for_build_*
++    if "egg_info" in sys.argv:
++        rust_extensions = []
++    else:
++        from setuptools_rust import Binding, RustExtension
++
++        rust_extensions = [
++            RustExtension(
++                "dulwich._objects",
++                "crates/objects/Cargo.toml",
++                binding=Binding.PyO3,
++                optional=optional,
++            ),
++            RustExtension(
++                "dulwich._pack",
++                "crates/pack/Cargo.toml",
++                binding=Binding.PyO3,
++                optional=optional,
++            ),
++            RustExtension(
++                "dulwich._diff_tree",
++                "crates/diff-tree/Cargo.toml",
++                binding=Binding.PyO3,
++                optional=optional,
++            ),
++        ]
+ 
+ 
+ setup(
+     package_data={"": ["py.typed"]},
+     rust_extensions=rust_extensions,
++    setup_requires=setup_requires,
+     tests_require=tests_require,
+ )

--- a/python/py-dulwich/files/patch-strnlen-lion.diff
+++ b/python/py-dulwich/files/patch-strnlen-lion.diff
@@ -1,0 +1,11 @@
+--- dulwich/_objects.c~	2011-11-06 13:52:35.000000000 +1100
++++ dulwich/_objects.c	2011-11-06 13:52:41.000000000 +1100
+@@ -25,7 +25,7 @@
+ typedef int Py_ssize_t;
+ #endif
+ 
+-#if defined(__MINGW32_VERSION) || defined(__APPLE__)
++#if defined(__MINGW32_VERSION) || (defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070)
+ size_t rep_strnlen(char *text, size_t maxlen);
+ size_t rep_strnlen(char *text, size_t maxlen)
+ {


### PR DESCRIPTION
#### Description

@dgilman This should fix the issue.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
