### PR TITLE
vtk: Add python 3.12 support

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -133,7 +133,7 @@ variant qt5 description {Add Qt5 support.} {
 }
 
 # Supported pythons
-set python_versions {38 39 310 311}
+set python_versions {38 39 310 311 312}
 
 foreach pyver ${python_versions} {
     # Conflicting python versions

--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -133,7 +133,7 @@ variant qt5 description {Add Qt5 support.} {
 }
 
 # Supported pythons
-set python_versions {38 39 310 311 312}
+set python_versions {39 310 311 312}
 
 foreach pyver ${python_versions} {
     # Conflicting python versions


### PR DESCRIPTION
#### Description

vtk: Add python 3.12 support.
Also remove 3.8 support, EOL.
No rev bump.  Only added a new non-default variant.

###### Type(s)

- [x] enhancement

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?