### PR TITLE
plfit: fix running tests, fix build with gcc

### DIFF
--- a/math/plfit/Portfile
+++ b/math/plfit/Portfile
@@ -25,9 +25,16 @@ test.target         test
 
 compiler.c_standard 1999
 
-configure.args-append    -DBUILD_SHARED_LIBS=ON \
-                         -DPLFIT_ENABLE_LTO=AUTO \
-                         -DPLFIT_USE_OPENMP=OFF
+configure.args-append   -DBUILD_SHARED_LIBS=ON \
+                        -DPLFIT_ENABLE_LTO=AUTO \
+                        -DPLFIT_USE_OPENMP=OFF
+
+configure.pre_args-replace \
+                        -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                        -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+
+# ld: unknown option: --version-script=/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_math_plfit/plfit/work/plfit-1.0.0/src/plfit.map
+patchfiles-append   patch-fix-linking-gcc.diff
 
 variant openmp description {Enable OpenMP support} {
     configure.args-replace       -DPLFIT_USE_OPENMP=OFF -DPLFIT_USE_OPENMP=ON

--- a/math/plfit/files/patch-fix-linking-gcc.diff
+++ b/math/plfit/files/patch-fix-linking-gcc.diff
@@ -1,0 +1,11 @@
+--- src/CMakeLists.txt	2024-11-21 17:12:31.000000000 +0800
++++ src/CMakeLists.txt	2024-12-03 09:42:09.000000000 +0800
+@@ -25,7 +25,7 @@
+     target_link_libraries(plfit OpenMP::OpenMP_C)
+ endif()
+ 
+-if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
++if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
+   set_target_properties(plfit PROPERTIES LINK_FLAGS "-Wl,--version-script=${PROJECT_SOURCE_DIR}/src/plfit.map")
+   set_target_properties(plfit PROPERTIES LINK_DEPENDS ${PROJECT_SOURCE_DIR}/src/plfit.map)
+ endif()


### PR DESCRIPTION
#### Description

1. Tests are broken, since the build does not find dylibs.
2. Build fails to link with gcc due to invalid linker argument.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
