### PR TITLE
py313-mypy: fix compilation on OS X <= 10.9

### DIFF
--- a/python/py-mypy/Portfile
+++ b/python/py-mypy/Portfile
@@ -3,6 +3,7 @@
 PortSystem 1.0
 PortGroup python 1.0
 PortGroup select 1.0
+PortGroup compiler_blacklist_versions 1.0
 
 name                py-mypy
 version             1.13.0
@@ -37,7 +38,8 @@ if {${name} ne ${subport}} {
     }
 
     compiler.blacklist-append \
-                            *gcc-4.0 *gcc-4.2
+                            *gcc-4.0 *gcc-4.2 \
+                            {clang < 602}
 
     build.env-append        MYPY_USE_MYPYC=1
 


### PR DESCRIPTION
#### Description

Build failed on 10.9 because the code uses C11 features, but AppleClang 600 (provided by Xcode 6.2, the latest available version on 10.9) defaults to an earlier dialect. It issues a warning, which turns into an error because of compiler flags. Clang 3.6, upon which AppleClang 602 (from Xcode 6.3, which requires OS X 10.10) is based, switched to C11 as its default dialect. Setting `compiler.c_standard 2011` did not seem to set the correct flags to fix the problem, so the easiest solution was to blacklist Clang < 602. This causes MacPorts to pick a newer compiler, MacPorts Clang 17 in my case, and the build succeeds.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Tested by running the binaries without options.