### PR TITLE
xmlsec: fix build with Xcode gcc

### DIFF
--- a/security/xmlsec/Portfile
+++ b/security/xmlsec/Portfile
@@ -31,6 +31,10 @@ depends_lib                 port:libxml2 \
 
 patchfiles                  patch-src-dl.c.diff
 
+if {[string match *gcc-4.* ${configure.compiler}]} {
+    patchfiles-append       patch-gcc4.diff
+}
+
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/src/dl.c
 }

--- a/security/xmlsec/files/patch-gcc4.diff
+++ b/security/xmlsec/files/patch-gcc4.diff
@@ -1,0 +1,19 @@
+--- configure.orig	2024-10-22 21:05:41.000000000 +0800
++++ configure	2024-11-17 15:35:57.000000000 +0800
+@@ -19123,15 +19123,11 @@
+ printf "%s\n" "disabled" >&6; }
+ else
+     CFLAGS="$CFLAGS -O -std=c99 -pedantic -pedantic-errors -W -Wall -Wextra"
+-    CFLAGS="$CFLAGS -fno-inline -Wnull-dereference -Wdouble-promotion"
++    CFLAGS="$CFLAGS -fno-inline"
+     CFLAGS="$CFLAGS -Wformat=2 -Wformat-security -Wformat-nonliteral"
+     CFLAGS="$CFLAGS -Wconversion -Wunused -Wshadow -Wpointer-arith -Wcast-align"
+     CFLAGS="$CFLAGS -Wwrite-strings -Wmissing-prototypes"
+     CFLAGS="$CFLAGS -Wnested-externs -Wredundant-decls"
+-
+-    if test "z$build_with_gcc" = "zyes" ; then
+-        CFLAGS="$CFLAGS -Wformat-overflow=2 -Wformat-signedness"
+-    fi
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ printf "%s\n" "yes" >&6; }
+ fi


### PR DESCRIPTION
#### Description

Fix the build with old compilers

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
