### PR TITLE
mise: Update to 2024.11.8

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.11.6 v
+github.setup        jdx mise 2024.11.8 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  7115e38a0a879a44a8bac7accb1cf6f92fe20b80 \
-                    sha256  78a57263dfe27fdee52b393b650bda3172c9c03163a7fd08a6fb66af0565fd80 \
-                    size    3133096
+                    rmd160  ddac006b38db0ca4602bd3f950d86e5776627e38 \
+                    sha256  2cb33bcbc9a852cbfaf03d1bf13c967200a319636665f302f62bf332f1506896 \
+                    size    3153641
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -146,7 +146,7 @@ cargo.crates \
     contracts                        0.6.3  f1d1429e3bd78171c65aa010eabcdf8f863ba3254728dbfb0ad4b1545beac15c \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
-    cpufeatures                     0.2.14  608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0 \
+    cpufeatures                     0.2.15  0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6 \
     crc                              3.2.1  69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636 \
     crc-catalog                      2.4.0  19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
@@ -338,7 +338,7 @@ cargo.crates \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
-    platforms                        3.2.0  14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0 \
+    platforms                        3.5.0  d43467300237085a4f9e864b937cf0bc012cef7740be12be1a48b10d2c8a3701 \
     portable-atomic                  1.9.0  cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
@@ -362,7 +362,7 @@ cargo.crates \
     redox_syscall                    0.5.7  9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
-    regex-automata                   0.4.8  368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3 \
+    regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     reqwest                         0.12.9  a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f \
@@ -373,7 +373,7 @@ cargo.crates \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
-    rustix                         0.38.39  375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee \
+    rustix                         0.38.40  99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0 \
     rustls                         0.23.16  eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e \
     rustls-native-certs              0.8.0  fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
@@ -389,13 +389,14 @@ cargo.crates \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     self_update                     0.41.0  469a3970061380c19852269f393e74c0fe607a4e23d85267382cf25486aa8de5 \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
-    serde                          1.0.214  f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5 \
+    serde                          1.0.215  6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f \
     serde-value                      0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
-    serde_derive                   1.0.214  de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766 \
+    serde_derive                   1.0.215  ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0 \
     serde_ignored                   0.1.10  a8e319a36d1b52126a0d608f24e93b2d81297091818cd70625fcf50a15d84ddf \
     serde_json                     1.0.132  d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03 \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
+    serde_yaml           0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     sevenz-rust                      0.6.1  26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
@@ -443,7 +444,9 @@ cargo.crates \
     test-log                        0.2.16  3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93 \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
+    thiserror                        2.0.3  c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
+    thiserror-impl                   2.0.3  f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     time                            0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
@@ -468,7 +471,7 @@ cargo.crates \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     typeid                           1.0.2  0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
-    ubi                              0.2.1  2548274fb2071b9f1f97522c77a433810f7e289b552c3e66d69055e706441457 \
+    ubi                              0.2.2  142b3c47969de63fa38283962c08273cc06fec0de2e7425da9003d14ed0a05fa \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     unic-char-property               0.9.0  a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221 \
     unic-char-range                  0.9.0  0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc \
@@ -479,10 +482,11 @@ cargo.crates \
     unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    unsafe-libyaml                  0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.3  8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                        1.2.0  c80a6a75819b2e997666722dc47342c1890af0a68b823104153be23ac0b43c94 \
+    usage-lib                        1.3.0  2cc06aea8587a38beb1691e4ecf680b8bcd1ab425e2350279c778de1d60d70aa \
     utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -490,7 +494,7 @@ cargo.crates \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
-    vfox                             0.3.1  124e7a9b4bf350dd7824f0b4b345d4266011aab13933f8e34fd25637df86543a \
+    vfox                             0.3.2  c36fe3d5b017c69c1f1fbddc0defdf77c358ba5cc00450cca895cf8d4a2664ae \
     vte                             0.10.1  6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983 \
     vte_generate_state_changes       0.1.2  2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
@@ -537,7 +541,7 @@ cargo.crates \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
-    xx                               1.1.8  fb963ecf2940991825550e580efaaa1ab882191027f45362c4376de15d09bfe9 \
+    xx                               1.1.9  cf77a847b8a88b00563bb61a1041c90a8697bc23f0382eb1ecbe852098df351c \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                             0.7.4  6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5 \


### PR DESCRIPTION
#### Description

mise: Update to 2024.11.8

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
