### PR TITLE
ncmpcpp: update to 0.10.1

### DIFF
--- a/audio/ncmpcpp/Portfile
+++ b/audio/ncmpcpp/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           boost 1.0
+PortGroup           github 1.0
 
 # Boost 1.76 has a bug which breaks builds with modern gcc.
 # configure: error: cannot find boost/math/special_functions.hpp
@@ -9,12 +10,12 @@ PortGroup           boost 1.0
 # /opt/local/include/gcc13/c++/utility: error: '__and_' was not declared in this scope; did you mean 'std::__and_'?
 boost.version       1.81
 
-name                ncmpcpp
-version             0.9.2
-revision            5
-checksums           rmd160  112c518bd0b7f1467ba7949d2f25ca19c64abcf2 \
-                    sha256  faabf6157c8cb1b24a059af276e162fa9f9a3b9cd3810c43b9128860c9383a1b \
-                    size    486266
+github.setup        ncmpcpp ncmpcpp 0.10.1
+revision            0
+checksums           rmd160  f7ff8ac8b81e79bb9ad5799222869cbc82f93d71 \
+                    sha256  ddc89da86595d272282ae8726cc7913867b9517eec6e765e66e6da860b58e2f9 \
+                    size    231032
+github.tarball_from archive
 
 categories          audio
 maintainers         nomaintainer
@@ -25,12 +26,13 @@ long_description    Ncmpcpp has UI very similar to ncmpc's one, but it provides 
                     sort playlist, local filesystem browser and other minor functions.
 homepage            https://rybczak.net/ncmpcpp/
 license             GPL-2+
-master_sites        ${homepage}stable/
-use_bzip2           yes
 
-depends_build       port:pkgconfig
+use_autoreconf      yes
 
-depends_lib         port:curl \
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  port:curl \
                     path:lib/pkgconfig/icu-uc.pc:icu \
                     port:libmpdclient \
                     port:ncurses \
@@ -48,7 +50,3 @@ variant visualizer description "Enable Visualizer" {
     configure.args-replace  --without-fftw --with-fftw=${prefix}
     configure.args-append   --enable-visualizer
 }
-
-livecheck.type      regex
-livecheck.url       ${homepage}installation/
-livecheck.regex     "stable\/${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
