### PR TITLE
ecCodes: update to 2.39.0

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -5,7 +5,7 @@ PortGroup cmake     1.1
 PortGroup compilers 1.0
 
 name                ecCodes
-version             2.38.3
+version             2.39.0
 revision            0
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
@@ -17,9 +17,9 @@ homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
 
-checksums           rmd160  d1db4e38def67d35c0fcf4ce47c7463d4890ea07 \
-                    sha256  fa7b7ffb22973ed1dfbeb208c042a67a805ab070f1288a0f1f0707a1020d1c81 \
-                    size    12289702
+checksums           rmd160  e7bfef7982c789b61bc1ec23e0964c4c13c80107 \
+                    sha256  0c4d746700acc49af9c878925f1b26bdd42443ff7c2d7c676deb2babb6847afb \
+                    size    12581144
 
 patchfiles          patch-pkg-config.diff
 


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.39.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1.1 24B91 x86_64
Command Line Tools 16.1.0.0.1.1729049160

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
