### PR TITLE
xmlto: Fix build in trace mode

### DIFF
--- a/textproc/xmlto/Portfile
+++ b/textproc/xmlto/Portfile
@@ -27,7 +27,14 @@ checksums           rmd160  8ab75903683c3c88c519850ba8d9dc1d0176e270 \
                     sha256  6000d8e8f0f9040426c4f85d7ad86789bc88d4aeaef585c4d4110adb0b214f21 \
                     size    54700
 
-depends_build       port:util-linux
+# Needs xsltproc at build time, not just at runtime
+depends_build       port:docbook-xml \
+                    port:docbook-xsl-nons \
+                    port:libxslt \
+                    port:util-linux
+
+depends_skip_archcheck-append \
+                    libxslt
 
 depends_run         port:docbook-xml \
                     port:docbook-xsl-nons \


### PR DESCRIPTION
#### Description

xsltproc, docbook-xml and docbook-xsl-nons are not just required at runtime (`depends_run`), but also at build time (i.e., they must be in `depends_build`).

Since xmlto does not care what architecture the xsltproc binary is and does not link against libxslt.dylib, add it to `depends_skip_archcheck`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
