### PR TITLE
xml-security-c: fix after xercesc3 update

### DIFF
--- a/security/xml-security-c/Portfile
+++ b/security/xml-security-c/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                xml-security-c
 version             2.0.4
+revision            1
 categories          security xml textproc shibboleth
 license             Apache-2
 maintainers         {snc @nerdling} {scantor @scantor}
@@ -14,9 +15,9 @@ long_description    The C++ library is an implementation of the XML Digital \
                     Linux, FreeBSD, NetBSD and Windows.
 homepage            http://santuario.apache.org/
 
-platforms           darwin
-depends_build       port:pkgconfig
-depends_lib         port:xercesc3 path:lib/libssl.dylib:openssl
+depends_build       path:bin/pkg-config:pkgconfig
+depends_lib         path:lib/libssl.dylib:openssl \
+                    port:xercesc3
 
 master_sites        apache:santuario/c-library/
 use_bzip2           yes
@@ -28,6 +29,9 @@ checksums           rmd160  eaa83db36dff1f6655621294c4db89a3648f18c7 \
 configure.args      --without-xalan \
                     --with-openssl \
                     --without-nss
+
+# error: cstdint: No such file or directory
+compiler.cxx_standard   2011
 
 if {[variant_isset universal]} {
     depends_lib-append  port:libtool


### PR DESCRIPTION
#### Description

Requires revbump, since broken by xercesc3 update. Also add a minor fix along.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
