### PR TITLE
py-dateutil: update to 2.9.0.post0, add py313 subport (including dependencies)

### DIFF
--- a/python/py-dateutil/Portfile
+++ b/python/py-dateutil/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-dateutil
 python.rootname     python-dateutil
-version             2.8.2
+version             2.9.0.post0
 revision            0
 
 platforms           {darwin any}
@@ -20,13 +20,18 @@ long_description    The dateutil module provides powerful extensions \
 
 homepage            https://github.com/dateutil/dateutil/
 
-checksums           rmd160  b61a18d5135f4bb241831d7c7b3295999f6cb27e \
-                    sha256  0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
-                    size    357324
+checksums           rmd160  851f5c2fac0997c3c45c7a137e3df985f03adaf2 \
+                    sha256  37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
+                    size    342432
 
-python.versions     27 35 36 37 38 39 310 311 312
+python.versions     27 35 36 37 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
+    patchfiles-append \
+                    patch-setuptools_command_test_gone.diff \
+                    patch-setuptools_scm_version.diff \
+                    patch-test_no_pytest-cov.diff
+
     depends_build-append \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm

--- a/python/py-dateutil/files/patch-setuptools_command_test_gone.diff
+++ b/python/py-dateutil/files/patch-setuptools_command_test_gone.diff
@@ -1,0 +1,43 @@
+Avoids:
+
+SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
+
+https://github.com/pypa/setuptools/issues/4520
+https://github.com/pypa/setuptools/commit/c437aaa8d5b969a9fe8c8147463bfcb85b31ab26
+
+diff --git setup.py setup.py
+index 069514f4a2b6..dd1ee27b98d0 100644
+--- setup.py
++++ setup.py
+@@ -4,7 +4,6 @@ import os
+ 
+ import setuptools
+ from setuptools import setup, find_packages
+-from setuptools.command.test import test as TestCommand
+ 
+ from distutils.version import LooseVersion
+ import warnings
+@@ -20,13 +19,6 @@ if LooseVersion(setuptools.__version__) <= LooseVersion("24.3"):
+                   UserWarning)
+ 
+ 
+-class Unsupported(TestCommand):
+-    def run(self):
+-        sys.stderr.write("Running 'test' with setup.py is not supported. "
+-                         "Use 'pytest' or 'tox' to run the tests.\n")
+-        sys.exit(1)
+-
+-
+ ###
+ # Load metadata
+ 
+@@ -51,8 +43,5 @@ setup(
+           'write_to': 'src/dateutil/_version.py',
+       },
+       ## Needed since doctest not supported by PyPA.
+-      long_description = README,
+-      cmdclass={
+-          "test": Unsupported
+-      }
++      long_description = README
+       )

--- a/python/py-dateutil/files/patch-setuptools_scm_version.diff
+++ b/python/py-dateutil/files/patch-setuptools_scm_version.diff
@@ -1,0 +1,13 @@
+diff --git pyproject.toml pyproject.toml
+index b609717607d7..67ad619fc965 100644
+--- pyproject.toml
++++ pyproject.toml
+@@ -3,7 +3,7 @@ requires = [
+     "setuptools; python_version != '3.3'",
+     "setuptools<40.0; python_version == '3.3'",
+     "wheel",
+-    "setuptools_scm<8.0"
++    "setuptools_scm"
+ ]
+ build-backend = "setuptools.build_meta"
+ 

--- a/python/py-dateutil/files/patch-test_no_pytest-cov.diff
+++ b/python/py-dateutil/files/patch-test_no_pytest-cov.diff
@@ -1,0 +1,18 @@
+https://github.com/macports/macports-ports/pull/26391#pullrequestreview-2417141749
+
+diff --git tests/conftest.py tests/conftest.py
+index 78ed70acb3c4..4eafb2634e0b 100644
+--- tests/conftest.py
++++ tests/conftest.py
+@@ -14,11 +14,6 @@ def pytest_collection_modifyitems(items):
+ 
+         marker = marker_getter('xfail')
+ 
+-        # Need to query the args because conditional xfail tests still have
+-        # the xfail mark even if they are not expected to fail
+-        if marker and (not marker.args or marker.args[0]):
+-            item.add_marker(pytest.mark.no_cover)
+-
+ 
+ def set_tzpath():
+     """

--- a/python/py-freezegun/Portfile
+++ b/python/py-freezegun/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        spulec freezegun 1.4.0
+github.setup        spulec freezegun 1.5.1
 github.tarball_from archive
 name                py-freezegun
 revision            0
@@ -19,11 +19,11 @@ description         FreezeGun is a library that allows your python tests \
                     to travel through time by mocking the datetime module.
 long_description    {*}${description}
 
-checksums           rmd160  6ed5c8de7ebd7576f8ac6c7168dfa84b321ea9b7 \
-                    sha256  0d5cce752ee31e0fe053e5a43d5f8d463212488bdf0daeb967f35f40d1724ead \
-                    size    29340
+checksums           rmd160  bc315045eba40eec81a43ec3d807b74eb73e1612 \
+                    sha256  8758cac200d23c4e498c694d79f040f8ffe54bcb2eb3aafdcb7320036fefabc8 \
+                    size    31309
 
-python.versions     27 35 36 37 38 39 310 311 312
+python.versions     27 35 36 37 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
