### PR TITLE
sox: hard-code sox_uint64_t to unsigned long long

### DIFF
--- a/audio/sox/Portfile
+++ b/audio/sox/Portfile
@@ -28,7 +28,8 @@ depends_build	\
 		port:pkgconfig
 
 patchfiles      patch-curl.diff \
-                yosemite-libtool.patch
+                yosemite-libtool.patch \
+                uint64_t.diff
 
 platform darwin 11 {
 	# System grep fails: "grep: Regular expression too big"

--- a/audio/sox/files/uint64_t.diff
+++ b/audio/sox/files/uint64_t.diff
@@ -1,0 +1,18 @@
+diff --git src/sox.h src/sox.h
+index 155742e..139e21f 100644
+--- src/sox.h.orig
++++ src/sox.h
+@@ -458,13 +458,7 @@ typedef long long sox_int64_t;
+ Client API:
+ Unsigned 64-bit type. Typically defined as unsigned long or unsigned long long.
+ */
+-#if ULONG_MAX==0xffffffffffffffff
+-typedef unsigned long sox_uint64_t;
+-#elif defined(_MSC_VER)
+-typedef unsigned __int64 sox_uint64_t;
+-#else
+ typedef unsigned long long sox_uint64_t;
+-#endif
+ 
+ #ifndef _DOXYGEN_
+ lsx_static_assert(sizeof(sox_int8_t)==1,   sox_int8_size);


### PR DESCRIPTION
The sox.h and util.h header files use different preprocessor macros to pick an unsigned 64 bit integer type. On macos Sequoia these macros return different results (unsigned long in sox.h, unsigned long long in util.h) causing a compilation error.

This commit hard-codes the unsigned 64 bit integer type in sox.h to unsigned long long.

Closes: https://trac.macports.org/ticket/70720

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->


macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`? -- Port lint has warnings that predate this commit
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? -- Yes, but `-t` fails. `port install -vs sox` does work
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? -- Not applicable, Portfile has no variants

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
