### PR TITLE
libcddb: fix typo in two headers

### DIFF
--- a/devel/libcddb/Portfile
+++ b/devel/libcddb/Portfile
@@ -1,33 +1,32 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem      1.0
 
-name             libcddb
-version          1.3.2
-revision         1
-categories       devel
-license          LGPL
-maintainers      nomaintainer
-description      library to access data on a CDDB server
+name            libcddb
+version         1.3.2
+revision        1
+categories      devel
+license         LGPL
+maintainers     nomaintainer
+description     library to access data on a CDDB server
 long_description \
-	Libcddb is a C library to access data on a CDDB server \
-	(freedb.org). It allows you to search the database for \
-	possible CD matches, retrieve detailed information about \
-	a specific CD, and submit new CD entries to the database.
-homepage         http://libcddb.sourceforge.net/
-platforms        darwin
+    Libcddb is a C library to access data on a CDDB server \
+    (freedb.org). It allows you to search the database for \
+    possible CD matches, retrieve detailed information about \
+    a specific CD, and submit new CD entries to the database.
+homepage        https://libcddb.sourceforge.net
 
-depends_lib      port:libiconv
+depends_lib     port:libiconv
 
-master_sites     sourceforge:project/libcddb/libcddb/${version}
+master_sites    sourceforge:project/libcddb/libcddb/${version}
 
-checksums        md5     8bb4a6f542197e8e9648ae597cd6bc8a \
-                 sha1    2a7855918689692ff5ca3316d078a859d51959ce \
-                 rmd160  e38ed8c7dd5a9b4a5b2a1772a9e98f914872c397
+checksums       rmd160  e38ed8c7dd5a9b4a5b2a1772a9e98f914872c397 \
+                sha256  35ce0ee1741ea38def304ddfe84a958901413aa829698357f0bee5bb8f0a223b \
+                size    352909
 
-use_bzip2        yes
+use_bzip2       yes
 
-configure.args   --without-cdio
+configure.args  --without-cdio
 
-test.run         yes
-test.target      check
+test.run        yes
+test.target     check

--- a/devel/libcddb/Portfile
+++ b/devel/libcddb/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            libcddb
 version         1.3.2
-revision        1
+revision        2
 categories      devel
 license         LGPL
 maintainers     nomaintainer
@@ -25,6 +25,8 @@ checksums       rmd160  e38ed8c7dd5a9b4a5b2a1772a9e98f914872c397 \
                 size    352909
 
 use_bzip2       yes
+
+patchfiles      patch-fix-log-headers.diff
 
 configure.args  --without-cdio
 

--- a/devel/libcddb/files/patch-fix-log-headers.diff
+++ b/devel/libcddb/files/patch-fix-log-headers.diff
@@ -1,0 +1,27 @@
+--- include/cddb/cddb_log_ni.h	2005-03-12 05:29:29
++++ include/cddb/cddb_log_ni.h	2024-11-29 11:24:22
+@@ -19,8 +19,8 @@
+     Boston, MA  02111-1307, USA.
+ */
+ 
+-#ifndef CDDB_LOH_NI_H
+-#define CDDB_LOG_NI_H
++#ifndef CDDB_LOG_NI_H
++#define CDDB_LOG_NI_H 1
+ 
+ #ifdef __cplusplus
+     extern "C" {
+
+--- include/cddb/cddb_log.h	2005-03-12 05:29:29
++++ include/cddb/cddb_log.h	2024-11-29 11:24:03
+@@ -19,8 +19,8 @@
+     Boston, MA  02111-1307, USA.
+ */
+ 
+-#ifndef CDDB_LOH_H
+-#define CDDB_LOG_H
++#ifndef CDDB_LOG_H
++#define CDDB_LOG_H 1
+ 
+ #ifdef __cplusplus
+     extern "C" {


### PR DESCRIPTION
#### Description

Also clean-up portfile.

P. S. All other headers use `#define SOME_HEADER_H 1`, hence here too.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7
Xcode 15.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
