### PR TITLE
cargo2port: update to 0.3.0

### DIFF
--- a/sysutils/cargo2port/Portfile
+++ b/sysutils/cargo2port/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        l2dy cargo2port 0.2.1
+github.setup        l2dy cargo2port 0.3.0
 github.tarball_from archive
 revision            0
 categories          sysutils macports
@@ -15,9 +15,9 @@ description         A tool for generating cargo.crates option from Cargo.lock
 long_description    {*}${description}.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  cc08af61bca45c3f0ec806120611d1bd5936f41d \
-                    sha256  9d3d9ac5f84b09818a3ea8f803f2d0e48a59cc43b86c914e9f7563f167aabfe6 \
-                    size    127049
+                    rmd160  4fc51d87c73dd1adb7e6beecfb161f0fd030b1c5 \
+                    sha256  4d5341b04911571073e749a9a0e450d6a15301f30209ddb61a23bb33ba63d48b \
+                    size    157226
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

I don't use cargo2port very frequently, but I found myself yesterday being unable to use it the way I had before:

```sh
% cargo2port <(curl -s https://raw.githubusercontent.com/l2dy/cargo2port/refs/tags/0.3.0/Cargo.lock)|pbcopy
Error: cannot find file /dev/fd/12/Cargo.lock
```

So I updated to get the ability to read stdin.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1 24B83 x86_64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
