### PR TITLE
unrar: fix build when ccache is used

### DIFF
--- a/archivers/unrar/Portfile
+++ b/archivers/unrar/Portfile
@@ -30,11 +30,7 @@ worksrcdir          ${name}
 
 use_configure       no
 
-variant universal {}
-
-if {[tbool configure.ccache]} {
-    configure.cxx "ccache ${configure.cxx}"
-}
+variant universal   {}
 
 # error: unknown type name 'constexpr'
 compiler.cxx_standard \
@@ -44,7 +40,12 @@ configure.cxxflags-append \
 
 # error: invalid cpu feature string for builtin
 # uses newer intrinsic functions
-compiler.blacklist  {*gcc-[3-4].*} {clang < 900}
+compiler.blacklist  {clang < 900}
+
+# Should go after blacklists.
+if {[tbool configure.ccache]} {
+    configure.cxx "ccache ${configure.cxx}"
+}
 
 set cxx_stdlibflags {}
 if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {


### PR DESCRIPTION
#### Description

The compiler choice gets wrong when ccache is active. Fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
