### PR TITLE
rogue: solve build errors on Sequoia

### DIFF
--- a/games/rogue/Portfile
+++ b/games/rogue/Portfile
@@ -21,13 +21,20 @@ homepage            http://rogue.rogueforge.net
 master_sites        ${homepage}/files/rogue5.4/
 
 checksums           md5     033288f46444b06814c81ea69d96e075 \
-                    sha1    aef9e589c4f31eb6d3eeb9d543ab8787b00fb022
+                    sha1    aef9e589c4f31eb6d3eeb9d543ab8787b00fb022 \
+                    sha256  7d37a61fc098bda0e6fac30799da347294067e8e079e4b40d6c781468e08e8a1 \
+                    rmd160  5988b9425c2ba42e82d8d8f961001378554032f6 \
+                    size    209839
+
 
 distname            ${name}${version}-src
 
 worksrcdir          ${name}${version}
 
 depends_lib-append  port:ncurses
+
+patch.pre_args-replace  -p0 -p1
+patchfiles          ncurses-compat-fix.patch
 
 configure.args-append       --with-ncurses
 configure.cflags-append     -I${prefix}/include/ncurses

--- a/games/rogue/files/ncurses-compat-fix.patch
+++ b/games/rogue/files/ncurses-compat-fix.patch
@@ -1,0 +1,75 @@
+diff -Nuar rogue5.4.4.orig/extern.h rogue5.4.4/extern.h
+--- rogue5.4.4.orig/extern.h	2007-09-06 04:08:06.000000000 +0900
++++ rogue5.4.4/extern.h	2024-11-24 10:16:48.684919316 +0900
+@@ -131,11 +131,11 @@
+ void	doctor();
+ void	end_line();
+ void    endit(int sig);
+-void	fatal();
++void	fatal(char *s);
+ void	getltchars();
+ void	land();
+ void    leave(int);
+-void	my_exit();
++void	my_exit(int st);
+ void	nohaste();
+ void	playit();
+ void    playltchars(void);
+@@ -144,7 +144,7 @@
+ void    resetltchars(void);
+ void	rollwand();
+ void	runners();
+-void	set_order();
++void	set_order(int*, int);
+ void	sight();
+ void	stomach();
+ void	swander();
+diff -Nuar rogue5.4.4.orig/main.c rogue5.4.4/main.c
+--- rogue5.4.4.orig/main.c	2007-09-06 04:08:06.000000000 +0900
++++ rogue5.4.4/main.c	2024-11-24 10:17:16.586566729 +0900
+@@ -238,8 +238,8 @@
+     getyx(curscr, y, x);
+     mvcur(y, x, oy, ox);
+     fflush(stdout);
+-    curscr->_cury = oy;
+-    curscr->_curx = ox;
++    oy = getcury(curscr);
++    ox = getcurx(curscr);
+ }
+ 
+ /*
+diff -Nuar rogue5.4.4.orig/rip.c rogue5.4.4/rip.c
+--- rogue5.4.4.orig/rip.c	2007-09-06 04:08:06.000000000 +0900
++++ rogue5.4.4/rip.c	2024-11-24 10:17:40.265722120 +0900
+@@ -230,7 +230,6 @@
+     char **dp, *killer;
+     struct tm *lt;
+     static time_t date;
+-    struct tm *localtime();
+ 
+     signal(SIGINT, SIG_IGN);
+     purse -= purse / 10;
+diff -Nuar rogue5.4.4.orig/rogue.h rogue5.4.4/rogue.h
+--- rogue5.4.4.orig/rogue.h	2007-09-06 04:08:06.000000000 +0900
++++ rogue5.4.4/rogue.h	2024-11-24 10:18:08.129746886 +0900
+@@ -729,7 +729,7 @@
+ 
+ extern struct delayed_action {
+     int d_type;
+-    void (*d_func)();
++    void (*d_func)(int d_arg);
+     int d_arg;
+     int d_time;
+ } d_list[MAXDAEMONS];
+diff -Nuar rogue5.4.4.orig/state.c rogue5.4.4/state.c
+--- rogue5.4.4.orig/state.c	2007-09-06 04:08:06.000000000 +0900
++++ rogue5.4.4/state.c	2024-11-24 10:18:31.635472170 +0900
+@@ -1413,7 +1413,7 @@
+ 
+     for (i = 0; i < cnt; i++) 
+     {
+-        l = new_item(sizeof(THING));
++        l = new_item();
+ 
+         memset(l,0,sizeof(THING));
+ 


### PR DESCRIPTION
* add patch for build errors and warnings
* add sha256, rmd160 checksum to Portfile

Closes: https://trac.macports.org/ticket/70909

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1.1 24B91 x86_64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
