### PR TITLE
libgcrypt: Avoid opportunistic use of ggrep

### DIFF
--- a/devel/libgcrypt/Portfile
+++ b/devel/libgcrypt/Portfile
@@ -8,7 +8,7 @@ PortGroup       muniversal 1.0
 
 name            libgcrypt
 version         1.11.0
-revision        0
+revision        1
 categories      devel security
 # libs are LGPL, executables and docs are GPL
 license         {GPL-2+ LGPL-2.1+}
@@ -32,6 +32,14 @@ checksums       rmd160  6f9bd06fa04fdcb397a349a4ecdc6fcc25ac1bb5 \
 depends_lib     port:libgpg-error
 
 configure.args  --disable-asm
+
+# libgcrypt detects GNU grep in $prefix/bin/ggrep when it is installed and uses
+# it in its libgcrypt-config file; If GNU grep is later uninstalled, building
+# against libgcrypt will fail. This can either be fixed by not relying on
+# $prefix/bin/ggrep, or by declaring a runtime dependency on the grep port.
+# This does the former.
+configure.args-append \
+                GREP="/usr/bin/grep"
 
 # Build fix for compilers that default to c99 (clang)
 configure.cflags-append "-std=gnu89"


### PR DESCRIPTION
#### Description

This fixes the build of gnupg2 in trace mode.

Closes: https://trac.macports.org/ticket/71317

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?