### PR TITLE
uv: Update to 0.5.3

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.5.2
+github.setup            astral-sh uv 0.5.3
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  80b4baa10e9b05fc1d6e7bee41f228591354971f \
-                        sha256  14b4ed7c955acdf4ae2b47537addbefb8a486e47cada903970f10e28f40b518c \
-                        size    2886231
+                        rmd160  4dcd371c5761eb10e2b000cb5e58312b28a893f3 \
+                        sha256  1adf6fc673c7124983084fdf129c13879abdd2b5a607cc276472d0d986a9ffc7 \
+                        size    2908026
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -120,14 +120,13 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.20  b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8 \
-    clap_builder                    4.5.20  19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54 \
+    clap                            4.5.21  fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f \
+    clap_builder                    4.5.21  b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec \
     clap_complete                   4.5.36  86bc73de94bc81e52f3bebec71bc4463e9748f7a59166663e32044669577b0e2 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.4  315902e790cc6e5ddd20cbd313c1d0d49db77f191e149f96397230fb82a17677 \
     clap_derive                     4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
     clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
-    cmake                           0.1.51  fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a \
     codspeed                         2.7.2  450a0e9df9df1c154156f4344f99d8f6f6e69d0fc4de96ef6e2e68b2ec3bce97 \
     codspeed-criterion-compat        2.7.2  8eb1a6cb9c20e177fde58cdef97c1c7c9264eb1424fe45c4fccedc2fb078a569 \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
@@ -179,7 +178,7 @@ cargo.crates \
     fdeflate                         0.3.6  07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
-    flate2                          1.0.34  a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0 \
+    flate2                          1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
     float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                         0.1.3  f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2 \
@@ -187,6 +186,7 @@ cargo.crates \
     fontdb                          0.12.0  ff20bef7942a72af07104346154a70a70b089c572e454b41bef6eb6cb10e9c06 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fs-err                          2.11.0  88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41 \
+    fs-err                           3.0.0  8bb60e7409f34ef959985bc9d9c5ee8f5db24ee46ed9775850548021710f807f \
     fs2                              0.4.3  9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
     futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
     futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
@@ -242,7 +242,7 @@ cargo.crates \
     image                           0.25.4  bc144d44a31d753b02ce64093d532f55ff8dc4ebf2ffb8a63c0dda691385acae \
     imagesize                       0.11.0  b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf \
     indexmap                         2.6.0  707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da \
-    indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
+    indicatif                       0.17.9  cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     insta                           1.41.1  7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8 \
     instant                         0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
@@ -267,7 +267,7 @@ cargo.crates \
     libc                           0.2.161  8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1 \
     libmimalloc-sys                 0.1.39  23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    libz-ng-sys                     1.1.16  4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438 \
+    libz-rs-sys                      0.4.0  39cc71ac688c22a9f5730a38171ac94795c071ac81d1a0ab5537f6ef164fff30 \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
     litemap                          0.7.3  643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704 \
@@ -363,7 +363,7 @@ cargo.crates \
     reflink-copy                    0.1.20  17400ed684c3a0615932f00c271ae3eea13e47056a1455821995122348ab6438 \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
-    regex-automata                   0.4.8  368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3 \
+    regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     rend                             0.5.2  a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215 \
@@ -404,11 +404,11 @@ cargo.crates \
     security-framework-sys          2.12.0  ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
-    serde                          1.0.214  f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5 \
+    serde                          1.0.215  6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f \
     serde-untagged                   0.1.6  2676ba99bd82f75cae5cbd2c8eda6fa0b8760f18978ea840e980dd5567b5c5b6 \
-    serde_derive                   1.0.214  de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766 \
+    serde_derive                   1.0.215  ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0 \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                     1.0.132  d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03 \
+    serde_json                     1.0.133  c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377 \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
@@ -426,7 +426,7 @@ cargo.crates \
     smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
     smawk                            0.3.2  b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c \
     socket2                          0.5.7  ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c \
-    spdx                            0.10.6  47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc \
+    spdx                            0.10.7  bae30cc7bfe3656d60ee99bf6836f472b0c53dddcbf335e253329abb16e535a2 \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     strict-num                       0.1.1  6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731 \
@@ -458,7 +458,9 @@ cargo.crates \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
     textwrap                        0.16.1  23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9 \
     thiserror                       1.0.67  3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd \
+    thiserror                        2.0.3  c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa \
     thiserror-impl                  1.0.67  b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6 \
+    thiserror-impl                   2.0.3  f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tikv-jemalloc-sys 0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d \
     tikv-jemallocator                0.6.0  4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865 \
@@ -503,6 +505,7 @@ cargo.crates \
     unicode-script                   0.5.7  9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f \
     unicode-vo                       0.1.0  b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94 \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
+    unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
     unscanny                         0.1.0  e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.3  8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada \
@@ -529,6 +532,7 @@ cargo.crates \
     wasm-streams                     0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
     wasm-timer                       0.2.5  be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f \
     web-sys                         0.3.72  f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112 \
+    web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                    0.26.6  841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958 \
     weezl                            0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
     which                            7.0.0  c9cad3279ade7346b96e38731a641d7343dd6a53d55083dd54eadfa5a1b38c6b \
@@ -592,6 +596,7 @@ cargo.crates \
     zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
     zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
     zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
+    zlib-rs                          0.4.0  2ca4a9dc6566c9224cc161dedc5577bd81f4a9ee0f9fbe80592756d096b07ee5 \
     zstd                            0.13.2  fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9 \
     zstd-safe                        7.2.1  54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059 \
     zstd-sys             2.0.13+zstd.1.5.6  38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.5.3

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
