### PR TITLE
py-acor: add py312, py313 subports

### DIFF
--- a/python/py-acor/Portfile
+++ b/python/py-acor/Portfile
@@ -20,9 +20,14 @@ checksums           rmd160  d6e0c55e4db74b45e2ed632a0a553851ef6fe017 \
                     sha256  4c647d30326004cfcfbcf630e97586ce574954e36bebf75b657d33d5d79e94e3 \
                     size    6122
 
-python.versions     311
+python.versions     311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-numpy
+
+    # pyatomic.h: error: #error "no available pyatomic implementation for this platform/compiler"
+    if {${python.version} > 312} {
+        compiler.c_standard 2011
+    }
 }


### PR DESCRIPTION
#### Description

Add subport for new pythons.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
