### PR TITLE
tk: do not switch to quartz on 32-bit where it fails

### DIFF
--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -52,7 +52,8 @@ post-destroot {
 configure.args.x86_64-append    --enable-64bit
 configure.args.ppc64-append     --enable-64bit
 
-if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx" && ${os.major} >= 10} {
+if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx" \
+    && ${os.major} >= 10 && ${configure.build_arch} ni [list i386 ppc]} {
     variant quartz conflicts x11 {
         depends_lib-delete \
                     port:fontconfig \


### PR DESCRIPTION
See: https://trac.macports.org/ticket/71444

#### Description

Unbreak the port after recent update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
