### PR TITLE
google-cloud-sdk: update to 500.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             499.0.0
+version             500.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  44c562a2ac148a06c3a4716411e1948a9bebbe38 \
-                    sha256  6d1f381211e8803db0f12340f2965f899b0a4338cf4139063c133b2c852475b7 \
-                    size    52389033
+    checksums       rmd160  c6dc8253e8dbd6f58329af761877b0ebafc7bbb7 \
+                    sha256  0f6f59bec1974e93ed407ad8fbf8ad631af1b5873ae173a3082e708e0180feba \
+                    size    52443515
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  e95f450931ea2cd291870dc50679ce7af212a50b \
-                    sha256  6e3f576bedc046350b3e83f7e1872fd7ddf5145151705144aeaa4d508152fa22 \
-                    size    53738968
+    checksums       rmd160  b0c4376f3e3eaa3b51e8c0eae5a269d06b51947e \
+                    sha256  06cb3d429fa053835ab91e83479f31123c7c83d5249387ae0a2df77caf0781ea \
+                    size    53790169
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  968ef18ffef670759ac3a7e32dd65983fc53b21b \
-                    sha256  00cfaa70af5963c5556dcfd004d47ef6e917cf571721181067308ad7a01aa2b7 \
-                    size    53686797
+    checksums       rmd160  449fdc798160e9cc1db1ecf261eafd7168170683 \
+                    sha256  b7dee445d16680aec38bd25841062cb330aa41f9586cef24842a56adc9763eee \
+                    size    53738026
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 500.0.0.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?