### PR TITLE
weechat: update to 4.4.3, update Python and Ruby variants

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.4.2
+version             4.4.3
 revision            0
-checksums           rmd160  31a20f43cc2efcb7fd80939b10bed82d602f7359 \
-                    sha256  d4df289a9c5bca03a6d4fae006e52037064ef03bad6fbe959c538f3197434dec \
-                    size    2728232
+checksums           rmd160  e4d6451236846719acf3e9e5805b9609ae7fcb51 \
+                    sha256  295612f8dc24af28c918257d3014eb53342a5d077d5e3d9a3eadf303bd8febfa \
+                    size    2730188
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes
@@ -39,7 +39,7 @@ long_description    WeeChat (Wee Enhanced Environment for Chat) is \
                     \n - and much more!
 
 categories          irc
-maintainers         {isi.edu:calvin @cardi} openmaintainer
+maintainers         {acm.org:cardi @cardi} openmaintainer
 
 depends_build-append \
                     port:asciidoctor \
@@ -76,65 +76,62 @@ configure.args-append \
                     -DENABLE_TCL=OFF \
                     -DENABLE_TESTS=OFF
 
-variant python requires python312 description {Compatibility variant, requires +python312} {}
+variant python requires python313 description {Compatibility variant, requires +python313} {}
 
-variant python38 description "Bindings for Python 3.8 plugins" conflicts python39 python310 python311 python312 {
-    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
-    configure.pkg_config_path-append \
-                            ${frameworks_dir}/Python.framework/Versions/3.8/lib/pkgconfig
-    depends_lib-append      port:python38
-}
-
-variant python39 description "Bindings for Python 3.9 plugins" conflicts python38 python310 python311 python312 {
+variant python39 description "Bindings for Python 3.9 plugins" conflicts python310 python311 python312 python313 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.pkg_config_path-append \
                             ${frameworks_dir}/Python.framework/Versions/3.9/lib/pkgconfig
     depends_lib-append      port:python39
 }
 
-variant python310 description "Bindings for Python 3.10 plugins" conflicts python38 python39 python311 python312 {
+variant python310 description "Bindings for Python 3.10 plugins" conflicts python39 python311 python312 python313 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.pkg_config_path-append \
                             ${frameworks_dir}/Python.framework/Versions/3.10/lib/pkgconfig
     depends_lib-append      port:python310
 }
 
-variant python311 description "Bindings for Python 3.11 plugins" conflicts python38 python39 python310 python312 {
+variant python311 description "Bindings for Python 3.11 plugins" conflicts python39 python310 python312 python313 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.pkg_config_path-append \
                             ${frameworks_dir}/Python.framework/Versions/3.11/lib/pkgconfig
     depends_lib-append      port:python311
 }
 
-variant python312 description "Bindings for Python 3.12 plugins" conflicts python38 python39 python310 python311 {
+variant python312 description "Bindings for Python 3.12 plugins" conflicts python39 python310 python311 python313 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.pkg_config_path-append \
                             ${frameworks_dir}/Python.framework/Versions/3.12/lib/pkgconfig
     depends_lib-append      port:python312
 }
 
-variant ruby requires ruby32 description {Compatibility variant, requires +ruby32} {}
-
-variant ruby30 description "Bindings for Ruby 3.0 plugins" conflicts ruby31 ruby32 {
-    configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
-    configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
-    depends_lib-append      port:ruby30
-
-    patchfiles-append       FindRuby.cmake.diff
+variant python313 description "Bindings for Python 3.13 plugins" conflicts python39 python310 python311 python312 {
+    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    configure.pkg_config_path-append \
+                            ${frameworks_dir}/Python.framework/Versions/3.13/lib/pkgconfig
+    depends_lib-append      port:python313
 }
 
-variant ruby31 description "Bindings for Ruby 3.1 plugins" conflicts ruby30 ruby32 {
+variant ruby requires ruby33 description {Compatibility variant, requires +ruby33} {}
+
+variant ruby31 description "Bindings for Ruby 3.1 plugins" conflicts ruby32 ruby33 {
     configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
-    configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
     depends_lib-append      port:ruby31
 
     patchfiles-append       FindRuby.cmake.diff
 }
 
-variant ruby32 description "Bindings for Ruby 3.2 plugins" conflicts ruby30 ruby31 {
+variant ruby32 description "Bindings for Ruby 3.2 plugins" conflicts ruby31 ruby33 {
     configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
-    configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
     depends_lib-append      port:ruby32
+
+    patchfiles-append       FindRuby.cmake.diff
+}
+
+variant ruby33 description "Bindings for Ruby 3.3 plugins" conflicts ruby31 ruby32 {
+    configure.args-replace  -DENABLE_RUBY=OFF -DENABLE_RUBY=ON
+    depends_lib-append      port:ruby33
 
     patchfiles-append       FindRuby.cmake.diff
 }
@@ -144,12 +141,12 @@ post-patch {
     # specify Ruby version for CMake to find and use
     set patchfile ${worksrcpath}/cmake/FindRuby.cmake
 
-    if {[variant_isset ruby30]} {
-        reinplace -E {s|pkg_search_module\(RUBY (.*)\)|pkg_search_module\(RUBY ruby-3.0\)|g} ${patchfile}
-    } elseif {[variant_isset ruby31]} {
+    if {[variant_isset ruby31]} {
         reinplace -E {s|pkg_search_module\(RUBY (.*)\)|pkg_search_module\(RUBY ruby-3.1\)|g} ${patchfile}
     } elseif {[variant_isset ruby32]} {
         reinplace -E {s|pkg_search_module\(RUBY (.*)\)|pkg_search_module\(RUBY ruby-3.2\)|g} ${patchfile}
+    } elseif {[variant_isset ruby33]} {
+        reinplace -E {s|pkg_search_module\(RUBY (.*)\)|pkg_search_module\(RUBY ruby-3.3\)|g} ${patchfile}
     }
 }
 


### PR DESCRIPTION
#### Description
weechat: update to 4.4.3, update Python and Ruby variants
* remove variants for EOL ruby-3.0, python-3.8

* add variants for ruby-3.3, python-3.13

* Ruby variants: no longer need to set PKG_CONFIG_PATH, which was also interfering with Python's PKG_CONFIG_PATH if both a Ruby and Python variant was specified

* update maintainer email

###### Tested on
macOS 12.7.6 21H1320 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
