### PR TITLE
sbcl: fix including pthread in 2.4.10

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -39,7 +39,9 @@ patchfiles      0001-fix-building-when-root-directory-contain-non-ASCII-c.patch 
 # https://github.com/sbcl/sbcl/pull/62
 patchfiles-append \
                 0003-runtime.c-fix-time-header-for-LISP_FEATURE_AVOID_CLO.patch
-
+# https://github.com/sbcl/sbcl/pull/64
+patchfiles-append \
+                0004-fix-pthread-macOS.patch
 
 checksums           rmd160  9eb94f4a551e8a5e9f63ae9cac7a093e7102c1b3 \
                     sha256  ceeb396b69d2913eee04841c2af6beca5c342ce1464c3fe3e453f2de10c5e2f8 \

--- a/lang/sbcl/files/0004-fix-pthread-macOS.patch
+++ b/lang/sbcl/files/0004-fix-pthread-macOS.patch
@@ -1,0 +1,23 @@
+From 5f43f4a284ec1ab2b22267710e0aa3c462412443 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sun, 10 Nov 2024 21:33:55 +0800
+Subject: [PATCH] runtime/thread.c: fix including pthread on macOS
+
+---
+ src/runtime/thread.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/runtime/thread.c b/src/runtime/thread.c
+index 544cae574d..479235ca6d 100644
+--- src/runtime/thread.c
++++ src/runtime/thread.c
+@@ -12,6 +12,9 @@
+ #ifdef __linux__
+ #define _GNU_SOURCE // for pthread_setname_np()
+ #endif
++#ifdef __APPLE__
++#define _DARWIN_C_SOURCE // for pthread_mach_thread_np()
++#endif
+ #include "genesis/sbcl.h"
+ 
+ #include <stdlib.h>


### PR DESCRIPTION
#### Description

Fix building 2.4.10 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
