### PR TITLE
lldb-{12…19,devel}: Python is a lib dependency

### DIFF
--- a/lang/llvm-12/Portfile
+++ b/lang/llvm-12/Portfile
@@ -33,7 +33,7 @@ use_xz                  yes
 name                    llvm-${llvm_version}
 revision                3
 subport                 clang-${llvm_version} {revision 4}
-subport                 lldb-${llvm_version}  {revision 3}
+subport                 lldb-${llvm_version}  {revision 4}
 dist_subdir             llvm
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -255,7 +255,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     description         the LLVM debugger
     long_description    lldb is the "LLVM native" debugger.
 
-    depends_lib-append  port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
+    depends_lib-append  port:libedit port:libffi port:ncurses port:python${py_ver_nodot} path:lib/libxar.dylib:xar port:zlib
     depends_lib-append  port:llvm-${llvm_version} port:clang-${llvm_version}
     depends_build-append port:swig-python path:bin/doxygen:doxygen
     depends_run-append  port:lldb_select

--- a/lang/llvm-13/Portfile
+++ b/lang/llvm-13/Portfile
@@ -27,7 +27,7 @@ name                    llvm-${llvm_version}
 revision                2
 subport                 mlir-${llvm_version}  { revision 0 }
 subport                 clang-${llvm_version} { revision 4 }
-subport                 lldb-${llvm_version}  { revision 2 }
+subport                 lldb-${llvm_version}  { revision 3 }
 subport                 flang-${llvm_version} { revision 1 }
 
 checksums               rmd160  ae542658ad0e97b4bf088b1cfba66fa10b9b52d8 \
@@ -368,7 +368,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     description         the LLVM debugger
     long_description    lldb is the "LLVM native" debugger.
 
-    depends_lib-append  port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
+    depends_lib-append  port:libedit port:libffi port:ncurses port:python${py_ver_nodot} path:lib/libxar.dylib:xar port:zlib
     depends_lib-append  port:llvm-${llvm_version} port:clang-${llvm_version}
     depends_build-append port:swig-python path:bin/doxygen:doxygen
     depends_run-append  port:lldb_select

--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -28,7 +28,7 @@ name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision 0 }
 subport                 clang-${llvm_version} { revision 3 }
-subport                 lldb-${llvm_version}  { revision 1 }
+subport                 lldb-${llvm_version}  { revision 2 }
 subport                 flang-${llvm_version} { revision 1 }
 
 checksums               rmd160  2b8b71bbb9fa5718c85f78924a0aa7e700cbd2ee \
@@ -375,7 +375,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     description         the LLVM debugger
     long_description    lldb is the "LLVM native" debugger.
 
-    depends_lib-append  port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
+    depends_lib-append  port:libedit port:libffi port:ncurses port:python${py_ver_nodot} path:lib/libxar.dylib:xar port:zlib
     depends_lib-append  port:llvm-${llvm_version} port:clang-${llvm_version}
     depends_build-append port:swig-python path:bin/doxygen:doxygen
     depends_run-append  port:lldb_select

--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -28,7 +28,7 @@ name                    llvm-${llvm_version}
 revision                1
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 3 ] }
-subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
+subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 2 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
 checksums               rmd160  a6d22eab24e3143461505c05786015b6f9769f31 \
@@ -369,7 +369,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     description         the LLVM debugger
     long_description    lldb is the "LLVM native" debugger.
 
-    depends_lib-append  port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
+    depends_lib-append  port:libedit port:libffi port:ncurses port:python${py_ver_nodot} path:lib/libxar.dylib:xar port:zlib
     depends_lib-append  port:llvm-${llvm_version} port:clang-${llvm_version}
     depends_build-append port:swig-python path:bin/doxygen:doxygen
     depends_run-append  port:lldb_select

--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -28,7 +28,7 @@ name                    llvm-${llvm_version}
 revision                1
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 5 ] }
-subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
+subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 2 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
 checksums               rmd160  b86eeac2e1dd052a182022109374372844934cfc \
@@ -394,7 +394,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     description         the LLVM debugger
     long_description    lldb is the "LLVM native" debugger.
 
-    depends_lib-append  port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
+    depends_lib-append  port:libedit port:libffi port:ncurses port:python${py_ver_nodot} path:lib/libxar.dylib:xar port:zlib
     depends_lib-append  port:llvm-${llvm_version} port:clang-${llvm_version}
     depends_build-append port:swig-python path:bin/doxygen:doxygen
     depends_run-append  port:lldb_select

--- a/lang/llvm-17/Portfile
+++ b/lang/llvm-17/Portfile
@@ -30,7 +30,7 @@ name                    llvm-${llvm_version}
 revision                1
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 2 ] }
-subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
+subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
 checksums               rmd160  10f44d5a8e3d0d5fc1a1961a8adaac945733ec07 \
@@ -383,7 +383,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     description         the LLVM debugger
     long_description    lldb is the "LLVM native" debugger.
 
-    depends_lib-append  port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
+    depends_lib-append  port:libedit port:libffi port:ncurses port:python${py_ver_nodot} path:lib/libxar.dylib:xar port:zlib
     depends_lib-append  port:llvm-${llvm_version} port:clang-${llvm_version}
     depends_build-append port:swig-python path:bin/doxygen:doxygen
     depends_run-append  port:lldb_select

--- a/lang/llvm-18/Portfile
+++ b/lang/llvm-18/Portfile
@@ -30,7 +30,7 @@ name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 3 ] }
-subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
+subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 
 checksums               rmd160  7f2aa95a10e79cd79b52933f0702d70185d7b862 \
@@ -336,7 +336,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     description         the LLVM debugger
     long_description    lldb is the "LLVM native" debugger.
 
-    depends_lib-append  port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
+    depends_lib-append  port:libedit port:libffi port:ncurses port:python${py_ver_nodot} path:lib/libxar.dylib:xar port:zlib
     depends_lib-append  port:llvm-${llvm_version} port:clang-${llvm_version}
     depends_build-append port:swig-python path:bin/doxygen:doxygen
     depends_run-append  port:lldb_select

--- a/lang/llvm-19/Portfile
+++ b/lang/llvm-19/Portfile
@@ -30,7 +30,7 @@ name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 0 ] }
-subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
+subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
 
 checksums               rmd160  0f450d97c264de3538fdaf2ea430907953fc2699 \
@@ -329,7 +329,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     description         the LLVM debugger
     long_description    lldb is the "LLVM native" debugger.
 
-    depends_lib-append  port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
+    depends_lib-append  port:libedit port:libffi port:ncurses port:python${py_ver_nodot} path:lib/libxar.dylib:xar port:zlib
     depends_lib-append  port:llvm-${llvm_version} port:clang-${llvm_version}
     depends_build-append port:swig-python path:bin/doxygen:doxygen
     depends_run-append  port:lldb_select

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -49,7 +49,7 @@ checksums               rmd160  004294eb7c8d2266a5198d542eaf0b7d6ae2a7b6 \
 name                    llvm-${llvm_version}
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 0 ] }
-subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
+subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
 
 dist_subdir             llvm
@@ -362,7 +362,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
     description         the LLVM debugger
     long_description    lldb is the "LLVM native" debugger.
 
-    depends_lib-append  port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
+    depends_lib-append  port:libedit port:libffi port:ncurses port:python${py_ver_nodot} path:lib/libxar.dylib:xar port:zlib
     depends_lib-append  port:llvm-${llvm_version} port:clang-${llvm_version}
     depends_build-append port:swig-python path:bin/doxygen:doxygen
 


### PR DESCRIPTION
Python was only specified as a build dependency, but for lldb, it’s actually a lib dependency. For example, after removing python310:

```
--->  Scanning binaries for linking errors
--->  Found 3 broken files, matching files to ports
--->  Found 3 broken ports, determining rebuild order
You can always run 'port rev-upgrade' again to fix errors.
The following ports will be rebuilt:
 lldb-12 @12.0.1
 lldb-13 @13.0.1
 lldb-14 @14.0.6
```

```
% lldb-mp-12
dyld[…]: Library not loaded: /opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python
  Referenced from: <…> /opt/local/libexec/llvm-12/lib/liblldb.12.0.1.dylib
  Reason: tried: '/opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python' (no such file), '/opt/local/Library/Frameworks/Python.framework/Versions/3.10/Python' (no such file)
zsh: abort	lldb-mp-12
```

This may be necessary for versions before lldb-12 as well, but I’ve only tested lldb-12 and later.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
