### PR TITLE
unac: Include patches to fix build

### DIFF
--- a/textproc/unac/Portfile
+++ b/textproc/unac/Portfile
@@ -4,8 +4,8 @@ PortSystem              1.0
 
 name                    unac
 version                 1.8.0
+revision                1
 categories              textproc
-platforms               darwin
 maintainers             nomaintainer
 license                 GPL-2+
 
@@ -13,23 +13,32 @@ description             library that removes accents from characters
 
 long_description        ${name} is a ${description}.
 
-homepage                http://www.senga.org/
-master_sites            http://ftp.de.debian.org/debian/pool/main/u/unac/
+homepage                https://savannah.nongnu.org/projects/unac
+master_sites            debian:u/${name}
 
 distname                ${name}_${version}.orig
 worksrcdir              ${name}-${version}.orig
 
 checksums               rmd160  6cc899d4e55fe740ecaf96342a9904555601156b \
-                        sha256  29d316e5b74615d49237556929e95e0d68c4b77a0a0cfc346dc61cf0684b90bf
+                        sha256  29d316e5b74615d49237556929e95e0d68c4b77a0a0cfc346dc61cf0684b90bf \
+                        size    281807
 
 patchfiles              patch-configure.diff
+patchfiles-append       gcc-4-fix-bug-556379.patch
 
 use_autoreconf          yes
+autoreconf.cmd          ./autogen.sh
 
-depends_build-append    port:perl5
+depends_build-append    port:perl5 \
+                        port:autoconf \
+                        port:automake \
+                        port:gettext \
+                        port:libtool
 
-depends_lib             port:libiconv
+depends_lib-append      port:libiconv
 
-pre-configure {
-    touch ${worksrcpath}/config.rpath
+# Provide missing configuration files to fix build
+post-extract {
+    copy ${prefix}/share/gettext/config.rpath ${worksrcpath}/config.rpath
+    reinplace -W ${worksrcpath} "s|libtoolize|glibtoolize|" autogen.sh
 }

--- a/textproc/unac/files/gcc-4-fix-bug-556379.patch
+++ b/textproc/unac/files/gcc-4-fix-bug-556379.patch
@@ -1,0 +1,53 @@
+Description: fix building with GCC 4.4 and x86-64 architecture
+Author: Emmanuel Engelhart <emmanuel@engelhart.org>
+Bug-Debian: https://bugs.debian.org/556379
+Last-Update: 2010-09-17
+
+Description: type error in causes segfault
+Author: Phil Armstrong <phil@kantaka.co.uk>
+Bug-Debian: https://bugs.debian.org/623340
+Last-Update: 2011-04-19
+===================================================================
+--- unac.c.orig	Fri Sep 17 10:35:14 2010 +0200
++++ unac.c	Fri Sep 17 10:36:07 2010 +0200
+@@ -13873,9 +13873,9 @@
+     *out_lengthp = 0;
+   } else {
+     char* utf16 = 0;
+-    int utf16_length = 0;
++    size_t utf16_length = 0;
+     char* utf16_unaccented = 0;
+-    int utf16_unaccented_length = 0;
++    size_t utf16_unaccented_length = 0;
+   
+     if(convert(charset, utf16be(), in, in_length, &utf16, &utf16_length) < 0) {
+       return -1;
+--- unaccent.c.orig	Fri Sep 17 10:35:14 2010 +0200
++++ unaccent.c	Fri Sep 17 10:40:34 2010 +0200
+@@ -90,7 +90,7 @@
+     const char* charset = argv[optind++];
+ 
+     char* unaccented = 0;
+-    int unaccented_length = 0;
++    size_t unaccented_length = 0;
+ 
+     if(optind >= argc) {
+ #define BUFFER_SIZE 10240
+@@ -101,7 +101,7 @@
+ 	  perror("");
+ 	  exit(1);
+ 	}
+-	printf("%.*s", unaccented_length, unaccented);
++	printf("%.*s", (int)unaccented_length, unaccented);
+       }
+     } else {
+       const char* string = argv[optind++];
+@@ -114,7 +114,7 @@
+ 
+       if(debug_level > UNAC_DEBUG_NONE)
+ 	fprintf(stderr, "unaccented version is ");
+-      printf("%.*s\n", unaccented_length, unaccented);
++      printf("%.*s\n", (int)unaccented_length, unaccented);
+ 
+       if(optind < argc) {
+ 	const char* expected = argv[optind++];


### PR DESCRIPTION
#### Description

Update `unac` to include patches from Debian to fix issues, such as type errors causing segfault, and fixing the build by providing the appropiate configuration files.

See: https://trac.macports.org/ticket/69904

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.6 23G80 arm64
Command Line Tools 16.1.0.0.1.1729049160

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
