### PR TITLE
py-geomagpy: new port (remove py-magpy)

### DIFF
--- a/python/py-cdflib/Portfile
+++ b/python/py-cdflib/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cdflib
+version             1.3.2
+revision            0
+
+categories-append   science
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         A python CDF reader toolkit
+long_description    {*}${description}
+
+homepage            https://github.com/MAVENSDC/cdflib
+
+checksums           rmd160  ca0429d3fd0e84cc048db2edf56d51097813e4a7 \
+                    sha256  97f27ac629e4c0ac1367eb8f4edd7a1d184190272ab98a6401e999f3a2e05687 \
+                    size    240218
+
+python.versions     312
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools_scm
+
+    depends_lib-append \
+                    port:py${python.version}-numpy
+
+    post-destroot {
+        # do not install "tests" and "benchmark" directories into ".../site-packages"
+        move ${destroot}${python.pkgd}/tests ${destroot}${python.pkgd}/${python.rootname}
+        move ${destroot}${python.pkgd}/benchmarks ${destroot}${python.pkgd}/${python.rootname}
+    }
+}

--- a/python/py-cftime/Portfile
+++ b/python/py-cftime/Portfile
@@ -20,21 +20,14 @@ checksums           rmd160  efcf3fa122f0e6844298cbcb8d932eb15ac58b66 \
                     sha256  aaca6a88f970cdb20be9383b84a4fb9c52545eba460635469dfd815075fadd94 \
                     size    61825
 
-python.versions     27 39 310 311 312 313
-python.pep517       no
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
-    if {${python.version} == 27} {
-        github.setup    Unidata cftime 1.5.2 v rel
-        revision        0
-        epoch           1
-        checksums       rmd160  acd812fb21765ecf044d68c186ac39e83ffe0a92 \
-                        sha256  86e1ec04135828f0c8a4e4ac4b9baff08f8b57d0b1f31662dbf0209fdcc63a2d \
-                        size    580452
-    }
+    patchfiles      patch-numpy-pyproject.toml.diff
 
     depends_build-append \
-                    port:py${python.version}-cython
+                    port:py${python.version}-cython \
+                    port:py${python.version}-oldest-supported-numpy
 
     depends_lib-append \
                     port:py${python.version}-numpy
@@ -47,6 +40,4 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} README.md Changelog \
             LICENSE ${destroot}${docdir}
     }
-
-    livecheck.type  none
 }

--- a/python/py-cftime/files/patch-numpy-pyproject.toml.diff
+++ b/python/py-cftime/files/patch-numpy-pyproject.toml.diff
@@ -1,0 +1,10 @@
+--- pyproject.toml.orig	2024-11-28 07:21:09
++++ pyproject.toml	2024-11-28 07:21:24
+@@ -4,6 +4,6 @@
+     "cython>=0.29.20",
+     "wheel",
+     "oldest-supported-numpy ; python_version < '3.9'",
+-    "numpy>=2.0.0rc1,<3 ; python_version >= '3.9'",
++    "numpy",
+ ]
+ build-backend = "setuptools.build_meta"

--- a/python/py-geomagpy/Portfile
+++ b/python/py-geomagpy/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-geomagpy
+version             1.1.8
+revision            0
+
+categories-append   science
+platforms           {darwin any}
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         Geomagnetic analysis tools.
+long_description    {*}${description}
+
+homepage            https://github.com/geomagpy/magpy
+
+checksums           rmd160  114656b160e66296a3c86d8ff0cc0c8aa13b2d27 \
+                    sha256  c1d7c4e6bf83b8bdd37333e97a3dc34ef6df06f335fcbf8ffaacf769a3a1b9f2 \
+                    size    25487570
+
+python.versions     312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+            port:py${python.version}-matplotlib \
+            port:py${python.version}-numpy \
+            port:py${python.version}-scipy \
+            port:py${python.version}-paho-mqtt \
+            port:py${python.version}-pymysql \
+            port:py${python.version}-cdflib \
+            port:py${python.version}-pexpect \
+            port:py${python.version}-pypubsub
+
+    variant gui description "Build the GUI" {
+        depends_run-append \
+            port:py${python.version}-wxpython-4.0
+    }
+}

--- a/python/py-magpy/Portfile
+++ b/python/py-magpy/Portfile
@@ -1,48 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           python 1.0
-PortGroup           github 1.0
+PortGroup           obsolete 1.0
 
-github.setup        geomagpy magpy 0.4.7 v
 name                py-magpy
-platforms           {darwin any}
-supported_archs     noarch
+replaced_by         py-geomagpy
 license             GPL-3
-maintainers         {mojca @mojca} openmaintainer
+revision            1
 
-description         Geomagnetic analysis tools.
-long_description    {*}${description}
-
-checksums           rmd160  2493f090aa46af18693b985f2b7b1ac8879603cd \
-                    sha256  0a3f789c7916393fa888855fcef51d476aa574fef9f9663b7a5f3e40ade7705a \
-                    size    8177303
-
-# python3 versions are currently broken
-python.versions     27
-
-# TODO:
-# - add a port py-autobahn
-if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-    depends_run-append \
-                    port:py${python.version}-numpy \
-                    port:py${python.version}-netcdf4 \
-                    port:py${python.version}-pexpect
-    # optional
-    depends_run-append \
-                    port:py${python.version}-pymysql \
-                    port:py${python.version}-matplotlib \
-                    port:py${python.version}-scipy
-    if {${python.version} == 27} {
-        depends_run-append \
-                    port:py${python.version}-wxpython-3.0
-    }
-
-    post-patch {
-        reinplace "s|/usr/bin/env python|${python.bin}|" ${worksrcpath}/magpy/gui/xmagpy.py
-    }
-
-    livecheck.type      none
-}
+# remove after 2025-11-27

--- a/python/py-netcdf4/Portfile
+++ b/python/py-netcdf4/Portfile
@@ -6,11 +6,10 @@ PortGroup           mpi 1.0
 
 name                py-netcdf4
 python.rootname     netCDF4
-version             1.6.5
-revision            2
+version             1.7.2
+revision            0
 
 categories-append   science
-platforms           darwin
 license             MIT
 maintainers         {fastmail.fm:jswhit @jswhit} openmaintainer
 
@@ -24,9 +23,11 @@ long_description    netCDF version 4 has many features not found in \
 
 homepage            https://unidata.github.io/netcdf4-python/
 
-checksums           rmd160  1f755b8e348196379e403f06fc4b0bf333f6510b \
-                    sha256  824881d0aacfde5bd982d6adedd8574259c85553781e7b83e0ce82b890bfa0ef \
-                    size    764969
+distname            netcdf4-${version}
+
+checksums           rmd160  1465d546f8fb95bffa306b05b5628bab3d4b7cd2 \
+                    sha256  a4c6375540b19989896136943abb6d44850ff6f1fa7d3f063253b1ad3f8b7fce \
+                    size    835064
 
 mpi.enforce_variant netcdf
 mpi.setup
@@ -34,35 +35,26 @@ mpi.setup
 build.env-append    USE_NCCONFIG=1
 destroot.env-append USE_NCCONFIG=1
 
-python.versions     27 39 310 311 312
-
-# Fixes "Missing dependencies: oldest-supported-numpy"
-# See https://trac.macports.org/ticket/67136
-# This fix copies the method used for py311-cftime:
-#   https://trac.macports.org/ticket/66898
-python.pep517       no
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
-    if {${python.version} == 27} {
-        version         1.5.3
-        revision        10
-        checksums       rmd160  b855fcb0cc51bf349824ada5129feab9f3911728 \
-                        sha256  2a3ca855848f4bbf07fac366da77a681fcead18c0a8813d91d46302f562dc3be \
-                        size    790343
-    }
+    patchfiles      patch-numpy-pyproject.toml.diff
 
     depends_build-append \
-                    path:bin/cython-${python.branch}:py${python.version}-cython
+                    path:bin/cython-${python.branch}:py${python.version}-cython \
+                    port:py${python.version}-oldest-supported-numpy \
+                    port:py${python.version}-setuptools_scm
 
     depends_lib-append \
                     port:netcdf \
+                    port:py${python.version}-certifi \
                     port:py${python.version}-cftime \
                     port:hdf5 \
-                    port:py${python.version}-numpy \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-numpy
 
     depends_test-append \
-                    port:py${python.version}-certifi
+                    path:bin/cython-${python.branch}:py${python.version}-cython \
+                    port:py${python.version}-packaging
 
     pre-configure {
         # py-netcdf4's setup.py uses nc-config for flags and libs but not compiler
@@ -70,9 +62,6 @@ if {${name} ne ${subport}} {
     }
 
     test.run        yes
-    python.test_framework
-    test.dir        ${build.dir}/test
-    test.cmd        ${python.bin} run_all.py
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-netcdf4/files/patch-numpy-pyproject.toml.diff
+++ b/python/py-netcdf4/files/patch-numpy-pyproject.toml.diff
@@ -1,0 +1,11 @@
+--- pyproject.toml.orig	2024-11-27 23:06:32
++++ pyproject.toml	2024-11-27 23:06:47
+@@ -2,7 +2,7 @@
+ requires = [
+     "Cython>=0.29",
+     "oldest-supported-numpy ; python_version < '3.9'",
+-    "numpy>=2.0.0rc1 ; python_version >= '3.9'",
++    "numpy",
+     "setuptools>=61", "setuptools_scm[toml]>=3.4"
+ ]
+ build-backend = "setuptools.build_meta"

--- a/python/py-paho-mqtt/Portfile
+++ b/python/py-paho-mqtt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-paho-mqtt
-version             1.6.1
+version             2.1.0
 revision            0
 
 license             {EPL-2 EDL-1}
@@ -17,8 +17,11 @@ long_description    Eclipse Paho MQTT Python client library
 
 homepage            https://eclipse.org/paho
 
-checksums           rmd160  d6bccf7fdb166109d901a63fafc99432c195ef68 \
-                    sha256  2a8291c81623aec00372b5a85558a372c747cbca8e9934dfe218638b8eefc26f \
-                    size    99373
+distname            paho_mqtt-${version}
 
-python.versions     38 39 310
+checksums           rmd160  7caf39a7e4a1b430ac4be1e6bf6a976533551d69 \
+                    sha256  12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834 \
+                    size    148848
+
+python.versions     39 310 311 312
+python.pep517_backend hatch

--- a/python/py-pypubsub/Portfile
+++ b/python/py-pypubsub/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                py-pypubsub
+github.setup        schollii pypubsub 4.0.3 v
+github.tarball_from archive
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         Python Publish-Subscribe Package
+long_description    {*}${description}
+
+checksums           rmd160  4279f7f5e4fd4bd22781f9003a75bd9638584666 \
+                    sha256  0df83daa1cb0021bab858ff6812d836c9712dea59a5172be1888bb554c3a89a2 \
+                    size    174033
+
+python.versions     312
+
+if {${name} ne ${subport}} {
+    test.run        yes
+    test.dir        ${build.dir}/tests/suite
+}


### PR DESCRIPTION
#### Description
- remove `py-magpy` (PY27 only, no dependents) ; replaced by `py-geomagpy` (new port, py312 subport)
- new ports as dependents of `py-geomagpy`: `py-pypubsub` and `py-cdflib`
- `py-paho-mqtt`: update to 2.1.0, update Python subports
- `py-netcdf4`: update 1.72, drop py27 subport
- `py-cftime`: drop py27 subport

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1.1 24B91 x86_64
Xcode 16.1 16B40
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
