### PR TITLE
py-numpy: fixed version filtering part

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -104,7 +104,7 @@ if {${name} ne ${subport}} {
 
     # NumPy (and SciPy) only support the Accelerate framework for macOS 13.3+
     # see: https://github.com/numpy/numpy/blob/v1.26.4/INSTALL.rst#macos
-    if {${os.platform} eq "darwin" && (${os.major} > 22 || ${os.major} == 22 && ${os.minor} >= 3)} {
+    if {${os.platform} eq "darwin" && (${os.major} > 22 || ${os.major} == 22 && ${os.minor} >= 4)} {
         variant accelerate conflicts openblas flexiblas blis description "Use Apples Accelerate Framework" {
             build.args-append -Csetup-args=-Dblas=accelerate -Csetup-args=-Dlapack=accelerate
         }
@@ -137,7 +137,7 @@ if {${name} ne ${subport}} {
     if {![variant_isset accelerate] && ![variant_isset openblas] && ![variant_isset flexiblas] && ![variant_isset blis]} {
         # default to macOS Accelerate framework if macOS 13.3 or higher, otherwise OpenBLAS
         # see: https://github.com/numpy/numpy/blob/v1.26.4/INSTALL.rst#macos
-        if {${os.platform} eq "darwin" && (${os.major} > 22 || ${os.major} == 22 && ${os.minor} >= 3)} {
+        if {${os.platform} eq "darwin" && (${os.major} > 22 || ${os.major} == 22 && ${os.minor} >= 4)} {
             default_variants +accelerate
         } else {
             default_variants +openblas


### PR DESCRIPTION
#### Description
MacOS 13.2 was failed to build py-numpy.
This is because they try to use Accelerate variants though they cannot use it.

Fixed not to use Accelerate variatns on MacOS 13.2, 13.2.1

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
