### PR TITLE
py-rasterstats, py-owslib, py-pytest-env: updates

### DIFF
--- a/python/py-owslib/Portfile
+++ b/python/py-owslib/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-owslib
 python.rootname     OWSLib
-version             0.31.0
+version             0.32.0
 revision            0
 
 categories-append   gis science net
@@ -23,9 +23,9 @@ long_description    \
 
 homepage            https://owslib.readthedocs.io/
 
-checksums           rmd160  410ddc5bbd8c9732a24d32524b813e6abe49f26b \
-                    sha256  2ed6540087445cc57d905138a590b6ae58624ec7661b5c1682ed4e3303bcd150 \
-                    size    185317
+checksums           rmd160  75f28eefaf2777b8017c9168031c6feb1fbe51db \
+                    sha256  7513860d3102ae8d4dc5efd8652ff3c61eca3a8cb220d6c8601121357cd2b01a \
+                    size    191988
 
 python.versions     39 310 311 312 313
 
@@ -34,8 +34,16 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-lxml \
                             port:py${python.version}-pyproj \
                             port:py${python.version}-requests \
-                            port:py${python.version}-tz \
                             port:py${python.version}-yaml
+
+    if {${python.version} <= 39} {
+        version             0.31.0
+        revision            0
+        checksums           rmd160  410ddc5bbd8c9732a24d32524b813e6abe49f26b \
+                            sha256  2ed6540087445cc57d905138a590b6ae58624ec7661b5c1682ed4e3303bcd150 \
+                            size    185317
+        depends_lib-append  port:py${python.version}-tz
+    }
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-pytest-env/Portfile
+++ b/python/py-pytest-env/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest-env
-version             1.1.3
+version             1.1.5
 revision            0
 
 categories-append   devel
@@ -21,9 +21,9 @@ homepage            https://github.com/pytest-dev/pytest-env
 
 distname            [string map {- _} ${python.rootname}]-${version}
 
-checksums           rmd160  d92e54bb1b755877683dc41b3a62d9b15ced3f30 \
-                    sha256  fcd7dc23bb71efd3d35632bde1bbe5ee8c8dc4489d6617fb010674880d96216b \
-                    size    8627
+checksums           rmd160  20bec45ee4d805c18f09155cc276cb924e45a044 \
+                    sha256  91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf \
+                    size    8911
 
 python.versions     310 311 312
 python.pep517_backend \

--- a/python/py-rasterstats/Portfile
+++ b/python/py-rasterstats/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-rasterstats
-version             0.19.0
+version             0.20.0
 revision            0
 
 categories-append   gis
@@ -20,9 +20,9 @@ long_description    {*}${description} based on vector geometries. It includes fu
 
 homepage            https://pythonhosted.org/rasterstats/
 
-checksums           rmd160  66bcf2cbc7e9908212676ea7fabd3466e216ff37 \
-                    sha256  066c44feb6f3936804a0c79d112271fa5bf5de0d5058823ab5c1e0047ab7bbbc \
-                    size    23434
+checksums           rmd160  8497bb1458dadaa28b6d909c51c335add6ef475c \
+                    sha256  5b8ee775e815727767e0d359c03f3dd1c7840876d1d1d0c7a5a88ecf3e492938 \
+                    size    24017
 
 python.versions     39 310 311 312
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Updates:

- py-owslib: update to 0.32.0 (and pins 0.31.0 to Python 3.9)
- py-pytest-env: update to 1.1.5
- py-rasterstats: update to 0.20.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
