### PR TITLE
libheif: backport upstream fix for 1.19.3; enable openh264

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -38,6 +38,9 @@ depends_lib-append \
                             port:svt-av1 \
                             port:webp
 
+# # https://trac.macports.org/ticket/71352
+patchfiles-append           c5cba3186e7382abe6247317c888490493708edd.patch
+
 configure.args-append \
                             -DWITH_X265:BOOL=OFF \
                             -DWITH_KVAZAAR:BOOL=OFF \

--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 18
 legacysupport.use_mp_libcxx yes
 
 github.setup                strukturag libheif 1.19.3 v
-revision                    0
+revision                    1
 
 checksums                   rmd160  6515bb88753a776bac59ddf884ebc3c88e58c415 \
                             sha256  1e6d3bb5216888a78fbbf5fd958cd3cf3b941aceb002d2a8d635f85cc59a8599 \
@@ -35,6 +35,7 @@ depends_lib-append \
                             port:libde265 \
                             path:include/turbojpeg.h:libjpeg-turbo \
                             port:libpng \
+                            port:openh264 \
                             port:svt-av1 \
                             port:webp
 

--- a/multimedia/libheif/files/c5cba3186e7382abe6247317c888490493708edd.patch
+++ b/multimedia/libheif/files/c5cba3186e7382abe6247317c888490493708edd.patch
@@ -1,0 +1,23 @@
+From c5cba3186e7382abe6247317c888490493708edd Mon Sep 17 00:00:00 2001
+From: Dirk Farin <dirk.farin@gmail.com>
+Date: Mon, 18 Nov 2024 23:58:37 +0100
+Subject: [PATCH] potential fix of add_and_encode_full_grid() (#1393)
+
+---
+ libheif/image-items/grid.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/libheif/image-items/grid.cc b/libheif/image-items/grid.cc
+index cc1002e346..3621dd0a77 100644
+--- libheif/image-items/grid.cc
++++ libheif/image-items/grid.cc
+@@ -735,6 +735,9 @@ Result<std::shared_ptr<ImageItem_Grid>> ImageItem_Grid::add_and_encode_full_grid
+     if (encodingResult.error) {
+       return encodingResult.error;
+     }
++    else {
++      out_tile = *encodingResult;
++    }
+ 
+     heif_item_id tile_id = out_tile->get_id();
+     file->get_infe_box(tile_id)->set_hidden_item(true); // only show the full grid


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/71352

#### Description

Fix the build.
Support `openh264`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
