### PR TITLE
hugo: update to 0.139.0

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,14 +3,14 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.138.0 v
+go.setup            github.com/gohugoio/hugo 0.139.0 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  540b9593466ed790dabfcc9e12d272b5f976cb2e \
-                    sha256  2527f9df57d872c2651ad8e8895c7256c7af9a58c73e5e72f5ba0ae9714cad8e \
-                    size    21232634
+checksums           rmd160  9bbb95523e784689c50877b9544aeb2f20e58c51 \
+                    sha256  4eeba2c3f993d05267d604eca2a5929a090663c437a1585c0607bfcfaa5a8c95 \
+                    size    21235374
 
 categories          www
 installs_libs       no


### PR DESCRIPTION
#### Description
hugo: update to 0.139.0

###### Tested on
macOS 12.7.6 21H1320 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
