### PR TITLE
postgres95: Bugfix, Make PostgreSQL work with newer libxml2

### DIFF
--- a/databases/postgresql95/Portfile
+++ b/databases/postgresql95/Portfile
@@ -7,7 +7,6 @@ PortGroup deprecated 1.0
 
 # Final release was on 2021-02-08
 deprecated.upstream_support no
-known_fail      yes
 
 #remember to update the -doc and -server as well
 name			postgresql95
@@ -37,6 +36,10 @@ use_bzip2		yes
 
 # do not build man or html files (use postgresqlXY-doc instead)
 patchfiles-append   patch-no_doc.diff
+
+# https://www.postgresql.org/message-id/attachment/152769/v1-0001-Make-PostgreSQL-work-with-newer-version-of-libxml.patch
+# diff -NaurdwB ./postgresql95-orig ./postgresql95-new | sed -E -e 's/\.\/postgresql95-(orig|new)/\./g' | sed -E -e 's|/opt/local|@@PREFIX@@|g' > ~/Downloads/patch-xml_c.diff
+patchfiles-append   patch-xml_c.diff
 
 depends_lib		port:readline path:lib/libssl.dylib:openssl port:zlib port:libxml2 port:libxslt
 depends_build		port:bison

--- a/databases/postgresql95/files/patch-xml_c.diff
+++ b/databases/postgresql95/files/patch-xml_c.diff
@@ -1,0 +1,31 @@
+diff -NaurdwB ./src/backend/utils/adt/xml.c ./src/backend/utils/adt/xml.c
+--- ./src/backend/utils/adt/xml.c	2024-11-23 14:50:40
++++ ./src/backend/utils/adt/xml.c	2024-11-23 14:57:53
+@@ -117,7 +117,12 @@
+ 
+ static xmlParserInputPtr xmlPgEntityLoader(const char *URL, const char *ID,
+ 				  xmlParserCtxtPtr ctxt);
++/* https://www.postgresql.org/message-id/attachment/152769/v1-0001-Make-PostgreSQL-work-with-newer-version-of-libxml.patch */
++#if LIBXML_VERSION >= 21200
++static void xml_errorHandler(void *data, const xmlError *error);
++#else
+ static void xml_errorHandler(void *data, xmlErrorPtr error);
++#endif
+ static void xml_ereport_by_code(int level, int sqlcode,
+ 					const char *msg, int errcode);
+ static void chopStringInfoNewlines(StringInfo str);
+@@ -1655,8 +1660,12 @@
+ /*
+  * Error handler for libxml errors and warnings
+  */
+-static void
+-xml_errorHandler(void *data, xmlErrorPtr error)
++/* https://www.postgresql.org/message-id/attachment/152769/v1-0001-Make-PostgreSQL-work-with-newer-version-of-libxml.patch */
++#if LIBXML_VERSION >= 21200
++static void xml_errorHandler(void *data, const xmlError *error)
++#else
++static void xml_errorHandler(void *data, xmlErrorPtr error)
++#endif
+ {
+ 	PgXmlErrorContext *xmlerrcxt = (PgXmlErrorContext *) data;
+ 	xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) error->ctxt;


### PR DESCRIPTION
Fixes:

* https://www.postgresql.org/message-id/attachment/152769/v1-0001-Make-PostgreSQL-work-with-newer-version-of-libxml.patch
* https://lists.macports.org/pipermail/macports-dev/2024-November/045952.html

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
