### PR TITLE
py-numpy: upstream fix for f2py; py-scipy: drop patched in flag, fix reinplace

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                py-numpy
 version             1.26.4
-revision            1
+revision            2
 
 # stealth update recipe, due to swith to PyPI
 dist_subdir         ${name}/${version}_1
@@ -53,6 +53,10 @@ if {${name} ne ${subport}} {
     # will be set to 13.0 in MacPorts eventhough the macOS version is, for example, 13.3
     patchfiles-append \
                     patch_vendored-meson-meson-mesonbuild-dependencies-blas_lapack.py.diff
+
+    # https://github.com/numpy/numpy/pull/27729
+    patchfiles-append \
+                    patch-threads.diff
 
     post-patch {
         # https://trac.macports.org/ticket/46392

--- a/python/py-numpy/files/patch-threads.diff
+++ b/python/py-numpy/files/patch-threads.diff
@@ -1,0 +1,46 @@
+--- numpy/f2py/cfuncs.py	2024-02-06 05:17:48.000000000 +0800
++++ numpy/f2py/cfuncs.py	2024-11-13 10:02:16.000000000 +0800
+@@ -540,24 +540,31 @@
+ #error You need to install NumPy version 0.13 or higher. See https://scipy.org/install.html
+ #endif
+ """
++
++# Defining the correct value to indicate thread-local storage in C without
++# running a compile-time check (which we have no control over in generated
++# code used outside of NumPy) is hard. Therefore we support overriding this
++# via an external define - the f2py-using package can them use the same
++# compile-time checks as we use for `NPY_TLS` when building NumPy.
++#
++# __STDC_NO_THREADS__ should not be coupled to the availability of _Thread_local.
++# In case we get a bug report, guard it with __STDC_NO_THREADS__ after all.
++#
++# `thread_local` has become a keyword in C23, but don't try to use that yet
++# (too new, doing so while C23 support is preliminary will likely cause more
++#  problems than it solves).
++#
++# Note: do not try to use `threads.h`, its availability is very low
++# *and* threads.h isn't actually used where `F2PY_THREAD_LOCAL_DECL` is
++# in the generated code. See gh-27718 for more details.
+ cppmacros["F2PY_THREAD_LOCAL_DECL"] = """
+ #ifndef F2PY_THREAD_LOCAL_DECL
+ #if defined(_MSC_VER)
+ #define F2PY_THREAD_LOCAL_DECL __declspec(thread)
+ #elif defined(NPY_OS_MINGW)
+ #define F2PY_THREAD_LOCAL_DECL __thread
+-#elif defined(__STDC_VERSION__) \\
+-      && (__STDC_VERSION__ >= 201112L) \\
+-      && !defined(__STDC_NO_THREADS__) \\
+-      && (!defined(__GLIBC__) || __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 12)) \\
+-      && !defined(NPY_OS_OPENBSD) && !defined(NPY_OS_HAIKU)
+-/* __STDC_NO_THREADS__ was first defined in a maintenance release of glibc 2.12,
+-   see https://lists.gnu.org/archive/html/commit-hurd/2012-07/msg00180.html,
+-   so `!defined(__STDC_NO_THREADS__)` may give false positive for the existence
+-   of `threads.h` when using an older release of glibc 2.12
+-   See gh-19437 for details on OpenBSD */
+-#include <threads.h>
+-#define F2PY_THREAD_LOCAL_DECL thread_local
++#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
++#define F2PY_THREAD_LOCAL_DECL _Thread_local
+ #elif defined(__GNUC__) \\
+       && (__GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ >= 4)))
+ #define F2PY_THREAD_LOCAL_DECL __thread

--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -9,7 +9,7 @@ PortGroup               python 1.0
 
 name                    py-scipy
 version                 1.14.1
-revision                0
+revision                1
 
 checksums               rmd160  a47254b77f71db2dc36dcf4ad98eb668cc75667e \
                         sha256  5a275584e726026a5699459aa72f828a610821006228e841b94275c4a7c08417 \
@@ -45,10 +45,8 @@ if {${name} ne ${subport}} {
     boost.version       1.81
 
     if {${os.platform} eq "darwin" && [string match *gcc* ${configure.compiler}]} {
-        # scipy/linalg/_flapackmodule.c:90:10: fatal error: threads.h: No such file or directory
-        # See: https://github.com/scipy/scipy/issues/14364
-        #      https://github.com/numpy/numpy/issues/27718
-        #      https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53769
+        # https://github.com/scipy/scipy/pull/21861
+        # https://github.com/scipy/scipy/pull/21870
         patchfiles-append \
                         0001-Fix-cmath.patch
 

--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -66,6 +66,7 @@ if {${name} ne ${subport}} {
                         0003-Use-legacysupport-manually-for-strnlen.patch
         post-patch {
             reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/scipy/io/meson.build \
+                        ${worksrcpath}/scipy/optimize/meson.build \
                         ${worksrcpath}/scipy/sparse/linalg/_eigen/arpack/meson.build \
                         ${worksrcpath}/scipy/sparse/linalg/_propack/meson.build
         }

--- a/python/py-scipy/files/0002-patch-extra-flags.patch
+++ b/python/py-scipy/files/0002-patch-extra-flags.patch
@@ -1,6 +1,6 @@
 --- meson.build	2024-08-21 06:43:12.000000000 +0800
-+++ meson.build	2024-11-10 14:02:31.000000000 +0800
-@@ -88,10 +88,8 @@
++++ meson.build	2024-11-13 10:15:29.000000000 +0800
+@@ -88,10 +88,7 @@
  endif
  
  if host_machine.system() == 'darwin'
@@ -8,7 +8,6 @@
 -    # New linker introduced in macOS 14 not working yet, see gh-19357 and gh-19387
 -    add_project_link_arguments('-Wl,-ld_classic', language : ['c', 'cpp', 'fortran'])
 -  endif
-+  add_project_arguments('-D__STDC_NO_THREADS__', language : ['c', 'cpp'])
 +  add_project_arguments('-Wno-error=incompatible-pointer-types', language: 'c')
    if cc.has_link_argument('-Wl,-dead_strip')
      # Allow linker to strip unused symbols


### PR DESCRIPTION
#### Description

@reneeotten A follow-up

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
