### PR TITLE
mise: Update to 2024.11.6

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.11.5 v
+github.setup        jdx mise 2024.11.6 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  77206d5b563df38e8ccd378948b7021efe4a1338 \
-                    sha256  19294d91b7f54510a28ec0fe27211bdb0780c9a669b0df6acb3e3c02f1a89958 \
-                    size    3130956
+                    rmd160  7115e38a0a879a44a8bac7accb1cf6f92fe20b80 \
+                    sha256  78a57263dfe27fdee52b393b650bda3172c9c03163a7fd08a6fb66af0565fd80 \
+                    size    3133096
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -293,8 +293,8 @@ cargo.crates \
     miniz_oxide                      0.7.4  b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08 \
     miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
     mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
-    mlua                            0.10.0  0f6ddbd668297c46be4bdea6c599dcc1f001a129586272d53170b7ac0a62961e \
-    mlua-sys                         0.6.4  e9eebac25c35a13285456c88ee2fde93d9aee8bcfdaf03f9d6d12be3391351ec \
+    mlua                            0.10.1  0ae9546e4a268c309804e8bbb7526e31cbfdedca7cd60ac1b987d0b212e0d876 \
+    mlua-sys                         0.6.5  efa6bf1a64f06848749b7e7727417f4ec2121599e2a10ef0a8a3888b0e9a5a0d \
     mlua_derive                     0.10.0  2cfc5faa2e0d044b3f5f0879be2920e0a711c97744c42cf1c295cb183668933e \
     native-tls                      0.2.12  a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466 \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
@@ -442,8 +442,8 @@ cargo.crates \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
     test-log                        0.2.16  3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93 \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
-    thiserror                       1.0.68  02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892 \
-    thiserror-impl                  1.0.68  a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e \
+    thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
+    thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     time                            0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \


### PR DESCRIPTION
#### Description

mise: Update to 2024.11.6

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
