### PR TITLE
gitlab-runner: Update to 17.5.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 16.8.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 17.5.1 v
 revision            0
 
 homepage            https://docs.gitlab.com/runner/
@@ -22,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9ed42256923bd8eb181348e757686cbaaba3d2db \
-                    sha256  159a25aff547e45d45d907b9d3f93820f2c18ce76e07bb8e134a75a76687e060 \
-                    size    1349626
+checksums           rmd160  f220b828fb31bede2ab761543efc945858569935 \
+                    sha256  caf8c9295242cb41be526f07daa9939651a190fdf5b8e96bb083d84afc7031f6 \
+                    size    1727140
 
 # Allow Go to fetch deps at build time
 go.offline_build no


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

macOS 13.7.1 22H221 x86_64
Command Line Tools 15.1.0.0.1.1700200546

macOS 10.15.7 19H2026 x86_64
Command Line Tools 12.4.0.0.1.1610135815

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
