### PR TITLE
offpunk: update to 2.4

### DIFF
--- a/net/offpunk/Portfile
+++ b/net/offpunk/Portfile
@@ -9,8 +9,10 @@ revision            0
 categories          net gemini
 license             AGPL
 maintainers         nomaintainer
-description         Command-line and offline-first smolnet browser/feed reader for Gemini, Gopher, Spartan and Web by Ploum.
-long_description    {*}${description}. The goal of Offpunk is to be able to synchronise your content once (a day, a week, a month) \
+description         Command-line and offline-first smolnet browser/feed reader \
+                    for Gemini, Gopher, Spartan and Web by Ploum
+long_description    {*}${description}. The goal of Offpunk is to be able \
+                    to synchronise your content once (a day, a week, a month) \
                     and then browse/organise it while staying disconnected.
 
 checksums           rmd160  2351c67c90a61cd625ea6ecedec4c15ab2dd766b \

--- a/net/offpunk/Portfile
+++ b/net/offpunk/Portfile
@@ -4,20 +4,20 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           sourcehut 1.0
 
-sourcehut.setup     lioploum offpunk 2.3 v
+sourcehut.setup     lioploum offpunk 2.4 v
 revision            0
 categories          net gemini
 license             AGPL
-maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+maintainers         nomaintainer
 description         Command-line and offline-first smolnet browser/feed reader for Gemini, Gopher, Spartan and Web by Ploum.
 long_description    {*}${description}. The goal of Offpunk is to be able to synchronise your content once (a day, a week, a month) \
                     and then browse/organise it while staying disconnected.
 
-checksums           rmd160  065a61d99e890856ae46268d2ea95a6484c10d54 \
-                    sha256  9b3e4c38a9517b77280cc97a38f4a24e3b7ef07945bebdf2f7c58064a1d72b9e \
-                    size    232831
+checksums           rmd160  2351c67c90a61cd625ea6ecedec4c15ab2dd766b \
+                    sha256  f79c1a2369da20c1ef278a4eca65d320d3d7cef6cc9c2a90475c6d6132ace3fd \
+                    size    471822
 
-python.default_version 311
+python.default_version 312
 
 depends_lib-append  port:chafa \
                     port:less \

--- a/python/py-readability-lxml/Portfile
+++ b/python/py-readability-lxml/Portfile
@@ -21,12 +21,9 @@ checksums           rmd160  df491e4c463f7816f2269740cc63fc18926bcc93 \
                     sha256  e51fea56b5909aaf886d307d48e79e096293255afa567b7d08bca94d25b1a4e1 \
                     size    15878
 
-python.versions     38 39 310 311
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
     depends_lib-append \
                     port:py${python.version}-chardet \
                     port:py${python.version}-cssselect \


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
