### PR TITLE
audacious*: update to 4.4.2, fix big-endian back

### DIFF
--- a/audio/audacious-core/Portfile
+++ b/audio/audacious-core/Portfile
@@ -7,7 +7,7 @@ name                audacious-core
 set real_name       audacious
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
-version             4.4.1
+version             4.4.2
 revision            0
 
 license             BSD
@@ -30,9 +30,9 @@ long_description    ${description} It is free, lightweight, based on GTK3, \
 master_sites        https://distfiles.audacious-media-player.org
 distname            ${real_name}-${version}
 use_bzip2           yes
-checksums           rmd160  8504f58e4b0fcc95520ae9cc31858bb4401525d1 \
-                    sha256  260d988d168e558f041bbb56692e24c535a96437878d60dfd01efdf6b1226416 \
-                    size    636301
+checksums           rmd160  7a195d96a2b4f8d449c2e182a964059ff862f65a \
+                    sha256  34509504f8c93b370420d827703519f0681136672e42d56335f26f7baec95005 \
+                    size    636838
 
 universal_variant   no
 
@@ -53,6 +53,11 @@ configure.args      -Ddbus=true \
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig
+
+# This issue was supposed to be fixed, but it did not work as intended.
+# Temporarily revert upstream commit and restore our patch. This is tested.
+# https://github.com/audacious-media-player/audacious-plugins/pull/166
+patchfiles-append   patch-big-endian.diff
 
 post-destroot {
     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${real_name}

--- a/audio/audacious-core/files/patch-big-endian.diff
+++ b/audio/audacious-core/files/patch-big-endian.diff
@@ -1,0 +1,12 @@
+Reverts https://github.com/audacious-media-player/audacious/commit/9e51ffa0c0ec79b537cc970158d51557273970ea
+
+--- src/config.h.meson	2024-11-04 04:00:44.000000000 +0800
++++ src/config.h.meson	2024-11-11 02:05:46.000000000 +0800
+@@ -5,7 +5,6 @@
+ #mesondefine EXPORT
+ #mesondefine PLUGIN_SUFFIX
+ #mesondefine VALGRIND_FRIENDLY
+-#mesondefine WORDS_BIGENDIAN
+ 
+ #define PACKAGE_VERSION VERSION
+ #define ICONV_CONST

--- a/audio/audacious-plugins/Portfile
+++ b/audio/audacious-plugins/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 name                audacious-plugins
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
-version             4.4.1
+version             4.4.2
 revision            0
 
 # FIXME: probably more licenses involved here...
@@ -27,9 +27,9 @@ long_description    This ports bundles most of the functionality for audacious. 
 
 master_sites        https://distfiles.audacious-media-player.org
 use_bzip2           yes
-checksums           rmd160  0e7622a61287868735a8bf9be8bfcceb1ace4f07 \
-                    sha256  484ed416b1cf1569ce2cc54208e674b9c516118485b94ce577d7bc5426d05976 \
-                    size    1815238
+checksums           rmd160  3ce31585b2721e32d219f987864b7369c7bbcc93 \
+                    sha256  50f494693b6b316380fa718c667c128aa353c01e954cd77a65c9d8aedf18d4bd \
+                    size    1816431
 
 universal_variant   no
 
@@ -127,6 +127,11 @@ configure.args-append \
 # interface
 configure.args-append \
                     -Dmoonstone=false
+
+# This issue was supposed to be fixed, but it did not work as intended.
+# Temporarily revert upstream commit and restore our patch. This is tested.
+# https://github.com/audacious-media-player/audacious-plugins/pull/166
+patchfiles-append   patch-big-endian.diff
 
 # Even if we disable blocks to make it build with GCC, it is broken
 # and outputs only hiss. Use SDL audio out instead, until fixed.

--- a/audio/audacious-plugins/files/patch-big-endian.diff
+++ b/audio/audacious-plugins/files/patch-big-endian.diff
@@ -1,0 +1,37 @@
+Reverts https://github.com/audacious-media-player/audacious-plugins/commit/c175d8b9cece8a53d86ce54fc252454287814e9e
+
+--- src/config.h.meson	2024-11-04 04:02:39.000000000 +0800
++++ src/config.h.meson	2024-11-11 02:06:51.000000000 +0800
+@@ -3,7 +3,6 @@
+ #mesondefine COPYRIGHT
+ #mesondefine EXPORT
+ #mesondefine PLUGIN_SUFFIX
+-#mesondefine WORDS_BIGENDIAN
+ 
+ #define PACKAGE_VERSION VERSION
+ #define ICONV_CONST
+
+
+From 343d20c6ece2d48dba06a8ba4f474499a8a3a1f0 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Thu, 25 Jul 2024 23:33:55 +0800
+Subject: [PATCH] xsf/desmume/types.h: ensure LOCAL_BE gets defined on
+ Big-endian platforms
+
+---
+ src/xsf/desmume/types.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git src/xsf/desmume/types.h src/xsf/desmume/types.h
+index 61d858cec..d3113fccd 100644
+--- src/xsf/desmume/types.h
++++ src/xsf/desmume/types.h
+@@ -96,7 +96,7 @@ using s8 = int8_t;
+ 
+ /*----------------------*/
+ 
+-#ifdef __BIG_ENDIAN__
++#if defined(__BIG_ENDIAN__) || (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+ # ifndef WORDS_BIGENDIAN
+ #  define WORDS_BIGENDIAN
+ # endif

--- a/audio/audacious/Portfile
+++ b/audio/audacious/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                audacious
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
-version             4.4.1
+version             4.4.2
 revision            0
 
 license             BSD GPL-2+


### PR DESCRIPTION
#### Description

Update, big-endian fix (we just restore what we had in 4.4 and 4.3.1).

P. S. Last attempt to fix BE builds with upstream did not go well, and we got a broken sound output in 4.4.1.
For now, revert those changes and use our patch which works correctly.
This has been tested and confirmed to work.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
