### PR TITLE
pdfgrep: Update to 2.2.0

### DIFF
--- a/textproc/pdfgrep/Portfile
+++ b/textproc/pdfgrep/Portfile
@@ -3,14 +3,13 @@
 PortSystem          1.0
 
 name                pdfgrep
-version             2.1.2
+version             2.2.0
 revision            0
-checksums           rmd160  59fe7845f96c988a3f96cf324a0bb72fcc6d8b97 \
-                    sha256  0ef3dca1d749323f08112ffe68e6f4eb7bc25f56f90a2e933db477261b082aba \
-                    size    197289
+checksums           rmd160  1526045539e03217faaedc2aad7e2f5fda7c0772 \
+                    sha256  0661e531e4c0ef097959aa1c9773796585db39c72c84a02ff87d2c3637c620cb \
+                    size    213237
 
 categories          textproc
-platforms           darwin
 license             GPL-2+
 maintainers         {raimue @raimue}
 description         A tool to search text in PDF files.
@@ -20,20 +19,12 @@ long_description \
 homepage            https://pdfgrep.org
 master_sites        ${homepage}/download/
 
-subport pdfgrep-legacy {
-    # Obsolete Date: 2022-07-12
-    replaced_by     pdfgrep
-    PortGroup       obsolete 1.0
+compiler.cxx_standard 2014
 
-    version         1.3.2
-    revision        2
-}
-
-compiler.cxx_standard 2011
-
-depends_build       port:pkgconfig
-depends_lib         path:lib/pkgconfig/poppler.pc:poppler \
-                    port:pcre \
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+depends_lib-append  path:lib/pkgconfig/poppler.pc:poppler \
+                    port:pcre2 \
                     port:libgcrypt
 
 patchfiles          scandir.patch
@@ -41,9 +32,9 @@ patchfiles          scandir.patch
 configure.args      --without-unac
 
 variant unac description {Use unac to remove accents and ligatures before searching} {
-    depends_lib-append port:unac
-    configure.args-delete --without-unac
-    configure.args-append --with-unac
+    depends_lib-append  port:unac
+    configure.args-replace \
+                        --without-unac --with-unac
 }
 
 livecheck.type      regex

--- a/textproc/pdfgrep/files/scandir.patch
+++ b/textproc/pdfgrep/files/scandir.patch
@@ -1,10 +1,10 @@
 The prototype of scandir changed in the 10.8 SDK. Use the old prototype on old SDKs.
 https://gitlab.com/pdfgrep/pdfgrep/-/merge_requests/14
---- src/cache.cc.orig	2018-11-19 05:44:28.000000000 -0600
-+++ src/cache.cc	2021-12-02 18:31:06.000000000 -0600
+--- src/cache.cc.orig	2024-03-15 12:58:00.000000000 +0000
++++ src/cache.cc	2024-11-27 18:10:44.792593267 +0000
 @@ -35,6 +35,15 @@
- #include <errno.h>
- #include <string.h>
+ #include <cerrno>
+ #include <cstring>
  
 +#ifdef __APPLE__
 +#include <AvailabilityMacros.h>
@@ -17,8 +17,8 @@ https://gitlab.com/pdfgrep/pdfgrep/-/merge_requests/14
 +
  using namespace std;
  
- Cache::Cache(string cache_file)
-@@ -86,9 +95,13 @@
+ const char *CACHE_VERSION = "1";
+@@ -115,9 +124,13 @@
  
  // I feel so bad...
  static const char *cache_directory;
@@ -34,8 +34,8 @@ https://gitlab.com/pdfgrep/pdfgrep/-/merge_requests/14
 +	std::string B = string(cache_directory) + "/" + (*(const struct dirent **)b)->d_name;
  
  	struct stat bufa, bufb;
- 	if (stat(A.c_str(), &bufa) != 0) return 0;
-@@ -97,7 +110,11 @@
+ 	if (stat(A.c_str(), &bufa) != 0) {
+@@ -130,7 +143,11 @@
  	return bufb.st_mtime - bufa.st_mtime;
  }
  
@@ -45,6 +45,6 @@ https://gitlab.com/pdfgrep/pdfgrep/-/merge_requests/14
 +#else
 +static int agefilter(struct dirent *a) {
 +#endif
- 	if (a->d_name[0] == '.') return false;
- 	std::string A = string(cache_directory) + "/" + a->d_name;
- 	struct stat bufa;
+ 	if (a->d_name[0] == '.') {
+ 		return 0;
+ 	}


### PR DESCRIPTION
#### Description

Update `pdfgrep` to its latest released verison, 2.2.0. This update removes `pdfgrep-legacy`, since the obsolete date has passed.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.6 23G80 arm64
Command Line Tools 16.1.0.0.1.1729049160

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
