### PR TITLE
cpp-peglib: update to 1.9.1

### DIFF
--- a/devel/cpp-peglib/Portfile
+++ b/devel/cpp-peglib/Portfile
@@ -10,7 +10,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 16
 legacysupport.use_mp_libcxx yes
 
-github.setup        yhirose cpp-peglib 1.9.0 v
+github.setup        yhirose cpp-peglib 1.9.1 v
 revision            0
 categories          devel
 # Do not set is as noarch until this issue is fixed:
@@ -21,9 +21,9 @@ license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         A single file C++ header-only PEG (Parsing Expression Grammars) library
 long_description    {*}${description}
-checksums           rmd160  5d88a6f132fd203bc7d8896a48befb790612bc6d \
-                    sha256  6f4f0956ea2f44fd1c5882f8adc5782451ba9d227c467d214196390ddedb024c \
-                    size    228072
+checksums           rmd160  374020009ffed7bc719fec8bdbf1499849b4a521 \
+                    sha256  f57aa0f14372cbb772af29e3a4549a8033ea07eb25c39949cba6178e0e2ba9cc \
+                    size    228336
 github.tarball_from archive
 
 # The port needs Gtest for building tests, however linking to external Gtest fails.


### PR DESCRIPTION
#### Description

update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
