### PR TITLE
libsql: update to 0.5.0

### DIFF
--- a/databases/libsql/Portfile
+++ b/databases/libsql/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github  1.0
 
-github.setup        libsql libsql 0.2.2 v
+github.setup        tursodatabase libsql 0.5.0 libsql-rs-v
 github.tarball_from archive
 revision            0
 
@@ -31,12 +31,21 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 conflicts           sqlite3
 
-checksums           rmd160  82b5dcaebd66f9b1520fc6351b177b0b3449280e \
-                    sha256  ded251f9f313383c98f57669999201de1c99ad1a99e65796f452af44b7481fab \
-                    size    21089999
+checksums           rmd160  2962147a64cba57928c02157eb3761fea54bd4ca \
+                    sha256  cd0703768f821d8ead45069c7b1c8fb1f925d730facd57da75acec4bf36d08bb \
+                    size    29020412
+
+worksrcdir          ${worksrcpath}/libsql-sqlite3
+
+# Use 8-byte pointer on ppc64:
+# https://github.com/tursodatabase/libsql/pull/1861
+patchfiles          0001-sqliteInt.h-fix-pointer-size-for-ppc64.patch
 
 depends_lib-append  port:libedit \
                     port:ncurses \
                     port:zlib
+
+# sqlite3.h:13483: error: redefinition of typedef ‘sqlite3_pcache_page’
+compiler.c_standard 2011
 
 test.run            yes

--- a/databases/libsql/files/0001-sqliteInt.h-fix-pointer-size-for-ppc64.patch
+++ b/databases/libsql/files/0001-sqliteInt.h-fix-pointer-size-for-ppc64.patch
@@ -1,0 +1,22 @@
+From 293d647a1f28556053986386d1cb52cf7de970ed Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Sun, 1 Dec 2024 12:07:06 +0800
+Subject: [PATCH] sqliteInt.h: fix pointer size for ppc64
+
+---
+ libsql-sqlite3/src/sqliteInt.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git libsql-sqlite3/src/sqliteInt.h libsql-sqlite3/src/sqliteInt.h
+index cd9bf41dfa..1717fb5a84 100644
+--- src/sqliteInt.h
++++ src/sqliteInt.h
+@@ -894,7 +894,7 @@ typedef INT16_TYPE LogEst;
+ #   define SQLITE_PTRSIZE __SIZEOF_POINTER__
+ # elif defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
+        defined(_M_ARM)   || defined(__arm__)    || defined(__x86)   ||    \
+-      (defined(__APPLE__) && defined(__POWERPC__)) ||                     \
++      (defined(__APPLE__) && defined(__ppc__))  ||                        \
+       (defined(__TOS_AIX__) && !defined(__64BIT__))
+ #   define SQLITE_PTRSIZE 4
+ # else


### PR DESCRIPTION
#### Description

Update

P. S. @herbygillot While I am not gonna do that myself (approval will take forever), perhaps consider switching everything which depends on `sqlite3` to path-style dependency? Otherwise this port cannot be usable in MacPorts.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
