### PR TITLE
mise: Update to 2024.11.36

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.11.30 v
+github.setup        jdx mise 2024.11.36 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2e2e24791fbe76dca809e4b848740bb9aaa240f9 \
-                    sha256  eb9827c6db7741e86a2a398dd6bc7e144920b81169ee5f6b4025138316dbbdb1 \
-                    size    3223242
+                    rmd160  99801dfaa38545d7718f9faf28966df428c17891 \
+                    sha256  6703fa0479104be64ffc33971694ddff7c54d9728011c87e57c07c7a5f96b38c \
+                    size    3222136
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -73,11 +73,15 @@ destroot {
 }
 
 notes {
-    Mise shell completions have been installed for bash, fish, and zsh.
-    Use of these completions require an additional program, 'usage',
-    which should be installed with mise.
+  Shell completions have been installed. These completions require an
+  additional program, 'usage', which should be managed with mise.
 
-      mise use -g usage
+      mise use -g usage # only required after initial install
+      mise update usage # required when usage updates
+
+  Upgrading mise may cause deserialiazation warnings to be printed when
+  internal data structures change. Restarting the terminal session
+  will resolve those issues.
 }
 
 cargo.crates \
@@ -99,7 +103,6 @@ cargo.crates \
     arbitrary                        1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
     ascii-canvas                     4.0.0  ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891 \
-    assert_cmd                      2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     async-compression               0.4.18  df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
@@ -118,12 +121,12 @@ cargo.crates \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytecount                        0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                            1.8.0  9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da \
+    bytes                            1.9.0  325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b \
     bzip2                            0.4.4  bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8 \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                               1.2.1  fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47 \
+    cc                               1.2.2  f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
@@ -169,10 +172,8 @@ cargo.crates \
     derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
     deunicode                        1.6.0  339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00 \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
-    difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
-    doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
     document-features               0.2.10  cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0 \
     dotenvy                         0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
     duct                            0.13.7  e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c \
@@ -189,7 +190,7 @@ cargo.crates \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     erased-serde                     0.4.5  24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d \
     errno                            0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
-    errno                            0.3.9  534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba \
+    errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
     errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
     exec                             0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
     expr-lang                        0.1.6  199e9811b4ebd07c6f82a2cf4b2447e32acd3e4bedd436b704a0fc1c01f96406 \
@@ -200,7 +201,6 @@ cargo.crates \
     filetime_creation                0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
     flate2                          1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
-    float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
@@ -267,6 +267,7 @@ cargo.crates \
     itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     js-sys                          0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
+    junction                         1.2.0  72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16 \
     kdl                              4.6.0  062c875482ccb676fd40c804a40e3824d4464c18c364547456d1c8e8e951ae47 \
     keccak                           0.1.5  ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654 \
     lalrpop                         0.22.0  06093b57658c723a21da679530e061a8c25340fa5a6f98e313b542268c7e2a1f \
@@ -274,7 +275,7 @@ cargo.crates \
     lazy-regex                       3.3.0  8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda \
     lazy-regex-proc_macros           3.3.0  76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.165  fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e \
+    libc                           0.2.166  c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36 \
     libgit2-sys               0.17.0+1.8.1  10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224 \
     libm                            0.2.11  8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
@@ -309,7 +310,6 @@ cargo.crates \
     new_debug_unreachable            1.0.6  650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086 \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
-    normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
     nt-time                          0.8.1  2de419e64947cd8830e66beb584acc3fb42ed411d103e3c794dda355d1b374b5 \
     nu-ansi-term                    0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
     num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
@@ -323,10 +323,11 @@ cargo.crates \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
     openssl-sys                    0.9.104  45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741 \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
+    os-release                       0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
     os_pipe                          1.2.1  5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     owo-colors                       3.5.0  c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f \
-    papergrid                       0.12.0  c7419ad52a7de9b60d33e11085a0fe3df1fbd5926aa3f93d3dd53afbc9e86725 \
+    papergrid                       0.13.0  d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     parse-zoneinfo                   0.3.1  1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24 \
@@ -355,12 +356,11 @@ cargo.crates \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
     precomputed-hash                 0.1.1  925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
-    predicates                       3.1.2  7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97 \
-    predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
-    predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
+    proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro2                     1.0.92  37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0 \
     quick-xml                       0.23.1  11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea \
     quinn                           0.11.6  62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef \
@@ -387,7 +387,7 @@ cargo.crates \
     rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.41  d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6 \
-    rustls                         0.23.18  9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f \
+    rustls                         0.23.19  934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.10.0  16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b \
@@ -430,7 +430,7 @@ cargo.crates \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     slug                             0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
     smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
-    socket2                          0.5.7  ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c \
+    socket2                          0.5.8  c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8 \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
@@ -446,18 +446,14 @@ cargo.crates \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     system-configuration             0.6.1  3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b \
     system-configuration-sys         0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
-    tabled                          0.16.0  77c9303ee60b9bedf722012ea29ae3711ba13a67c9b9ae28993838b63057cb1b \
-    tabled_derive                    0.8.0  bf0fb8bfdc709786c154e24a66777493fb63ae97e3036d914c8666774c477069 \
+    tabled                          0.17.0  c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a \
+    tabled_derive                    0.9.0  931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1 \
     tar                             0.4.43  c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6 \
     tempfile                        3.14.0  28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
     term                             1.0.0  4df4175de05129f31b80458c6df371a15e7fc3fd367272e6bf938e5c351c7ea0 \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                    0.4.0  4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef \
-    termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
-    test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
-    test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
-    test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
     test-log                        0.2.16  3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93 \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
@@ -480,7 +476,7 @@ cargo.crates \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                      0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
-    tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
+    tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-core                    0.1.33  e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c \
     tracing-error                    0.2.0  d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
@@ -498,7 +494,7 @@ cargo.crates \
     unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
     unicode-ident                   1.0.14  adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83 \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
-    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     unsafe-libyaml                  0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
@@ -516,7 +512,6 @@ cargo.crates \
     vfox                             0.3.3  5a909ee4afc8dccf80dae7b73581198b1204a0dbf7b22615f95bddd3e306a439 \
     vte                             0.10.1  6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983 \
     vte_generate_state_changes       0.1.2  2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e \
-    wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \


### PR DESCRIPTION
#### Description

mise: Update to 2024.11.36

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
