### PR TITLE
mp3cat: Update to 0.5

### DIFF
--- a/audio/mp3cat/Portfile
+++ b/audio/mp3cat/Portfile
@@ -1,33 +1,37 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
 
-name                mp3cat
-version             0.4
+github.setup        tomclegg mp3cat 0.5
+github.tarball_from archive
+revision            0
 categories          audio
-platforms           darwin
 license             GPL-2+
 maintainers         nomaintainer
 
 description         Read and write MP3 files
-long_description    ${description}
+long_description    {*}${description}.
 
-homepage            http://tomclegg.net/mp3cat
-master_sites        http://tomclegg.net/software/
+homepage            https://tomclegg.ca/mp3cat
 
-checksums           rmd160  d6fa7a549ed1b2d81f6217b2fe0ed52e28c18aaa \
-                    sha256  fd2b0d58018f5117bd1e22298c899bef5e6af61a0c540186d16d2bf516d6849a
+checksums           rmd160  4d2a022b68995ae27f883b51d75322e347ec95da \
+                    sha256  b1ec915c09c7e1c0ff48f54844db273505bc0157163bed7b2940792dca8ff951 \
+                    size    15711
 
-patchfiles          patch-Makefile.diff \
-                    implicit.patch
-
-use_configure       no
-
-variant universal {}
-
-build.env           CC=${configure.cc} \
-                    "CFLAGS=${configure.cflags} [get_canonical_archflags cc]"
+patchfiles          patch-Makefile.diff
+patchfiles-append   implicit.patch
 
 destroot {
-    xinstall -m 755 -W ${worksrcpath} mp3cat mp3log mp3log-conf mp3dirclean mp3http mp3stream-conf ${destroot}${prefix}/bin
+    xinstall -m 755 -W ${worksrcpath} \
+        ${name} \
+        mp3log \
+        mp3log-conf \
+        mp3dirclean \
+        mp3http \
+        mp3stream-conf \
+        ${destroot}${prefix}/bin/
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 ${worksrcpath}/COPYING ${destroot}${prefix}/share/doc/${name}/
 }

--- a/audio/mp3cat/files/implicit.patch
+++ b/audio/mp3cat/files/implicit.patch
@@ -1,24 +1,6 @@
---- read_buf.c.orig	2003-05-05 08:02:23.000000000 +1000
-+++ read_buf.c	2020-12-15 03:06:21.000000000 +1100
-@@ -7,6 +7,7 @@
- #include <fcntl.h>
- #include <errno.h>
- #include <stdio.h>
-+#include <string.h>
- 
- static int Infile_is_open=0;
- static int Infd=STDIN_FILENO;
---- write_buf.c.orig	2003-05-05 08:02:23.000000000 +1000
-+++ write_buf.c	2020-12-15 03:10:03.000000000 +1100
-@@ -9,6 +9,7 @@
- #include <stdio.h>
- #include <stdlib.h>
- #include <errno.h>
-+#include <string.h>
- 
- #ifndef O_NOFOLLOW
- #define O_NOFOLLOW 0
-@@ -82,6 +83,7 @@ int write_buf (const char* buffer, int w
+--- write_buf.c.orig	2014-02-25 21:03:01.000000000 +0000
++++ write_buf.c	2024-11-28 22:25:15.966663532 +0000
+@@ -87,6 +87,7 @@
        sleep (1);
      }
    }

--- a/audio/mp3cat/files/patch-Makefile.diff
+++ b/audio/mp3cat/files/patch-Makefile.diff
@@ -1,10 +1,11 @@
---- Makefile.orig	2003-05-05 08:02:23.000000000 +1000
-+++ Makefile	2020-12-15 03:04:44.000000000 +1100
-@@ -1,6 +1,6 @@
+--- Makefile.orig	2014-02-25 21:03:01.000000000 +0000
++++ Makefile	2024-11-28 22:21:10.619192061 +0000
+@@ -4,7 +4,7 @@
+ INSTALL_COMMAND?=install -o $(INSTALL_USER) -g $(INSTALL_GROUP) -m 0555
  all: mp3cat
  mp3cat: *.c *.h
 -	cc -o mp3cat *.c
 +	$(CC) $(CFLAGS) -o mp3cat *.c
- install: mp3cat mp3log mp3log-conf mp3stream-conf
- 	install -o root -g wheel mp3cat /usr/local/bin/mp3cat
- 	install -o root -g wheel mp3log /usr/local/bin/mp3log
+ install: install_bin install_scripts
+ install_bin: mp3cat
+ 	mkdir -p $(PREFIX)/bin


### PR DESCRIPTION
#### Description

Update `mp3cat` to version 0.5, modernizing the Portfile with appropiate PortGroups, indentation, etc.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
