### PR TITLE
tellico: avoid old Xcode gcc, it fails to build this

### DIFF
--- a/kde/tellico/Portfile
+++ b/kde/tellico/Portfile
@@ -7,7 +7,6 @@ name                tellico
 version             2.3.12
 revision            7
 categories          kde kde4
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-2+
 
@@ -43,6 +42,10 @@ configure.env-append PKG_CONFIG_PATH=${prefix}/libexec/poppler-qt4-mac/lib/pkgco
 build.env-append PKG_CONFIG_PATH=${prefix}/libexec/poppler-qt4-mac/lib/pkgconfig:${prefix}/lib/pkgconfig
 
 patchfiles-append   patch-CMakeLists-ksane.diff
+
+# poppler-annotation.h: error: expected ‘;’ before ‘override’
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
 pre-configure {
     reinplace "s|@KDEINCLUDEDIR@|${kde4.include_dirs}|g" ${worksrcpath}/CMakeLists.txt


### PR DESCRIPTION
[skip ci]

KDE4 ports won’t build due to broken dependencies, and also this change is inconsequential for all systems for which buildbots exist, since 10.6 Intel uses clang-11 in MacPorts by default, not gcc-4.2.

#### Description

Fix build on old systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
