### PR TITLE
gdal: Add missing dep librasterlite2

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -9,7 +9,7 @@ PortGroup           muniversal 1.0
 
 name                gdal
 version             3.9.3
-revision            0
+revision            1
 
 checksums           rmd160  bebe1fbec5e6fca9c43510b080118cf398db4704 \
                     sha256  34a037852ffe6d2163f1b8948a1aa7019ff767148aea55876c1339b22ad751f1 \
@@ -80,6 +80,7 @@ depends_lib-append \
                     port:pcre2 \
                     port:qhull \
                     port:spatialite \
+                    port:librasterlite2 \
                     port:sqlite3 \
                     port:webp \
                     port:zlib \


### PR DESCRIPTION
#### Description

* Closes https://trac.macports.org/ticket/68655
* Also see https://trac.macports.org/ticket/71156

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  Mac OS 13, 14, 15.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?