### PR TITLE
mise: Update to 2024.11.20

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.11.19 v
+github.setup        jdx mise 2024.11.20 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2ac6e69d69d9f1c6a7a6aa0b2352faa6253dbb0a \
-                    sha256  cfffb1d58f132e40c9836877afd2da3e613a6342831c02a1cbda57115ae2004e \
-                    size    3193597
+                    rmd160  06382ac3f5f40440c3b218a15cf35ece4dc6b73c \
+                    sha256  4789c2afd768067d1d57ebf6fdfe637eb1d2769d46325383b71555ebfe844ffc \
+                    size    3193627
 
 patchfiles          patch-src_cli_self_update.diff
 


### PR DESCRIPTION
#### Description

mise: Update to 2024.11.20

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
