### PR TITLE
micronaut: update to 4.7.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.6.3 v
+github.setup    micronaut-projects micronaut-starter 4.7.0 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  feeff8d66b20af6b83da1324abd6e2e29d3a9e8b \
-                 sha256  6c442cacde5e6606d2f34384a03fe35b27421903e4dd826e4383e29b94b286df \
-                 size    25505190
+    checksums    rmd160  3f5535e0cfdebfed368f5b1c55625cace50f7686 \
+                 sha256  8f66f1f857ad0f85bbfe37bf0d59926e1e8dada6d54ec2a8ac3566b2daf691a0 \
+                 size    27587239
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  020cce77f55d1e66607f98dbf80c9515c2296a0f \
-                 sha256  4e9b7ceb8039653337f51151b1a8659118b89901d16df5508b36a11e989f2abf \
-                 size    25311323
+    checksums    rmd160  67cd4e4c82dcc328f5606eefbd3a9570b1e45ddb \
+                 sha256  7d29ada613a50d2f59b8e5986b3698612a89ac7f80b44d707e94caac9b80c46d \
+                 size    27587836
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.7.0.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?