### PR TITLE
ffmpeg-devel: fix compilation for OS X 10.7 through 10.12

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -127,6 +127,12 @@ patchfiles-append   patch-libavcodec-librsvgdec.diff
 # so the FFMpeg team does not seem to care to include this functionality
 patchfiles-append   patch-add-pixeldensity.diff
 
+# Typedef AVMediaType to NSString* on older systems
+# Patch submitted to upstream, remove once upstream has included it
+if {${os.platform} eq "darwin" && ${os.major} < 17} {
+    patchfiles-append   patch-libavdevice-avfoundation.diff
+}
+
 # enable auto configure of asm optimizations
 # requires Xcode 3.1 or better on Leopard
 minimum_xcodeversions {9 3.1}

--- a/multimedia/ffmpeg-devel/files/patch-libavdevice-avfoundation.diff
+++ b/multimedia/ffmpeg-devel/files/patch-libavdevice-avfoundation.diff
@@ -1,0 +1,14 @@
+--- libavdevice/avfoundation.m
++++ libavdevice/avfoundation.m
+@@ -763,6 +763,11 @@ static int get_audio_config(AVFormatContext *s)
+     return 0;
+ }
+
++#if (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED < 110000) || \
++    ((!defined(TARGET_OS_OSX) || TARGET_OS_OSX) && __MAC_OS_X_VERSION_MAX_ALLOWED < 101300)
++typedef NSString* AVMediaType;
++#endif
++
+ static NSArray* getDevicesWithMediaType(AVMediaType mediaType) {
+ #if ((TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500))
+     NSMutableArray *deviceTypes = nil;


### PR DESCRIPTION
#### Description

PR #25416 is stuck in moderation, however after testing #26520 this patch should be added to ffmpeg-devel.
I'll rebase it if #26775 is merged first.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
