### PR TITLE
openjdk8-powerpc: update to 8u432

### DIFF
--- a/java/openjdk8-powerpc/Portfile
+++ b/java/openjdk8-powerpc/Portfile
@@ -11,9 +11,9 @@ conflicts           openjdk8
 # https://github.com/openjdk/jdk8u/tags
 # Tags: https://github.com/openjdk/jdk8u/tags
 set major           8
-set update          422
+set update          432
 # Set to the build of the 'jdk8u${update}-b${build}' tag that corresponds to the latest tag with '-ga'
-set build           05
+set build           06
 version             ${major}u${update}
 revision            0
 categories          java lang devel
@@ -31,9 +31,9 @@ use_xz              yes
 distname            openjdk${version}-b${build}
 worksrcdir          jdk${version}-b${build}
 
-checksums           rmd160  d8340a12e1c5da00e2b5fd2d81348d02085b539e \
-                    sha256  c447e801b2d66823af320710738c44d51e6d62496569d39bfbe5d0dd822bd8c5 \
-                    size    60233820
+checksums           rmd160  54c21a006f650d95b6fecdfd41fc0600a8f31bda \
+                    sha256  472251057179a56789fa0f54ea8ed4e0bc257832e6d4425a5711e7400e6e394c \
+                    size    60079816
 
 # Generic patches:
 patchfiles          0001-Fix-timebomb-bug-in-GenerateCurrencyData.patch \

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -25,6 +25,27 @@ master_sites        https://git.openjdk.org/jdk8u/archive/refs/tags/
 distname            jdk${major}u${update}-ga
 worksrcdir          jdk8u-${distname}
 
+if {${configure.build_arch} eq "ppc"} {
+    # On PowerPC this is a stub, the real JDK
+    # is installed by openjdk8-powerpc port.
+    # Independent versioning, pegged here.
+    version         8u
+    revision        0
+    epoch           1
+
+    depends_lib     port:${name}-powerpc
+
+    distfiles
+    patchfiles
+    use_configure   no
+    build           {}
+    destroot {
+        xinstall -d ${destroot}${prefix}/share/doc/${name}
+        system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/README"
+    }
+} else {
+    # x86* and arm64
+
 checksums           rmd160  7ffec6da71e24d2913b717b5f31d6be9c2fa7b7e \
                     sha256  3235a744b51896beb1e8b738412982ebc06e2affb9d50ae3371203d9a46504da \
                     size    88002433
@@ -122,19 +143,7 @@ post-patch {
     }
 }
 
-if {${configure.build_arch} eq "ppc"} {
-    depends_build-append       port:openjdk7-bootstrap
-    configure.args-append      --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk7-bootstrap
-    configure.post_args --disable-headful
-    post-patch {
-        reinplace "s|WARNINGS_ARE_ERRORS = -Werror|WARNING_FLAGS =|g" hotspot/make/bsd/makefiles/gcc.make
-        reinplace "s|WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wformat=2|WARNING_FLAGS = |g" hotspot/make/bsd/makefiles/gcc.make
-        reinplace "s|@ZERO_ARCHDEF@|PPC|g" hotspot/make/bsd/platform_zero.in
-        reinplace "s|@ZERO_LIBARCH@|ppc|g" hotspot/make/bsd/platform_zero.in
-        reinplace "s|dtraceCheck| |g" hotspot/make/bsd/makefiles/vm.make
-        reinplace "s|LP64=1|LP64=0|g" hotspot/make/bsd/Makefile
-    }
-} elseif {${configure.build_arch} in "arm64 x86_64"} {
+if {${configure.build_arch} in "arm64 x86_64"} {
     if {${os.platform} eq "darwin" && ${os.major} < 11} {
         # NOTE: openjdk8-bootstrap's doesn't work enough to bootstrap openjdk on 10.6
         # It is fails with errors like:
@@ -254,7 +263,9 @@ export JAVA_HOME=${jdk_path}/Contents/Home
 If you want to make the JRE installed by the ${name} the default JRE, add this to shell profile:
 export JAVA_HOME=${jre_path}/Contents/Home
 "
-    
+
+}
+
 livecheck.type      regex
 livecheck.url       https://github.com/openjdk/jdk8u/tags
 livecheck.regex     jdk(8u\[0-9\]+)-ga


### PR DESCRIPTION
#### Description

Also make `openjdk8` a stub on powerpc, otherwise users try installing it and it expectedly fails.

P. S. @breun Please take a look. Hope this is fine, the change in the main port only concerns powerpc. Otherwise I got complaints when someone tried to install it and got a bunch of errors: it is not really evident that one should install `-powerpc` port and not the generic one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
