### PR TITLE
auto-multiple-choice-devel : update to version 1.6.0-git20240805161640

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -8,7 +8,6 @@ PortGroup               texlive 1.0
 
 name                    auto-multiple-choice
 categories              x11 tex education
-platforms               darwin
 license                 GPL-2+
 maintainers             nomaintainer
 
@@ -41,12 +40,12 @@ if {${subport} eq ${name}} {
 } else {
     # devel
     set amc.version.main        1.6.0
-    set amc.version.secondary   20240317102301
+    set amc.version.secondary   20240805161640
     set amc.version         ${amc.version.main}+git${amc.version.secondary}
     version                 ${amc.version.main}-git${amc.version.secondary}
-    checksums               rmd160  718b9e95615a49b07aa42a3d7ba5af387ead1b7c \
-                            sha256  143a05d354d5c7a68ae9dc78e7d3344336e48d524251c5130e96bf69cc9314e2 \
-                            size    15155724
+    checksums               rmd160  1bcb05d689fa539ed88aeb1c9489fd56adb27450 \
+                            sha256  11c51f29ca4685f8ae7bade99656b1bb62689344e41b50f5386bb656763347a2 \
+                            size    15151070
 
     conflicts               auto-multiple-choice
 }
@@ -89,6 +88,7 @@ depends_run             \
                         port:p${perl5.major}-clone \
                         port:p${perl5.major}-dbd-sqlite \
                         port:p${perl5.major}-digest-md5 \
+                        port:p${perl5.major}-email-address \
                         port:p${perl5.major}-email-mime \
                         port:p${perl5.major}-email-sender \
                         port:p${perl5.major}-file-basedir \


### PR DESCRIPTION
Update auto-multiple-choice-devel.

Solve bug #943: https://project.auto-multiple-choice.net/issues/943

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
MacPort 2.10.4
macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
