### PR TITLE
mise: Update to 2024.11.19

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.11.18 v
+github.setup        jdx mise 2024.11.19 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ef4d1e5d52098ad4d7471edcfe3190900b15ee97 \
-                    sha256  43ad97a8276b1d57cc3934d1d8d5dfbd2ff8c7c9f948cb1a9885833ea93a7504 \
-                    size    3188876
+                    rmd160  2ac6e69d69d9f1c6a7a6aa0b2352faa6253dbb0a \
+                    sha256  cfffb1d58f132e40c9836877afd2da3e613a6342831c02a1cbda57115ae2004e \
+                    size    3193597
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -155,7 +155,7 @@ cargo.crates \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
     crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
-    ctor                             0.2.8  edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f \
+    ctor                             0.2.9  32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501 \
     curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
@@ -258,7 +258,7 @@ cargo.crates \
     ipnet                           2.10.1  ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
-    itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
+    itoa                            1.0.13  540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     js-sys                          0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
     kdl                              4.6.0  062c875482ccb676fd40c804a40e3824d4464c18c364547456d1c8e8e951ae47 \
@@ -284,6 +284,7 @@ cargo.crates \
     lzma-rust                        0.1.7  5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661 \
     lzma-sys                        0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
+    md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     miette                          5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
     miette-derive                   5.10.0  49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c \
@@ -424,7 +425,7 @@ cargo.crates \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                             2.0.87  25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d \
-    sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
+    sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     system-configuration             0.6.1  3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b \
@@ -478,7 +479,7 @@ cargo.crates \
     unic-segment                     0.9.0  e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23 \
     unic-ucd-segment                 0.9.0  2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700 \
     unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
-    unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
+    unicode-ident                   1.0.14  adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83 \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
     unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \


### PR DESCRIPTION
#### Description

mise: Update to 2024.11.19

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
