### PR TITLE
ddev: new port, version 1.23.5

### DIFF
--- a/devel/ddev/Portfile
+++ b/devel/ddev/Portfile
@@ -1,0 +1,335 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/ddev/ddev 1.23.5 v
+
+checksums           rmd160  ed4bb63c2d40888fa850e92f956b923570d4f0d5 \
+                    sha256  c25a5d8fb03a9af877676c33c8e3cb7823300ae67c17ca474a2988dfee43472e \
+                    size    19394502
+
+categories          devel
+license             Apache-2
+maintainers         {@jlorenzetti} openmaintainer
+
+description         Local PHP development environment management tool
+long_description    DDEV is an open source tool for launching local PHP web development \
+                    environments in minutes. It helps developers create and manage \
+                    Docker-based development environments with support for multiple PHP \
+                    versions, web servers, databases, and other tools.
+
+homepage            https://ddev.com
+
+# Go module dependencies
+go.vendors          cloud.google.com/go/compute v1.20.1 \
+                        h1:6aKEtlUiwEpJzM001l0yFkpXmUVXaN8W+fbkb2AZNbg= \
+                    cloud.google.com/go/compute/metadata v0.2.3 \
+                        h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY= \
+                    github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 \
+                        h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0= \
+                    github.com/MakeNowJust/heredoc/v2 v2.0.1 \
+                        h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A= \
+                    github.com/Masterminds/goutils v1.1.1 \
+                        h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI= \
+                    github.com/Masterminds/semver/v3 v3.2.1 \
+                        h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0= \
+                    github.com/Masterminds/sprig/v3 v3.2.3 \
+                        h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA= \
+                    github.com/Microsoft/go-winio v0.6.1 \
+                        h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow= \
+                    github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c \
+                        h1:kMFnB0vCcX7IL/m9Y5LO+KQYv+t1CQOiFe6+SV2J7bE= \
+                    github.com/amplitude/analytics-go v1.0.2 \
+                        h1:GiKYxFwuuEcEgNpw8p4lPiIXHL6z9iEXa8QlkZDQpUk= \
+                    github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 \
+                        h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so= \
+                    github.com/bwesterb/go-ristretto v1.2.3 \
+                        h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw= \
+                    github.com/cenkalti/backoff/v4 v4.2.1 \
+                        h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM= \
+                    github.com/cheggaaa/pb v1.0.29 \
+                        h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo= \
+                    github.com/chzyer/logex v1.2.1 \
+                        h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM= \
+                    github.com/chzyer/readline v1.5.1 \
+                        h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI= \
+                    github.com/chzyer/test v1.0.0 \
+                        h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04= \
+                    github.com/cloudflare/circl v1.3.7 \
+                        h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU= \
+                    github.com/containerd/log v0.1.0 \
+                        h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I= \
+                    github.com/corpix/uarand v0.0.0-20170723150923-031be390f409 \
+                        h1:9A+mfQmwzZ6KwUXPc8nHxFtKgn9VIvO3gXAOspIcE3s= \
+                    github.com/cpuguy83/go-md2man/v2 v2.0.3 \
+                        h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM= \
+                    github.com/creack/pty v1.1.18 \
+                        h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY= \
+                    github.com/davecgh/go-spew v1.1.1 \
+                        h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c= \
+                    github.com/denisbrodbeck/machineid v1.0.1 \
+                        h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ= \
+                    github.com/dimchansky/utfbom v1.1.1 \
+                        h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U= \
+                    github.com/distribution/reference v0.5.0 \
+                        h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0= \
+                    github.com/docker/docker v27.1.1+incompatible \
+                        h1:hO/M4MtV36kzKldqnA37IWhebRA+LnqqcqDja6kVaKY= \
+                    github.com/docker/go-connections v0.5.0 \
+                        h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c= \
+                    github.com/docker/go-units v0.5.0 \
+                        h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4= \
+                    github.com/fatih/color v1.9.0 \
+                        h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s= \
+                    github.com/felixge/httpsnoop v1.0.4 \
+                        h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg= \
+                    github.com/frankban/quicktest v1.14.6 \
+                        h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8= \
+                    github.com/go-logr/logr v1.4.1 \
+                        h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ= \
+                    github.com/go-logr/stdr v1.2.2 \
+                        h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag= \
+                    github.com/gogo/protobuf v1.3.2 \
+                        h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q= \
+                    github.com/golang/protobuf v1.5.3 \
+                        h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg= \
+                    github.com/goodhosts/hostsfile v0.1.6 \
+                        h1:aK6DxpNV6pZ1NbdvNE2vYBMTnvIJF5O2J/8ZOlp2eMY= \
+                    github.com/google/go-cmp v0.6.0 \
+                        h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI= \
+                    github.com/google/go-github/v52 v52.0.0 \
+                        h1:uyGWOY+jMQ8GVGSX8dkSwCzlehU3WfdxQ7GweO/JP7M= \
+                    github.com/google/go-querystring v1.1.0 \
+                        h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8= \
+                    github.com/google/uuid v1.5.0 \
+                        h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU= \
+                    github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 \
+                        h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms= \
+                    github.com/huandu/xstrings v1.4.0 \
+                        h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU= \
+                    github.com/icrowley/fake v0.0.0-20221112152111-d7b7e2276db2 \
+                        h1:qU3v73XG4QAqCPHA4HOpfC1EfUvtLIDvQK4mNQ0LvgI= \
+                    github.com/imdario/mergo v0.3.16 \
+                        h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4= \
+                    github.com/inconshreveable/mousetrap v1.1.0 \
+                        h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8= \
+                    github.com/jedib0t/go-pretty/v6 v6.4.9 \
+                        h1:vZ6bjGg2eBSrJn365qlxGcaWu09Id+LHtrfDWlB2Usc= \
+                    github.com/joho/godotenv v1.5.1 \
+                        h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0= \
+                    github.com/kisielk/errcheck v1.5.0 \
+                        h1:e8esj/e4R+SAOwFwN+n3zr0nYeCyeweozKfO23MvHzY= \
+                    github.com/kisielk/gotool v1.0.0 \
+                        h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg= \
+                    github.com/kr/pretty v0.3.1 \
+                        h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE= \
+                    github.com/kr/pty v1.1.1 \
+                        h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw= \
+                    github.com/kr/text v0.2.0 \
+                        h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY= \
+                    github.com/magefile/mage v1.15.0 \
+                        h1:BvGheCMAsG3bWUDbZ8AyXXp4UJ4ba27QIbdDc1cD77A= \
+                    github.com/manifoldco/promptui v0.9.0 \
+                        h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA= \
+                    github.com/maruel/natural v1.1.1 \
+                        h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo= \
+                    github.com/mattn/go-colorable v0.1.13 \
+                        h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA= \
+                    github.com/mattn/go-isatty v0.0.20 \
+                        h1:xfD0iDuEKnDKl03q4limB+vH+GxLEtL/jb4xVJSWWEY= \
+                    github.com/mattn/go-runewidth v0.0.15 \
+                        h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U= \
+                    github.com/mitchellh/copystructure v1.2.0 \
+                        h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw= \
+                    github.com/mitchellh/go-homedir v1.1.0 \
+                        h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y= \
+                    github.com/mitchellh/mapstructure v1.5.0 \
+                        h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY= \
+                    github.com/mitchellh/reflectwalk v1.0.2 \
+                        h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ= \
+                    github.com/moby/docker-image-spec v1.3.1 \
+                        h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0= \
+                    github.com/moby/term v0.5.0 \
+                        h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0= \
+                    github.com/morikuni/aec v1.0.0 \
+                        h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A= \
+                    github.com/opencontainers/go-digest v1.0.0 \
+                        h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U= \
+                    github.com/opencontainers/image-spec v1.1.0 \
+                        h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug= \
+                    github.com/otiai10/copy v1.14.0 \
+                        h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU= \
+                    github.com/otiai10/mint v1.5.1 \
+                        h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks= \
+                    github.com/pkg/errors v0.9.1 \
+                        h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4= \
+                    github.com/pkg/profile v1.6.0 \
+                        h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k8r5dM= \
+                    github.com/pmezard/go-difflib v1.0.0 \
+                        h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM= \
+                    github.com/rivo/uniseg v0.4.4 \
+                        h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis= \
+                    github.com/rogpeppe/go-internal v1.11.0 \
+                        h1:cWPdQD27gjM8MVNuicgxIjxpm4K7x4jp8sis= \
+                    github.com/russross/blackfriday v1.6.0 \
+                        h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww= \
+                    github.com/russross/blackfriday/v2 v2.1.0 \
+                        h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk= \
+                    github.com/shopspring/decimal v1.3.1 \
+                        h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8= \
+                    github.com/sirupsen/logrus v1.9.3 \
+                        h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ= \
+                    github.com/spf13/cast v1.6.0 \
+                        h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0= \
+                    github.com/spf13/cobra v1.8.0 \
+                        h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0= \
+                    github.com/spf13/pflag v1.0.5 \
+                        h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA= \
+                    github.com/stretchr/objx v0.5.0 \
+                        h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c= \
+                    github.com/stretchr/testify v1.8.4 \
+                        h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk= \
+                    github.com/ulikunitz/xz v0.5.11 \
+                        h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8= \
+                    github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1 \
+                        h1:+dBg5k7nuTE38VVdoroRsT0Z88fmvdYrI2EjzJst35I= \
+                    github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f \
+                        h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c= \
+                    github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 \
+                        h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0= \
+                    github.com/xeipuuv/gojsonschema v1.2.0 \
+                        h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74= \
+                    github.com/yuin/goldmark v1.4.13 \
+                        h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE= \
+                    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 \
+                        h1:jq9TW8u3so/bN+JPT166wjOI6/xAaC9C3N3wfWbVP0= \
+                    go.opentelemetry.io/otel v1.24.0 \
+                        h1:0LAOdjNmQeSTzGBzduGe/rU4tZhMwL5rWgtp9Ku5Jfo= \
+                    go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.22.0 \
+                        h1:9M3+rhx7kZCIQQhQRYaZCdNu1V73tm4TvXs2ntl98C4= \
+                    go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.22.0 \
+                        h1:FyjCyI9jVEfqhUh2MoSkmolPjfh5fp2hnV0b0irxH4Q= \
+                    go.opentelemetry.io/otel/metric v1.24.0 \
+                        h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGXlc88kI= \
+                    go.opentelemetry.io/otel/sdk v1.22.0 \
+                        h1:6coWHw9xw7EFClIC/+O31R8IY3/+EiRFHevmHafB2Gw= \
+                    go.opentelemetry.io/otel/trace v1.24.0 \
+                        h1:CsKnnL4dUAr/0llH9FKuc4dUr4eBb2Kw/5LfQ/2Yeli= \
+                    go.opentelemetry.io/proto/otlp v1.0.0 \
+                        h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I= \
+                    golang.org/x/crypto v0.18.0 \
+                        h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc= \
+                    golang.org/x/mod v0.16.0 \
+                        h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic= \
+                    golang.org/x/net v0.22.0 \
+                        h1:9sGLhx7iRIHEiX0oAJ3MRZMUCElJgy7Br1nO+AMN3Tc= \
+                    golang.org/x/oauth2 v0.15.0 \
+                        h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ= \
+                    golang.org/x/sync v0.6.0 \
+                        h1:5BMeUDZ7vkXGfEr1x9U/LP0PkLCS9tbxHdi/U= \
+                    golang.org/x/sys v0.18.0 \
+                        h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4= \
+                    golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2 \
+                        h1:IRJeR9r1pYWsHKTRe/IInb7lYvbBVIqOgsX/u0mbOWY= \
+                    golang.org/x/term v0.16.0 \
+                        h1:m+B6fahuftsE9qjo0VWp2FW0mB3MTJvR0BaMQrq0pmE= \
+                    golang.org/x/text v0.14.0 \
+                        h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ= \
+                    golang.org/x/time v0.5.0 \
+                        h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk= \
+                    golang.org/x/tools v0.19.0 \
+                        h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw= \
+                    golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 \
+                        h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE= \
+                    google.golang.org/appengine v1.6.8 \
+                        h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM= \
+                    google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97 \
+                        h1:W18sezcAYs+3tDZX4F80yctqa12jcP1PUS2gQu1zTPU= \
+                    google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97 \
+                        h1:6GQBEOdGkX6MMTLT9V+TjtIRZCw9VPD5Z+yHY9wMgS0= \
+                    google.golang.org/grpc v1.60.1 \
+                        h1:26+wFr+cNqSGFcOXcabYC0lUVJVRa2Sb2ortSK7VrEU= \
+                    google.golang.org/protobuf v1.33.0 \
+                        h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI= \
+                    gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c \
+                        h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk= \
+                    gopkg.in/yaml.v2 v2.3.0 \
+                        h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU= \
+                    gopkg.in/yaml.v3 v3.0.1 \
+                        h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA= \
+                    gotest.tools/v3 v3.4.0 \
+                        h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o= \
+                    muzzammil.xyz/jsonc v1.0.0 \
+                        h1:B6kaT3wHueZ87mPz3q1nFuM1BlL32IG0wcq0/uOsQ18=
+
+# Dependencies
+depends_build       port:go \
+                    port:gmake
+
+depends_run         port:mkcert
+
+# Build configuration
+build.env-append    CGO_ENABLED=0 \
+                    GOFLAGS="-mod=vendor -buildvcs=false"
+
+build.cmd           make
+
+# Set build target based on architecture
+if {${build_arch} eq "x86_64"} {
+    set go_arch "amd64"
+} elseif {${build_arch} eq "arm64"} {
+    set go_arch "arm64"
+}
+
+build.target    darwin_${go_arch}
+
+# Initialize a git repository because ddev's build process uses git information
+# for version detection and embedding build information in the binary
+post-extract {
+    system -W ${worksrcpath} "git init"
+    system -W ${worksrcpath} "git config user.email 'macports@localhost'"
+    system -W ${worksrcpath} "git config user.name 'MacPorts Build'"
+    system -W ${worksrcpath} "git add ."
+    system -W ${worksrcpath} "git commit -m 'Initial commit'"
+    system -W ${worksrcpath} "git tag v${version}"
+}
+
+build {
+    system -W ${worksrcpath} "git config --global --add safe.directory ${worksrcpath}"
+    system -W ${worksrcpath} "${build.cmd} ${build.target}"
+}
+
+destroot {
+    # Install binary
+    xinstall -m 755 ${worksrcpath}/.gotmp/bin/darwin_${go_arch}/ddev ${destroot}${prefix}/bin/
+    
+    # Generate shell completions
+    system -W ${worksrcpath} "git config --global --add safe.directory ${worksrcpath}"
+    system -W ${worksrcpath} "GOFLAGS=-buildvcs=false ${build.cmd} completions"
+    
+    # Extract completions
+    system -W ${worksrcpath} "mkdir -p .gotmp/bin/completions_extracted"
+    system -W ${worksrcpath} "tar xzf .gotmp/bin/completions.tar.gz -C .gotmp/bin/completions_extracted"
+    
+    # Install shell completions
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 644 ${worksrcpath}/.gotmp/bin/completions_extracted/ddev_bash_completion.sh \
+        ${destroot}${prefix}/share/bash-completion/completions/ddev
+        
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 644 ${worksrcpath}/.gotmp/bin/completions_extracted/ddev_zsh_completion.sh \
+        ${destroot}${prefix}/share/zsh/site-functions/_ddev
+        
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 644 ${worksrcpath}/.gotmp/bin/completions_extracted/ddev_fish_completion.sh \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/ddev.fish
+}
+
+test.run            yes
+test.cmd            make
+test.target         test
+
+livecheck.type      regex
+livecheck.url       ${homepage}/releases
+livecheck.regex     {/v([0-9.]+)/}


### PR DESCRIPTION
DDEV is an open source tool for launching local PHP web development environments in minutes. It helps developers create and manage Docker-based development environments with support for multiple PHP versions, web servers, databases, and other tools.

## Testing

- `port lint --nitpick`: ✅ 0 errors, 0 warnings
- Installation: ✅ successful
- Uninstallation: ✅ successful
- Reinstallation: ✅ successful
- Clean & reinstall: ✅ successful
- Dependencies check: ✅ correct
  - Build: go, gmake
  - Runtime: mkcert

## Platform
- macOS 13.7.1
- MacPorts 2.10.4

## Additional Information
- Homepage: https://ddev.com
- License: Apache-2