### PR TITLE
ruff: Update to 0.7.3

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.7.2
+github.setup        astral-sh ruff 0.7.3
 github.tarball_from archive
 revision            0
 
@@ -24,15 +24,15 @@ long_description    \
 categories          devel python
 installs_libs       no
 license             MIT
-platforms           {darwin >= 16}
+platforms           {darwin >= 17}
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {gmail.com:therealketo @TheRealKeto} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  88798bfb67e331c893020b43bff186661bd03f92 \
-                    sha256  e678307f10bd316f4bc8f0ca7419646e04be25b387f1ff84ea4470d482e240ba \
-                    size    5282856
+                    rmd160  58dd4c3e218d90ff05719f06dc350b6b2c4e81b3 \
+                    sha256  6b2aa675bb50124f636bda2c671f3394a8cfc7bf32d2fce63f852f7d43ce4810 \
+                    size    5325798
 
 cargo.offline_cmd
 
@@ -77,7 +77,7 @@ cargo.crates \
     anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
     anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
     anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
-    anyhow                          1.0.91  c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8 \
+    anyhow                          1.0.92  74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13 \
     append-only-vec                  0.1.5  74d9f7083455f1a474276ccd32374958d2cb591024aac45101c7623b10271347 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     argfile                          0.2.1  0a1cc0ba69de57db40674c66f7cf2caee3981ddef084388482c95c0e2133e5e8 \
@@ -189,12 +189,12 @@ cargo.crates \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
     imara-diff                       0.1.7  fc9da1a252bd44cd341657203722352efc9bc0c847d06ea6d2dc1cd1135e0a01 \
     imperative                       1.0.6  29a1f6526af721f9aec9ceed7ab8ebfca47f3399d08b80056c2acca3fcb694a9 \
-    indexmap                         2.5.0  68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5 \
+    indexmap                         2.6.0  707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
-    inotify                          0.9.6  f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff \
+    inotify                         0.10.2  fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc \
     inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
-    insta                           1.41.0  a1f72d3e19488cf7d8ea52d2fc0f8754fc933398b337cd3cbdb28aaeb35159ef \
+    insta                           1.41.1  7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8 \
     insta-cmd                        0.6.0  ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6 \
     instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
@@ -228,13 +228,14 @@ cargo.crates \
     minicov                          0.3.5  5c71e683cd655513b99affab7d317deb690528255a0d5f717f1024093c12b169 \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.7.2  9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7 \
-    mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
+    mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
     natord                           1.0.9  308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c \
     newtype-uuid                     1.1.0  3526cb7c660872e401beaf3297f95f548ce3b4b4bdd8121b7c0713771d7c4a6e \
     nix                             0.28.0  ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4 \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
-    notify                           6.1.1  6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d \
+    notify                           7.0.0  c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009 \
+    notify-types                     1.0.0  7393c226621f817964ffb3dc5704f9509e107a8b024b489cc2c1b217378785df \
     nu-ansi-term                    0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
     nu-ansi-term                    0.50.1  d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399 \
     num-traits                      0.2.18  da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a \
@@ -256,7 +257,7 @@ cargo.crates \
     peg-macros                       0.8.4  bdad6a1d9cf116a059582ce415d5f5566aabcd4008646779dab7fdc2a9a9d426 \
     peg-runtime                      0.8.3  e3aeb8f54c078314c2065ee649a7241f46b9d8e418e1a9581ba0546657d7aa3a \
     pep440_rs                        0.4.0  e0c29f9c43de378b4e4e0cd7dbcce0e5cfb80443de8c05620368b2948bc936a1 \
-    pep440_rs                        0.7.1  7c8ee724d21f351f9d47276614ac9710975db827ba9fe2ca5a517ba648193307 \
+    pep440_rs                        0.7.2  0922a442c78611fa8c5ed6065d2d898a820cf12fa90604217fdb2d01675efec7 \
     pep508_rs                        0.3.0  910c513bea0f4f833122321c0f20e8c704e01de98692f6989c2ec21f43d88b1e \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
     pest                            2.7.11  cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95 \
@@ -309,9 +310,9 @@ cargo.crates \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
-    serde                          1.0.213  3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1 \
+    serde                          1.0.214  f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5 \
     serde-wasm-bindgen               0.6.5  8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b \
-    serde_derive                   1.0.213  7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5 \
+    serde_derive                   1.0.214  de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766 \
     serde_derive_internals          0.29.0  330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3 \
     serde_json                     1.0.132  d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03 \
     serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
@@ -334,7 +335,7 @@ cargo.crates \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     subtle                           2.5.0  81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.85  5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56 \
+    syn                             2.0.87  25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     tempfile                        3.13.0  f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b \
     terminal_size                    0.4.0  4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef \
@@ -343,8 +344,8 @@ cargo.crates \
     test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
     test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
-    thiserror                       1.0.65  5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5 \
-    thiserror-impl                  1.0.65  ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602 \
+    thiserror                       1.0.67  3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd \
+    thiserror-impl                  1.0.67  b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tikv-jemalloc-sys 0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d \
     tikv-jemallocator                0.6.0  4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865 \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.7.3

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
