### PR TITLE
openjdk8-openj9: update to 8u432

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -15,11 +15,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
-version      ${feature}u422
-revision     1
+version      ${feature}u432
+revision     0
 
-set build    05
-set openj9_version 0.46.1
+set build    06
+set openj9_version 0.48.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -30,9 +30,9 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  04a6641cba0505ca783b1ce5632ee2ff18ba3a8d \
-             sha256  24801efbebc51beb6e2ebb55d0004a89bed97e024a4dbfd2bff9146606f014f7 \
-             size    122625962
+checksums    rmd160  ea290b2c5d9e89e4a08f2481b17c41c8befa09cb \
+             sha256  dc08d1a8abc688957526b65fc7f8a8e3e8d1fb16743ad1400998e9841baa7a7f \
+             size    122679154
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8u432.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?