### PR TITLE
sgrep2: Fix build on Apple Silicon

### DIFF
--- a/textproc/sgrep2/Portfile
+++ b/textproc/sgrep2/Portfile
@@ -1,14 +1,15 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
 
 name            sgrep2
 version         1.94a
-revision        0
+revision        1
 checksums       rmd160  d75f644fc4ba9b0eb916f8097bf58ebe4b73154c \
                 sha256  d5b16478e3ab44735e24283d2d895d2c9c80139c95228df3bdb2ac446395faf9 \
                 size    193267
 
 categories      textproc
-platforms       darwin
 maintainers     nomaintainer
 description     structured grep is a tool for searching SGML, XML and   \
                 HTML files
@@ -18,17 +19,30 @@ long_description \
     criteria.
 
 homepage        https://www.cs.helsinki.fi/u/jjaakkol/sgrep.html
-master_sites    freebsd
-distname        sgrep-${version}
+master_sites    debian:s/sgrep
+
+distname        sgrep_${version}.orig
+worksrcdir      sgrep-${version}
 
 patchfiles      implicit.patch
 
 configure.args  --program-suffix=2 \
-                --mandir=${prefix}/share/man
+                --mandir=${prefix}/share/man \
+                --datadir=${prefix}/share/${name}
 
 test.run        yes
 test.target     check
 
-livecheck.type  regex
-livecheck.url   https://www.cs.helsinki.fi/u/jjaakkol/sgrep/download.html
-livecheck.regex {sgrep-([0-9a-z.]+)\.tar}
+platform darwin arm {
+    depends_build-append \
+                port:automake
+
+    # Workaround ancient configuration files not detecting Apple Silicon (aarch64)
+    post-extract {
+        set automake_ver 1.17
+        foreach file {config.guess config.sub} {
+            delete ${worksrcpath}/${file}
+            copy ${prefix}/share/automake-${automake_ver}/${file} ${worksrcpath}/${file}
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Fix `sgrep2` building on Apple Silicon. Though [#26764](https://github.com/macports/macports-ports/pull/26764) was ultimately reverted, the fixes were simply applied to the wrong port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
