### PR TITLE
openssl3: use cctools only on macOS <10.7

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -56,13 +56,22 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
     }
 }
 
-# Doesn't build on Snow Leopard with the system compiler, see
-# https://github.com/macports/macports-ports/pull/26250#issuecomment-2437709579.
+# https://github.com/macports/macports-ports/pull/26250#issuecomment-2437709579
+# OpenSSL 3.4.0 implements new intrinsic code that increases compiler
+# requirements. We can only use bootstrap Clang because the newer
+# one depends on openssl by default and causes a dependency cycle.
 if {${os.platform} eq "darwin" && ${os.major} < 18} {
     if {${configure.build_arch} in {"x86_64" "i386"}} {
-        depends_build-append port:cctools port:clang-11-bootstrap
+        depends_build-append port:clang-11-bootstrap
         configure.cc ${prefix}/libexec/clang-11-bootstrap/bin/clang
         configure.cxx ${prefix}/libexec/clang-11-bootstrap/bin/clang++
+        # https://trac.macports.org/ticket/71201
+        # https://trac.macports.org/ticket/71246
+        # cctools is only needed for Snow Leopard i386/x86_64 and older.
+        # On Yosemite and newer systems it triggers the dependency cycle again.
+        if {${os.major} < 11} {
+            depends_build-append port:cctools
+        }
     }
 }
 


### PR DESCRIPTION
It is not clear to me if revbump is needed, I also ask @jmroot to review it.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
