### PR TITLE
cmus: revbump for libmad update

### DIFF
--- a/audio/cmus/Portfile
+++ b/audio/cmus/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
 
 github.setup        cmus cmus 2.12.0 v
-revision            0
+revision            1
 categories          audio
 maintainers         {@Traace hotmail.de:xxtraacexx} \
                     openmaintainer
@@ -22,7 +22,7 @@ checksums           rmd160  3d9f9c27371371bef3c3e9e9a3a514c7bdde268c \
                     sha256  5c04f14cc57e864b51b0ba92aca0f96f4fef72ce250c90bd91e96a1f4e490fd3 \
                     size    348740
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         port:libao \
                     port:libmad \
                     port:libogg \
@@ -121,7 +121,7 @@ variant opus  description {Support Opus files} {
 
 variant ffmpeg  description {Support ffmpeg} {
     set ffmpeg_ver        7
-    depends_lib-append    port:ffmpeg${ffmpeg_ver}
+    depends_lib-append    path:libexec/ffmpeg${ffmpeg_ver}/lib/libavcodec.dylib:ffmpeg${ffmpeg_ver}
     configure.pkg_config_path-prepend \
                           ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
     configure.args-delete CONFIG_FFMPEG=n


### PR DESCRIPTION
#### Description

Revbump.
Fix dependency on ffmpeg7.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
