### PR TITLE
xar: Don't try to use e2fsprogs

### DIFF
--- a/archivers/xar/Portfile
+++ b/archivers/xar/Portfile
@@ -77,6 +77,10 @@ patchfiles-append   patch-lib-filetree.c.diff
 # see: https://trac.macports.org/ticket/65839
 patchfiles-append   dont-overlink-to-libxml2.patch
 
+# see: https://trac.macports.org/ticket/71270
+configure.args-append \
+                    ac_cv_header_ext2fs_ext2_fs_h=no
+
 post-patch {
     set automake_dirs [glob -directory ${prefix}/share automake-*]
     set automake_dir [lindex [lsort -command vercmp $automake_dirs] end]


### PR DESCRIPTION
#### Description

Don't try to use e2fsprogs. Fixes build failure when e2fsprogs is installed.

Closes: https://trac.macports.org/ticket/71270

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
