### PR TITLE
ddev: update to 1.24.0

### DIFF
--- a/devel/ddev/Portfile
+++ b/devel/ddev/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ddev/ddev 1.23.5 v
+go.setup            github.com/ddev/ddev 1.24.0 v
 go.offline_build    no
 fetch.type          git
 


### PR DESCRIPTION
Update ddev to version 1.24.0

- PHP 8.4.1 included
- New drupal11 project type
- Smaller ddev-webserver image
- Various bug fixes and improvements