### PR TITLE
google-java-format: update to 1.24.0

### DIFF
--- a/java/google-java-format/Portfile
+++ b/java/google-java-format/Portfile
@@ -2,9 +2,8 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           java 1.0
 
-github.setup        google google-java-format 1.22.0 v
+github.setup        google google-java-format 1.24.0 v
 revision            0
 
 maintainers         {@danchr danchr} openmaintainer
@@ -14,16 +13,16 @@ categories          java devel textproc
 description         Reformat Java source code to comply with Google Java Style
 long_description    {*}${description}
 
-checksums           rmd160  e78583949067e08bfd4115eabac01e83cf3cbb70 \
-                    sha256  81b5e7f100beec5b5d9e1e7cae48d1852b010df76e6b80c9b35a4cb3a18a769d \
-                    size    207311
+checksums           rmd160  e9bbbdf963e63329d5b49c165adbc720542a44bd \
+                    sha256  3346e4fdb4d0820988b3aaab9d14aec07030d4ddbd5bf7b62b5ebe9a6933e497 \
+                    size    208303
 
 depends_build       bin:mvn3:maven3 \
                     port:openjdk21-graalvm
 
 use_configure       no
 
-java.home           ${prefix}/Library/Java/JavaVirtualMachines/jdk-21-oracle-graalvm-community.jdk
+set java_home       ${prefix}/Library/Java/JavaVirtualMachines/jdk-21-oracle-graalvm-community.jdk/Contents/Home
 
 set maven_local_repository ${worksrcpath}/.m2/repository
 
@@ -33,11 +32,11 @@ pre-build {
 
 build.cmd           mvn3
 build.target        "package"
+build.env-append    JAVA_HOME=${java_home}
 build.pre_args-append \
                     -Dmaven.repo.local=${maven_local_repository} \
                     -DskipTests -Pnative
 build.dir           ${worksrcpath}/core
-
 
 destroot {
     # Ensure needed directories
@@ -52,5 +51,3 @@ destroot {
     xinstall -m 755 ${worksrcpath}/core/target/${name} \
         ${destroot}${prefix}/bin/${name}
 }
-
-


### PR DESCRIPTION
#### Description

Update google-java-format to 1.24.
Fix build (previous solution did not work reliably when multiple JDK's are installed on the system).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1
Xcode 16.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
