### PR TITLE
eigen3-devel: update to 20241122

### DIFF
--- a/math/eigen3/Portfile
+++ b/math/eigen3/Portfile
@@ -34,21 +34,21 @@ if {${subport} eq ${name}} {
 }
 
 subport eigen3-devel {
-    gitlab.setup        libeigen eigen e67c494c
+    gitlab.setup        libeigen eigen 8ad4344c
     # For when there is no current development version (other than rolling snapshot)
-    version             3.4-tracking-20241114
+    version             3.4-tracking-20241122
     revision            0
     epoch               3
-    gitlab.livecheck.branch 3.4
+    gitlab.livecheck.branch master
 
     conflicts           eigen3
 
     long_description    {*}${description} This (-devel) version tracks \
                         development of the current (3.4) branch.
 
-    checksums           rmd160  ba24d5296d620b6bed6270e26bebd6e48b52320a \
-                        sha256  65a1ad8e52e5717fcc23f56160fa4798a966981f562de19a93174edcbb6e4ee5 \
-                        size    2148891
+    checksums           rmd160  c7891fe0d6b45c82bb938a0fa596803148456abb \
+                        sha256  2550f496965bc1409f421f3fb20e4b3adecb374712cdb3e57f173e1f4f23a97c \
+                        size    2278889
 
     # Eigen's source code specifically checks the version of Apple Clang.
     compiler.blacklist-append \


### PR DESCRIPTION
#### Description

Unfortunately, last update left `eigen3-devel` broken again, since turned out, the fix has not been backported into 3.4 branch. I have opened an issue for that: https://gitlab.com/libeigen/eigen/-/issues/2875
But in any case, -devel should rather track master, and master branch works correctly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
