### PR TITLE
clisp: update to 2.50.0-20241112, fix legacy systems installation

### DIFF
--- a/lang/clisp/Portfile
+++ b/lang/clisp/Portfile
@@ -4,13 +4,12 @@ PortSystem      1.0
 PortGroup       compiler_blacklist_versions 1.0
 PortGroup       gitlab 1.0
 
-gitlab.setup    gnu-clisp clisp 66924971790e4cbee3d58f36e530caa0ad568e5f
-version         2.50.0-20230719
+gitlab.setup    gnu-clisp clisp beeb63752543b8f2f7e8eecd7fef5fc8ff711a72
+version         2.50.0-20241112
 
 revision        0
 categories      lang
 maintainers     {easieste @easye} openmaintainer
-platforms       darwin
 license         GPL-2
 description     The CLISP ANSI Common Lisp Implementation
 long_description        \
@@ -27,9 +26,9 @@ long_description        \
 
 homepage        https://clisp.sourceforge.io
 
-checksums       rmd160  e802a6c0bff3c1c5d2f67bc1d8ac0fb81f7b70ab \
-                sha256  6b9777d79faa0c35944a5961aded89aca873feac58946c363d796ecb49c96577 \
-                size    9004928
+checksums       rmd160  218c9acf818f05f161560ef04ffb54f1911c76f3 \
+                sha256  cbec72cbc80eb33758b01009f2319f3cc1b35b881bc9d313dd332322a7172567 \
+                size    9109508
 
 depends_build-append \
                 port:ghostscript
@@ -52,7 +51,13 @@ post-patch {
 # Works with Xcode 7.0 and macports-clang-3.4
 # Failed in Lion (https://trac.macports.org/ticket/33344)
 # Assuming {clang < 300}, but please refine if more datapoints become available
-compiler.blacklist {clang < 300}
+# Also blacklist old gcc, because base/makevars bakes in compiler value,
+# and we do not want CC='/usr/bin/gcc-4.2 -std=gnu99' there,
+# it breaks some dependents. Likewise, disable ccache.
+# /bin/sh: /usr/bin/gcc-4.2 -std=gnu99: No such file or directory
+compiler.blacklist-append \
+                    {clang < 300} *gcc-4.0 *gcc-4.2
+configure.ccache    no
 
 configure.cflags    ${configure.cc_archflags}
 
@@ -98,4 +103,3 @@ build.target
 
 test.run            yes
 test.target         check
-


### PR DESCRIPTION
#### Description

1. Update.
2. On legacy systems avoid old Xcode gccs: they require c99, and clisp bakes in CC value as `/usr/bin/gcc-4.2 -std=gnu99`, which in turn breaks some dependents. We also do not want to be restricted by an archaic compiler. This change is confirmed to fix installation of `cl-osicat`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
