### PR TITLE
openjdk21-openj9: update to 21.0.5

### DIFF
--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -20,11 +20,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.4
-revision     1
+version      ${feature}.0.5
+revision     0
 
-set build    7
-set openj9_version 0.46.1
+set build    11
+set openj9_version 0.48.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -34,14 +34,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  fab7f8fc73757fa0bbad1a7b907cf319cfeb4146 \
-                 sha256  97455456a43f06beb984df20dc275a621f712618bf3815c834b697f53d4cb9d6 \
-                 size    225687571
+    checksums    rmd160  8423f7bbfef3553de74938e793113514c3efca84 \
+                 sha256  519aaa538606805a276ab518f15fad712a192085f6d478f66367785d1f150c11 \
+                 size    225038163
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  6eae22ff20ee54f7c4a80658042274feed23091d \
-                 sha256  2ca92c44997fb7ed5ede97e7df89cb51164a24f5aa3097068536e86a00315213 \
-                 size    218880261
+    checksums    rmd160  f3444037cd069639605796e46d00c919a4edcf54 \
+                 sha256  b8c158a54851c9e987c2bbbe23caaa9883db22dfbf04adab0fadb850899ff5d9 \
+                 size    218283716
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 21.0.5.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?