### PR TITLE
nco: Stop using xercesc3

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 github.setup        nco nco 5.2.9
-revision            1
+revision            2
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
                     openmaintainer
@@ -38,8 +38,7 @@ depends_lib         port:curl \
                     port:gettext \
                     port:netcdf \
                     port:udunits2 \
-                    port:gsl \
-                    port:xercesc3
+                    port:gsl
 depends_build       port:antlr \
                     port:bison \
                     port:m4 \
@@ -51,7 +50,6 @@ configure.env       HAVE_ANTLR=yes ANTLR_ROOT=${prefix} \
 configure.cppflags-append   -I${prefix}/include/udunits2 \
                             -I${prefix}/include \
                             -DENABLE_NETCDF4
-configure.ldflags-append    -lxerces-c
 configure.args      --disable-dependency-tracking \
                     --mandir=${prefix}/share/man  \
                     --disable-shared              \


### PR DESCRIPTION
#### Description

See: https://trac.macports.org/ticket/71310

This is to remove the linking with `xercesc3` now that it has been marked as deprecated.
In fact, `nco` was wrongly linked to `xercesc3` in the first place, since there was no code requiring it.
Its presence in the `Portfile` was a leftover of support for `esmf`, which was taken out of the port as deprecated over 2 years ago (#14756).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1 24B83 x86_64
Command Line Tools 16.1.0.0.1.1729049160

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
