### PR TITLE
libnick, parabolic: new ports and their deps

### DIFF
--- a/devel/libnick/Portfile
+++ b/devel/libnick/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           boost 1.0
+PortGroup           cmake 1.1
+PortGroup           conflicts_build 1.0
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+boost.version       1.81
+
+github.setup        NickvisionApps libnick 2024.11.1
+revision            0
+categories          devel
+license             GPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Cross-platform base for native Nickvision applications
+long_description    {*}${description}
+checksums           rmd160  96bbe8fbe2a1087c44fb7bc07a0ce12707ace3fa \
+                    sha256  6b80c2b00822f6f80507096d547d3499f619941e6083df85275b35dd039951bf \
+                    size    2570471
+github.tarball_from archive
+
+depends_build-append \
+                    port:gtest \
+                    port:maddy-parser \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  port:curl \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    port:gettext-runtime
+
+compiler.cxx_standard   2020
+
+# https://github.com/NickvisionApps/libnick/issues/50
+conflicts_build     boost
+
+variant secret description "Use libsecret instead of Apple keychain" {
+    depends_lib-append \
+                    port:libsecret
+    configure.args-append \
+                    -DUSE_LIBSECRET=ON
+}
+
+if {${os.platform} ne "darwin" || ${os.major} < 12} {
+    default_variants-append \
+                    +secret
+}

--- a/devel/maddy-parser/Portfile
+++ b/devel/maddy-parser/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+name                maddy-parser
+github.setup        progsource maddy 1.3.0
+revision            0
+categories          devel
+platforms           any
+license             MIT
+maintainers         nomaintainer
+description         C++ markdown to HTML header-only parser library
+long_description    {*}${description}
+checksums           rmd160  8104fb3640c9e1d7066e8d01172932c145a248bd \
+                    sha256  561681f8c8d2b998c153cda734107a0bc1dea4bb0df69fd813922da63fa9f3e7 \
+                    size    26357
+github.tarball_from archive
+supported_archs     noarch
+
+compiler.cxx_standard   2014
+
+configure.args-append   -DMADDY_BUILD_WITH_TESTS=OFF
+
+destroot {
+    copy ${worksrcpath}/include/maddy ${destroot}${prefix}/include/
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} CHANGELOG.md LICENSE README.md ${destroot}${docdir}
+}

--- a/gnome/blueprint-compiler/Portfile
+++ b/gnome/blueprint-compiler/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           meson 1.0
+
+gitlab.instance     https://gitlab.gnome.org
+gitlab.setup        jwestman blueprint-compiler 0.14.0 v
+revision            0
+categories          gnome devel
+platforms           {darwin any}
+license             GPL-3
+maintainers         nomaintainer
+supported_archs     noarch
+description         Markup language for GTK user interfaces
+long_description    {*}${description}
+
+checksums           rmd160  c5a99a4d8b18a5e17874c42442cf7a49a84925cf \
+                    sha256  a4e6fa362a16d9f7f95e229c836e9ca2fd2df803b1d2b453f6cf640c127aeeff \
+                    size    95760
+
+set py_ver          3.12
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+
+depends_lib-append  port:python${py_ver_nodot}
+
+depends_run-append  port:py${py_ver_nodot}-gobject3
+
+configure.python    ${prefix}/bin/python${py_ver}
+
+post-patch {
+    reinplace "s|python3|${configure.python}|" ${worksrcpath}/meson.build
+    reinplace "s|/usr/bin/env python3|${configure.python}|" ${worksrcpath}/blueprint-compiler.py
+}

--- a/net/parabolic/Portfile
+++ b/net/parabolic/Portfile
@@ -1,0 +1,89 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           active_variants 1.1
+PortGroup           boost 1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+boost.version       1.81
+
+name                parabolic
+github.setup        NickvisionApps Parabolic 2024.11.1
+revision            0
+categories          net gnome multimedia
+license             GPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Download web video and audio
+long_description    GTK-based app to download video and audio \
+                    from the web.
+checksums           rmd160  7d7e0f92e916e0a4bd65704ef31a2f2ab19bf78b \
+                    sha256  d334c52fb23b7e56ae369b59276c0748e95537c2ed4b7d0f229c2e63a2b34228 \
+                    size    4371049
+github.tarball_from archive
+
+depends_build-append \
+                    port:blueprint-compiler \
+                    port:gettext \
+                    port:itstool \
+                    path:bin/pkg-config:pkgconfig \
+                    port:yelp-tools
+
+depends_lib-append  port:desktop-file-utils \
+                    port:gettext-runtime \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    path:lib/pkgconfig/gtk+-4.0.pc:gtk4 \
+                    port:libadwaita \
+                    port:libepoxy \
+                    port:libnick \
+                    port:libxmlxx5
+
+compiler.cxx_standard   2020
+
+configure.args-append \
+                    -DCMAKE_INSTALL_LIBDIR=${prefix}/libexec/${name} \
+                    -DUI_PLATFORM=gnome
+
+variant secret description "Use libsecret instead of Apple keychain" {
+    require_active_variants \
+                    libnick secret
+
+    depends_lib-append \
+                    port:libsecret
+    configure.args-append \
+                    -DUSE_LIBSECRET=ON
+}
+
+if {${os.platform} ne "darwin" || ${os.major} < 12} {
+    default_variants-append \
+                    +secret
+}
+
+post-destroot {
+    # In a case of libstdc++ we install our wrapper to fix malloc errors.
+    # Otherwise we just rename existing wrapper so that it is recognizable.
+    # The real binary sits in libexec.
+    if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libc++"} {
+        delete ${destroot}${prefix}/bin/org.nickvision.tubeconverter
+        copy ${filespath}/${name} ${destroot}${prefix}/bin/
+        reinplace "s|@PREFIX@|${prefix}|g" ${destroot}${prefix}/bin/${name}
+        file attributes ${destroot}${prefix}/bin/${name} -permissions 0755
+    } else {
+        move ${destroot}${prefix}/bin/org.nickvision.tubeconverter \
+            ${destroot}${prefix}/bin/${name}
+    }
+}
+
+post-activate {
+    system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
+    system "${prefix}/bin/gtk4-update-icon-cache -f -t ${prefix}/share/icons/hicolor"
+}
+
+# https://trac.macports.org/ticket/70137
+notes "
+If you get an error upon launching the app,\
+try setting GSK_RENDERER=cairo in the environment.\
+Legacy macOS versions may also need LIBGL_ALLOW_SOFTWARE=true.\
+These can be set on a command line or via a shell config file.
+"

--- a/net/parabolic/files/parabolic
+++ b/net/parabolic/files/parabolic
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ -n "$DYLD_LIBRARY_PATH" ]; then
+   DYLD_LIBRARY_PATH=@PREFIX@/lib/libgcc:${DYLD_LIBRARY_PATH}
+else
+   DYLD_LIBRARY_PATH=@PREFIX@/lib/libgcc
+fi
+export DYLD_LIBRARY_PATH
+
+exec @PREFIX@/libexec/parabolic/org.nickvision.tubeconverter/org.nickvision.tubeconverter.gnome "$@"


### PR DESCRIPTION
#### Description

A port for this library: https://github.com/NickvisionApps/libnick
It will allow to build some useful apps which depend on it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7
Xcode 15.4

macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
