### PR TITLE
python39+: fix `ttyname_r` build error on Tiger gcc14

### DIFF
--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -239,6 +239,12 @@ variant lto description {enable Link-Time Optimization} {
     configure.args-append   --with-lto
 }
 
+# Fixes the return type of `ttyname_r`
+# See https://github.com/python/cpython/issues/127614
+platform darwin 8 {
+    configure.cppflags-append -D__DARWIN_UNIX03=1
+}
+
 platform darwin {
     # Build failures on 10.9 and older
     if {${os.major} > 11} {

--- a/lang/python311/Portfile
+++ b/lang/python311/Portfile
@@ -246,6 +246,12 @@ variant lto description {enable Link-Time Optimization} {
     configure.args-append   --with-lto
 }
 
+# Fixes the return type of `ttyname_r`
+# See https://github.com/python/cpython/issues/127614
+platform darwin 8 {
+    configure.cppflags-append -D__DARWIN_UNIX03=1
+}
+
 platform darwin {
     # Build failures on 10.9 and older
     if {${os.major} > 11} {

--- a/lang/python312/Portfile
+++ b/lang/python312/Portfile
@@ -231,6 +231,12 @@ variant lto description {enable Link-Time Optimization} {
     configure.args-append   --with-lto
 }
 
+# Fixes the return type of `ttyname_r`
+# See https://github.com/python/cpython/issues/127614
+platform darwin 8 {
+    configure.cppflags-append -D__DARWIN_UNIX03=1
+}
+
 platform darwin {
     # Build failures on 10.9 and older
     if {${os.major} > 11} {

--- a/lang/python313/Portfile
+++ b/lang/python313/Portfile
@@ -232,6 +232,12 @@ variant lto description {enable Link-Time Optimization} {
     configure.args-append   --with-lto
 }
 
+# Fixes the return type of `ttyname_r`
+# See https://github.com/python/cpython/issues/127614
+platform darwin 8 {
+    configure.cppflags-append -D__DARWIN_UNIX03=1
+}
+
 platform darwin {
     # Build failures on 10.10 and older
     if {${os.major} > 11} {

--- a/lang/python314-devel/Portfile
+++ b/lang/python314-devel/Portfile
@@ -232,6 +232,12 @@ variant lto description {enable Link-Time Optimization} {
     configure.args-append   --with-lto
 }
 
+# Fixes the return type of `ttyname_r`
+# See https://github.com/python/cpython/issues/127614
+platform darwin 8 {
+    configure.cppflags-append -D__DARWIN_UNIX03=1
+}
+
 platform darwin {
     # Build failures on 10.10 and older
     if {${os.major} > 11} {

--- a/lang/python39/Portfile
+++ b/lang/python39/Portfile
@@ -242,6 +242,12 @@ variant lto description {enable Link-Time Optimization} {
     configure.args-append   --with-lto
 }
 
+# Fixes the return type of `ttyname_r`
+# See https://github.com/python/cpython/issues/127614
+platform darwin 8 {
+    configure.cppflags-append -D__DARWIN_UNIX03=1
+}
+
 platform darwin {
     # Build failures on 10.9 and older
     if {${os.major} > 11} {


### PR DESCRIPTION
#### Description

On Tiger, the modern `ttyname_r` signature is not available without this define.
Fixes Python v3.9+ build on Tiger with gcc14.
Older Python versions are not affected because `ttyname_r` is only used since Python v3.9+.

Verified with gcc14 from #26655.
This was not an error on earlier gcc versions (it  was only a warning).

Tested with:

* 3.9 - ✅ https://glebm.github.io/macports-tiger-ppc-binary-archives/dist/python39
* 3.10 - ✅ https://glebm.github.io/macports-tiger-ppc-binary-archives/dist/python310
* 3.11 - ✅ https://glebm.github.io/macports-tiger-ppc-binary-archives/dist/python311
* 3.12 - ✅ https://glebm.github.io/macports-tiger-ppc-binary-archives/dist/python312
* 3.13 - ❌ fails due to https://trac.macports.org/ticket/71206
* 3.14-devel - ❌ same as 3.13 

I've also filed https://github.com/python/cpython/issues/127614 upstream.

**Aside:** Perhaps we should always do `-D__DARWIN_UNIX03=1` for all darwin 8 compilation. That'd require rebuilding everything which would take weeks.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

/cc @kencu @barracuda156 @AJenbo