### PR TITLE
sigil-qt4: revbump after xercesc3 update

### DIFF
--- a/editors/sigil-qt4/Portfile
+++ b/editors/sigil-qt4/Portfile
@@ -26,7 +26,8 @@ description             Sigil, the ePub editor
 long_description        Sigil is a multi-platform WYSIWYG ebook editor. \
                         It is designed to edit books in ePub format.
 
-patchfiles-append       patch-newboost.diff
+patchfiles-append       patch-newboost.diff \
+                        patch-sys_icache_invalidate.diff
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 

--- a/editors/sigil-qt4/Portfile
+++ b/editors/sigil-qt4/Portfile
@@ -10,7 +10,7 @@ name                    sigil-qt4
 conflicts               sigil
 
 github.setup            Sigil-Ebook Sigil 0.6.2
-revision                0
+revision                1
 checksums               rmd160  2d0d67d5d27a7e868151d6efd2f0219233dec62f \
                         sha256  707506840d6ca90e2a794914700ecf347c090b28883e10222018a4fd27c00fbd \
                         size    10488473

--- a/editors/sigil-qt4/files/patch-sys_icache_invalidate.diff
+++ b/editors/sigil-qt4/files/patch-sys_icache_invalidate.diff
@@ -1,0 +1,11 @@
+--- src/pcre/sljit/sljitConfigInternal.h
++++ src/pcre/sljit/sljitConfigInternal.h	2024-11-13 05:45:22.000000000 +0800
+@@ -200,7 +200,7 @@
+ #define SLJIT_CACHE_FLUSH(from, to)
+ 
+ #elif defined __APPLE__
+-
++#include <libkern/OSCacheControl.h>
+ /* Supported by all macs since Mac OS 10.5.
+    However, it does not work on non-jailbroken iOS devices,
+    although the compilation is successful. */


### PR DESCRIPTION
#### Description

Unbreak the port after `xercesc3` update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
