### PR TITLE
kegworks: new port

### DIFF
--- a/emulators/kegworks/Portfile
+++ b/emulators/kegworks/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        Kegworks-App Winery 2.0.3 v
+github.tarball_from releases
+revision            0
+name                kegworks
+platforms           {darwin >= 19.4}
+# Winery is LGPL-2.1 but will be changed later once the new codebase it finished
+license             LGPL-2.1
+categories          emulators
+
+supported_archs     x86_64
+maintainers         {@Gcenx}
+homepage            https://github.com/Kegworks-App/Kegworks/
+
+description         ${name} is a user-friendly tool used to make ports of Microsoft Windows software to Apple's macOS.
+long_description    {*}${description}
+
+distname            winery-v${version}
+use_xz              yes
+
+checksums           rmd160  53386e1f55163e397680fc061307dd71f46a1581 \
+                    sha256  bc30236554c7333f35fbff78b7eb849854b5c9521a917007cc9b4944421c5b6a \
+                    size    856768
+
+use_configure       no
+build {}
+
+destroot {
+    move "${workpath}/Winery.app" "${destroot}${applications_dir}/Kegworks Winery.app"
+    system -W ${destroot}${applications_dir} "/usr/bin/codesign --deep --force --sign - 'Kegworks Winery.app'"
+}


### PR DESCRIPTION
#### Description

My own project that replaces my wineskin tail fork.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.1 23H222 x86_64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
