### PR TITLE
google-cloud-sdk: update comment about Python version

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -41,8 +41,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 
 worksrcdir          ${name}
 
-# Most recent supported Python version according to https://cloud.google.com/sdk/docs/install#mac
-# Exception: gsutil is not compatible with Python 3.12 yet
+# Most recent supported Python version according to both
+# https://cloud.google.com/sdk/docs/install#mac and
+# https://cloud.google.com/storage/docs/gsutil_install#specifications
 python.default_version 311
 
 post-patch {


### PR DESCRIPTION
#### Description

Note that the Python version should also be supported by `gsutil`.