### PR TITLE
openldap: Reduce dependencies

### DIFF
--- a/databases/openldap/Portfile
+++ b/databases/openldap/Portfile
@@ -8,7 +8,7 @@ name                openldap
 conflicts           openldap-devel
 set my_name         openldap
 version             2.6.8
-revision            0
+revision            1
 
 checksums           rmd160  84ad02add29add7d1e33716731a9139fa982f09c \
                     sha256  48969323e94e3be3b03c6a132942dcba7ef8d545f2ad35401709019f696c3c4e \
@@ -55,8 +55,12 @@ patchfiles-append   patch-ltmain.diff
 patchfiles-append   patch-dynamic_lookup-11.diff
 patchfiles-append   patch-fix_implicit.diff
 patchfiles-append   patch-libressl.diff
+
 # Use 'gdate', rather than 'date', for tests
 patchfiles-append   patch-tests-gdate.diff
+
+# Use 'msoelim', rather than 'soelim', to replace 'groff' dependency.
+patchfiles-append   patch-soelim-name.diff
 
 configure.env-append \
                     LANG=C
@@ -76,8 +80,11 @@ platform darwin {
     if {${os.major} >= 22} {
         # The openldap build uses soelim from groff, and newer OS versions do
         # not provide groff as part of the base OS install.
+        #
+        # Replace soelim command from heavy port groff with lightweight mandoc.
+        # Patch required for change in 'soelim' command name.
         depends_build-append \
-                    port:groff
+                    port:mandoc
     }
 }
 

--- a/databases/openldap/files/patch-soelim-name.diff
+++ b/databases/openldap/files/patch-soelim-name.diff
@@ -1,0 +1,13 @@
+Replace soelim command from heavy port groff with lightweight mandoc.
+
+--- build/top.mk.orig	2024-05-21 11:19:11
++++ build/top.mk	2024-11-21 16:43:14
+@@ -153,7 +153,7 @@
+ MANCOMPRESS=$(CAT)
+ MANCOMPRESSSUFFIX=
+ 
+-SOELIM=soelim
++SOELIM=msoelim
+ 
+ INCLUDEDIR= $(top_srcdir)/include
+ LDAP_INCPATH= -I$(LDAP_INCDIR) -I$(INCLUDEDIR)


### PR DESCRIPTION
#### Description

* Replace heavy port `groff` with lightweight `mandoc`.
* Needed only to build man pages using "soelim".
* Recursive dependencies for openldap reduced from 103 to 33.
* Part of the conversation in https://trac.macports.org/ticket/69601.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?