### PR TITLE
qt5-qtcreator: fix build with clang16+

### DIFF
--- a/devel/qt5-qtcreator/Portfile
+++ b/devel/qt5-qtcreator/Portfile
@@ -54,6 +54,10 @@ if { ${subport} eq ${name}  } {
     configure.env-append PATH=${python_framework}/bin:$env(PATH)
     build.env-append     PATH=${python_framework}/bin:$env(PATH)
 
+    # fixed in v10.0.2
+    # see https://trac.macports.org/ticket/71319
+    patchfiles-append      patch-clang16_Wenum_constexpr_conversion.diff
+
     # do not opportunistically use QtWebengine
     patchfiles-append      patch-no_qtwebengine.diff
 

--- a/devel/qt5-qtcreator/files/patch-clang16_Wenum_constexpr_conversion.diff
+++ b/devel/qt5-qtcreator/files/patch-clang16_Wenum_constexpr_conversion.diff
@@ -1,0 +1,19 @@
+--- src/plugins/cppeditor/cppquickfixes.cpp.orig	2024-11-15 19:37:42
++++ src/plugins/cppeditor/cppquickfixes.cpp	2024-11-15 22:04:19
+@@ -3716,6 +3716,7 @@
+         GenerateProperty = 1 << 5,
+         GenerateConstantProperty = 1 << 6,
+         HaveExistingQProperty = 1 << 7,
++        Invalid = -1,
+     };
+ 
+     GenerateGetterSetterOp(const CppQuickFixInterface &interface,
+@@ -4398,7 +4399,7 @@
+     };
+     using Flag = GenerateGetterSetterOp::GenerateFlag;
+     constexpr static Flag ColumnFlag[] = {
+-        static_cast<Flag>(-1),
++        Flag::Invalid,
+         Flag::GenerateGetter,
+         Flag::GenerateSetter,
+         Flag::GenerateSignal,


### PR DESCRIPTION
#### Description

Add a patch to fix a build error [-Wenum-constexpr-conversion] with clang v16 and later. This patch is already applied in qtcreator v10.0.2.

I tried to update qtcreator version to 11.0.3 (version 10 and below are archived), but it seems that it requires creating a new port with a new Portfile.

Here is a [track ticket 71319](https://trac.macports.org/ticket/71319) with this issue.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1 24B83 x86_64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
