### PR TITLE
Tcl/Tk: Update to 8.6.15

### DIFF
--- a/lang/tcl/Portfile
+++ b/lang/tcl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                tcl
-version             8.6.14
+version             8.6.15
 revision            0
 # Tk (x11/tk) port depends on this version
 categories          lang
@@ -21,9 +21,10 @@ long_description    \
 homepage            https://www.tcl-lang.org/
 master_sites        sourceforge:project/tcl/Tcl/${version}
 
-checksums           rmd160  9de599069a0fba1efe28951a010486bce793c80a \
-                    sha256  5880225babf7954c58d4fb0f5cf6279104ce1cd6aa9b71e9a6322540e1c4de66 \
-                    size    11627322
+checksums           md5 c13a4d5425b5ae335258342b38ba34c2 \
+                    sha1 4192f59ea2804936e6b0d81629726c11f2c65f3d \
+                    rmd160 5eca06d75b3cbfb9c9dd3d712f3ffd968d6c768b \
+                    sha256 861e159753f2e2fbd6ec1484103715b0be56be3357522b858d3cbb5f893ffef1
 
 distname            ${name}${version}-src
 worksrcdir          ${name}${version}/unix
@@ -83,7 +84,7 @@ platform darwin {
     configure.args-append tcl_cv_type_64bit="long long"
 }
 
-default_variants +threads
+default_variants-append +threads
 
 platform darwin 8 {
     # See http://trac.macports.org/ticket/32930 for why this is needed.

--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.1
 
 name                tk
-version             8.6.14
+version             8.6.15
 revision            0
 categories          x11
 license             Tcl/Tk
@@ -20,9 +20,10 @@ dist_subdir         tcltk
 distname            ${name}${version}-src
 worksrcdir          ${name}${version}
 
-checksums           rmd160  8558b15ead6b04728e885d87a86c6e5b1039333d \
-                    sha256  8ffdb720f47a6ca6107eac2dd877e30b0ef7fac14f3a84ebbd0b3612cee41a94 \
-                    size    4510695
+checksums           md5 6d64b6eb021062f378017d403fedcbe6 \
+                    sha1 ef44f7be00d0249e281ad87785650f5475bbc939 \
+                    rmd160 3cb0ef6823829ed2f7ff0870c7754ea8be20b82a \
+                    sha256 550969f35379f952b3020f3ab7b9dd5bfd11c1ef7c9b7c6a75f5c49aca793fec
 
 depends_build       port:pkgconfig
 
@@ -34,9 +35,6 @@ depends_lib         port:fontconfig \
 
 configure.dir      ${worksrcpath}/unix
 build.dir          ${configure.dir}
-
-# https://core.tcl-lang.org/tk/info/8912083dcfb7
-patchfiles-append  fix-aqua-i386-clang-crash.patch
 
 configure.args      --mandir=${prefix}/share/man --with-tcl=${prefix}/lib
 # see https://trac.macports.org/ticket/58447
@@ -79,8 +77,8 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx" && ${os.major} >
 
     variant x11 conflicts quartz {}
 
-    if {![variant_isset quartz]} {
-        default_variants +x11
+    if {![variant_isset x11]} {
+        default_variants +quartz
     }
 } else {
     # Even though X11 is the only option, make a variant so that other ports

--- a/x11/tk/files/fix-aqua-i386-clang-crash.patch
+++ b/x11/tk/files/fix-aqua-i386-clang-crash.patch
@@ -1,15 +1,0 @@
-diff --git macosx/tkMacOSXFont.c macosx/tkMacOSXFont.c
-index d413f0b146..e2397019c4 100644
---- macosx/tkMacOSXFont.c
-+++ macosx/tkMacOSXFont.c
-@@ -171,10 +171,8 @@ static int		CreateNamedSystemFont(Tcl_Interp *interp,
-     return _ds;
- }
- 
--#ifndef __clang__
- @synthesize UTF8String = _UTF8String;
- @synthesize DString = _ds;
--#endif
- @end
- 
- #define GetNSFontTraitsFromTkFontAttributes(faPtr) \


### PR DESCRIPTION
Also change tk's default variant to +quartz, which better matches user expectations (see e.g. https://trac.macports.org/ticket/71359), matches the system Tk, and requires many fewer dependencies.

If you're wondering about the md5 and sha1 hashes, unfortunately that's all that upstream publishes.

###### Tested on
macOS 14.7.1 23H222 x86_64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
