### PR TITLE
http_ping: Update to 20160309

### DIFF
--- a/net/http_ping/Portfile
+++ b/net/http_ping/Portfile
@@ -1,29 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem              1.0
+PortGroup               openssl 1.0
+PortGroup               makefile 1.0
 
 name                    http_ping
-version                 29jun2005
+version                 09Mar2016
+revision                0
 categories              net www
 license                 BSD
 maintainers             nomaintainer
+
 description             Sends HTTP requests every few seconds and times how long they take
-long_description        ${description}
-homepage                http://www.acme.com/software/http_ping/
-platforms               darwin
+long_description        {*}${description}
+
+homepage                https://www.acme.com/software/http_ping/
 master_sites            ${homepage}
 distname                ${name}_${version}
-checksums               md5 6ff0319344f934baa5a5f9bc6df7eaf7
-use_configure           no
+
+checksums               rmd160  ec19e900d7ad738f3ba4863ade11a2e7148c5d9a \
+                        sha256  f8b95773aaed09839a44a1927f979a62752d57aace79da3846bfb73e6c9805e9 \
+                        size    8106
 
 worksrcdir              ${name}
-build.target
+patchfiles-append       makefile-support-macports-openssl3.diff
 
 destroot {
-	xinstall -m 755 -d ${destroot}${prefix}/bin
-	xinstall -m 755 -d ${destroot}${prefix}/man/man1
-	xinstall -m 755 ${worksrcpath}/http_ping \
-		${destroot}${prefix}/bin
-	xinstall -m 755 ${worksrcpath}/http_ping.1 \
-		${destroot}${prefix}/man/man1
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 644 ${worksrcpath}/${name}.1 ${destroot}${prefix}/share/man/man1/
 }
 
 livecheck.type          regex

--- a/net/http_ping/Portfile
+++ b/net/http_ping/Portfile
@@ -1,21 +1,20 @@
-PortSystem 1.0
+PortSystem              1.0
 
-name		http_ping
-version		29jun2005
-categories	net www
-license		BSD
-maintainers	nomaintainer
-description	Sends HTTP requests every few seconds and times how \
-		long they take
-long_description	${description}
-homepage	http://www.acme.com/software/http_ping/
-platforms	darwin
-master_sites	${homepage}
-distname	${name}_${version}
-checksums	md5 6ff0319344f934baa5a5f9bc6df7eaf7
-use_configure	no
+name                    http_ping
+version                 29jun2005
+categories              net www
+license                 BSD
+maintainers             nomaintainer
+description             Sends HTTP requests every few seconds and times how long they take
+long_description        ${description}
+homepage                http://www.acme.com/software/http_ping/
+platforms               darwin
+master_sites            ${homepage}
+distname                ${name}_${version}
+checksums               md5 6ff0319344f934baa5a5f9bc6df7eaf7
+use_configure           no
 
-worksrcdir	${name}
+worksrcdir              ${name}
 build.target
 
 destroot {
@@ -27,5 +26,5 @@ destroot {
 		${destroot}${prefix}/man/man1
 }
 
-livecheck.type	regex
-livecheck.regex	${name}_(\[0-9A-Za-z._\]+)\\.tar
+livecheck.type          regex
+livecheck.regex         ${name}_(\[0-9A-Za-z._\]+)\\.tar

--- a/net/http_ping/files/makefile-support-macports-openssl3.diff
+++ b/net/http_ping/files/makefile-support-macports-openssl3.diff
@@ -1,0 +1,17 @@
+--- Makefile	2014-08-11 19:13:31.000000000 +0000
++++ Makefile	2024-11-24 19:47:54.834320939 +0000
+@@ -9,10 +9,10 @@
+ # http://www.openssl.org/  Make sure the SSL_TREE definition points to the
+ # tree with your OpenSSL installation - depending on how you installed it,
+ # it may be in /usr/local instead of /usr/local/ssl.
+-#SSL_TREE =	/usr/local/ssl
+-#SSL_DEFS =	-DUSE_SSL
+-#SSL_INC =	-I$(SSL_TREE)/include
+-#SSL_LIBS =	-L$(SSL_TREE)/lib -lssl -lcrypto
++SSL_TREE =	$(PREFIX)/libexec/openssl3
++SSL_DEFS =	-DUSE_SSL
++SSL_INC =	-I$(SSL_TREE)/include
++SSL_LIBS =	-L$(SSL_TREE)/lib -lssl -lcrypto
+ 
+ 
+ BINDIR =	/usr/local/bin


### PR DESCRIPTION
#### Description

Update `http_ping` to its "latest released" version, released back in March 9, 2016. Much of this PR modernizes the Portfile (by using appropiate indentation, modline, and PortGroups)

One quirk I didn't fix was the `livecheck` method; it reports `09Mar2016` as being older than `29jun2005`.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
