### PR TITLE
openjdk23-openj9: update to 23.0.1

### DIFF
--- a/java/openjdk23-openj9/Portfile
+++ b/java/openjdk23-openj9/Portfile
@@ -15,11 +15,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}
+version      ${feature}.0.1
 revision     0
 
-set build    37
-set openj9_version 0.47.0
+set build    11
+set openj9_version 0.48.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Short Term Support until March 2025)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -29,14 +29,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  64688052b53c892dec2e7531eaa4e65d6b3a8f2e \
-                 sha256  a109ec179e54fd5eb6e92f1d728d9da11faf2a3b6724946fb11f24c0615eb840 \
-                 size    231699611
+    checksums    rmd160  3b590fa1dadb73a6489037461343da3144fc9695 \
+                 sha256  5478b6656138b21eb173c0cf4e7bad738df84a4fe0be132ef71dcbf0753d629a \
+                 size    231788789
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  2cdde446a5c34e105b93425389cbec58bea0ffb4 \
-                 sha256  a2c62b51be2f18ac23b491ed784063c9ced0f3f83c8c3bbe7ee77260ee696a15 \
-                 size    224977553
+    checksums    rmd160  05d0d327460d0cb8d20605b15e56e2944b2ccae1 \
+                 sha256  1ce5105ed9140b181ff517e62b733d025b0906e56674049bc493997720ef1dc2 \
+                 size    225087559
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 23.0.1.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?