### PR TITLE
cubeb: fix linking, add variants

### DIFF
--- a/audio/cubeb/Portfile
+++ b/audio/cubeb/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           cmake   1.1
 PortGroup           github  1.0
 
-github.setup        mozilla cubeb 2bee6bcbd37b121ab197193fe466eef0e91b62b1
-version             20240924
+github.setup        mozilla cubeb 78b2bce70e0d1c21d3c175b72f322c50801b2e94
+version             20241024
 revision            0
 
 description         Cross platform audio library
@@ -19,19 +19,32 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 fetch.type          git
 
+set py_ver          3.12
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+
 depends_build-append \
                     path:bin/doxygen:doxygen \
-                    port:python312
+                    path:bin/pkg-config:pkgconfig \
+                    port:python${py_ver_nodot}
+
+depends_lib-append  port:speexDSP
 
 post-fetch {
     system -W ${worksrcpath} "git submodule update --init --recursive"
 }
 
+# https://trac.macports.org/ticket/71197
+patchfiles-append   patch-CMakeLists.diff
+
 # https://trac.macports.org/ticket/71027
 compiler.cxx_standard   2017
 
 configure.args-append \
+                    -DBUILD_SHARED_LIBS=ON \
                     -DBUILD_TESTS=OFF \
+                    -DENABLE_JACK=OFF \
+                    -DENABLE_PULSE=OFF \
+                    -DLAZY_LOAD_LIBS=OFF \
                     -DUSE_AUDIOUNIT=OFF
 
 # AudioUnit configure check is wrong: it only verifies the header,
@@ -41,4 +54,28 @@ if {(${os.platform} eq "darwin" && ${os.major} > 9) \
     && [string match *clang* ${configure.compiler}]} {
     configure.args-replace \
                     -DUSE_AUDIOUNIT=OFF -DUSE_AUDIOUNIT=ON
+}
+
+platform darwin powerpc {
+    # Rust is not built by default, but just to make sure.
+    # libsanitizer is not supported on powerpc*-*-darwin.
+    configure.args-append \
+                    -DBUILD_RUST_LIBS=OFF \
+                    -DUSE_SANITIZERS=OFF
+}
+
+variant jack description "Enable pusleaudio" {
+    # Should not be used with gcc:
+    # https://github.com/jackaudio/jack2/issues/950
+    depends_lib-append \
+                    port:jack
+    configure.args-replace \
+                    -DENABLE_JACK=OFF -DENABLE_JACK=ON
+}
+
+variant pulse description "Enable pusleaudio" {
+    depends_lib-append \
+                    port:pulseaudio
+    configure.args-replace \
+                    -DENABLE_PULSE=OFF -DENABLE_PULSE=ON
 }

--- a/audio/cubeb/files/patch-CMakeLists.diff
+++ b/audio/cubeb/files/patch-CMakeLists.diff
@@ -1,0 +1,41 @@
+--- CMakeLists.txt	2024-11-08 00:39:37.000000000 +0800
++++ CMakeLists.txt	2024-11-08 01:01:07.000000000 +0800
+@@ -13,6 +13,8 @@
+ option(BUNDLE_SPEEX "Bundle the speex library" OFF)
+ option(LAZY_LOAD_LIBS "Lazily load shared libraries" ON)
+ option(USE_SANITIZERS "Use sanitizers" ON)
++option(ENABLE_JACK "Enable Jack support" OFF)
++option(ENABLE_PULSE "Enable PulseAudio support" OFF)
+ # Set debugging for runtime libraries if requested.
+ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+ 
+@@ -184,12 +186,14 @@
+ 
+   find_package(PkgConfig REQUIRED)
+ 
++if(ENABLE_PULSE)
+   pkg_check_modules(libpulse IMPORTED_TARGET libpulse)
+   if(libpulse_FOUND)
+     set(USE_PULSE ON)
+     target_compile_definitions(cubeb PRIVATE DISABLE_LIBPULSE_DLOPEN)
+     target_link_libraries(cubeb PRIVATE PkgConfig::libpulse)
+   endif()
++endif()
+ 
+   pkg_check_modules(alsa IMPORTED_TARGET alsa)
+   if(alsa_FOUND)
+@@ -198,12 +202,14 @@
+     target_link_libraries(cubeb PRIVATE PkgConfig::alsa)
+   endif()
+ 
++if(ENABLE_JACK)
+   pkg_check_modules(jack IMPORTED_TARGET jack)
+   if(jack_FOUND)
+     set(USE_JACK ON)
+     target_compile_definitions(cubeb PRIVATE DISABLE_LIBJACK_DLOPEN)
+     target_link_libraries(cubeb PRIVATE PkgConfig::jack)
+   endif()
++endif()
+ 
+   check_include_files(sndio.h USE_SNDIO)
+   if(USE_SNDIO)


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/71197

#### Description

@herbygillot Speex should be fine to just depend on, right? Builds everywhere, I guess.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
