### PR TITLE
libzita-resampler: build with NEON intrinsics on arm64, revbump

### DIFF
--- a/audio/audiowmark/Portfile
+++ b/audio/audiowmark/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 gitlab.instance     https://code.uplex.de
 gitlab.setup        stefan audiowmark 0.6.2
-revision            0
+revision            1
 
 categories          audio
 maintainers         {@aeiouaeiouaeiouaeiouaeiouaeiou outlook.com:aeioudev} openmaintainer

--- a/audio/libzita-resampler/Portfile
+++ b/audio/libzita-resampler/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 
 name                libzita-resampler
 version             1.11.2
-revision            0
+revision            1
 
 categories          audio
 license             GPL-3+
@@ -39,8 +39,12 @@ distname            zita-resampler-${version}
 # Makefiles are such a mess, so use the CMake patch from FreeBSD ports
 patchfiles          use-cmake.diff
 
-if {${configure.build_arch} in {i386 x86_64}} {
-     configure.cxxflags-append -DENABLE_SSE2
+if {![variant_isset universal]} {
+     if {${configure.build_arch} in {i386 x86_64}} {
+          configure.cxxflags-append -DENABLE_SSE2
+     } elseif {${configure.build_arch} eq "arm64"} {
+          configure.cxxflags-append -DENABLE_NEON
+     }
 }
 
 livecheck.url       ${master_sites}


### PR DESCRIPTION
#### Description

I don't actually have access to Apple Silicon machines, but CI successfully builds the code. Also added a check that these flags are not used on `+universal`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
