### PR TITLE
openssl3: Fix building on 10.4 Intel

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -60,7 +60,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
 # OpenSSL 3.4.0 implements new intrinsic code that increases compiler
 # requirements. We can only use bootstrap Clang because the newer
 # one depends on openssl by default and causes a dependency cycle.
-if {${os.platform} eq "darwin" && ${os.major} < 18} {
+if {${os.platform} eq "darwin" && ${os.major} < 18 && ${os.major} > 8} {
     if {${configure.build_arch} in {"x86_64" "i386"}} {
         depends_build-append port:clang-11-bootstrap
         depends_skip_archcheck-append clang-11-bootstrap


### PR DESCRIPTION
#### Description

clang-11-bootstrap does not build on older versions of Mac OS, so guard against it and let it use the normal 10.4 workarounds later in the script.

@neverpanic I'm thinking it would be relevant for you to take a look at this PR since you added the code that it's modifying.

See https://trac.macports.org/ticket/71442
(I didn't expect I would be submitting a PR when I created it)

###### Type(s)

- [x] bugfix

###### Tested on
macOS 10.4.11 8S2167 i386
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0 
Xcode 2.5

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?