### PR TITLE
gallery-dl: update to 1.28

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.27.7 v
+github.setup        mikf gallery-dl 1.28.0 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  d40c0f1477317ed0b50d0e6fb107af4c7b6d0370 \
-                    sha256  f587310fb007e14d9d3a1022527927c30185cbda69945150ed19f870ebc37447 \
-                    size    498869
+checksums           rmd160  9158e489ab6ad90dfda8496da65d189ec96f63b1 \
+                    sha256  e046785d8670fab3527c4e0275b73ace4d7f2ffddf0868afc20cce89a6b6a990 \
+                    size    515100
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites


### PR DESCRIPTION
#### Description

gallery-dl: update to 1.28.0

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
