### PR TITLE
R: update to 4.4.2, adjust Accelerate variant

### DIFF
--- a/_resources/port1.0/group/R-1.0.tcl
+++ b/_resources/port1.0/group/R-1.0.tcl
@@ -198,7 +198,7 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libc++"} {
 
 global prefix frameworks_dir
 # Please update R version here:
-set Rversion        4.4.1
+set Rversion        4.4.2
 set branch          [join [lrange [split ${Rversion} .] 0 1] .]
 set packages        ${frameworks_dir}/R.framework/Versions/${branch}/Resources/library
 set suffix          .tar.gz

--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -8,8 +8,8 @@ PortGroup                   legacysupport 1.1
 name                        R
 # Remember to set revision to 0 when bumping version
 # And also to update Rversion in R PortGroup
-version                     4.4.1
-revision                    4
+version                     4.4.2
+revision                    0
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science
@@ -33,9 +33,9 @@ homepage                    https://www.r-project.org
 master_sites                https://cran.rstudio.com/src/base/R-4/ \
                             https://cran.r-project.org/src/base/R-4/
 
-checksums                   rmd160  bdc0bbab5ec655cbd97ba44e3c5e34c988fb5d4a \
-                            sha256  b4cb675deaaeb7299d3b265d218cde43f192951ce5b89b7bb1a5148a36b2d94d \
-                            size    37353459
+checksums                   rmd160  f988ada6892f197178f3a61cc1a1b1b1684c4a15 \
+                            sha256  1578cd603e8d866b58743e49d8bf99c569e81079b6a60cf33cdf7bdffeb817ec \
+                            size    37582785
 
 # Avoid Apple clangs:
 compiler.blacklist-append   {clang}
@@ -199,7 +199,13 @@ platform darwin 13 {
 }
 
 variant accelerate conflicts atlas builtin_lapack openblas description {build using the BLAS and Lapack in Apple's Accelerate framework} {
-    configure.args-append   --with-blas="-framework Accelerate" --with-lapack
+    if { ([vercmp ${xcodeversion} >= 14.3] || \
+        [vercmp ${xcodecltversion} >= 14.3]) && \
+        (${os.platform} eq "darwin" && ${os.version} >=  22.3) } {
+            configure.args-append --with-newAccelerate=lapack
+    } else {
+        configure.args-append   --with-blas="-framework Accelerate" --with-lapack
+    }
 }
 
 variant atlas conflicts accelerate builtin_lapack openblas description {build using the BLAS in the atlas port} {


### PR DESCRIPTION
#### Description

* update to 4.4.2
* adjust accelarate variant to use BLAS and LAPACK libraries under the Accelerate framework that 'are [...] inline with reference version 3.9.1’ # see https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Accelerate-1


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
