### PR TITLE
bun: Update to 1.1.37

### DIFF
--- a/devel/bun/Portfile
+++ b/devel/bun/Portfile
@@ -6,7 +6,7 @@ PortGroup           npm 1.0
 npm.nodejs_version  22
 
 name                bun
-version             1.1.36
+version             1.1.37
 maintainers         {johnlindop.com:git @JLindop} openmaintainer
 revision            0
 
@@ -20,6 +20,6 @@ categories          devel
 homepage            https://bun.sh
 license             MIT
 
-checksums           rmd160  d0fe00f60f0b207ccd242f3ed5e37b79ca16491d \
-                    sha256  5e221418945edfc73dd1b161145aa162ceb7b223dc62c992fc85c9cb564af7cb \
+checksums           rmd160  8dc80d20d970aaaf925b3621ff619da65a9b555f \
+                    sha256  0b8775c0175dcedb7d9577d154f920398e725d293d4df8970da0809970425fa5 \
                     size    5395


### PR DESCRIPTION
#### Description

Update bun to 1.1.37
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
