### PR TITLE
p5-dbd-mysql: Fix variant conflicts issues

### DIFF
--- a/perl/p5-dbd-mysql/Portfile
+++ b/perl/p5-dbd-mysql/Portfile
@@ -13,7 +13,7 @@ long_description    {*}${description}
 ###############################################################################
 # Create an array of DBD:MYSQL versions
 ###############################################################################
-# "DBD:MYSQL Major Verion" {
+# "DBD:MYSQL Major Version" {
 #     version    DBD:MYSQL version
 #     rmd160     value
 #     sha256     value
@@ -85,9 +85,9 @@ perl5.setup                 DBD-mysql [lindex [array get $install_version versio
 checksums                   rmd160  [lindex [array get $install_version rmd160] 1] \
                                     sha256  [lindex [array get $install_version sha256] 1] \
                                     size    [lindex [array get $install_version size] 1]
-# version gets set to the "current version" values to prevenet constant upgraing by port upgrade
+# version gets set to the "current version" values to prevent constant upgrading by port upgrade
 version                     [perl5_convert_version [lindex [array get version_current version] 1]]
-revision                    0
+revision                    1
 
 if {${perl5.major} != ""} {
     depends_build-append \
@@ -99,17 +99,12 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-dbi
 
     # loop over the array creating the specified variants
-    # with the multiple versioning change, the conflicts lists no longer apepears
-    # to be enforced, so this will be handled later in the pre-fetch stage with
-    # active_vaiants.  The conflicts list is left here so the user gets the approprate
-    # warning when running port variant
+    # the {*} is necessary to break out the conflict_list into multiple variants vs.
+    # one single incorrectly formatted conflict
     foreach variant_name [array names db_variants] {
         set idx [lsearch [array names db_variants] $variant_name]
         set conflict_list [lreplace [array names db_variants] $idx $idx]
-        variant $variant_name conflicts $conflict_list description "build with $variant_name" {}
-        if {[variant_isset $variant_name]} {
-            set active_conflicts $conflict_list
-        }
+        variant $variant_name conflicts {*}$conflict_list description "build with $variant_name" {}
     }
 
     # add the build dependencies, this must be done outside the variant call to work
@@ -122,21 +117,6 @@ if {${perl5.major} != ""} {
             depends_lib-append      port:$reqPort
             configure.args-append   --mysql_config=${prefix}/lib/$reqPort/bin/mysql_config
         }
-    }
-}
-
-# Use active_variants to enforce that only one variant can be installed at any given time
-pre-fetch {
-    if {![catch {set result [active_variants p${perl5.major}-dbd-mysql $active_conflicts ""]}]} {
-        ui_error "
-            ****
-            **** p${perl5.major}-dbd-mysql can only have one active variant installed
-            **** If you need this vaiant, deactivate the previously installed one with
-            ****     port deactivate p${perl5.major}-dbd-mysql
-            **** or uninstall is with
-            ****     sudo port uninstall p${perl5.major}-dbd-mysql
-            ****"
-        error "Error: p${perl5.major}-dbd-mysql variant already installed"
     }
 }
 


### PR DESCRIPTION
Fix issue where multiple variant conflicts were being set as a single
  conflict. Fixing this also allowed for the removal of the
  active_vartiants workaround.

  - fix variant conflicts
  - remove active variants workaround\
  - fix typos
  
Closes: https://trac.macports.org/ticket/60517
Closes: https://trac.macports.org/ticket/71360
Closes: https://trac.macports.org/ticket/71381

Note - I have these broken into 2 commits to allow them to be tracked easier.

#### Description

Correct improper variant conflicts issue where all conflicts were handled as a single port.  Additionally, attempt to address typos (at least the ones I can find) and add back the legacy mariadb10_2 variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
