### PR TITLE
py-matplotlib and all its (recursive) dependencies: add py313 subport

### DIFF
--- a/python/py-blockdiag/Portfile
+++ b/python/py-blockdiag/Portfile
@@ -11,7 +11,7 @@ license             Apache-2
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-chardet/Portfile
+++ b/python/py-chardet/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  03bd0ba9cb2b0a150bed313cedf1c824439705b5 \
                     sha256  96481c3479f67911078b49063daa4978e4a7425d4a33353966c00b6208e732b9 \
                     size    1924276
 
-python.versions     27 38 39 310 311 312
+python.versions     27 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-fonttools/Portfile
+++ b/python/py-fonttools/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  f5cd1868d6a77e9c5095f7f3baf6ec74f8ea7cf1 \
                     sha256  957f669d4922f92c171ba01bef7f29410668db09f6c02111e22b2bce446f3285 \
                     size    3463867
 
-python.versions     38 39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-fonttools/files/fonttools-313
+++ b/python/py-fonttools/files/fonttools-313
@@ -1,0 +1,5 @@
+bin/fonttools-3.13
+bin/pyftmerge-3.13
+bin/pyftsubset-3.13
+bin/ttx-3.13
+${frameworks_dir}/Python.framework/Versions/3.13/share/man/man1/ttx.1

--- a/python/py-fonttools/files/fonttools-38
+++ b/python/py-fonttools/files/fonttools-38
@@ -1,5 +1,0 @@
-bin/fonttools-3.8
-bin/pyftmerge-3.8
-bin/pyftsubset-3.8
-bin/ttx-3.8
-${frameworks_dir}/Python.framework/Versions/3.8/share/man/man1/ttx.1

--- a/python/py-funcparserlib/Portfile
+++ b/python/py-funcparserlib/Portfile
@@ -11,7 +11,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 python.pep517_backend poetry
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-gobject3/Portfile
+++ b/python/py-gobject3/Portfile
@@ -11,7 +11,6 @@ revision            0
 categories-append   gnome
 license             LGPL-2.1+
 maintainers         {devans @dbevans} {mascguy @mascguy} openmaintainer
-platforms           darwin
 description         Python bindings for GObject, version 3
 
 long_description    PyGObject is a Python dynamic module that enables developers to use the \
@@ -24,7 +23,7 @@ checksums           rmd160  ab889fe19d883dbe9ce693cfe6d4af048a353014 \
                     sha256  426008b2dad548c9af1c7b03b59df0440fde5c33f38fb5406b103a43d653cafc \
                     size    561552
 
-python.versions     36 37 38 39 310 311 312
+python.versions     36 37 38 39 310 311 312 313
 python.pep517       no
 
 if {${name} ne ${subport}} {

--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  e895790ac0f0c3483e7299a92370393b4514724d \
                     sha256  96ab43906269ca64a6366934106fa01534454a69e471b7bf3d79083981aaab92 \
                     size    36088381
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 python.pep517_backend meson
 
 if {${name} ne ${subport}} {

--- a/python/py-pyobjc/Portfile
+++ b/python/py-pyobjc/Portfile
@@ -30,7 +30,7 @@ long_description    The PyObjC project aims to provide a bridge between \
                     Python based functionality.
 homepage            https://pyobjc.readthedocs.io
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-reportlab/Portfile
+++ b/python/py-reportlab/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-reportlab
-version             4.1.0
+version             4.2.5
 revision            0
 categories-append   textproc
 license             BSD
 platforms           {darwin any}
 supported_archs     noarch
 
-python.versions     38 39 310 311 312
+python.versions     39 310 311 312 313
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -22,9 +22,9 @@ long_description    The ReportLab Toolkit is a library for programatically \
 
 homepage            https://www.reportlab.com/software/opensource/rl-toolkit/
 
-checksums           rmd160  3e04ae6cbe4682303dba28d3c9f1f35768646674 \
-                    sha256  3a99faf412691159c068b3ff01c15307ce2fd2cf6b860199434874e002040a84 \
-                    size    3146958
+checksums           rmd160  0b5659ca9e00296759a602616b79ecdef33edd32 \
+                    sha256  5cf35b8fd609b68080ac7bbb0ae1e376104f7d5f7b2d3914c7adc63f2593941f \
+                    size    3581379
 
 if {${name} ne ${subport}} {
     depends_lib-append  path:${python.pkgd}/PIL:py${python.version}-Pillow \

--- a/python/py-sphinxcontrib-blockdiag/Portfile
+++ b/python/py-sphinxcontrib-blockdiag/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  1fbe5f0cd13d0ac1aab70f28ea05e8297be00647 \
                     sha256  aa49bf924516f5de8a479994c7be81e077df5599c9da2a082003d5b388e1d450 \
                     size    6070
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_run-append \

--- a/python/py-unicodedata2/Portfile
+++ b/python/py-unicodedata2/Portfile
@@ -11,17 +11,16 @@ maintainers         {amake @amake} openmaintainer
 
 description         Unicodedata backport for Python 2/3 updated to the latest Unicode \
                     version.
-long_description    ${description}
+long_description    {*}${description}
+
+homepage            http://github.com/fonttools/unicodedata2
 
 checksums           rmd160  95403fd8edde714ff40273983e72dc43b32d2a73 \
                     sha256  cb30f189ad66482f8529a45da71b2a8841e9bd2bb376cc2933003a4a55a07648 \
                     size    592892
 
-python.versions     37 38 39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
-
     test.run            yes
 }

--- a/python/py-webcolors/Portfile
+++ b/python/py-webcolors/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description
- add py313 subport for `py-matplotlib`
- update a few dependencies to their latest versions
- update Python versions in subport (i.e., drop EOL)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1 24B83 x86_64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
