### PR TITLE
rogue: increase revision number and correct wrong patch

### DIFF
--- a/games/rogue/Portfile
+++ b/games/rogue/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                rogue
 version             5.4.4
-revision            3
+revision            4
 categories          games
 maintainers         nomaintainer
 license             BSD

--- a/games/rogue/files/ncurses-compat-fix.patch
+++ b/games/rogue/files/ncurses-compat-fix.patch
@@ -1,6 +1,6 @@
 diff -Nuar rogue5.4.4.orig/extern.h rogue5.4.4/extern.h
 --- rogue5.4.4.orig/extern.h	2007-09-06 04:08:06.000000000 +0900
-+++ rogue5.4.4/extern.h	2024-11-24 10:16:48.684919316 +0900
++++ rogue5.4.4/extern.h	2024-11-25 15:32:38.468557242 +0900
 @@ -131,11 +131,11 @@
  void	doctor();
  void	end_line();
@@ -26,21 +26,19 @@ diff -Nuar rogue5.4.4.orig/extern.h rogue5.4.4/extern.h
  void	swander();
 diff -Nuar rogue5.4.4.orig/main.c rogue5.4.4/main.c
 --- rogue5.4.4.orig/main.c	2007-09-06 04:08:06.000000000 +0900
-+++ rogue5.4.4/main.c	2024-11-24 10:17:16.586566729 +0900
-@@ -238,8 +238,8 @@
++++ rogue5.4.4/main.c	2024-11-25 15:33:12.378402187 +0900
+@@ -238,8 +238,6 @@
      getyx(curscr, y, x);
      mvcur(y, x, oy, ox);
      fflush(stdout);
 -    curscr->_cury = oy;
 -    curscr->_curx = ox;
-+    oy = getcury(curscr);
-+    ox = getcurx(curscr);
  }
  
  /*
 diff -Nuar rogue5.4.4.orig/rip.c rogue5.4.4/rip.c
 --- rogue5.4.4.orig/rip.c	2007-09-06 04:08:06.000000000 +0900
-+++ rogue5.4.4/rip.c	2024-11-24 10:17:40.265722120 +0900
++++ rogue5.4.4/rip.c	2024-11-25 15:32:38.470185854 +0900
 @@ -230,7 +230,6 @@
      char **dp, *killer;
      struct tm *lt;
@@ -51,7 +49,7 @@ diff -Nuar rogue5.4.4.orig/rip.c rogue5.4.4/rip.c
      purse -= purse / 10;
 diff -Nuar rogue5.4.4.orig/rogue.h rogue5.4.4/rogue.h
 --- rogue5.4.4.orig/rogue.h	2007-09-06 04:08:06.000000000 +0900
-+++ rogue5.4.4/rogue.h	2024-11-24 10:18:08.129746886 +0900
++++ rogue5.4.4/rogue.h	2024-11-25 15:32:38.471140388 +0900
 @@ -729,7 +729,7 @@
  
  extern struct delayed_action {
@@ -63,7 +61,7 @@ diff -Nuar rogue5.4.4.orig/rogue.h rogue5.4.4/rogue.h
  } d_list[MAXDAEMONS];
 diff -Nuar rogue5.4.4.orig/state.c rogue5.4.4/state.c
 --- rogue5.4.4.orig/state.c	2007-09-06 04:08:06.000000000 +0900
-+++ rogue5.4.4/state.c	2024-11-24 10:18:31.635472170 +0900
++++ rogue5.4.4/state.c	2024-11-25 15:32:38.472070995 +0900
 @@ -1413,7 +1413,7 @@
  
      for (i = 0; i < cnt; i++) 


### PR DESCRIPTION
* increse the revision number missing from the previous commit
* correct wrong patch code

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
