### PR TITLE
imagemagick7: Update to 7.1.1-41

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -21,12 +21,12 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-github.setup        ImageMagick ImageMagick 7.1.1-38
-revision            2
+github.setup        ImageMagick ImageMagick 7.1.1-41
+revision            0
 
-checksums           rmd160  9b461dc2111125fd05ca0949db5480794b87bef2 \
-                    sha256  109c4ce940db01e6e45ede67800e58ad1beaac9b04f27c618ffc4a1ec317159d \
-                    size    15657803
+checksums           rmd160  33aaaa6f16fd50916abfaa646c56d2c5d25da52e \
+                    sha256  38b8de7ca1f2b3cabfba3f1dd2010a63e07818bce41b930c6565f9f1ad1cf2fb \
+                    size    15669516
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \


### PR DESCRIPTION
#### Description

imagemagick7: Normal update from 7.1.1-38 to 7.1.1-41

###### Type(s)

* Update

###### Tested on

macOS 14.6.1 23G93 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `port -s install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?