### PR TITLE
uv: Update to 0.5.4

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.5.3
+github.setup            astral-sh uv 0.5.4
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  4dcd371c5761eb10e2b000cb5e58312b28a893f3 \
-                        sha256  1adf6fc673c7124983084fdf129c13879abdd2b5a607cc276472d0d986a9ffc7 \
-                        size    2908026
+                        rmd160  08b1d7a5408956535360d475928982ede7c140de \
+                        sha256  3c1c95bcc99930b929e18665d7691b219ce4bef3555711a9be80139c183b9595 \
+                        size    2915932
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -99,11 +99,11 @@ cargo.crates \
     bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     boxcar                           0.2.7  7f839cdf7e2d3198ac6ca003fd8ebc61715755f41c1cad15ff13df67531e00ed \
-    bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
+    bstr                            1.11.0  1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22 \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytecheck                        0.8.0  50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f \
     bytecheck_derive                 0.8.0  523363cbe1df49b68215efdf500b103ac3b0fb4836aed6d15689a076eadb8fff \
-    bytemuck                        1.19.0  8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d \
+    bytemuck                        1.20.0  8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     byteorder-lite                   0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
     bytes                            1.8.0  9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da \
@@ -113,7 +113,7 @@ cargo.crates \
     camino                           1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
     cargo-util                      0.2.15  b6dd67a24439ca5260a08128b6cbf4b0f4453497a2f60508163ab9d5b534b122 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
-    cc                              1.1.31  c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f \
+    cc                               1.2.1  fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     charset                          0.1.5  f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e \
@@ -122,11 +122,11 @@ cargo.crates \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
     clap                            4.5.21  fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f \
     clap_builder                    4.5.21  b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec \
-    clap_complete                   4.5.36  86bc73de94bc81e52f3bebec71bc4463e9748f7a59166663e32044669577b0e2 \
+    clap_complete                   4.5.38  d9647a559c112175f17cf724dc72d3645680a883c58481332779192b0d8e7a01 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.4  315902e790cc6e5ddd20cbd313c1d0d49db77f191e149f96397230fb82a17677 \
     clap_derive                     4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
-    clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
+    clap_lex                         0.7.3  afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7 \
     codspeed                         2.7.2  450a0e9df9df1c154156f4344f99d8f6f6e69d0fc4de96ef6e2e68b2ec3bce97 \
     codspeed-criterion-compat        2.7.2  8eb1a6cb9c20e177fde58cdef97c1c7c9264eb1424fe45c4fccedc2fb078a569 \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
@@ -137,7 +137,7 @@ cargo.crates \
     console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
-    cpufeatures                     0.2.14  608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0 \
+    cpufeatures                     0.2.15  0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
     criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
     criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
@@ -174,7 +174,7 @@ cargo.crates \
     etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
     event-listener                   5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
     event-listener-strategy          0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
-    fastrand                         2.1.1  e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6 \
+    fastrand                         2.2.0  486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4 \
     fdeflate                         0.3.6  07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
@@ -193,7 +193,7 @@ cargo.crates \
     futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
     futures-executor                0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
     futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
-    futures-lite                     2.4.0  3f1fa2f9765705486b33fd2acf1577f8ec449c2ba1f318ae5447697b7c08d210 \
+    futures-lite                     2.5.0  cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1 \
     futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
     futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
     futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
@@ -206,7 +206,7 @@ cargo.crates \
     globset                         0.4.15  15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     goblin                           0.9.2  53ab3f32d1d77146981dea5d6b1e8fe31eedcb7013e5e00d6ccd1259a4b4d923 \
-    h2                               0.4.6  524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205 \
+    h2                               0.4.7  ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                       0.15.1  3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3 \
@@ -223,7 +223,7 @@ cargo.crates \
     http-content-range               0.2.0  91314cc9d86f625097a3365cab4e4b6f190eac231650f8f41c1edd8080cea1d0 \
     httparse                         1.9.5  7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    hyper                            1.5.0  bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a \
+    hyper                            1.5.1  97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f \
     hyper-rustls                    0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
     hyper-util                      0.1.10  df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4 \
     icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
@@ -239,7 +239,7 @@ cargo.crates \
     idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
-    image                           0.25.4  bc144d44a31d753b02ce64093d532f55ff8dc4ebf2ffb8a63c0dda691385acae \
+    image                           0.25.5  cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b \
     imagesize                       0.11.0  b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf \
     indexmap                         2.6.0  707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da \
     indicatif                       0.17.9  cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281 \
@@ -264,7 +264,7 @@ cargo.crates \
     kurbo                            0.8.3  7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449 \
     kurbo                            0.9.5  bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.161  8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1 \
+    libc                           0.2.164  433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f \
     libmimalloc-sys                 0.1.39  23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     libz-rs-sys                      0.4.0  39cc71ac688c22a9f5730a38171ac94795c071ac81d1a0ab5537f6ef164fff30 \
@@ -344,9 +344,9 @@ cargo.crates \
     procfs-core                     0.17.0  239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec \
     ptr_meta                         0.3.0  fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90 \
     ptr_meta_derive                  0.3.0  ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1 \
-    quinn                           0.11.5  8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684 \
-    quinn-proto                     0.11.8  fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6 \
-    quinn-udp                        0.5.6  e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780 \
+    quinn                           0.11.6  62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef \
+    quinn-proto                     0.11.9  a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d \
+    quinn-udp                        0.5.7  7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da \
     quote                           1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
     quoted_printable                 0.5.1  640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73 \
     rancor                           0.1.0  caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947 \
@@ -384,8 +384,8 @@ cargo.crates \
     rust-netrc                       0.1.2  7e98097f62769f92dbf95fb51f71c0a68ec18a4ee2e70e0d3e4f47ac005d63e9 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
-    rustix                         0.38.40  99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0 \
-    rustls                         0.23.16  eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e \
+    rustix                         0.38.41  d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6 \
+    rustls                         0.23.17  7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e \
     rustls-native-certs              0.8.0  fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.10.0  16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b \
@@ -393,7 +393,7 @@ cargo.crates \
     rustybuzz                        0.7.0  162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    schannel                        0.1.26  01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1 \
+    schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
     schemars                        0.8.21  09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92 \
     schemars_derive                 0.8.21  b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
@@ -401,7 +401,7 @@ cargo.crates \
     scroll_derive                   0.12.0  7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
-    security-framework-sys          2.12.0  ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6 \
+    security-framework-sys          2.12.1  fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
     serde                          1.0.215  6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f \
@@ -457,9 +457,9 @@ cargo.crates \
     test-log                        0.2.16  3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93 \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
     textwrap                        0.16.1  23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9 \
-    thiserror                       1.0.67  3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd \
+    thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
     thiserror                        2.0.3  c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa \
-    thiserror-impl                  1.0.67  b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6 \
+    thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                   2.0.3  f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tikv-jemalloc-sys 0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.5.4

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
