### PR TITLE
xaos: use `${build.dir}` for convenience

### DIFF
--- a/graphics/xaos/Portfile
+++ b/graphics/xaos/Portfile
@@ -12,7 +12,6 @@ github.tarball_from     archive
 
 name                    xaos
 categories              graphics math
-platforms               darwin
 license                 GPL-2+
 maintainers             nomaintainer
 
@@ -53,10 +52,10 @@ cmake.module_path-append \
 
 destroot {
     # See tools/deploy-mac for the origin of the following four steps:
-    file mkdir ${workpath}/build/XaoS.app/Contents/Resources/examples/
-    copy {*}[glob ${worksrcpath}/examples/*/*] ${workpath}/build/XaoS.app/Contents/Resources/examples/
-    copy ${worksrcpath}/catalogs ${workpath}/build/XaoS.app/Contents/Resources/
-    copy ${worksrcpath}/tutorial ${workpath}/build/XaoS.app/Contents/Resources/
+    file mkdir ${build.dir}/XaoS.app/Contents/Resources/examples/
+    copy {*}[glob ${worksrcpath}/examples/*/*] ${build.dir}/XaoS.app/Contents/Resources/examples/
+    copy ${worksrcpath}/catalogs ${build.dir}/XaoS.app/Contents/Resources/
+    copy ${worksrcpath}/tutorial ${build.dir}/XaoS.app/Contents/Resources/
 
-    move ${workpath}/build/XaoS.app ${destroot}${applications_dir}
+    move ${build.dir}/XaoS.app ${destroot}${applications_dir}
 }


### PR DESCRIPTION
#### Description

This just cleans up the portfile a bit by using `build.dir`. I wasn't able to find `build.dir` when I submitted the last update to this port, and had to resort to an uglier solution. No need for revision bump.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.7 23H124 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
