### PR TITLE
micronaut: update to 4.7.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.7.0 v
+github.setup    micronaut-projects micronaut-starter 4.7.1 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  3f5535e0cfdebfed368f5b1c55625cace50f7686 \
-                 sha256  8f66f1f857ad0f85bbfe37bf0d59926e1e8dada6d54ec2a8ac3566b2daf691a0 \
-                 size    27587239
+    checksums    rmd160  73d1a43860d3cc452df9741b201c2811ffe448a6 \
+                 sha256  5f674fb70129322dbf39d2bbe959510bf4c83568220b726e1d2a138068a7c090 \
+                 size    27586407
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  67cd4e4c82dcc328f5606eefbd3a9570b1e45ddb \
-                 sha256  7d29ada613a50d2f59b8e5986b3698612a89ac7f80b44d707e94caac9b80c46d \
-                 size    27587836
+    checksums    rmd160  1f86ced15c68870598a5f7c629a4cfdcb426a2d2 \
+                 sha256  c7ec0ca510d507cd2eb64d392e0d88f87ae08c8cdfe1c11a79b70607f82d24ba \
+                 size    27586978
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut 4.7.1.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?