### PR TITLE
py-shiboken: revert breakage introduced by C++11 requirement

### DIFF
--- a/python/py-shiboken/Portfile
+++ b/python/py-shiboken/Portfile
@@ -45,8 +45,7 @@ if {${name} ne ${subport}} {
                         port:libxslt \
                         port:sparsehash
     use_configure   yes
-    compiler.cxx_standard 2011
-    configure.cxxflags-append -std=c++11
+
     # build.cmd must be set before configure.args is changed
     #    (see https://github.com/macports/macports-ports/commit/63c9c8e6e312c8e36603cb118d94f995aa8a6e67)
     build.cmd       make


### PR DESCRIPTION
#### Description

C++11 was added as a hack around a reported build failure. However, it breaks the build with gcc-4.2, and on PowerPC clangs do not exist.
While it is unclear what exactly is at fault, at least revert the breaking change for PowerPC, so that the port can build normally.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
