### PR TITLE
ocp: revbump for libmad, use legacysupport

### DIFF
--- a/audio/ocp/Portfile
+++ b/audio/ocp/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
+PortGroup               legacysupport 1.1
+
+# strnlen, clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 github.setup            mywave82 opencubicplayer 0.2.109 v
 revision                1
@@ -42,6 +46,15 @@ depends_lib-append      port:ancient \
 
 # ancient requires C++17
 compiler.cxx_standard   2017
+
+# The code provides its own fallback for a missing clock_gettime,
+# which uses type definitions conflicting with legacysupport.
+# types.h:90:13: error: conflicting types for 'clockid_t'; have 'int'
+patchfiles-append       patch-types.h.diff
+
+# Upstream patch from:
+# https://github.com/mywave82/opencubicplayer/issues/120
+patchfiles-append       patch-xmload.c.diff
 
 configure.args          --with-ncurses \
                         --without-alsa \

--- a/audio/ocp/files/patch-types.h.diff
+++ b/audio/ocp/files/patch-types.h.diff
@@ -1,0 +1,11 @@
+--- types.h	2024-04-05 03:54:03.000000000 +0800
++++ types.h	2024-12-01 13:28:40.000000000 +0800
+@@ -77,7 +77,7 @@
+ # ifdef HAVE_AVAILABILITYMACROS_H
+ #  include <AvailabilityMacros.h>
+ # endif
+-# if !defined(MAC_OS_X_VERSION_10_12) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12
++# if 0
+ # include <time.h>
+ # include <mach/clock_types.h>
+ #  define CLOCK_REALTIME CALENDAR_CLOCK

--- a/audio/ocp/files/patch-xmload.c.diff
+++ b/audio/ocp/files/patch-xmload.c.diff
@@ -1,0 +1,13 @@
+--- playxm/xmload.c	2024-04-05 03:54:03.000000000 +0800
++++ playxm/xmload.c	2024-12-03 10:27:37.000000000 +0800
+@@ -453,8 +453,8 @@
+ 			cpifaceSession->cpiDebug (cpifaceSession, "[XM/XM] warning, Panning loop end point (%d) >= Number of panning points (%d), truncating\n", ins2.ploope, ins2.pnum);
+ 			ins2.ploope=ins2.pnum-1;
+ 		}
+-		for (k=0;k<12;k++)
+-			for (j=0;j<2;j++)
++		for (k=0;k<2;k++)
++			for (j=0;j<12;j++)
+ 			{
+ 				ins2.venv[j][k] = uint16_little (ins2.venv[j][k]);
+ 				ins2.penv[j][k] = uint16_little (ins2.penv[j][k]);


### PR DESCRIPTION
#### Description

Revbump for `libmad`, also fix for old systems and gcc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
