### PR TITLE
wget2: update to 2.2.0

### DIFF
--- a/net/wget2/Portfile
+++ b/net/wget2/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                wget2
-version             2.1.0
-revision            1
+version             2.2.0
+revision            0
 
 homepage            https://gitlab.com/gnuwget/wget2
 
@@ -22,16 +22,15 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 master_sites        gnu:wget
 use_lzip            yes
 
-checksums           rmd160  c078e8d02bd9b0d741f53f23cb01d3bd9c687df6 \
-                    sha256  bc034194b512bb83ce0171d15a8db33e1c5c3ab8b3e343e1e6f2cf48f9154fad \
-                    size    2122122
+checksums           rmd160  1195a2fc4e3cc229d1b95c04db0b62afe446b89a \
+                    sha256  ffa5e49db90c9ddc0c830b66e473630c679b1b0a26a53d24981d4f0efa1c90b6 \
+                    size    2214840
 
 depends_build-append \
                     port:gettext \
                     path:bin/pkg-config:pkgconfig
 
-depends_lib-append  path:lib/pkgconfig/gnutls.pc:gnutls \
-                    port:brotli \
+depends_lib-append  port:brotli \
                     port:bzip2 \
                     port:gettext-runtime \
                     port:gpgme \
@@ -67,12 +66,31 @@ configure.args-append \
                     --with-libpsl \
                     --with-lzip \
                     --with-lzma \
-                    --with-ssl=gnutls \
                     --with-zlib \
-                    --with-zstd
+                    --with-zstd \
+                    --without-ssl
 
 compiler.blacklist-append \
                     {*gcc-[34].*}
+
+variant gnutls conflicts ssl description {SSL support via GnuTLS} {
+    configure.args-replace \
+                    --without-ssl --with-ssl=gnutls
+
+    depends_lib-append \
+                    path:lib/pkgconfig/gnutls.pc:gnutls
+}
+
+variant ssl conflicts gnutls description {SSL support via OpenSSL} {
+    PortGroup       openssl 1.0
+
+    configure.args-replace \
+                    --without-ssl --with-ssl=openssl
+}
+
+if {![variant_isset ssl]} {
+    default_variants +gnutls
+}
 
 post-destroot {
     xinstall -m 0444 ${worksrcpath}/docs/man/man1/${name}.1 \


### PR DESCRIPTION
- add OpenSSL variant

See: https://trac.macports.org/ticket/70769

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
