### PR TITLE
shell-fm, mt-daapd, daapd: revbump for libmad

### DIFF
--- a/audio/daapd/Portfile
+++ b/audio/daapd/Portfile
@@ -1,10 +1,10 @@
-PortSystem 1.0
+PortSystem      1.0
 
 name            daapd
 version         0.2.4b
+revision        1
 categories      audio net
 license         GPL-2
-platforms       darwin
 maintainers     nomaintainer
 description     A DAAP server emulating an iTunes server.
 long_description    daapd scans a directory for music files (mp3, aac, \

--- a/audio/mt-daapd/Portfile
+++ b/audio/mt-daapd/Portfile
@@ -1,14 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem      1.0
 
 name			mt-daapd
 version			0.2.4.2
-revision        3
+revision        4
 categories		audio net
 # GPL and APSL are incompatible
 license			GPL-2+ APSL-2 APSL-1.2 Restrictive
-platforms		darwin
 maintainers		nomaintainer
 description		A multi-threaded DAAP server emulating an iTunes server.
 long_description	${description}

--- a/audio/shell-fm/Portfile
+++ b/audio/shell-fm/Portfile
@@ -4,9 +4,8 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            jkramer shell-fm 0.8 v
-revision                2
+revision                3
 categories              audio
-platforms               darwin
 maintainers             fawong.com:waf
 license                 GPL-2
 
@@ -22,7 +21,7 @@ long_description        shell-fm is a lightweight, console-based player for Last
                         bookmark stations (quickly jump to bookmarked stations with a single key) \
                         ... probably more
 
-depends_build           port:pkgconfig
+depends_build           path:bin/pkg-config:pkgconfig
 
 depends_lib             port:libao \
                         port:taglib \


### PR DESCRIPTION
#### Description

These ports are broken on modern systems, so skipping CI:
https://ports.macports.org/port/daapd/details
https://ports.macports.org/port/mt-daapd/details
https://ports.macports.org/port/shell-fm/details

However, they do build for me on 10.6, so it still makes sense to revbump them for the sake of old systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
