### PR TITLE
uv: Update to 0.5.2

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.5.1
+github.setup            astral-sh uv 0.5.2
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  ba7f4dacdb563046aba885cdc3177888f9f6b594 \
-                        sha256  e8397ccea820e2b83bb5b1017525a1f5c599a53cddf424156412214e17b2ae36 \
-                        size    2839701
+                        rmd160  80b4baa10e9b05fc1d6e7bee41f228591354971f \
+                        sha256  14b4ed7c955acdf4ae2b47537addbefb8a486e47cada903970f10e28f40b518c \
+                        size    2886231
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -67,13 +67,14 @@ cargo.crates \
     addr2line                       0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
     adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
+    allocator-api2                  0.2.20  45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
-    anstream                        0.6.17  23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338 \
+    anstream                        0.6.18  8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b \
     anstyle                         1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
     anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                   3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
-    anyhow                          1.0.92  74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13 \
+    anyhow                          1.0.93  4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775 \
     arrayref                         0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
@@ -82,7 +83,7 @@ cargo.crates \
     async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
     async-compression               0.4.17  0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857 \
     async-trait                     0.1.83  721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd \
-    async_http_range_reader          0.9.0  4015e7130cf870da1c64a9c7ba474f4b3772a530edbeb05f8358bc9a02f8e505 \
+    async_http_range_reader          0.9.1  2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     axoasset                         1.0.1  90f16d4ba2365a6f9b4394b369597b9bc00a1651db758edbe6d63a34879b9024 \
@@ -97,7 +98,7 @@ cargo.crates \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    boxcar                           0.2.6  fba19c552ee63cb6646b75e1166d1bdb8a6d34a6d19e319dec88c8adadff2db3 \
+    boxcar                           0.2.7  7f839cdf7e2d3198ac6ca003fd8ebc61715755f41c1cad15ff13df67531e00ed \
     bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytecheck                        0.8.0  50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f \
@@ -146,7 +147,7 @@ cargo.crates \
     crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
-    csv                              1.3.0  ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe \
+    csv                              1.3.1  acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf \
     csv-core                        0.1.11  5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70 \
     ctrlc                            3.4.5  90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3 \
     dashmap                          6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
@@ -159,6 +160,7 @@ cargo.crates \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     dirs                             5.0.1  44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225 \
     dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
+    displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
     dotenvy                         0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
@@ -180,6 +182,7 @@ cargo.crates \
     flate2                          1.0.34  a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0 \
     float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foldhash                         0.1.3  f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2 \
     fontconfig-parser                0.5.7  c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7 \
     fontdb                          0.12.0  ff20bef7942a72af07104346154a70a70b089c572e454b41bef6eb6cb10e9c06 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
@@ -206,7 +209,7 @@ cargo.crates \
     h2                               0.4.6  524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205 \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashbrown                       0.15.0  1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb \
+    hashbrown                       0.15.1  3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
@@ -223,7 +226,18 @@ cargo.crates \
     hyper                            1.5.0  bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a \
     hyper-rustls                    0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
     hyper-util                      0.1.10  df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4 \
-    idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
+    icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
+    icu_locid                        1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
+    icu_locid_transform              1.5.0  01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e \
+    icu_locid_transform_data         1.5.0  fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e \
+    icu_normalizer                   1.5.0  19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f \
+    icu_normalizer_data              1.5.0  f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516 \
+    icu_properties                   1.5.1  93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5 \
+    icu_properties_data              1.5.0  67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569 \
+    icu_provider                     1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
+    icu_provider_macros              1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
+    idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
+    idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
     image                           0.25.4  bc144d44a31d753b02ce64093d532f55ff8dc4ebf2ffb8a63c0dda691385acae \
     imagesize                       0.11.0  b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf \
@@ -256,6 +270,7 @@ cargo.crates \
     libz-ng-sys                     1.1.16  4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438 \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
+    litemap                          0.7.3  643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
     log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
     lzma-sys                        0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
@@ -345,7 +360,7 @@ cargo.crates \
     redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
     redox_syscall                    0.5.7  9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f \
     redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
-    reflink-copy                    0.1.19  dc31414597d1cd7fdd2422798b7652a6329dda0fe0219e6335a13d5bcaa9aeb6 \
+    reflink-copy                    0.1.20  17400ed684c3a0615932f00c271ae3eea13e47056a1455821995122348ab6438 \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                   0.4.8  368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3 \
@@ -353,6 +368,8 @@ cargo.crates \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     rend                             0.5.2  a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215 \
     reqwest                         0.12.9  a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f \
+    reqwest-middleware               0.4.0  d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3 \
+    reqwest-retry                    0.7.0  29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178 \
     resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
     retry-policies                   0.4.0  5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c \
     rgb                             0.8.50  57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a \
@@ -367,7 +384,7 @@ cargo.crates \
     rust-netrc                       0.1.2  7e98097f62769f92dbf95fb51f71c0a68ec18a4ee2e70e0d3e4f47ac005d63e9 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
-    rustix                         0.38.38  aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a \
+    rustix                         0.38.40  99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0 \
     rustls                         0.23.16  eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e \
     rustls-native-certs              0.8.0  fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
@@ -411,6 +428,7 @@ cargo.crates \
     socket2                          0.5.7  ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c \
     spdx                            0.10.6  47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
+    stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     strict-num                       0.1.1  6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
@@ -423,12 +441,13 @@ cargo.crates \
     svgtypes                        0.10.0  98ffacedcdcf1da6579c907279b4f3c5492fbce99fbbf227f5ed270a589c2765 \
     syn                             2.0.87  25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d \
     sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
+    synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     tagu                             0.1.6  eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a \
     tar                             0.4.43  c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6 \
     target-lexicon                 0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
     temp-env                         0.3.6  96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050 \
-    tempfile                        3.13.0  f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b \
+    tempfile                        3.14.0  28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
     terminal_size                    0.4.0  4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef \
     termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
@@ -445,10 +464,11 @@ cargo.crates \
     tikv-jemallocator                0.6.0  4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865 \
     tiny-skia                        0.8.4  df8493a203431061e901613751931f047d1971337153f96d0e5e363d6dbf6a67 \
     tiny-skia-path                   0.8.4  adbfb5d3f3dd57a0e11d12f4f13d4ebbbc1b5c15b7ab0a156d030b21da5f677c \
+    tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.41.0  145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb \
+    tokio                           1.41.1  22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33 \
     tokio-macros                     2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
     tokio-rustls                    0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
     tokio-socks                      0.5.2  0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f \
@@ -480,17 +500,18 @@ cargo.crates \
     unicode-general-category         0.6.0  2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7 \
     unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
     unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
-    unicode-normalization           0.1.24  5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956 \
     unicode-script                   0.5.7  9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f \
     unicode-vo                       0.1.0  b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94 \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unscanny                         0.1.0  e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
+    url                              2.5.3  8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
     usvg                            0.29.0  63b6bb4e62619d9f68aa2d8a823fea2bff302340a1f2d45c264d5b0be170832e \
     usvg-text-layout                0.29.0  195386e01bc35f860db024de275a76e7a31afdf975d18beb6d0e44764118b4db \
+    utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8-width                       0.1.7  86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3 \
+    utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     uuid                            1.11.0  f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a \
     valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
@@ -555,13 +576,21 @@ cargo.crates \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     winsafe                         0.0.22  7d6ad6cbd9c6e5144971e326303f0e453b61d82e4f72067fccf23106bccd8437 \
     wiremock                         0.6.2  7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646 \
+    write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
+    writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
     xmlparser                       0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
+    yoke                             0.7.4  6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5 \
+    yoke-derive                      0.7.4  28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95 \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
     zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
+    zerofrom                         0.1.4  91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55 \
+    zerofrom-derive                  0.1.4  0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5 \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
+    zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
+    zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
     zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
     zstd                            0.13.2  fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9 \
     zstd-safe                        7.2.1  54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.5.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
