### PR TITLE
Beets: allow installing minimal version on legacy systems, fix dependencies

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 name                beets
 version             1.6.0
-revision            1
+revision            2
 
 categories          audio
 platforms           {darwin any}
@@ -85,13 +85,20 @@ if {${name} eq ${subport} || "${name}-devel" eq ${subport}} {
                     port:py${python.version}-pyxdg \
                     port:py${python.version}-yaml
 
+    # ffmpeg-devel now tracks ffmpeg7,
+    # so no path-style for ffmpeg v. 4.x.
     depends_run-append \
                     port:chromaprint \
-                    path:lib/libavcodec.dylib:ffmpeg \
-                    port:flac \
-                    port:mp3val \
                     port:ImageMagick \
+                    port:ffmpeg \
+                    port:flac \
+                    port:mp3val
+
+    # Do not pull in Go on PowerPC
+    if {${os.arch} ne "powerpc"} {
+        depends_run-append \
                     port:ipfs
+    }
 
     depends_test-append \
                     port:py${python.version}-coverage \

--- a/python/py-jellyfish/Portfile
+++ b/python/py-jellyfish/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cargo_fetch 1.0
 PortGroup           python 1.0
 
 name                py-jellyfish
@@ -11,7 +10,7 @@ revision            0
 license             BSD
 maintainers         nomaintainer
 
-description         A library for doing approximate and phonetic matching\
+description         A library for doing approximate and phonetic matching \
                     of strings.
 long_description    {*}${description}
 
@@ -22,22 +21,53 @@ checksums           ${distname}${extract.suffix} \
                     sha256  ddb22b7155f208e088352283ee78cb4ef2d2067a76e148a8bb43d177f32b37d2 \
                     size    363670
 
-python.pep517_backend   maturin
-
 python.versions     38 39 310 311 312
 
+set cryptography_darwin_min_ver 11
+
 if {${name} ne ${subport}} {
-    # Test is disabled, see: https://github.com/macports/macports-ports/pull/18480
-    # test.run        yes
+    # Legacy systems support
+    # https://github.com/jamesturk/jellyfish/issues/219
+    if {${os.platform} eq "darwin" && ${os.major} < ${cryptography_darwin_min_ver}} {
+        version         0.10.0
+        revision        0
+        checksums       ${distname}${extract.suffix} \
+                        rmd160  135c8cb64f7201993257eb00543f8113b96e8aef \
+                        sha256  c58d221cca1b91fe9afe8cf30a721904054533add4482075c9980c809f7d05bd \
+                        size    125949
+        depends_build-append \
+                    port:py${python.version}-setuptools
+        depends_test-append \
+                    port:py${python.version}-pytest
+        pre-test {
+            test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+        }
+        test.run        yes
+        test.cmd        py.test-${python.branch}
+        test.target     ${worksrcpath}/build/lib*/jellyfish/test.py
+        # Keeps its own block for destroot to avoid accidental breakage:
+        post-destroot {
+            set docdir ${prefix}/share/doc/${subport}
+            xinstall -d ${destroot}${docdir}
+            xinstall -m 0644 -W ${worksrcpath} LICENSE README.md \
+                ${destroot}${docdir}
+        }
+    } else {
+        PortGroup       cargo_fetch 1.0
 
-    post-destroot {
-        set docdir ${prefix}/share/doc/${subport}
-        xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} LICENSE README.md \
-            ${destroot}${docdir}
-    }
+        python.pep517_backend   maturin
 
-    cargo.crates \
+        # Test is disabled, see: https://github.com/macports/macports-ports/pull/18480
+        # test.run        yes
+
+        post-destroot {
+            set docdir ${prefix}/share/doc/${subport}
+            xinstall -d ${destroot}${docdir}
+            xinstall -m 0644 -W ${worksrcpath} LICENSE README.md \
+                ${destroot}${docdir}
+        }
+
+        cargo.crates \
         ahash                            0.8.6  91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a \
         autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
         bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
@@ -88,4 +118,5 @@ if {${name} ne ${subport}} {
         windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
         zerocopy                        0.7.26  e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0 \
         zerocopy-derive                 0.7.26  dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f
+    }
 }

--- a/python/py-py7zr/Portfile
+++ b/python/py-py7zr/Portfile
@@ -20,9 +20,7 @@ checksums           rmd160  3aa2e3e10a71e3fe66f502fed601ba3d078b17a1 \
                     sha256  c6c7aea5913535184003b73938490f9a4d8418598e533f9ca991d3b8e45a139e \
                     size    4992926
 
-python.pep517       yes
-
-python.versions     38 39 310 311 312 313
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -33,11 +31,22 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-inflate64 \
                     port:py${python.version}-multivolumefile \
                     port:py${python.version}-psutil\
-                    port:py${python.version}-pybcj \
                     port:py${python.version}-pycryptodomex \
                     port:py${python.version}-pyppmd \
                     port:py${python.version}-pyzstd \
                     port:py${python.version}-texttable
+
+    platform darwin {
+        if {${os.major} > 10} {
+            depends_lib-append \
+                    port:py${python.version}-pybcj
+        } elseif {${python.version} <= 310} {
+            # Legacy fallback, supported up to Python 3.10.
+            # This does not appear to be a required dependency anyway.
+            depends_lib-append \
+                    port:py${python.version}-pyobjc6
+        }
+    }
 
     depends_test-append \
                     port:py${python.version}-cpuinfo \

--- a/python/py-pyppmd/Portfile
+++ b/python/py-pyppmd/Portfile
@@ -13,7 +13,7 @@ maintainers         nomaintainer
 description         PPMd compression/decompression library
 long_description    {*}${description}
 
-homepage            http://github.com/miurahr/pyppmd
+homepage            https://github.com/miurahr/pyppmd
 
 checksums           rmd160  b6e031e24a5a50868051266922fbaae0c03a8973 \
                     sha256  1d38ce2e4b7eb84b53bc8a52380b94f66ba6c39328b8800b30c2b5bf31693973 \
@@ -25,6 +25,10 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm
+
+    # error: ‘for’ loop initial declaration used outside C99 mode
+    compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
     depends_test-append \
                     port:py${python.version}-coverage \

--- a/python/py-pyzstd/Portfile
+++ b/python/py-pyzstd/Portfile
@@ -24,5 +24,11 @@ patchfiles-append   patch-setuptools_no_version.diff
 python.versions     38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
+    # https://github.com/Rogdham/pyzstd/issues/22
+    if {[string match *gcc-4.* ${configure.compiler}]} {
+        patchfiles-append \
+                    patch-no-flto.diff
+    }
+
     test.run        yes
 }

--- a/python/py-pyzstd/files/patch-no-flto.diff
+++ b/python/py-pyzstd/files/patch-no-flto.diff
@@ -1,0 +1,19 @@
+--- setup.py	2024-10-11 03:39:50.000000000 +0800
++++ setup.py	2024-11-08 18:43:47.000000000 +0800
+@@ -70,14 +70,14 @@
+                 #   This option runs the standard link-time optimizer. To use the
+                 #   link-time optimizer, -flto and optimization options should be
+                 #   specified at compile time and during the final link.
+-                more_options = ['-g0', '-flto']
++                more_options = ['-g0']
+                 if self.PYZSTD_AVX2:
+                     instrs = ['-mavx2', '-mlzcnt', '-mbmi', '-mbmi2']
+                     more_options.extend(instrs)
+                 if self.PYZSTD_WARNING_AS_ERROR:
+                     more_options.append('-Werror')
+                 extension.extra_compile_args.extend(more_options)
+-                extension.extra_link_args.extend(['-g0', '-flto'])
++                extension.extra_link_args.extend(['-g0'])
+             elif self.compiler.compiler_type == 'msvc':
+                 # Remove .S source files, they use gcc/clang syntax.
+                 extension.sources = [i for i in extension.sources


### PR DESCRIPTION
#### Description

See commits.

Likely this is not gonna pass CI, since it requires a lot of ports, and uses python310.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
