### PR TITLE
rebels-in-the-sky: Update to 1.0.25

### DIFF
--- a/games/rebels-in-the-sky/Portfile
+++ b/games/rebels-in-the-sky/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        ricott1 rebels-in-the-sky 1.0.24 v
+github.setup        ricott1 rebels-in-the-sky 1.0.25 v
 revision            0
 
 categories          games
@@ -29,9 +29,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix}  \
-                    rmd160  87d2fa0cccb26baa2f968078cfe78c12bc189932 \
-                    sha256  e664b43e8fe56fc2b26fdc1a8a57d9335eda1f5ad8602befd73c78eebb7c7b93 \
-                    size    9755992
+                    rmd160  bd700e0a7a56c8456878bd8840ac946f6372d744 \
+                    sha256  5811167ae2ac31d7bb48d421a8a838c6d4fdf265c08cde9d1e27f117fa0f8aeb \
+                    size    9758280
 
 cargo.crates \
     ab_glyph                           0.2.29  ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0 \
@@ -93,11 +93,11 @@ cargo.crates \
     bytemuck                           1.20.0  8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a \
     byteorder                           1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     byteorder-lite                      0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
-    bytes                               1.8.0  9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da \
+    bytes                               1.9.0  325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b \
     cassowary                           0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     castaway                            0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
     cbc                                 0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.1  fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47 \
+    cc                                  1.2.2  f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc \
     cesu8                               1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cexpr                               0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-expr                           0.15.8  d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02 \
@@ -172,7 +172,7 @@ cargo.crates \
     enum-ordinalize                     4.3.0  fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5 \
     enum-ordinalize-derive              4.3.1  0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff \
     equivalent                          1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
-    errno                               0.3.9  534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba \
+    errno                              0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
     event-listener                      5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
     event-listener-strategy             0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
     exr                                1.73.0  f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0 \
@@ -276,13 +276,13 @@ cargo.crates \
     jni-sys                             0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
     jobserver                          0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jpeg-decoder                        0.3.1  f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0 \
-    js-sys                             0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
+    js-sys                             0.3.73  fb15147158e79fd8b8afd0252522769c4f48725460b37338544d8379d94fc8f9 \
     lazy_static                         1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     lebe                                0.5.2  03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8 \
     lewton                             0.10.2  777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030 \
-    libc                              0.2.166  c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36 \
+    libc                              0.2.167  09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc \
     libfuzzer-sys                       0.4.8  9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa \
-    libloading                          0.8.5  4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4 \
+    libloading                          0.8.6  fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34 \
     libm                               0.2.11  8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa \
     libp2p                             0.54.1  bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4 \
     libp2p-allow-block-list             0.4.0  d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041 \
@@ -325,7 +325,7 @@ cargo.crates \
     mime                               0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                     0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                         0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
-    mio                                 1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
+    mio                                 1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
     multiaddr                          0.18.2  fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961 \
     multibase                           0.9.1  9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404 \
     multihash                          0.19.2  cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2 \
@@ -484,7 +484,7 @@ cargo.crates \
     slab                                0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     smallvec                           1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
     snow                                0.9.6  850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85 \
-    socket2                             0.5.7  ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c \
+    socket2                             0.5.8  c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8 \
     spin                                0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
     spin                                0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     spki                                0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
@@ -503,7 +503,7 @@ cargo.crates \
     symphonia-core                      0.5.4  798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3 \
     symphonia-metadata                  0.5.4  bc622b9841a10089c5b18e99eb904f4341615d5aa55bbf4eedde1be721a4023c \
     syn                               1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                                2.0.89  44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e \
+    syn                                2.0.90  919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31 \
     sync_wrapper                        1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                       0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     system-configuration                0.6.1  3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b \
@@ -534,11 +534,11 @@ cargo.crates \
     toml_datetime                       0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                         0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
     tower-service                       0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
-    tracing                            0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
+    tracing                            0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-attributes                 0.1.28  395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d \
     tracing-core                       0.1.33  e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c \
     try-lock                            0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
-    ttf-parser                         0.25.0  5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e \
+    ttf-parser                         0.25.1  d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31 \
     tui-textarea                        0.7.0  0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae \
     typemap-ors                         1.0.0  a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867 \
     typenum                            1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
@@ -569,14 +569,14 @@ cargo.crates \
     walkdir                             2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                                0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi        0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                       0.2.95  128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e \
-    wasm-bindgen-backend               0.2.95  cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358 \
-    wasm-bindgen-futures               0.4.45  cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b \
-    wasm-bindgen-macro                 0.2.95  e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56 \
-    wasm-bindgen-macro-support         0.2.95  26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68 \
-    wasm-bindgen-shared                0.2.95  65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d \
+    wasm-bindgen                       0.2.96  21d3b25c3ea1126a2ad5f4f9068483c2af1e64168f847abe863a526b8dbfe00b \
+    wasm-bindgen-backend               0.2.96  52857d4c32e496dc6537646b5b117081e71fd2ff06de792e3577a150627db283 \
+    wasm-bindgen-futures               0.4.46  951fe82312ed48443ac78b66fa43eded9999f738f6022e67aead7b708659e49a \
+    wasm-bindgen-macro                 0.2.96  920b0ffe069571ebbfc9ddc0b36ba305ef65577c94b06262ed793716a1afd981 \
+    wasm-bindgen-macro-support         0.2.96  bf59002391099644be3524e23b781fa43d2be0c5aa0719a18c0731b9d195cab6 \
+    wasm-bindgen-shared                0.2.96  e5047c5392700766601942795a436d7d2599af60dcc3cc1248c9120bfb0827b0 \
     wasm-streams                        0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
-    web-sys                            0.3.72  f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112 \
+    web-sys                            0.3.73  476364ff87d0ae6bfb661053a9104ab312542658c3d8f963b7ace80b6f9b26b9 \
     web-time                            1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                       0.26.7  5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e \
     weezl                               0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \


### PR DESCRIPTION
#### Description

rebels-in-the-sky: Update to 1.0.25

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
