### PR TITLE
legacy-support-devel: Update to latest master.

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           clang_dependency 1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 PortGroup           muniversal 1.1
@@ -47,13 +46,13 @@ subport ${name} {
 
 subport ${name}-devel {
     conflicts           ${name}
-    github.setup        macports macports-legacy-support f1becf1234ee8065e8c8c8be8d9d0d87435eeeee
-    version             20241104
+    github.setup        macports macports-legacy-support 0f1292b4734aac30188ee03561ecd1430a255062
+    version             20241201
     revision            0
     livecheck.type      none
-    checksums           rmd160  5bb32b95fe51e43599fcf76bc3f5af9925c4f176 \
-                        sha256  73741106c0f039cd0f8a4dea6611c38f36bd22a145e9353a17a002113db4401b \
-                        size    109352
+    checksums           rmd160  355cb69d0b2cf8d4fc4074bb1e4711f80be9d325 \
+                        sha256  6e9e4af031dad99a89bb57b28ae8318a92dd9152e5b101f8eacaa6ec45c7de4f \
+                        size    122396
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
 }
@@ -66,6 +65,9 @@ subport ${name}-devel {
 
 configure.cxx_stdlib
 
+# NOTE: The variables LD, LIPO, and PLATFORM are no longer used by the
+# latest code.  Their definitions should be removed once that code becomes the
+# release version.
 build.env-append    LD=ld \
                     "LIPO=/usr/bin/lipo" \
                     PLATFORM=${os.major} \
@@ -78,6 +80,9 @@ platform darwin 8 {
     destroot.target-append  install-tiger
 }
 
+# NOTE: The variable FORCE_ARCH is no longer used by the
+# latest code.  Its definition should be removed once that becomes the
+# release version.
 foreach arch ${muniversal.architectures} {
     build.env.${arch}-append    FORCE_ARCH=${arch}
 }


### PR DESCRIPTION
Notable changes since last -devel version:

- Fixes stat inconsistency in some 32-bit 10.4 builds.
- Adds stat64 header support for 10.4 SDK.
- Adds INODE64 support for `*stat*()` on 10.4.
- Reworks `fstatat*()` support, similar to previous item, fixing buffer overrun in some cases.

Also (Portfile only):

- Removes pointless clang_dependency PG.
- Adds comments regarding obsolescent build symbols.

TESTED:
Tested both normal and -devel versions on 10.4-10.5 ppc, 10.5-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-15.x arm64. Builds and passes all tests on all tested platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.1 22H221, arm64, Xcode 15.2 15C500b
macOS 14.7.1 23H222, arm64, Xcode 16.1 16B40
macOS 15.1.1 24B91, arm64, Xcode 16.1 16B40
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
