### PR TITLE
hdf5: fix non-MPI build on libstdc++ systems

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -10,6 +10,16 @@ PortGroup           github 1.0
 github.setup        HDFGroup hdf5 1.14.5 hdf5_
 set distversion     1.14.5
 revision            0
+
+# A temporary fix for non-MPI version.
+# Please remove this with the next update.
+# https://trac.macports.org/ticket/67893
+if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libc++"} {
+    if {![mpi_variant_isset]} {
+        incr revision
+    }
+}
+
 #set mainversion     [lindex [split ${distversion} -] 0]
 #set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
 
@@ -141,6 +151,9 @@ variant cxx description {
 } {
     configure.args-delete       --disable-cxx
     configure.args-append       --enable-cxx
+
+    # See: https://github.com/ubarsc/kealib/issues/42
+    compiler.cxx_standard       2011
 }
 
 variant fortran description {


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/67893

#### Description

@eborisch A fix and revbump for non-MPI `libstdc++`-based systems, needed for hdf5, otherwise C++-using dependents fail to link.
`compiler.cxx_standard 2011` has no effect for any other systems, so revbump is specific. Also, MPI variant added the needed flag from its side, so no need to revbump it even for `libstdc++`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
