### PR TITLE
update to oath-toolkit

### DIFF
--- a/security/oath-toolkit/Portfile
+++ b/security/oath-toolkit/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           conflicts_build 1.0
 
 name                oath-toolkit
 version             2.6.12
@@ -19,12 +20,26 @@ long_description    The OATH Toolkit contains a shared library, command line \
                     the time-based TOTP algorithm. OATH is the Open \
                     AuTHentication organization which specify the algorithms.
 
-homepage            https://www.nongnu.org/oath-toolkit/
+homepage            http://oath-toolkit.nongnu.org/
 master_sites        savannah
 
 checksums           rmd160  b1fb77b34fdf2459d0899a9fcb8e33f9b9485097 \
                     sha256  cafdf739b1ec4b276441c6aedae6411434bbd870071f66154b909cc6e2d9e8ba \
                     size    4706950
+
+patch.pre_args-replace  -p0 -p1
+
+# Need to regenerate autotools scripts, due to previous patch; not needed for next release
+use_autoreconf      yes
+autoreconf.args     -fvi
+
+# This version of 'oath-toolkit' requires 'xmlsec-1.2'.
+# Once upstream releases support for xmlsec 1.3+, none of this will be needed.
+conflicts_build-append \
+                    xmlsec
+set xmlsec_lib      ${prefix}/lib/xmlsec-1.2/lib
+configure.pkg_config_path-prepend \
+                    ${xmlsec_lib}/pkgconfig
 
 depends_build-append \
                     port:gtk-doc \
@@ -33,7 +48,8 @@ depends_build-append \
 depends_lib-append \
                     port:libtool \
                     port:libxml2 \
-                    port:xmlsec
+                    port:libxslt \
+                    port:xmlsec-1.2
 
 configure.args-append \
                     --disable-silent-rules


### PR DESCRIPTION
#### Description

patches to fix Sequoia builds
see: https://trac.macports.org/ticket/70889

Portfile uploaded by yokuha fixes build issues on Sequoia

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7 23H124 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

[skip notification]