### PR TITLE
GPXSee: update to 13.27

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.26
+github.setup        tumic0 GPXSee 13.27
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  dff23614fe94cd4935727dd9759a4676b3fc572d \
-                    sha256  452743ab585f9f61fccf4e1344ab8eaddd689f3ad3463018626820884ea70027 \
-                    size    5638599
+checksums           rmd160  5aed89d4230c5954b45111e8b12c963c6c4ae956 \
+                    sha256  b58e77381a55c7a9a39eda87f527ffd897bc7d2c669b0c8a87d6ff577fdc6ea5 \
+                    size    5639124
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
