### PR TITLE
hugo: update to 0.138.0, add deploy variant

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,19 +3,19 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.136.5 v
+go.setup            github.com/gohugoio/hugo 0.138.0 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  b7e2a46973240b8d472b5e98b613d889a27326e7 \
-                    sha256  d08858d21faec46075b8988d1ed3b16239daea426574cd3b07efc1e23db927f5 \
-                    size    21228079
+checksums           rmd160  540b9593466ed790dabfcc9e12d272b5f976cb2e \
+                    sha256  2527f9df57d872c2651ad8e8895c7256c7af9a58c73e5e72f5ba0ae9714cad8e \
+                    size    21232634
 
 categories          www
 installs_libs       no
 license             Apache-2
-maintainers         {isi.edu:calvin @cardi} \
+maintainers         {acm.org:cardi @cardi} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
@@ -24,12 +24,17 @@ long_description    {*}${description}
 
 
 build.pre_args-append \
-    -ldflags \"-X ${go.package}/common/hugo.vendorInfo=macports\"
+                    -ldflags \"-X ${go.package}/common/hugo.vendorInfo=macports\"
 
 # build hugo extended with Sass/SCSS support by default
-build.args-append   --tags extended
+build.args-append   -tags extended
 
 depends_run-append  path:etc/bash_completion:bash-completion
+
+variant deploy description "Enables support to deploy site directly to Google Cloud Storage, AWS S3, or Azure Storage" {
+    build.args-append \
+                    {-tags extended} {-tags extended,withdeploy}
+}
 
 destroot {
     xinstall -d ${destroot}${prefix}/bin


### PR DESCRIPTION
#### Description
hugo: update to 0.138.0, add deploy variant
* adds new `deploy` variant which enables support for deploying site directly to Google Cloud Storage, AWS S3, or Azure Storage.

  this feature was pulled out into its own, separate build tag as of upstream v0.137.0 and building without this feature (default) significantly reduces the final binary size.

* minor Portfile reformatting


###### Tested on
macOS 12.7.6 21H1320 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?