### PR TITLE
vtk: create .dist-info folder for python variants

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -15,7 +15,7 @@ compiler.blacklist-append {clang < 900}
 
 name                vtk
 version             9.3.1
-revision            0
+revision            1
 categories          graphics devel
 license             BSD
 
@@ -150,7 +150,7 @@ foreach pyver ${python_versions} {
     set python_branch  "[string index ${pyver} 0].[string range ${pyver} 1 end]"
     set python_major_ver "[string index ${pyver} 0]"
 
-    variant python${pyver} conflicts {*}${other_python_versions} description "Add Python ${python_branch} support" "
+    variant python${pyver} conflicts {*}${other_python_versions} description "Add Python ${python_branch} support" {
             depends_lib-append  port:python${pyver}
             configure.args-delete \
                 -DVTK_WRAP_PYTHON:BOOL=OFF
@@ -167,7 +167,18 @@ foreach pyver ${python_versions} {
                 configure.args-append \
                     -DVTK_USE_SYSTEM_MPI4PY:BOOL=ON
             }
-    "
+
+            post-destroot {
+                # generate setup.py and other necessary files to create .dist-info folder
+                system -W ${workpath}/build "cmake -DVTK_WHEEL_BUILD:BOOL=ON -DVTK_VERSION_SUFFIX= ${worksrcpath}"
+                set site_pack_dir Library/Frameworks/Python.framework/Versions/${python_branch}/lib/python${python_branch}/site-packages
+                delete -force ${workpath}/build/vtkmodules
+                copy ${workpath}/build/${site_pack_dir}/vtkmodules ${workpath}/build
+                # create the .dist-info folder and contents
+                system -W ${workpath}/build "${prefix}/bin/python${python_branch} setup.py dist_info"
+                copy ${workpath}/build/${name}-${version}.dist-info ${destroot}${prefix}/${site_pack_dir}
+            }
+    }
 }
 
 variant xdmf description {Add XDMF readers} {


### PR DESCRIPTION
* create `.dist-info` folder for python variants
* create appropriate contents (`LICENSE`, `METADATA`, `top_level.txt`)

Closes: https://trac.macports.org/ticket/71163

#### Description
Having a `vtk-<version>.dist-info` folder in `.../site-packages`, with the appropriate installation files, informs Python's setuptools and pip that VTK with python wrappers is installed.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
