### PR TITLE
symfony-cli: update to 5.10.5

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.10.4
+version             5.10.5
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  6b1ce6389f49f397cbeaa3395de74adffed33e48 \
-                        sha256  0b3dcf937d778ee4c0f804aaa175f39f1690c66cec76efe6f795b2cb24c255db \
-                        size    273395
+    checksums           rmd160  37514f48b649bb6b7b7a5b5ec3e5c0c4f1bac9db \
+                        sha256  36d4f06c126255adab1b51610c8a86577ab1bfb61dec71e313ab1bc6356db11f \
+                        size    273649
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  c3de57dec3538fb43682e2f5892a04bd98ee52b6 \
-                        sha256  31ca20f167ca04ea06e9d7a41a1e34435314c91e2061dfe66a55a89af8b58d01 \
-                        size    11673049
+    checksums           rmd160  66e3bb2a96dd5a196f6f16baefb2692734b38c92 \
+                        sha256  345a4dacde39b448cb8f6ac4089e264b086e94649950c603ecf74eb6dc0766b3 \
+                        size    11674956
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.10.5

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
