### PR TITLE
py-blosc2: fix build on legacy systems and 32-bit archs

### DIFF
--- a/python/py-blosc2/Portfile
+++ b/python/py-blosc2/Portfile
@@ -31,7 +31,7 @@ if {$subport ne $name} {
                         path:bin/cmake:cmake \
                         port:ninja \
                         port:py${python.version}-oldest-supported-numpy \
-                        port:pkgconfig
+                        path:bin/pkg-config:pkgconfig
 
     depends_lib-append  port:blosc2 \
                         port:py${python.version}-numpy \
@@ -41,6 +41,14 @@ if {$subport ne $name} {
 
     patchfiles          patch-pyproject.toml.diff \
                         patch-setup.py.diff
+
+    # https://github.com/Blosc/python-blosc2/issues/320
+    patchfiles-append   patch-gnu99.diff
+
+    if {!([variant_exists universal] && [variant_isset universal])} {
+        # https://github.com/scikit-build/scikit-build/issues/1123
+        build.env-append    CMAKE_OSX_ARCHITECTURES=${configure.build_arch}
+    }
 
     test.run            yes
     test.cmd            ${python.bin} -m pytest

--- a/python/py-blosc2/files/patch-gnu99.diff
+++ b/python/py-blosc2/files/patch-gnu99.diff
@@ -1,0 +1,10 @@
+--- blosc2/CMakeLists.txt	2024-01-25 19:05:45.000000000 +0800
++++ blosc2/CMakeLists.txt	2024-11-08 16:08:30.000000000 +0800
+@@ -5,6 +5,7 @@
+     set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+     find_package(PkgConfig REQUIRED)
+     pkg_check_modules(Blosc2 REQUIRED IMPORTED_TARGET blosc2)
++    target_compile_options(blosc2_ext PRIVATE "-std=gnu99")
+     target_link_libraries(blosc2_ext PkgConfig::Blosc2)
+ else()
+     set(STATIC_LIB ON CACHE BOOL "Build a static version of the blosc library.")

--- a/python/py-scikit-build/Portfile
+++ b/python/py-scikit-build/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-scikit-build
 version             0.18.1
-revision            0
+revision            1
 categories-append   devel
 license             BSD
 platforms           {darwin any}
@@ -40,5 +40,10 @@ if {${name} ne ${subport}} {
 
     if {${python.version} < 311} {
         depends_lib-append  port:py${python.version}-tomli
+    }
+
+    # https://github.com/scikit-build/scikit-build/issues/1123
+    platform darwin {
+        patchfiles-append   patch-fix-macOS-archs.diff
     }
 }

--- a/python/py-scikit-build/files/patch-fix-macOS-archs.diff
+++ b/python/py-scikit-build/files/patch-fix-macOS-archs.diff
@@ -1,0 +1,11 @@
+--- skbuild/setuptools_wrap.py	2020-02-02 08:00:00.000000000 +0800
++++ skbuild/setuptools_wrap.py	2024-11-08 15:31:34.000000000 +0800
+@@ -574,7 +574,7 @@
+             elif "CMAKE_SYSTEM_PROCESSOR" in cmake_arg:
+                 machine = cmake_arg.split("=")[1]
+ 
+-        assert machine in {"x86_64", "arm64", "universal2"}, f"macOS arch {machine} not understood"
++        assert machine in {"x86_64", "arm64", "i386", "ppc", "ppc64", "universal2"}, f"macOS arch {machine} not understood"
+ 
+         set_skbuild_plat_name(f"macosx-{version}-{machine}")
+ 


### PR DESCRIPTION
#### Description

Fix the port for legacy systems

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
