### PR TITLE
qsv: properly set Python 3.12 as build dep

### DIFF
--- a/textproc/qsv/Portfile
+++ b/textproc/qsv/Portfile
@@ -29,8 +29,10 @@ checksums           rmd160  51a76f5dc51cb9cf0e5a6fa702261249734e69e5 \
                     size    11018284
 
 depends_build-append \
-                    bin:cmake:cmake
+                    bin:cmake:cmake \
+                    port:python312
 
+build.env-append    PYO3_PYTHON=${prefix}/bin/python3.12
 build.args-append   --features=distrib_features --bin ${name}
 
 cargo.offline_cmd


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/71455

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
