### PR TITLE
xercesc3: Fix _xercesc_messages_3_2_dat symbol problem

### DIFF
--- a/textproc/xercesc3/Portfile
+++ b/textproc/xercesc3/Portfile
@@ -1,6 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+# https://trac.macports.org/ticket/71310
+PortGroup           deprecated 1.0
+deprecated.upstream_support no
 
 name                xercesc3
 # Minor updates will require rev-bumping dependents

--- a/textproc/xercesc3/Portfile
+++ b/textproc/xercesc3/Portfile
@@ -8,7 +8,7 @@ deprecated.upstream_support no
 name                xercesc3
 # Minor updates will require rev-bumping dependents
 version             3.3.0
-revision            0
+revision            1
 categories          textproc xml shibboleth
 maintainers         {snc @nerdling} {scantor @scantor} openmaintainer
 license             Apache-2
@@ -23,6 +23,8 @@ homepage            https://xerces.apache.org/xerces-c/
 master_sites        apache:xerces/c/3/sources/
 distname            xerces-c-${version}
 use_bzip2           yes
+
+patchfiles          ICUMsgLoader.cpp.patch
 
 configure.args      --disable-silent-rules \
                     --enable-static \

--- a/textproc/xercesc3/files/ICUMsgLoader.cpp.patch
+++ b/textproc/xercesc3/files/ICUMsgLoader.cpp.patch
@@ -1,0 +1,20 @@
+Fix:
+
+dyld[…]: symbol not found in flat namespace (_xercesc_messages_3_2_dat)
+
+https://issues.apache.org/jira/browse/XERCESC-2255
+https://issues.apache.org/jira/browse/XERCESC-2257
+https://github.com/apache/xerces-c/commit/2bd4bfd2e0ac177c539054f29c3bf907d9ec1f6c
+--- src/xercesc/util/MsgLoaders/ICU/ICUMsgLoader.cpp.orig	2023-12-06 10:57:34.000000000 -0600
++++ src/xercesc/util/MsgLoaders/ICU/ICUMsgLoader.cpp	2024-11-13 19:52:23.000000000 -0600
+@@ -51,8 +51,8 @@
+  *  The application (this *.cpp) references that symbol here, and will pass the data address to ICU, which
+  *  will then  be able to fetch resources from the data.
+  */
+-#define ENTRY_POINT xercesc_messages_3_2_dat
+-#define BUNDLE_NAME "xercesc_messages_3_2"
++#define ENTRY_POINT xercesc_messages_3_3_dat
++#define BUNDLE_NAME "xercesc_messages_3_3"
+ 
+ extern "C" void U_IMPORT *ENTRY_POINT;
+ 


### PR DESCRIPTION
#### Description

For version 3.3.0 it should be `_xercesc_messages_3_3_dat`.

Closes: https://trac.macports.org/ticket/71304

Ports that link with the library do not need another revbump, but after merging this PR we should schedule new builds of all those ports on the buildbot workers in case they had failed to build because of this problem.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
