### PR TITLE
py-rasterio: update to 1.3.11, add py313 subport (including dependencies)

### DIFF
--- a/python/py-affine/Portfile
+++ b/python/py-affine/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 python.pep517_backend flit
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-click-plugins/Portfile
+++ b/python/py-click-plugins/Portfile
@@ -10,7 +10,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-cligj/Portfile
+++ b/python/py-cligj/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-rasterio/Portfile
+++ b/python/py-rasterio/Portfile
@@ -5,12 +5,12 @@ PortGroup           python 1.0
 PortGroup           compiler_wrapper 1.0
 
 name                py-rasterio
-version             1.3.9
-revision            2
+version             1.3.11
+revision            0
 categories-append   gis
 license             BSD
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/rasterio/rasterio
 
-checksums           rmd160  c689da41ea24c2843c0c6e6e927beeb4bc67db17 \
-                    sha256  fc6d0d290492fa1a5068711cfebb21cc936968891b7ed9da0690c8a7388885c5 \
-                    size    411741
+checksums           rmd160  28aa4815bc87ce7d3839907d5e18ca86cde7b4b6 \
+                    sha256  47aa70b4718ebc80d825bb7db3127577d74e31c53048ce215145c0baf530ece9 \
+                    size    413094
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -37,6 +37,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-click-plugins \
                         port:py${python.version}-setuptools \
                         port:gdal
+
+    patchfiles-append   patch-numpy_version.diff
 
     # cc1plus: error: unrecognized command line option "-stdlib=libc++"
     if {${configure.cxx_stdlib} ne "libc++"} {

--- a/python/py-rasterio/files/patch-numpy_version.diff
+++ b/python/py-rasterio/files/patch-numpy_version.diff
@@ -1,0 +1,13 @@
+diff --git pyproject.toml pyproject.toml
+index 95fc8d9590f6..aa4efdb3a323 100644
+--- pyproject.toml
++++ pyproject.toml
+@@ -3,7 +3,7 @@ requires = [
+     "setuptools>=67.8",
+     "wheel",
+     "cython~=3.0.2",
+-    "numpy>=2.0.0,<3.0; python_version >= '3.9'",
++    "numpy; python_version >= '3.9'",
+     "oldest-supported-numpy; python_version < '3.9'"
+ ]
+ 

--- a/python/py-snuggs/Portfile
+++ b/python/py-snuggs/Portfile
@@ -11,7 +11,7 @@ license             MIT
 platforms           {darwin any}
 supported_archs     noarch
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description

This is an update to 1.3.11 instead of 1.4.2, as 1.4.2 requires numpy 2.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
