### PR TITLE
mise: Update to 2024.11.4

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.11.3 v
+github.setup        jdx mise 2024.11.4 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  bf8da3fd317213587002ce404824627db76f0116 \
-                    sha256  38f93f4e22e35706cd17cc156ad696b0a5e128e96b636bae6d10e1f909cbcd5a \
-                    size    3126962
+                    rmd160  221a4716148924da5cfc9c4957bf6f58b6e6feae \
+                    sha256  0329b4a55f892dd7e195581f717bf85631d75541bb64b407d6ca39151199f5f8 \
+                    size    3128372
 
 patchfiles          patch-src_cli_self_update.diff
 


### PR DESCRIPTION
#### Description

mise: Update to 2024.11.4

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
