### PR TITLE
gimp3-devel: update to a recent commit

### DIFF
--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -1,19 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           active_variants 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           perl5 1.0
+PortGroup           meson 1.0
+PortGroup           debug 1.0
 
 name                gimp3-devel
 conflicts           gimp2 gimp2-devel
-set git_commit      9046c758e7b82ffe39b1acb93160a0c9c15743ff
-set git_date        20200223
-version             2.99.1-${git_date}
-revision            13
+set git_commit      677b517615d35d327c70b5423dd99f9eaaed23a4
+set git_date        20241107
+version             3.0.0rc1-${git_date}
+revision            0
 license             GPL-3+
 categories          graphics
 maintainers         {devans @dbevans} {mascguy @mascguy}
-platforms           darwin
 
 description         The GNU Image Manipulation Program
 long_description    The GNU Image Manipulation Program (GIMP) is a powerful \
@@ -29,15 +31,16 @@ homepage            https://gimp.org/
 fetch.type          git
 git.url             --depth 3000 https://gitlab.gnome.org/GNOME/gimp.git
 git.branch          ${git_commit}
+post-fetch {
+    system -W ${worksrcpath} "${git.cmd} submodule update --init --recursive"
+}
 
 depends_build       port:pkgconfig \
                     port:appstream-glib \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool \
-                    port:intltool \
+                    port:meson \
                     port:gtk-doc \
-                    port:perl${perl5.major}
+                    port:perl${perl5.major} \
+                    port:realpath
 
 depends_lib         port:desktop-file-utils \
                     port:iso-codes \
@@ -81,10 +84,6 @@ depends_lib         port:desktop-file-utils \
 
 depends_run         port:adwaita-icon-theme
 
-# libgimpwidgets/gimpwidgetsmarshal.h can be referenced by a parallel
-# build before it is created
-use_parallel_build  no
-
 # gcc-4.2 5493 and 5666.3_13: gimpcpuaccel.c:180: error: can't find a register in class 'BREG' while reloading 'asm'
 # redefinition of typedef is invalid in C [-Wtypedef-redefinition] (#50329)
 # as of version 2.10.0 requires a C++14 compatible compiler to configure
@@ -104,12 +103,6 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
                     patch-x11-widgets-fix.diff
 }
 
-post-patch {
-# fix pytrhon-console.py shebag to use our python3's installation path
-    reinplace "s|#!/usr/bin/python3|#!${configure.python}|" \
-        ${worksrcpath}/plug-ins/python/python-console/python-console.py
-}
-
 configure.perl      ${perl5.bin}
 
 configure.env       CC_FOR_BUILD=${configure.cc}
@@ -123,23 +116,12 @@ if {[vercmp $xcodeversion 4.3] < 0 && [string match "*macports*" ${configure.com
         RANLIB=${prefix}/bin/ranlib
 }
 
-configure.cmd       ./autogen.sh
-
-configure.args      --build=${configure.build_arch}-apple-${os.platform}${os.version} \
-                    --enable-mp \
-                    --with-bug-report-url=https://guide.macports.org/#project.tickets \
-                    --with-pdbgen \
-                    --with-x \
-                    --x-includes=${prefix}/include \
-                    --x-libraries=${prefix}/lib \
-                    --with-javascript=no \
-                    --with-lua=no \
-                    --disable-silent-rules \
-                    --disable-python \
-                    --without-alsa \
-                    --without-gudev \
-                    --without-webkit \
-                    ac_cv_path_PERL=${configure.perl}
+configure.args      -Dbug-report-url=https://guide.macports.org/#project.tickets \
+                    -Djavascript=disabled \
+                    -Dlua=false \
+                    -Dalsa=disabled \
+                    -Dgudev=disabled \
+                    -Dwebkit-unmaintained=false
 
 # keep empty GIMP font directory
 # silences warning message on startup:
@@ -149,45 +131,66 @@ destroot.keepdirs   ${destroot}${prefix}/share/gimp/2.99/fonts
 
 # requires python >= 3.6.0
 
-variant python38 description {Build with python plugin support using python 3.8} {
-    configure.args-delete     --disable-python
-    configure.python          ${prefix}/bin/python3.8
-    depends_lib-append        port:py38-cairo \
-                              port:py38-gobject3
-    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.8
+variant python39 description {Build with python plugin support using python 3.9} {
+    configure.python          ${prefix}/bin/python3.9
+    depends_lib-append        port:py39-cairo \
+                              port:py39-gobject3
+    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.9
     configure.pkg_config_path ${python_framework}/lib/pkgconfig
     configure.env-append      PATH=${python_framework}/bin:$env(PATH)
 }
 
-if {![variant_isset python38]} {
-    default_variants +python38
+variant python310 description {Build with python plugin support using python 3.10} {
+    configure.python          ${prefix}/bin/python3.10
+    depends_lib-append        port:py310-cairo \
+                              port:py310-gobject3
+    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.10
+    configure.pkg_config_path ${python_framework}/lib/pkgconfig
+    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
 }
 
-variant remote description {Enable building of obsolete gimp-remote helper app} {
-    configure.args-append   --enable-gimp-remote
+variant python311 description {Build with python plugin support using python 3.11} {
+    configure.python          ${prefix}/bin/python3.11
+    depends_lib-append        port:py311-cairo \
+                              port:py311-gobject3
+    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.11
+    configure.pkg_config_path ${python_framework}/lib/pkgconfig
+    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
 }
 
-variant debug description {Enable debugging} {
-    configure.args-append  --enable-debug
+variant python312 description {Build with python plugin support using python 3.12} {
+    configure.python          ${prefix}/bin/python3.12
+    depends_lib-append        port:py312-cairo \
+                              port:py312-gobject3
+    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.12
+    configure.pkg_config_path ${python_framework}/lib/pkgconfig
+    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
 }
 
-variant quartz {
+if {![variant_isset python39] && \
+    ![variant_isset python310] && \
+    ![variant_isset python311] && \
+    ![variant_isset python312]} {
+    default_variants-append +python312
+}
+
+# meson.build uses the GTK+ 3 backend to determine whether to enable X11.
+variant x11 conflicts quartz {
+    require_active_variants gtk3 x11
+}
+
+variant quartz conflicts x11 {
+    require_active_variants gtk3 quartz
     depends_lib-delete    port:xorg-libXcursor \
                           port:xorg-libXmu \
                           port:xorg-libXext \
                           port:xorg-libXfixes \
                           port:xpm
     depends_lib-append    port:gtk-osx-application-gtk3
-    configure.args-delete --with-x \
-                          --x-includes=${prefix}/include \
-                          --x-libraries=${prefix}/lib
-    configure.args-append --without-x
 }
 
-# create unversioned symbolic link to versioned executable for compatibility with gimp-app
-
-post-destroot {
-    ln -s ${prefix}/bin/gimp-2.99 ${destroot}${prefix}/bin/gimp
+if {![variant_isset quartz]} {
+    default_variants-append +x11
 }
 
 post-activate {

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           active_variants 1.1
 PortGroup           compiler_blacklist_versions 1.0
-PortGroup           perl5 1.0
-PortGroup           meson 1.0
 PortGroup           debug 1.0
+PortGroup           meson 1.0
+PortGroup           perl5 1.0
 
 name                gimp3-devel
 conflicts           gimp2 gimp2-devel
@@ -25,75 +25,80 @@ long_description    The GNU Image Manipulation Program (GIMP) is a powerful \
                     This is the GTK3 based development version leading \
                     to a future 3.0 release based on a recent snapshot of \
                     git master.
-
 homepage            https://gimp.org/
 
 fetch.type          git
 git.url             --depth 3000 https://gitlab.gnome.org/GNOME/gimp.git
 git.branch          ${git_commit}
 post-fetch {
-    system -W ${worksrcpath} "${git.cmd} submodule update --init --recursive"
+    system -W ${worksrcpath} \
+                    "${git.cmd} submodule update --init --recursive"
 }
 
-depends_build       port:pkgconfig \
+# Disable unexpected download of subprojects
+meson.wrap_mode     nodownload
+
+depends_build-append \
                     port:appstream-glib \
-                    port:meson \
+                    port:gettext \
                     port:gtk-doc \
                     port:perl${perl5.major} \
+                    path:bin/pkg-config:pkgconfig \
                     port:realpath
 
-depends_lib         port:desktop-file-utils \
-                    port:iso-codes \
-                    path:lib/pkgconfig/babl-0.1.pc:babl-devel \
-                    path:lib/pkgconfig/gegl-0.4.pc:gegl-devel \
+depends_lib-append \
+                    port:aalib \
                     port:atk \
+                    path:lib/pkgconfig/babl-0.1.pc:babl \
+                    port:bzip2 \
+                    port:cfitsio \
+                    port:curl \
+                    port:dbus-glib \
+                    port:desktop-file-utils \
+                    port:fontconfig \
+                    port:freetype \
                     path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
+                    path:lib/pkgconfig/gegl-0.4.pc:gegl-devel \
+                    port:gexiv2 \
+                    port:ghostscript \
                     port:glib-networking \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
-                    port:fontconfig \
-                    port:freetype \
-                    port:tiff \
-                    path:include/turbojpeg.h:libjpeg-turbo \
-                    port:zlib \
-                    port:bzip2 \
-                    port:ghostscript \
-                    port:libpng \
-                    port:libmng \
-                    port:libheif \
-                    port:openexr \
-                    port:openjpeg \
-                    port:gexiv2 \
-                    port:aalib \
-                    port:xpm \
-                    path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
-                    path:lib/pkgconfig/poppler.pc:poppler \
-                    port:curl \
-                    port:libwmf \
-                    port:libmypaint \
-                    port:mypaint-brushes1 \
+                    port:iso-codes \
                     port:lcms2 \
-                    port:dbus-glib \
+                    port:libheif \
+                    path:include/turbojpeg.h:libjpeg-turbo \
+                    port:libjxl \
+                    port:libmng \
+                    port:libmypaint \
+                    port:libpng \
+                    path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
+                    port:libwmf \
                     port:libxml2 \
                     port:libxslt \
+                    port:mypaint-brushes1 \
+                    port:openexr \
+                    port:openjpeg \
+                    path:lib/pkgconfig/poppler.pc:poppler \
+                    port:tiff \
+                    port:webp \
                     port:xdg-utils \
-                    port:xorg-libXcursor \
-                    port:xorg-libXmu \
-                    port:xorg-libXext \
-                    port:xorg-libXfixes
+                    port:zlib
 
-depends_run         port:adwaita-icon-theme
+depends_run-append \
+                    port:adwaita-icon-theme
 
 # gcc-4.2 5493 and 5666.3_13: gimpcpuaccel.c:180: error: can't find a register in class 'BREG' while reloading 'asm'
 # redefinition of typedef is invalid in C [-Wtypedef-redefinition] (#50329)
 # as of version 2.10.0 requires a C++14 compatible compiler to configure
 
 compiler.cxx_standard 2014
-compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 700}
+compiler.blacklist-append \
+                    *gcc-3.* *gcc-4.* {clang < 700}
 
-patchfiles          patch-etc-gimprc.in.diff \
-                    patch-quartz-32bit.diff \
-                    MYPAINT_BRUSHES_DIR.patch
+patchfiles-append   patch-etc-gimprc.in.diff
+patchfiles-append   patch-quartz-32bit.diff
+patchfiles-append   MYPAINT_BRUSHES_DIR.patch
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # avoid Cursor type conflict between X11 and Quickdraw
@@ -105,66 +110,82 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 
 configure.perl      ${perl5.bin}
 
-configure.env       CC_FOR_BUILD=${configure.cc}
+configure.env-append \
+                    CC_FOR_BUILD=${configure.cc}
 
 if {[vercmp $xcodeversion 4.3] < 0 && [string match "*macports*" ${configure.compiler}]} {
     # Xcode 4.2 fails with load commands in the newer toolchain
-    depends_build-append port:cctools
+    depends_build-append \
+                    port:cctools
 
     configure.env-append \
-        AR=${prefix}/bin/ar \
-        RANLIB=${prefix}/bin/ranlib
+                    AR=${prefix}/bin/ar \
+                    RANLIB=${prefix}/bin/ranlib
 }
 
-configure.args      -Dbug-report-url=https://guide.macports.org/#project.tickets \
-                    -Djavascript=disabled \
-                    -Dlua=false \
+configure.args-append \
                     -Dalsa=disabled \
+                    -Denable-console-bin=true \
+                    -Dbug-report-url=https://guide.macports.org/#project.tickets \
+                    -Dgi-docgen=disabled \
+                    -Dg-ir-doc=false \
                     -Dgudev=disabled \
+                    -Dilbm=disabled \
+                    -Djavascript=disabled \
+                    -Dlibbacktrace=false \
+                    -Dlibunwind=false \
+                    -Dlua=false \
+                    -Dopenmp=disabled \
                     -Dwebkit-unmaintained=false
 
 # keep empty GIMP font directory
 # silences warning message on startup:
 # GIMP-Message: Some fonts failed to load:
 # - /opt/local/share/gimp/2.99/fonts/
-destroot.keepdirs   ${destroot}${prefix}/share/gimp/2.99/fonts
+destroot.keepdirs-append \
+                    ${destroot}${prefix}/share/gimp/2.99/fonts
 
 # requires python >= 3.6.0
 
+proc py_setup {py_ver} {
+    global env prefix frameworks_dir
+    set py_ver_nodot [string map {. {}} ${py_ver}]
+
+    set python_frameworks_dir \
+                    ${frameworks_dir}/Python.framework/Versions/${py_ver}
+
+    configure.python \
+                    ${prefix}/bin/python${py_ver}
+
+    configure.pkg_config_path-append \
+                    ${python_frameworks_dir}/lib/pkgconfig
+
+    configure.env-append \
+                    PATH=${python_frameworks_dir}/bin:$env(PATH)
+    build.env-append \
+                    PATH=${python_frameworks_dir}/bin:$env(PATH)
+    destroot.env-append \
+                    PATH=${python_frameworks_dir}/bin:$env(PATH)
+
+    depends_lib-append \
+                    port:py${py_ver_nodot}-cairo \
+                    port:py${py_ver_nodot}-gobject3
+}
+
 variant python39 description {Build with python plugin support using python 3.9} {
-    configure.python          ${prefix}/bin/python3.9
-    depends_lib-append        port:py39-cairo \
-                              port:py39-gobject3
-    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.9
-    configure.pkg_config_path ${python_framework}/lib/pkgconfig
-    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
+    py_setup 3.9
 }
 
 variant python310 description {Build with python plugin support using python 3.10} {
-    configure.python          ${prefix}/bin/python3.10
-    depends_lib-append        port:py310-cairo \
-                              port:py310-gobject3
-    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.10
-    configure.pkg_config_path ${python_framework}/lib/pkgconfig
-    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
+    py_setup 3.10
 }
 
 variant python311 description {Build with python plugin support using python 3.11} {
-    configure.python          ${prefix}/bin/python3.11
-    depends_lib-append        port:py311-cairo \
-                              port:py311-gobject3
-    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.11
-    configure.pkg_config_path ${python_framework}/lib/pkgconfig
-    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
+    py_setup 3.11
 }
 
 variant python312 description {Build with python plugin support using python 3.12} {
-    configure.python          ${prefix}/bin/python3.12
-    depends_lib-append        port:py312-cairo \
-                              port:py312-gobject3
-    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.12
-    configure.pkg_config_path ${python_framework}/lib/pkgconfig
-    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
+    py_setup 3.12
 }
 
 if {![variant_isset python39] && \
@@ -177,16 +198,20 @@ if {![variant_isset python39] && \
 # meson.build uses the GTK+ 3 backend to determine whether to enable X11.
 variant x11 conflicts quartz {
     require_active_variants gtk3 x11
+
+    depends_lib-append \
+                    port:xorg-libXcursor \
+                    port:xorg-libXmu \
+                    port:xorg-libXext \
+                    port:xorg-libXfixes \
+                    port:xpm
 }
 
 variant quartz conflicts x11 {
     require_active_variants gtk3 quartz
-    depends_lib-delete    port:xorg-libXcursor \
-                          port:xorg-libXmu \
-                          port:xorg-libXext \
-                          port:xorg-libXfixes \
-                          port:xpm
-    depends_lib-append    port:gtk-osx-application-gtk3
+
+    depends_lib-append \
+                    port:gtk-osx-application-gtk3
 }
 
 if {![variant_isset quartz]} {

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -8,10 +8,9 @@ PortGroup           meson 1.0
 PortGroup           perl5 1.0
 
 name                gimp3-devel
+set my_name         gimp3
 conflicts           gimp2 gimp2-devel
-set git_commit      677b517615d35d327c70b5423dd99f9eaaed23a4
-set git_date        20241107
-version             3.0.0rc1-${git_date}
+version             2.99.rc1
 revision            0
 license             GPL-3+
 categories          graphics
@@ -27,13 +26,17 @@ long_description    The GNU Image Manipulation Program (GIMP) is a powerful \
                     git master.
 homepage            https://gimp.org/
 
-fetch.type          git
-git.url             --depth 3000 https://gitlab.gnome.org/GNOME/gimp.git
-git.branch          ${git_commit}
-post-fetch {
-    system -W ${worksrcpath} \
-                    "${git.cmd} submodule update --init --recursive"
-}
+# TODO: Once 3.0 officially released, eliminate these versions hacks
+set branch          3.0
+#set branch          [join [lrange [split ${version} .] 0 1] .]
+master_sites        gimp:gimp/v${branch}/
+dist_subdir         ${my_name}
+distname            gimp-3.0.0-RC1
+use_xz              yes
+
+checksums           rmd160  18f197f32e38304dba69b2d5af62534174892852 \
+                    sha256  b3d0b264c5e38e789faaf3417003397f3240014c59c7f417f9ca3bd39c5ffb66 \
+                    size    28863948
 
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload


### PR DESCRIPTION
* Bumped package version string to 3.0.0rc1 to match UI. (There doesn't seem to be a 3.0.0rc1 release branch, unless I'm missing something.)
* Build system switched to meson. Updated dependences and build options accordingly.
* Added more recent versions of python to variant selection. Removed obsolete Python 3.8.
* Added X11 variant for parity with other X11-or-Quartz packages. (This was also needed due to the meson change changing how the backend was specified at configure time.)
* Switched from hardcoded debug variant to standard PortGroup debug-1.0 variants.
* Removed +remote variant; gimp-remote has been removed.
* Removed some outdated patches and portfile rules.

Closes: https://trac.macports.org/ticket/71141

#### Description

Note that there may still be extraneous dependencies (especially in X11 mode).

gimp-remote is also gone, though that was already marked obsolete.

Some runtime issues that I'm not sure what to do with but that don't affect the program running at all:

Every time the program starts

```
gimp_font_factory_load_names: 91 unsupported fonts were ignored. Set the GIMP_DEBUG_FONTS environment variable for a listing.
```

Doing this results in a list of font files, mostly PostScript Type 1 fonts installed by ghostscript marked "not supported by pango".

The first time you run gimp after installing, you'll also see

```
[plug-in-spyrogimp] The catalog directory does not exist: /opt/local/Library/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/Resources/share/locale
[plug-in-spyrogimp] Override method set_i18n() for the plug-in to customize or disable localization.
[plug-in-spyrogimp] Localization disabled
```

for all plugins, regardless of python version.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.12.6 16G2136 x86_64
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
