### PR TITLE
Rev bumps for VTK update to 9.4.0

### DIFF
--- a/graphics/QCSXCAD/Portfile
+++ b/graphics/QCSXCAD/Portfile
@@ -11,7 +11,7 @@ version             20230106-[string range ${github.version} 0 7]
 checksums           rmd160  c619c2075e0e81b66c7b16dc3bc4ac9cbd44b1d0 \
                     sha256  510c0c4b7833e4fdac51205256cd33341c55df7c500e910633b046cf40c380e0 \
                     size    628662
-revision            0
+revision            1
 
 platforms           darwin macosx
 categories          graphics

--- a/python/py-mayavi/Portfile
+++ b/python/py-mayavi/Portfile
@@ -8,7 +8,7 @@ PortGroup           github 1.0
 github.setup        enthought mayavi 4.8.2
 github.tarball_from archive
 name                py-mayavi
-revision            0
+revision            1
 
 categories-append   devel graphics math
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer

--- a/science/AppCSXCAD/Portfile
+++ b/science/AppCSXCAD/Portfile
@@ -12,7 +12,7 @@ version             20230106-[string range ${github.version} 0 7]
 checksums           rmd160  fa4359e0d7b6f77ae2162720a47dfe7d2586083c \
                     sha256  53b107889de36ef7655829988575c69342c52d164edf76f76ca76f0b04fd68aa \
                     size    18807
-revision            3
+revision            4
 
 platforms           darwin macosx
 categories          science

--- a/science/gdcm/Portfile
+++ b/science/gdcm/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                    gdcm
 version                 3.0.22
-revision                1
+revision                2
 categories              science graphics
 license                 BSD
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -12,7 +12,7 @@ gitlab.setup            nektar nektar 5.6.0 v
 boost.version           1.76
 
 name                    nektarpp
-revision                0
+revision                1
 
 categories              science
 license                 MIT

--- a/science/openEMS/Portfile
+++ b/science/openEMS/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 
 github.setup        thliebig openEMS 1ccf0942477e9178b27f5e00dddd4d62bff78d29
 version             20240312-[string range ${github.version} 0 7]
-revision            0
+revision            1
 
 checksums           rmd160  c29d96ef9a7c08f6d6295aa6fe5eb0feddcb2362 \
                     sha256  984f5263562bb32d104bffd4f66c148abe2ee57df48c3ac6dd9751a15b83a312 \

--- a/textproc/CSXCAD/Portfile
+++ b/textproc/CSXCAD/Portfile
@@ -10,7 +10,7 @@ version             20231216-[string range ${github.version} 0 7]
 checksums           rmd160  2ee23413b125b8f69b5eb95bf5b517c48ed8070f \
                     sha256  fdfa181709d3fa10e4156a715342aaa95b1df60694ccb5cf18d380d312c326c6 \
                     size    170544
-revision            0
+revision            1
 
 platforms           darwin macosx
 categories          textproc


### PR DESCRIPTION
#### Description

* Rev bump for 7 library dependents of port VTK.
* Follows the VTK update 9.3.1 --> 9.4.0 in #26773.
* See previous conversation in draft PR #26823.
* Some dependents are broken for other reasons, and will continue to fail builds.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  Some builds failed.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?