### PR TITLE
sgrep: Update to 1.94a

### DIFF
--- a/textproc/sgrep/Portfile
+++ b/textproc/sgrep/Portfile
@@ -1,31 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem              1.0
 
 name                    sgrep
-version                 0.99
+version                 1.94a
+revision                0
 categories              textproc
 license                 GPL-2+
-platforms               darwin
 maintainers             nomaintainer
-description             structured grep is a tool for searching SGML, XML and HTML files
-long_description        sgrep (structured grep) is a tool for searching and \
-                        indexing text, SGML, XML and HTML files and filtering text streams \
-                        using structural criteria.
 
-homepage                http://www.cs.helsinki.fi/u/jjaakkol/sgrep.html
-master_sites            ftp://ftp.cs.helsinki.fi/pub/Software/Local/Sgrep/ freebsd
-checksums               md5 af09a90c4f1929bfae4818c8962a8907
+description             Search and index SGML, XML, and HTML
+long_description        ${name} (structured grep) is a tool for searching and \
+                        indexing text, SGML, XML, and HTML files, filtering using \
+                        structural critera.
 
-use_configure           no
+homepage                https://www.cs.helsinki.fi/u/jjaakkol/sgrep.html
+master_sites            debian:s/${name}
 
-build.args              BINDIR=${prefix}/bin LIBDIR=${prefix}/lib \
-                        MANFILE=${prefix}/share/man/man1/sgrep.1 \
-                        RCFILE=${prefix}/etc/sgreprc
+checksums               rmd160  d75f644fc4ba9b0eb916f8097bf58ebe4b73154c \
+                        sha256  d5b16478e3ab44735e24283d2d895d2c9c80139c95228df3bdb2ac446395faf9 \
+                        size    193267
 
-destroot.destdir        BINDIR=${destroot}${prefix}/bin \
-                        LIBDIR=${destroot}${prefix}/lib \
-                        MANFILE=${destroot}${prefix}/share/man/man1/sgrep.1 \
-                        RCFILE=${destroot}${prefix}/etc/sgreprc
-post-destroot {
-	xinstall -m 644 ${worksrcpath}/sample.sgreprc \
-		${destroot}${prefix}/etc/sgreprc.sample
+distname                ${name}_${version}.orig
+worksrcdir              ${name}-${version}
+
+configure.args-append   --mandir=${prefix}/share/man \
+                        --datadir=${prefix}/share/${name}
+
+# Fix building with newer Clang (clang >= 1403)
+configure.cflags-append -Wno-implicit-function-declaration
+
+platform darwin arm {
+    depends_build-append \
+                        port:automake
+
+    # Workaround ancient configuration files not detecting Apple Sillicon (aarch64 macos)
+    post-extract {
+        set automake_ver 1.17
+        foreach file {config.guess config.sub} {
+            delete ${worksrcpath}/${file}
+            copy ${prefix}/share/automake-${automake_ver}/${file} ${worksrcpath}/${file}
+        }
+    }
 }

--- a/textproc/sgrep/Portfile
+++ b/textproc/sgrep/Portfile
@@ -1,30 +1,30 @@
-PortSystem 1.0
+PortSystem              1.0
 
-name			sgrep
-version			0.99
-categories		textproc
-license			GPL-2+
-platforms		darwin
-maintainers		nomaintainer
-description		structured grep is a tool for searching SGML, XML and HTML files
-long_description	sgrep (structured grep) is a tool for searching and \
-			indexing text, SGML, XML and HTML files and filtering text streams \
-			using structural criteria.
+name                    sgrep
+version                 0.99
+categories              textproc
+license                 GPL-2+
+platforms               darwin
+maintainers             nomaintainer
+description             structured grep is a tool for searching SGML, XML and HTML files
+long_description        sgrep (structured grep) is a tool for searching and \
+                        indexing text, SGML, XML and HTML files and filtering text streams \
+                        using structural criteria.
 
-homepage		http://www.cs.helsinki.fi/u/jjaakkol/sgrep.html
-master_sites	ftp://ftp.cs.helsinki.fi/pub/Software/Local/Sgrep/ freebsd
-checksums		md5 af09a90c4f1929bfae4818c8962a8907
+homepage                http://www.cs.helsinki.fi/u/jjaakkol/sgrep.html
+master_sites            ftp://ftp.cs.helsinki.fi/pub/Software/Local/Sgrep/ freebsd
+checksums               md5 af09a90c4f1929bfae4818c8962a8907
 
-use_configure	no
+use_configure           no
 
-build.args		BINDIR=${prefix}/bin LIBDIR=${prefix}/lib \
-				MANFILE=${prefix}/share/man/man1/sgrep.1 \
-				RCFILE=${prefix}/etc/sgreprc
+build.args              BINDIR=${prefix}/bin LIBDIR=${prefix}/lib \
+                        MANFILE=${prefix}/share/man/man1/sgrep.1 \
+                        RCFILE=${prefix}/etc/sgreprc
 
-destroot.destdir	BINDIR=${destroot}${prefix}/bin \
-				LIBDIR=${destroot}${prefix}/lib \
-				MANFILE=${destroot}${prefix}/share/man/man1/sgrep.1 \
-				RCFILE=${destroot}${prefix}/etc/sgreprc
+destroot.destdir        BINDIR=${destroot}${prefix}/bin \
+                        LIBDIR=${destroot}${prefix}/lib \
+                        MANFILE=${destroot}${prefix}/share/man/man1/sgrep.1 \
+                        RCFILE=${destroot}${prefix}/etc/sgreprc
 post-destroot {
 	xinstall -m 644 ${worksrcpath}/sample.sgreprc \
 		${destroot}${prefix}/etc/sgreprc.sample


### PR DESCRIPTION
#### Description

Update `sgrep` to its last released version, 1.94a. This PR serves to modernize the Portfile by using appropiate indentation and fixing building on Apple Sillicon.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
