### PR TITLE
podman: Update to 5.3.1 & Fix checksums for pre-Monterey version

### DIFF
--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -54,9 +54,9 @@ if {${os.platform} eq "darwin" && ${os.major} <= 21} {
     epoch               1
 
     checksums           ${distname}${extract.suffix} \
-                        rmd160  7879d9a1e33f831ebe038d65d4a9c7faabe423f6 \
-                        sha256  0e1c4202d25dc270b996583cff97d806eab88682beb9586a6813431559273fc9 \
-                        size    23794235
+                        rmd160  51154051117060ccf70b68eef6112f27f7dcbf31 \
+                        sha256  51ba7995fb61f2781054e5baa6d8ef931158e3bf81d198355956626a2ea18ef6 \
+                        size    21733620
 
     depends_run-append   port:qemu
     depends_run-delete   port:vfkit

--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 # After the upgrade, it is highly recommended to test the `podman machine`.
 # This port has problems with this command from time to time.
 # See https://gist.github.com/judaew/85c6e8a62bf0e7f5be5188e020492e21
-go.setup            github.com/containers/podman 5.1.2 v
+go.setup            github.com/containers/podman 5.3.1 v
 github.tarball_from archive
 revision            0
 epoch               0
@@ -23,9 +23,9 @@ long_description    \
     install the remote client and then setup ssh connection information.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  7879d9a1e33f831ebe038d65d4a9c7faabe423f6 \
-                        sha256  0e1c4202d25dc270b996583cff97d806eab88682beb9586a6813431559273fc9 \
-                        size    23794235
+                        rmd160  44e1f84a44593486a10dfa46c78c743b8245d198 \
+                        sha256  5b4e9ddce69cc2c8c8b8529e90093ae3ea9cb2959e2fceb98469b282dbffbcc7 \
+                        size    24196440
 
 set py_ver          3.12
 set py_ver_nodot    [string map {. {}} ${py_ver}]


### PR DESCRIPTION
#### Description

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?