### PR TITLE
weechat: use right headers for htobe64, fix build

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -63,6 +63,10 @@ license_noconflict  asciidoctor
 
 patchfiles          no-extra-gcc-warnings.patch
 
+# core-crypto.c:533: error: implicit declaration of function ‘htobe64’
+# https://github.com/weechat/weechat/pull/2216
+patchfiles-append   patch-fix-htobe64.diff
+
 configure.args-append \
                     -DENABLE_GUILE=OFF \
                     -DENABLE_JAVASCRIPT=OFF \

--- a/irc/weechat/files/patch-fix-htobe64.diff
+++ b/irc/weechat/files/patch-fix-htobe64.diff
@@ -1,0 +1,28 @@
+From 2b9f4162a1bc0770380b6f3809919a15316dcf91 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Sun, 1 Dec 2024 20:09:14 +0800
+Subject: [PATCH] core-crypto.c: fix htobe64 for Darwin
+
+---
+ src/core/core-crypto.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git src/core/core-crypto.c src/core/core-crypto.c
+index ce93de879..dc23469aa 100644
+--- src/core/core-crypto.c
++++ src/core/core-crypto.c
+@@ -31,10 +31,13 @@
+ #include <math.h>
+ #include <gcrypt.h>
+ 
+-#ifdef __ANDROID__
+ /* Bring in htobe64 */
++#ifdef __ANDROID__
+ #define _BSD_SOURCE
+ #include <endian.h>
++#elif defined(__APPLE__)
++#include <libkern/OSByteOrder.h>
++#define htobe64 OSSwapHostToBigInt64
+ #endif
+ 
+ #include "weechat.h"


### PR DESCRIPTION
#### Description

Fix `htobe64`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
