### PR TITLE
mise: Update to 2024.11.17

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.11.16 v
+github.setup        jdx mise 2024.11.17 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  bde4def30b250979aa6c3111004011b9d52a1cb7 \
-                    sha256  c38f06c75d5dfb5ab0a67888edaaac19f55037c9391190835d83e48be02a75e3 \
-                    size    3170378
+                    rmd160  e5b39790d343e4ffb1678802fa9657d601b356b9 \
+                    sha256  b30ddc1fb2f2ad55070598c836cade25a299404cb67695e4f943b15b0f5087d2 \
+                    size    3188675
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -229,7 +229,7 @@ cargo.crates \
     httparse                         1.9.5  7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946 \
     humansize                        2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
     humantime                        2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
-    hyper                            1.5.0  bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a \
+    hyper                            1.5.1  97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f \
     hyper-rustls                    0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
     hyper-tls                        0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                      0.1.10  df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4 \
@@ -372,7 +372,7 @@ cargo.crates \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
-    rustix                         0.38.40  99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0 \
+    rustix                         0.38.41  d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6 \
     rustls                         0.23.17  7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e \
     rustls-native-certs              0.8.0  fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
@@ -381,7 +381,7 @@ cargo.crates \
     rustversion                     1.0.18  0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248 \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    schannel                        0.1.26  01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1 \
+    schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework-sys          2.12.1  fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2 \


### PR DESCRIPTION
#### Description

mise: Update to 2024.11.17

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
