### PR TITLE
various Python ports maintained by @dgilman: remove EOL subports, update to latest version

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    poetry
-version                 1.8.3
+version                 1.8.4
 revision                0
 categories-append       devel
 platforms               {darwin any}
@@ -23,21 +23,20 @@ long_description        Poetry: Dependency Management for Python. \
 
 homepage                https://python-poetry.org/
 
-checksums               rmd160  99539c1e473ac4cdf238dae6ef8f4969e836ddbd \
-                        sha256  67f4eb68288eab41e841cc71a00d26cf6bdda9533022d0189a145a34d0a35f48 \
-                        size    1518910
+checksums               rmd160  6d613084f993d446ad044cdf727565c83883d087 \
+                        sha256  5490f8da66d17eecd660e091281f8aaa5554381644540291817c249872c99202 \
+                        size    1519163
 
-variant python38 conflicts python39 python310 python311 python312 description {Use Python 3.8} {}
-variant python39 conflicts python38 python310 python311 python312 description {Use Python 3.9} {}
-variant python310 conflicts python38 python39 python311 python312 description {Use Python 3.10} {}
-variant python311 conflicts python38 python39 python310 python312 description {Use Python 3.11} {}
-variant python312 conflicts python38 python39 python310 python311 description {Use Python 3.12} {}
+variant python39 conflicts python310 python311 python312 description {Use Python 3.9} {}
+variant python310 conflicts python39 python311 python312 description {Use Python 3.10} {}
+variant python311 conflicts python39 python310 python312 description {Use Python 3.11} {}
+variant python312 conflicts python39 python310 python311 description {Use Python 3.12} {}
 
-if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+if {![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
     default_variants +python312
 }
 
-foreach pv {312 311 310 39 38} {
+foreach pv {312 311 310 39} {
     if {[variant_isset python${pv}]} {
         python.default_version  ${pv}
         break

--- a/python/py-cachecontrol/Portfile
+++ b/python/py-cachecontrol/Portfile
@@ -4,16 +4,15 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cachecontrol
-version             0.14.0
+version             0.14.1
 revision            0
 categories-append   devel
 platforms           {darwin any}
 license             Apache-2
 supported_archs     noarch
 
-python.versions     38 39 310 311 312
+python.versions     39 310 311 312
 
-python.pep517       yes
 python.pep517_backend \
                     flit
 
@@ -26,14 +25,11 @@ long_description    \
 
 homepage            https://github.com/psf/cachecontrol
 
-checksums           rmd160  9e6063efdbbc5067a727e25baf2fefe251d82c7e \
-                    sha256  7db1195b41c81f8274a7bbd97c956f44e8348265a1bc7641c37dfebc39f0c938 \
-                    size    28899
+checksums           rmd160  37018ab0ef5339cac0e578ac786057f293ad7678 \
+                    sha256  06ef916a1e4eb7dba9948cdfc9c76e749db2e02104a9a1277e8b642591a0f717 \
+                    size    28928
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-        port:py${python.version}-setuptools
-
     depends_lib-append \
         port:py${python.version}-requests \
         port:py${python.version}-msgpack

--- a/python/py-cleo/Portfile
+++ b/python/py-cleo/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     38 39 310 311 312
+python.versions     39 310 311 312
 
 maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 
@@ -30,7 +30,6 @@ checksums           rmd160  98a7043a3128d0fa78ddc33d59bf74a83b5f924a \
                     sha256  0b2c880b5d13660a7ea651001fb4acb527696c01f15c9ee650f377aa543fd523 \
                     size    79957
 
-python.pep517       yes
 python.pep517_backend poetry
 
 if {${name} ne ${subport}} {

--- a/python/py-clikit/Portfile
+++ b/python/py-clikit/Portfile
@@ -11,8 +11,7 @@ platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     38 39 310 311
-python.pep517       yes
+python.versions     39 310 311
 python.pep517_backend \
                     poetry
 

--- a/python/py-filelock/Portfile
+++ b/python/py-filelock/Portfile
@@ -23,9 +23,7 @@ checksums           rmd160  0d9040dc27c5363912b7dce9abb23963fc2fec10 \
                     sha256  c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435 \
                     size    18037
 
-# keep version for Python 2.7, this is an (indirect) dependencies of py-virtualenv
-# See: <https://trac.macports.org/wiki/Python#VersionPolicy>
-python.versions     27 38 39 310 311 312 313
+python.versions     27 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {

--- a/python/py-pastel/Portfile
+++ b/python/py-pastel/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     38 39 310 311
+python.versions     39 310 311
 python.pep517_backend \
                     poetry
 

--- a/python/py-poetry-plugin-export/Portfile
+++ b/python/py-poetry-plugin-export/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-poetry-plugin-export
-version             1.6.0
+version             1.8.0
 revision            0
 
 categories          python
@@ -19,13 +19,12 @@ homepage            https://python-poetry.org
 
 distname            poetry_plugin_export-${version}
 
-checksums           rmd160  9b7844090b1f443ebb0f68a1f1d85d59c1fc867b \
-                    sha256  091939434984267a91abf2f916a26b00cff4eee8da63ec2a24ba4b17cf969a59 \
-                    size    29265
+checksums           rmd160  f3c580be59521d4366953be07134b8dbcf916678 \
+                    sha256  1fa6168a85d59395d835ca564bc19862a7c76061e60c3e7dfaec70d50937fc61 \
+                    size    29840
 
-python.versions     38 39 310 311 312
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
-    python.pep517       yes
     python.pep517_backend poetry
 }

--- a/python/py-pylev/Portfile
+++ b/python/py-pylev/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 license             BSD
 supported_archs     noarch
 
-python.versions     38 39 310 311
+python.versions     39 310 311
 
 maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 


### PR DESCRIPTION
#### Description
-various Python ports maintained by @dgilman: remove EOL subports, update to latest version

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1 24B83 x86_64
Xcode 16.1 16B40


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
