### PR TITLE
libfive: update to 20241103

### DIFF
--- a/graphics/libfive/Portfile
+++ b/graphics/libfive/Portfile
@@ -5,20 +5,13 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
-# Version 601730dc8181f12aeb0c6c66bbe3f4f9b4523134 below does not build
-# with Eigen 3.4, which is the current Eigen version in MacPorts. Newer
-# versions require macOS 10.15 or later to be able to build with
-# Eigen 3.4+, so the update should be done by someone with access 10.15+.
-# See https://trac.macports.org/ticket/63664
-
 # libfive does not have releases; the master branch is recommended.
 # See https://libfive.com/download/
-github.setup        libfive libfive 601730dc8181f12aeb0c6c66bbe3f4f9b4523134
-version             20210717
+github.setup        libfive libfive 71899313d36ce14de6646ef760fa6bbc5c0cc067
+version             20241103
 revision            0
 
 categories          graphics math cad
-platforms           darwin
 license             MPL-2
 maintainers         nomaintainer
 
@@ -31,9 +24,9 @@ long_description    libfive is a software library and set of tools for solid mod
                     infrastructure for generative design, mass customization, and \
                     domain-specific CAD tools.
 
-checksums           rmd160  00534d1377c208a7cbcaa34f636dc9334fe70a1c \
-                    sha256  ee34bfd335062d89888e819e929f51926667ea5c33699bf6627e38ee572306f8 \
-                    size    879290
+checksums           rmd160  946e212d3de61c47d6ceb4bc0bd251ba5691ce39 \
+                    sha256  546cfc85e5321b0d22d920fa829119dc30a7c679bdeea29e04d3674b9686ad57 \
+                    size    917395
 
 # Even though eigen3 is header-only, it must be a library dependency because
 # the libfive headers include it.
@@ -53,13 +46,17 @@ configure.args-append \
                     -DBUILD_PYTHON_BINDINGS=OFF \
                     -DBUILD_STUDIO_APP=OFF
 
+# Workaround from https://github.com/libfive/libfive/blob/71899313d36ce14de6646ef760fa6bbc5c0cc067/CMakeLists.txt#L85
+configure.cxxflags-append \
+                    -D__USE_ISOC99
+
 patchfiles          patch-remove-march-native.diff
+patchfiles          patch-use-macports-guile.diff
 
 # Guile binding:
 
-# libfive supports Guile 3.0 as well, but MacPorts currently only includes 2.2
-variant guile description {Build guile 2.2 bindings} {
-    depends_lib-append      port:guile-2.2
+variant guile description {Build guile 3.0 bindings} {
+    depends_lib-append      port:guile-3.0
     configure.args-replace  -DBUILD_GUILE_BINDINGS=OFF -DBUILD_GUILE_BINDINGS=ON
 
     build.env-append        GUILE_AUTO_COMPILE=0
@@ -72,17 +69,16 @@ variant guile description {Build guile 2.2 bindings} {
 
 # Python bindings:
 
-# The minimum supported Python version is 3.7
-set pythons_suffixes {37 38 39}
+set pythons_versions {3.9 3.10 3.11 3.12 3.13}
 
 set pythons_ports {}
-foreach s ${pythons_suffixes} {
-    lappend pythons_ports python${s}
+foreach v ${pythons_versions} {
+    lappend pythons_ports python[string map {. {}} ${v}]
 }
 
-foreach s ${pythons_suffixes} {
+foreach v ${pythons_versions} {
+    set s [string map {. {}} ${v}]
     set p python${s}
-    set v [string index ${s} 0].[string index ${s} 1]
     set i [lsearch -exact ${pythons_ports} ${p}]
     set c [lreplace ${pythons_ports} ${i} ${i}]
 
@@ -157,8 +153,9 @@ test.target
 
 # Default variants:
 
-set selected_python python39
-foreach s ${pythons_suffixes} {
+set selected_python python312
+foreach v ${pythons_versions} {
+    set s [string map {. {}} ${v}]
     if {[variant_isset python${s}]} {
         set selected_python python${s}
     }

--- a/graphics/libfive/files/patch-remove-march-native.diff
+++ b/graphics/libfive/files/patch-remove-march-native.diff
@@ -1,11 +1,16 @@
---- CMakeLists.txt.old	2021-04-29 14:38:58.000000000 +0200
-+++ CMakeLists.txt	2021-04-29 14:39:18.000000000 +0200
-@@ -47,7 +47,7 @@
- ################################################################################
- 
+Do not use the -match=native flag.
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -57,12 +57,6 @@ endif()
  if(NOT MSVC)
--    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -g -fPIC -pedantic -Werror=switch -march=native")
-+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -g -fPIC -pedantic -Werror=switch")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra ${LIBFIVE_DEBUGGING}-fPIC -pedantic -Werror=switch")
+ 
+-    # Sometimes this flag is not supported (e.g. on Apple Silicon)
+-    check_cxx_compiler_flag("-march=native" MARCH_SUPPORTED)
+-    if(MARCH_SUPPORTED)
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+-    endif()
+-
      set(CMAKE_CXX_FLAGS_DEBUG "-O0")
      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -DEIGEN_NO_DEBUG")
  else()

--- a/graphics/libfive/files/patch-use-macports-guile.diff
+++ b/graphics/libfive/files/patch-use-macports-guile.diff
@@ -1,0 +1,42 @@
+Make sure that MacPorts's Guile 3.0 is used, with the customized executable names.
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -94,9 +94,11 @@ if(NOT MSVC)
+     find_package(Boost REQUIRED)
+     find_package(PkgConfig REQUIRED)
+ 
+-    pkg_check_modules(GUILE guile-2.2>=2.2.1)
+-    if (NOT(GUILE_FOUND))
+-        pkg_check_modules(GUILE guile-3.0>=3.0.0)
++    pkg_check_modules(GUILE guile-3.0>=3.0.0)
++
++    if (GUILE_FOUND)
++      pkg_get_variable(GUILE_EXEC guile-3.0 guile)
++      pkg_get_variable(GUILD_EXEC guile-3.0 guild)
+     endif()
+ 
+     pkg_check_modules(EIGEN REQUIRED eigen3>=3.2.92)
+--- libfive/bind/guile/CMakeLists.txt
++++ libfive/bind/guile/CMakeLists.txt
+@@ -28,10 +28,10 @@ foreach(SRC ${SRCS})
+     #
+     # Then, copy the file from Guile's compilation cache to the build directory
+     execute_process(
+-        COMMAND guile -c "(use-modules (system base compile))(format #t \"~A\" (compiled-file-name \"${FULL_SRC}\"))"
++        COMMAND ${GUILE_EXEC} -c "(use-modules (system base compile))(format #t \"~A\" (compiled-file-name \"${FULL_SRC}\"))"
+         OUTPUT_VARIABLE CCACHE_FILE)
+     add_custom_command(OUTPUT ${OUT}
+-        COMMAND ${CMAKE_COMMAND} -E env LIBFIVE_FRAMEWORK_DIR=$<TARGET_FILE_DIR:libfive>/ LIBFIVE_STDLIB_DIR=$<TARGET_FILE_DIR:libfive-stdlib>/ guild compile -L${CMAKE_CURRENT_SOURCE_DIR} ${FULL_SRC}
++        COMMAND ${CMAKE_COMMAND} -E env LIBFIVE_FRAMEWORK_DIR=$<TARGET_FILE_DIR:libfive>/ LIBFIVE_STDLIB_DIR=$<TARGET_FILE_DIR:libfive-stdlib>/ ${GUILD_EXEC} compile -L${CMAKE_CURRENT_SOURCE_DIR} ${FULL_SRC}
+         COMMAND ${CMAKE_COMMAND} -E copy ${CCACHE_FILE} ${CMAKE_CURRENT_BINARY_DIR}/${OUT}
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+         DEPENDS ${FULL_SRC} libfive libfive-stdlib)
+@@ -45,7 +45,7 @@ if(UNIX)
+     # Find the installation directory for compiled files
+     if (NOT DEFINED GUILE_CCACHE_DIR)
+         execute_process(
+-            COMMAND guile -c "(format #t \"~A\" (%site-ccache-dir))"
++            COMMAND ${GUILE_EXEC} -c "(format #t \"~A\" (%site-ccache-dir))"
+             OUTPUT_VARIABLE GUILE_CCACHE_DIR)
+     endif()
+ 


### PR DESCRIPTION
#### Description

 - Fixes build on recent macOS at the cost of breaking it on 10.14 and earlier
 - Use Guile 3.0
 - Add support for recent Python versions
 - Use Python 3.12 by default

Closes https://trac.macports.org/ticket/63664

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.7 23H124 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
