### PR TITLE
py-pacal: update to 1.6.1, drop python2, add python3

### DIFF
--- a/python/py-pacal/Portfile
+++ b/python/py-pacal/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pacal
+python.rootname     PaCal
 version             1.6.1
-categories          python
-platforms           darwin
 license             GPL-3+
 maintainers         {adfernandes @adfernandes} openmaintainer
 description         PaCAL - ProbAbilistic CALculator
@@ -14,30 +13,20 @@ long_description    What is PaCAL? PaCAL is a Python package which allows you to
                     arithmetic on random variables just like you do with ordinary program \
                     variables. The variables can follow practically any distribution.
 homepage            http://pacal.sourceforge.net/index.html
-master_sites        pypi:P/PaCal/
-distname            PaCal-${version}
 
 checksums           rmd160  2df0abd5ec1fff7244b783f107aaeb3d3cac3a18 \
                     sha256  6ad0ac60a73c5e8a05eac467d346134e5d18624f0dcc40bf2fc3c85e1aa34aa3 \
                     size    179419
 
-python.versions     	39 310 311 312
-python.default_version  312
+python.versions         39 310 311 312
 
 if {${name} ne ${subport}} {
 
     depends_lib-append  port:py${python.version}-numpy \
                         port:py${python.version}-matplotlib \
                         port:py${python.version}-sympy \
-                        port:py${python.version}-scipy \
-                        port:py${python.version}-cython
+                        port:py${python.version}-scipy
 
-    livecheck.type  none
-
-} else {
-
-    livecheck.type  regex
-    livecheck.url   ${homepage}
-    livecheck.regex {(?i)pacal\s+(\d+(?:\.\d+)*)\s+released}
+    depends_build-append port:py${python.version}-cython
 
 }

--- a/python/py-pacal/Portfile
+++ b/python/py-pacal/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pacal
-version             1.5.1
+version             1.6.1
 categories          python
 platforms           darwin
 license             GPL-3+
@@ -17,11 +17,12 @@ homepage            http://pacal.sourceforge.net/index.html
 master_sites        pypi:P/PaCal/
 distname            PaCal-${version}
 
-checksums           rmd160  96e018864f431a8558eb75a018dbe9c10ff0178e \
-                    sha256  ece7cf61448355dcb50d5566dc22fd3eb8819579e26db83abe6277bf735730f0
+checksums           rmd160  2df0abd5ec1fff7244b783f107aaeb3d3cac3a18 \
+                    sha256  6ad0ac60a73c5e8a05eac467d346134e5d18624f0dcc40bf2fc3c85e1aa34aa3 \
+                    size    179419
 
-# python3 is not supported
-python.versions     27
+python.versions     	39 310 311 312
+python.default_version  312
 
 if {${name} ne ${subport}} {
 


### PR DESCRIPTION
See https://trac.macports.org/ticket/71182