### PR TITLE
draco: fix build with gcc

### DIFF
--- a/archivers/draco/Portfile
+++ b/archivers/draco/Portfile
@@ -26,6 +26,9 @@ checksums           rmd160  8570f7264777ac166dfec8db1d09c07cd997f4ee \
 patchfiles          patch-gltf-decoder-cc.diff \
                     patch-draco-targets-cmake.diff
 
+# https://github.com/google/draco/pull/1089
+patchfiles-append   patch-gltf_utils.h.diff
+
 compiler.cxx_standard   2017
 cmake.set_cxx_standard  yes
 
@@ -33,7 +36,7 @@ depends_build-append \
                     port:ghc-filesystem \
                     port:gtest
 
-depends_lib-append  port:eigen3 \
+depends_lib-append  path:share/pkgconfig/eigen3.pc:eigen3 \
                     port:nlohmann-json \
                     port:stb \
                     port:tinygltf
@@ -50,6 +53,12 @@ configure.args-append \
                     -DDRACO_TINYGLTF_PATH=${prefix}/include \
                     -DDRACO_TRANSCODER_SUPPORTED=ON \
                     -DDRACO_VERBOSE=3 \
+
+# https://trac.macports.org/ticket/71430
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.cxxflags-append \
+                    -fpermissive
+}
 
 test.run            yes
 test.cmd            "./draco_tests"

--- a/archivers/draco/files/patch-gltf_utils.h.diff
+++ b/archivers/draco/files/patch-gltf_utils.h.diff
@@ -1,0 +1,21 @@
+From a4edf44280b4456ed9d4267fff27a6040221b566 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Sun, 1 Dec 2024 08:39:11 +0800
+Subject: [PATCH] gltf_utils.h: add a missing <cstdint>
+
+---
+ src/draco/io/gltf_utils.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git src/draco/io/gltf_utils.h src/draco/io/gltf_utils.h
+index befbacb..4547d42 100644
+--- src/draco/io/gltf_utils.h
++++ src/draco/io/gltf_utils.h
+@@ -21,6 +21,7 @@
+ #include <iomanip>
+ #include <sstream>
+ #include <string>
++#include <cstdint>
+ 
+ namespace draco {
+ 


### PR DESCRIPTION
#### Description

Fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
