### PR TITLE
openldap: New bug fix for all OS < 22

### DIFF
--- a/databases/openldap/Portfile
+++ b/databases/openldap/Portfile
@@ -59,9 +59,6 @@ patchfiles-append   patch-libressl.diff
 # Use 'gdate', rather than 'date', for tests
 patchfiles-append   patch-tests-gdate.diff
 
-# Use 'msoelim', rather than 'soelim', to replace 'groff' dependency.
-patchfiles-append   patch-soelim-name.diff
-
 configure.env-append \
                     LANG=C
 configure.cppflags-append \
@@ -82,9 +79,11 @@ platform darwin {
         # not provide groff as part of the base OS install.
         #
         # Replace soelim command from heavy port groff with lightweight mandoc.
-        # Patch required for change in 'soelim' command name.
         depends_build-append \
                     port:mandoc
+
+        # Use command 'msoelim', rather than 'soelim', when using `mandoc`.
+        patchfiles-append   patch-soelim-name.diff
     }
 }
 


### PR DESCRIPTION
#### Description

* Bug fix for PR #26700.  Broke all builders for OS < 22.
* Command name change for "soelim" to "msoelim" must be inside OS >= 22 conditional.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 13, 14 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?