### PR TITLE
python PortGroup: require C11 with py313 packages due to atomics requirement, adjust a few subports

### DIFF
--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -368,6 +368,13 @@ proc python_add_dependencies {} {
         } else {
             depends_lib-delete port:python${python.version}
             depends_lib-append port:python${python.version}
+            if {${python.version} >= 313} {
+                # Python 3.13 uses atomics, which is not supported in old Xcode compilers.
+                # Python.framework/Versions/3.13/include/python3.13/cpython/pyatomic.h:543:4:
+                # error: #error "no available pyatomic implementation for this platform/compiler"
+                # error: command '/usr/bin/gcc-4.2' failed with exit code 1
+                compiler.c_standard 2011
+            }
             if {[option python.pep517]} {
                 depends_build-delete    port:py${python.version}-build
                 depends_build-append    port:py${python.version}-build

--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -181,6 +181,14 @@ proc python_set_versions {option action args} {
                 lappend pycxxflags -isysroot${configure.sysroot}
                 lappend pyobjcflags -isysroot${configure.sysroot}
             }
+            # Only needed for Python 3.12, since later require C11.
+            if {${python.version} == 312} {
+                # python3.12/internal/pycore_frame.h:134: error:
+                # ‘for’ loop initial declaration used outside C99 mode
+                if {[string match *gcc-4.* ${configure.compiler}]} {
+                    lappend pycflags    -std=c99
+                }
+            }
             if {$pycflags ne ""} {
                 build.env-append        CFLAGS=[join $pycflags]
             }

--- a/python/py-acor/Portfile
+++ b/python/py-acor/Portfile
@@ -25,9 +25,4 @@ python.versions     311 312 313
 if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-numpy
-
-    # pyatomic.h: error: #error "no available pyatomic implementation for this platform/compiler"
-    if {${python.version} > 312} {
-        compiler.c_standard 2011
-    }
 }

--- a/python/py-bigfloat/Portfile
+++ b/python/py-bigfloat/Portfile
@@ -41,11 +41,6 @@ if {${name} ne ${subport}} {
         build.cmd-prepend   CFLAGS=-std=c99
     }
 
-    # pyatomic.h: error: #error "no available pyatomic implementation for this platform/compiler"
-    if {${python.version} > 312} {
-        compiler.c_standard 2011
-    }
-
     test.run        yes
     python.test_framework unittest
 


### PR DESCRIPTION
#### Description

_This does not change anything for Pythons themselves;_ this simply extends requirement for C11 from Python 3.13 to py313 packages, otherwise those fail to build, since Python 3.13 checks for C11 atomics and does not find it for old Xcode gcc.

@reneeotten I do not know how wide is c99 requirement for python312, it may be that many ports pass `-std=c99` anyway from upstream code, or it is a recent change, or I did not build affected ports earlier. Do you think this rather should also be done via PG?
Since pythons 311+ themselves cannot be built with pre-C11 compilers anyway, it may also be okay just to require it for py312+ ports, though it is not a requirement with py312- ones, strictly speaking.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
