### PR TITLE
vtk: Remove unused dependencies

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -46,27 +46,6 @@ checksums           rmd160  b265f1752ab0be2687ada62e2376177f54ccbbf0 \
 
 mpi.setup
 
-depends_lib-append \
-    port:double-conversion \
-    path:share/pkgconfig/eigen3.pc:eigen3 \
-    port:expat \
-    port:freetype \
-    port:gl2ps \
-    port:glew \
-    port:hdf5 \
-    path:include/turbojpeg.h:libjpeg-turbo \
-    port:jsoncpp \
-    port:libharu \
-    port:libogg \
-    port:libtheora \
-    port:lz4 \
-    port:netcdf-cxx \
-    port:pugixml \
-    port:tiff \
-    port:zlib
-
-mpi.enforce_variant hdf5
-
 # Re restoring support for legacy macOS, see:
 # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11171
 # https://gitlab.kitware.com/vtk/vtk/-/issues/19352


### PR DESCRIPTION
#### Description

Port vtk is currently configured to use many bundled (built-in) third party libraries. Therefore, external dependencies are redundant and should be removed to simplify builds.

* I DID check that all generated distfiles are functionally identical, by binary comparison.
* I did NOT analyze or change dependencies within declared variants.
* I did NOT check for run dependencies.
* No rev bump because only changes are unused dependencies, or related to them.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 14.6.1 23G93 x86_64
Xcode 15.4 15F31d
Command Line Tools 15.3.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -s install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
