### PR TITLE
ruby-build: Update to 20241105

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20241030 v
+github.setup        rbenv ruby-build 20241105 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  b2e328513361b83271333ae0b14db3132aa55f96 \
-                    sha256  21b95d0cd726914f6cd8c8271cbe293f5f7705256fa4ac89793f9f66cbc9a1d2 \
-                    size    93049
+checksums           rmd160  abccf0fabbb1d847eb30182fc574e4b814ef736c \
+                    sha256  5023c0225249b409e5936c70ae5c7cebe731566da686d6fbe3f7f5b09d6323ef \
+                    size    93112
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20241105

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 15.4 15F31d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
