### PR TITLE
uv: Update to 0.5.5

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.5.4
+github.setup            astral-sh uv 0.5.5
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  08b1d7a5408956535360d475928982ede7c140de \
-                        sha256  3c1c95bcc99930b929e18665d7691b219ce4bef3555711a9be80139c183b9595 \
-                        size    2915932
+                        rmd160  60023db4c6161827582af8db8f3fe4713a14f416 \
+                        sha256  48108de0a14dd91acf4ce73e1b28abb24f54969a3a477389b81e362ec2c098e5 \
+                        size    2932557
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 
@@ -81,7 +81,7 @@ cargo.crates \
     assert_cmd                      2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     assert_fs                        1.1.2  7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674 \
     async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
-    async-compression               0.4.17  0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857 \
+    async-compression               0.4.18  df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522 \
     async-trait                     0.1.83  721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd \
     async_http_range_reader          0.9.1  2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
@@ -209,7 +209,7 @@ cargo.crates \
     h2                               0.4.7  ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashbrown                       0.15.1  3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3 \
+    hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
@@ -339,7 +339,7 @@ cargo.crates \
     predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     priority-queue                   2.1.1  714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d \
-    proc-macro2                     1.0.89  f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e \
+    proc-macro2                     1.0.92  37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0 \
     procfs                          0.17.0  cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f \
     procfs-core                     0.17.0  239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec \
     ptr_meta                         0.3.0  fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90 \
@@ -439,7 +439,7 @@ cargo.crates \
     svgfilters                       0.4.0  639abcebc15fdc2df179f37d6f5463d660c1c79cd552c12343a4600827a04bce \
     svgtypes                         0.9.0  c9ee29c1407a5b18ccfe5f6ac82ac11bab3b14407e09c209a6c1a32098b19734 \
     svgtypes                        0.10.0  98ffacedcdcf1da6579c907279b4f3c5492fbce99fbbf227f5ed270a589c2765 \
-    syn                             2.0.87  25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d \
+    syn                             2.0.89  44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e \
     sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
@@ -508,7 +508,7 @@ cargo.crates \
     unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
     unscanny                         0.1.0  e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    url                              2.5.3  8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada \
+    url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
     usvg                            0.29.0  63b6bb4e62619d9f68aa2d8a823fea2bff302340a1f2d45c264d5b0be170832e \
     usvg-text-layout                0.29.0  195386e01bc35f860db024de275a76e7a31afdf975d18beb6d0e44764118b4db \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.5.5.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
