### PR TITLE
asio: update to 1.32.0

### DIFF
--- a/devel/asio/Portfile
+++ b/devel/asio/Portfile
@@ -6,12 +6,12 @@ PortGroup                   github 1.0
 PortGroup                   muniversal 1.0
 PortGroup                   openssl 1.0
 
-github.setup                chriskohlhoff asio 1-31-0 asio-
+github.setup                chriskohlhoff asio 1-32-0 asio-
 version                     [string map {- .} ${github.version}]
 revision                    0
-checksums                   rmd160  c5e7ef67433fffd4c31d2d281ef2cbfef07dfbe3 \
-                            sha256  530540f973498c2d297771af1bc852f69b27509bbb56bc7ac3309c928373286f \
-                            size    2857145
+checksums                   rmd160  0423632d026775525907daac33d66adbc0b11317 \
+                            sha256  f1b94b80eeb00bb63a3c8cef5047d4e409df4d8a3fe502305976965827d95672 \
+                            size    2857719
 github.tarball_from         archive
 
 license                     Boost-1
@@ -33,7 +33,7 @@ autoconf.cmd                ./autogen.sh
 depends_build-append        port:autoconf \
                             port:automake \
                             port:libtool \
-                            port:pkgconfig
+                            path:bin/pkg-config:pkgconfig
 
 compiler.cxx_standard       2014
 compiler.blacklist-append   {clang < 800}


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
