### PR TITLE
bind9: Suppress strchr implicit func decl warning

### DIFF
--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -59,6 +59,9 @@ compiler.blacklist \
                 {clang < 703} \
                 {clang >= 1500.0.40.1 < 1500.1.0.2.5 }
 
+# https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
+configure.checks.implicit_function_declaration.whitelist-append strchr
+
 patchfiles      atomics.patch \
                 lib_dns_Makefile.in.patch \
                 setrlimit.patch \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

