### PR TITLE
perl5.38: don't override deployment target

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -163,6 +163,12 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
             patchfiles-append \
                             ${perl5.major}/patch-want-implicit-errors.diff
         }
+        if {${perl5.major} >= 5.38} {
+            # Do not override deployment target
+            # https://trac.macports.org/ticket/71152
+            patchfiles-append \
+                            ${perl5.major}/perl538-remove-deployment-target-override.diff
+        }
 
         post-patch {
             reinplace -W ${worksrcpath} "s|__PREFIX__|${prefix}|g" \

--- a/lang/perl5/files/5.38/perl538-remove-deployment-target-override.diff
+++ b/lang/perl5/files/5.38/perl538-remove-deployment-target-override.diff
@@ -1,0 +1,13 @@
+--- hints/darwin.sh.orig
++++ hints/darwin.sh
+@@ -289,10 +289,6 @@
+    ;;
+ [7-9].*)   # OS X 10.3.x - 10.5.x
+    lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
+-   case "$ld" in
+-       *MACOSX_DEPLOYMENT_TARGET*) ;;
+-       *) ld="env MACOSX_DEPLOYMENT_TARGET=10.3 ${ld}" ;;
+-   esac
+    ;;
+ *)        # OS X 10.6.x - current
+    # The MACOSX_DEPLOYMENT_TARGET is not needed,


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/71152

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5 Intel

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
