### PR TITLE
ddev: fix parsing on unsupported architectures

### DIFF
--- a/devel/ddev/Portfile
+++ b/devel/ddev/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ddev/ddev 1.23.5 v
+go.setup            github.com/ddev/ddev 1.24.0 v
 go.offline_build    no
 fetch.type          git
 

--- a/devel/ddev/Portfile
+++ b/devel/ddev/Portfile
@@ -37,6 +37,8 @@ if {${build_arch} eq "x86_64"} {
     set go_arch "amd64"
 } elseif {${build_arch} eq "arm64"} {
     set go_arch "arm64"
+} else {
+    set go_arch "unsupported"
 }
 
 build.target    darwin_${go_arch}


### PR DESCRIPTION
Fix Trac ticket #71373

Add default case for go_arch variable to allow parsing on all architectures