### PR TITLE
timescaledb: update to 2.17.2

### DIFF
--- a/databases/timescaledb/Portfile
+++ b/databases/timescaledb/Portfile
@@ -5,7 +5,7 @@ PortGroup       compiler_blacklist_versions 1.0
 PortGroup       github    1.0
 PortGroup       perl5     1.0
 
-github.setup    timescale timescaledb 2.16.1
+github.setup    timescale timescaledb 2.17.2
 revision        0
 license         Apache-2
 description     A time-series database that integrates with PostgreSQL.
@@ -22,15 +22,15 @@ long_description \
                 as well as full SQL support. TimescaleDB is packaged \
                 as a PostgreSQL extension.
 
-checksums           rmd160  f657bb86924d61c007522355f45c815e1f60fdc6 \
-                    sha256  a4804e6b5d07465f599b369e3bb0cf8460811d42d2e3a158e41244a7951e86bc \
-                    size    7449735
+checksums       rmd160  c9c2be49270dc3f40a05bf99ff10a97a6f2cbb7f \
+                sha256  20cd2ebb73d776225efbc736502fa575c34f55f21a2ef6e8838b69d4dc1513f9 \
+                size    7567823
 
 depends_build   path:bin/cmake:cmake \
                 port:perl${perl5.major} \
                 port:p${perl5.major}-ipc-run
 
-set postgresql_branches {12 13 14 15 16}
+set postgresql_branches {12 13 14 15 16 17}
 
 foreach branch ${postgresql_branches} {
     subport pg${branch}-${name} {
@@ -101,11 +101,16 @@ variant timescale_license description {Enable Timescale License code, license wi
 }
 
 if {${name} eq ${subport}} {
-    PortGroup       obsolete 1.0
-    revision        1
-
+    # make it a stub port like py-foo
     supported_archs noarch
+    use_configure no
+    extract     {}
+    build       {}
+    destroot {
+        xinstall -d ${destroot}${prefix}/share/doc/${subport}
+        system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/README"
+    }
 
     set latest_branch [lindex ${postgresql_branches} end]
-    replaced_by     pg${latest_branch}-${name}
+    depends_lib     port:pg${latest_branch}-${name}
 }


### PR DESCRIPTION
* update to 2.17.2
* add postgresql17 support
* make it a stub port like py-foo

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Command Line Tools 14.2.0.0.1.1668646533


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
