### PR TITLE
py-svgelements: add py313 subport, enable tests

### DIFF
--- a/python/py-svgelements/Portfile
+++ b/python/py-svgelements/Portfile
@@ -23,9 +23,25 @@ checksums           rmd160  a58080a4efac91094c7b12605b09ccd2a2787745 \
                     sha256  7c02ad6404cd3d1771fd50e40fbfc0550b0893933466f86a6eb815f3ba3f37f7 \
                     size    162145
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
+    pre-patch {
+        # Fix CRLF newlines before patching.
+        reinplace "s/\r$//" \
+                    test/test_cubic_bezier.py \
+                    test/test_write.py
+    }
+    patchfiles-append \
+                    0001-Fix-tests-by-fixing-typos.patch
+
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    depends_test-append \
+                    port:py${python.version}-Pillow \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-scipy
+
+    test.run        yes
 }

--- a/python/py-svgelements/files/0001-Fix-tests-by-fixing-typos.patch
+++ b/python/py-svgelements/files/0001-Fix-tests-by-fixing-typos.patch
@@ -1,0 +1,36 @@
+https://github.com/meerk40t/svgelements/commit/6e385af7536457a3b63b750d5e9615d727888e1c.patch
+
+From 23da98941a94cf1afed39c10750222ccfee73c9f Mon Sep 17 00:00:00 2001
+From: Emi Vasilek <emi.vasilek@gmail.com>
+Date: Mon, 16 Oct 2023 15:04:25 +0200
+Subject: [PATCH] Fix tests by fixing typos
+
+typos in assertEqual(s) caused tests to fail
+---
+ test/test_cubic_bezier.py | 2 +-
+ test/test_write.py        | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git test/test_cubic_bezier.py test/test_cubic_bezier.py
+index 69274878..e4f5efa2 100644
+--- test/test_cubic_bezier.py
++++ test/test_cubic_bezier.py
+@@ -79,4 +79,4 @@ def test_cubic_bounds_issue_220(self):
+         p = Path(transform=Matrix(682.657124793113, 0.000000000003, -0.000000000003, 682.657124793113, 257913.248909660178, -507946.354527872754))
+         p += CubicBezier(start=Point(-117.139521365,1480.99923469), control1=Point(-41.342266634,1505.62725567), control2=Point(40.3422666342,1505.62725567), end=Point(116.139521365,1480.99923469))
+         bounds = p.bbox()
+-        self.assertNotAlmostEquals(bounds[1], bounds[3], delta=100)
++        self.assertNotAlmostEqual(bounds[1], bounds[3], delta=100)
+diff --git test/test_write.py test/test_write.py
+index 053a7143..fd09772c 100644
+--- test/test_write.py
++++ test/test_write.py
+@@ -24,7 +24,7 @@ def test_write(self):
+ 
+     def test_write_group(self):
+         g = Group()
+-        self.assertEquals(g.string_xml(), "<g />")
++        self.assertEqual(g.string_xml(), "<g />")
+ 
+     def test_write_rect(self):
+         r = Rect("1in", "1in", "3in", "3in", rx="5%")


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
