### PR TITLE
google-cloud-sdk: update to 502.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             501.0.0
+version             502.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  a59f1ab406532e926509e96751ba225b74f2781a \
-                    sha256  f77bbf8a99a2c61c097e6610d9cd2c1f6a1061fd8a726eaad1b16ffc027256b5 \
-                    size    52522408
+    checksums       rmd160  b614224ee9d01c484a561e5e42f5c147564ec3bd \
+                    sha256  64b69f1948e53cf84333f38b4f8dd6dc41c6ec726380ceb080c4880aac93a009 \
+                    size    52593724
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  4dc628ed8382dc1a906f6f365e87661cbc5ecfd1 \
-                    sha256  0c57551bbf6e7fdbf9d1114fa56aea1970ecae68bac18a70edcb78a391d1b1cc \
-                    size    53877215
+    checksums       rmd160  472c2ee8983cc8ab7665093ce589787e1df9cce1 \
+                    sha256  9d8543f742cd02b50e3a7553495b9dfcdb6c6b690b4e02c7c73f85780cc3d330 \
+                    size    53943066
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  f5951ce180932eaeae04243a6dcda558846c4ceb \
-                    sha256  944930e3f8aae7507b1b728d3bc95c8de99268e864cb469e0c081f032859f2a7 \
-                    size    53824201
+    checksums       rmd160  1598fd5451b470f24236802262b68555e9122081 \
+                    sha256  903b01237a2147f0bc550109a1085d6d713e9803374faa8fcd3f7a0ed81581e5 \
+                    size    53889708
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 502.0.0.

###### Tested on

macOS 15.1 24B83 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?