### PR TITLE
vtk-m: Update to 2.2.0

### DIFF
--- a/graphics/vtk-m/Portfile
+++ b/graphics/vtk-m/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           gitlab 1.0
 
-gitlab.setup        vtk vtk-m 1.7.1 v
+gitlab.setup        vtk vtk-m 2.2.0 v
 gitlab.instance     https://gitlab.kitware.com
-revision            1
+revision            0
 
 categories          graphics science devel
 license             BSD
@@ -22,9 +22,9 @@ long_description    ${description}. VTK-m supports the fine-grained concurrency 
 
 homepage            https://m.vtk.org/
 
-checksums           rmd160  2ccb4a5a4ab4aa55bcf20d1cc15627d6cdf5a5aa \
-                    sha256  eb513dd9893d086fb76f9283dd87ef4e1b1ac417723803f2f2374958ec6ef32b \
-                    size    10121883
+checksums           rmd160  e6da77d869b04eeba9d97f4f8070bf915f36a3ed \
+                    sha256  6e19fc0c59335df75aeb4844523686b9eacd11dce9c9ec0c29a3aa5a918da65b \
+                    size    75262882
 
 compiler.cxx_standard   2014
 compiler.thread_local_storage yes


### PR DESCRIPTION
#### Description

vtk-m: Update 1.7.1.-->  2.2.0

###### Type(s)

* Update

###### Tested on

CI only.  OS 13, 14, 15, only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?