### PR TITLE
openjdk17-openj9: update to 17.0.13

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -20,11 +20,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.12
-revision     1
+version      ${feature}.0.13
+revision     0
 
-set build    7
-set openj9_version 0.46.1
+set build    11
+set openj9_version 0.48.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -34,14 +34,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  514f047b4d03d2b2f3dc9016507db103f1d35277 \
-                 sha256  e6038c81a736fae8ef05924248601c7db8a87aa8193de6bfb45295aa8b756aab \
-                 size    213182081
+    checksums    rmd160  f14babfd9bcdd67b4365fb8260b0e88e1f992df8 \
+                 sha256  eaed7a64d97a4320c737b1a51f036bcbd1a484c6e21d568073c56157c23c6589 \
+                 size    212579920
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  d89eb1ccddcd538609d81db024dbed7cfb083317 \
-                 sha256  a406b3f51177c10f1dfe7e3a29fe3595bf51122c2d5ee8bcd8ad53a8cecd0b4d \
-                 size    206405252
+    checksums    rmd160  da5ecb9c3ff395bb0dc003c4dcfb3d2cd9f3f49e \
+                 sha256  7471a2db121be72c173b12189770b357bda93e3c58c0b3248c4cd84a1c596925 \
+                 size    205841599
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.13.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?