### PR TITLE
lf: Update to 33

### DIFF
--- a/sysutils/lf/Portfile
+++ b/sysutils/lf/Portfile
@@ -3,11 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gokcehan/lf 32 r
+go.setup            github.com/gokcehan/lf 33 r
 revision            0
 categories          sysutils
 maintainers         {judaew @judaew} openmaintainer
 license             MIT
+platforms           {darwin >= 17}
 
 description         Terminal file manager
 long_description    ${name} (as in \"list files\") is a terminal file manager \
@@ -17,9 +18,9 @@ long_description    ${name} (as in \"list files\") is a terminal file manager \
                     external tools.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  eb1c8d8ef935581d918630bbcee6f9f95b884cb8 \
-                        sha256  46efb7c58257820a35d10780a8253ca4b55de345c20eb454a715f354a6e0d308 \
-                        size    141938
+                        rmd160  0f54ae796714f0e53163967a3dbcde4ee7938e09 \
+                        sha256  bb22c16c30200142704e48eb044a8811db7d0f51edeed1662824ceb110da2060 \
+                        size    146119
 
 build.pre_args      -ldflags \"-s -w -X main.gVersion=${version}\"
 
@@ -29,25 +30,25 @@ go.vendors          golang.org/x/text \
                         sha256  ef54709caaafdd8b27ce3d5f7c53408f11bc5fd1688c1c4f328de8ed268b3188 \
                         size    8972503 \
                     golang.org/x/term \
-                        lock    v0.18.0 \
-                        rmd160  c183fe023094cf41b6a66e88cd765d97a35f439c \
-                        sha256  3441bd395a6788d71ab9d7fb4e16df2975c41f252cc21b5c8706feb92b9df47a \
-                        size    14742 \
+                        lock    v0.25.0 \
+                        rmd160  ca833ac737fee5ec966abbb66a96939a99bb0cc4 \
+                        sha256  b7e1430c8d62c201eeb85b4dabd2801c0bbe7e83cdeb71c35f3e4fa44faed0ad \
+                        size    14759 \
                     golang.org/x/sys \
-                        lock    v0.18.0 \
-                        rmd160  f2df5cddcd4f72d2eb7f75309ed3c1c821e05d66 \
-                        sha256  d8d4c0874ddc66e9fb0c1264b4eeb8b8625153740b751eae59220eb5ff17eacb \
-                        size    1448593 \
+                        lock    v0.26.0 \
+                        rmd160  19987e0da1912ad52b2b04531f53e61b342592e6 \
+                        sha256  4f47aa2c6f4fede87b4ff8bfb3da47c6b1ddc10bfdb2a5d85a97131f6a459313 \
+                        size    1509195 \
                     github.com/rivo/uniseg \
                         lock    v0.4.3 \
                         rmd160  8549c36ce2cf42213bec9682642a6711ef4041f3 \
                         sha256  7578a5eac90d671db12e8ffd6c808ec285af8751bdeaa6a59bddd4341698758a \
                         size    452761 \
                     github.com/mattn/go-runewidth \
-                        lock    v0.0.15 \
-                        rmd160  702d468077550681ac11c3c2f3f5c9f98a868798 \
-                        sha256  a6b5f47ffe7329895a605c356ff806dfd50b536bbc87af77773e55ad6e52d2db \
-                        size    18287 \
+                        lock    v0.0.16 \
+                        rmd160  297825c4365b5f723ae485e726259ebb620ecd66 \
+                        sha256  6c9e81a6b46220612b97ebc35e8d29d1907fd225a9ce3e40b7cebd64cc58d09c \
+                        size    18496 \
                     github.com/lucasb-eyer/go-colorful \
                         lock    v1.2.0 \
                         rmd160  a4183d0625e6c94474942cdc544c1061d35c4e34 \
@@ -63,6 +64,11 @@ go.vendors          golang.org/x/text \
                         rmd160  3ed8916f763a5b51db1bcc8bd3ad06cf3d12ec07 \
                         sha256  4f470c7308790bea8a526ea26cecbaa22345aad8dc566821cda6175b3d241ee1 \
                         size    10900 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.7.0 \
+                        rmd160  9198dec094f5008a8b24a2e51542ce4ec3453162 \
+                        sha256  d7cd46fbc8e25bfd37edb1b86851dcccc18c5180f09e533c6a35e4dcf2693d22 \
+                        size    57508 \
                     github.com/djherbis/times \
                         lock    v1.6.0 \
                         rmd160  74bbca79275e2c9a5c240f77e906b640b69543a7 \
@@ -129,9 +135,10 @@ global plugin directory. If you are using Neovim, add the following line to
 your init.vim:
     set rtp+=${prefix}/share/vim/vimfiles/ftdetect
 
-lfcd it's a shell script for change working dir in your shell to the last dir
-in lf on exit (adapted from ranger). If you want to use this script, you need
-to source it in a similar way as with sourcing completion for shell above. You
-can find the script on the following path:
+lfcd is a shell script that changes the working directory in your shell to
+the last directory in lf on exit, a feature adapted from ranger. If you want
+to use this script, you need to source it in a smilar way as with sourcing
+completions for any given shell. You can find the script on the following
+path:
     ${prefix}/share/${name}
 "


### PR DESCRIPTION
#### Description

Update `lf` to its latest released version, r33. The port note was changed for clarity.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
