### PR TITLE
xeus-sqlite: fix dependencies in the portfile

### DIFF
--- a/databases/xeus-sqlite/Portfile
+++ b/databases/xeus-sqlite/Portfile
@@ -19,7 +19,7 @@ checksums               rmd160  14000e84be51666bbe40efeeac7cf4209ae242cd \
 
 compiler.cxx_standard   2017
 
-depends_build-append    port:pkgconfig
+depends_build-append    path:bin/pkg-config:pkgconfig
 
 variant python38 conflicts python39 python310 python311 python312 description {Use Python 3.8} {}
 variant python39 conflicts python38 python310 python311 python312 description {Use Python 3.9} {}
@@ -40,13 +40,19 @@ foreach pv {312 311 310 39 38} {
 }
 
 depends_lib-append      port:nlohmann-json \
-                        port:py${python.version}-jupyterlab \
+                        path:lib/libssl.dylib:openssl \
                         port:sqlite3 \
                         port:sqlitecpp \
                         port:tabulate \
                         port:xeus-zmq \
                         port:xvega \
                         port:xvega-bindings
+
+if {${configure.build_arch} ni [list ppc ppc64]} {
+    # It pulls in Rust via one of dependencies, no Rust on PowerPC at the moment.
+    # This is not a required dependency for the build.
+    depends_lib-append  port:py${python.version}-jupyterlab
+}
 
 # xeus-sqlite PR that fixes https://github.com/jupyter-xeus/xeus-sqlite/issues/141
 patchfiles              143.diff


### PR DESCRIPTION
#### Description

Fix deps, allow building on powerpc as a consequence.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
