### PR TITLE
py-numpy: modify depends cython and fftw-3

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                py-numpy
 version             1.26.4
-revision            2
+revision            3
 
 # stealth update recipe, due to swith to PyPI
 dist_subdir         ${name}/${version}_1
@@ -90,7 +90,8 @@ if {${name} ne ${subport}} {
     }
 
     depends_build-append \
-                        path:bin/pkg-config:pkgconfig
+                        path:bin/pkg-config:pkgconfig \
+                        path:bin/cython-${python.branch}:py${python.version}-cython
 
     build.env-append    CYTHON=${prefix}/bin/cython-${python.branch}
 
@@ -102,9 +103,6 @@ if {${name} ne ${subport}} {
 
     # https://trac.macports.org/ticket/67136
     depends_run-append  port:py${python.version}-oldest-supported-numpy
-
-    depends_lib-append  port:fftw-3 \
-                        path:bin/cython-${python.branch}:py${python.version}-cython
 
     # NumPy (and SciPy) only support the Accelerate framework for macOS 13.3+
     # see: https://github.com/numpy/numpy/blob/v1.26.4/INSTALL.rst#macos


### PR DESCRIPTION
* move cython to depends_build
* drop obsolete depends fftw-3

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Command Line Tools 14.2.0.0.1.1668646533


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
