### PR TITLE
colima: update to 0.8.0

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.7.6 v
+go.setup            github.com/abiosoft/colima 0.8.0 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  6c5057fb9edb33de4734692e917f5c7f698aa2a8 \
-                    sha256  97a3130023e00b5e1a73a24167e958e7135f69a742ab555993a0d6033f31b60e \
-                    size    615586
+checksums           rmd160  6a9fcf6fd103b8cc7a3514b7a94bdf9cb4914424 \
+                    sha256  0040a1832a1e89cbffec9311382344546cb5965384bede079325dac8b2cbf4f0 \
+                    size    616094
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

Update to Colima 0.8.0.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?