### PR TITLE
py-xrachlarch: update to 0.9.81; add missing dependencies

### DIFF
--- a/python/py-emmet-core/Portfile
+++ b/python/py-emmet-core/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-emmet-core
+version             0.84.2
+revision            0
+
+categories-append   science databases devel
+platforms           {darwin any}
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         Core Emmet Library
+long_description    {*}${description}
+
+homepage            https://github.com/materialsproject/emmet
+
+checksums           rmd160  8c5b048712aa8d11c8e57a7bf0a6fd91916972ee \
+                    sha256  cc71e85492449d3245b7a26ba826379b1d8e0de6ee5200c6a6ea7d4f3486ac12 \
+                    size    204016
+
+python.versions     39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools_scm
+
+    depends_lib-append \
+                    port:py${python.version}-monty \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-pybtex \
+                    port:py${python.version}-pydantic \
+                    port:py${python.version}-pydantic_settings \
+                    port:py${python.version}-pymatgen \
+                    port:py${python.version}-typing_extensions
+}

--- a/python/py-maggma/Portfile
+++ b/python/py-maggma/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-maggma
+version             0.70.0
+revision            0
+
+categories-append   science devel
+platforms           {darwin any}
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         Framework to develop datapipelines from files on disk to \
+                    full dissemenation API
+long_description    {*}${description}
+
+homepage            https://github.com/materialsproject/maggma
+
+checksums           rmd160  6845d086044e88a5be142e528869173cc721f2a3 \
+                    sha256  1f42754d369b487411ead44aab9416d7d7ff7f08566fac9d2b04c00d25dc24d7 \
+                    size    225067
+
+python.versions     39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-aioitertools \
+                    port:py${python.version}-boto3 \
+                    port:py${python.version}-dnspython \
+                    port:py${python.version}-jsonlines \
+                    port:py${python.version}-jsonschema \
+                    port:py${python.version}-mongomock \
+                    port:py${python.version}-monty \
+                    port:py${python.version}-msgpack \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-orjson \
+                    port:py${python.version}-pandas \
+                    port:py${python.version}-pydantic \
+                    port:py${python.version}-pydantic_settings \
+                    port:py${python.version}-pydash \
+                    port:py${python.version}-pymongo \
+                    port:py${python.version}-dateutil \
+                    port:py${python.version}-zmq \
+                    port:py${python.version}-ruamel-yaml \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-sshtunnel \
+                    port:py${python.version}-tqdm
+}

--- a/python/py-mongomock/Portfile
+++ b/python/py-mongomock/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-mongomock
+version             4.3.0
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             ISC
+maintainers         nomaintainer
+
+description         Fake pymongo stub for testing simple MongoDB-dependent code
+long_description    {*}${description}
+
+homepage            https://github.com/mongomock/mongomock
+
+checksums           rmd160  7cfcdef7100f4a23aff5faf07f6312bd8ef3d167 \
+                    sha256  32667b79066fabc12d4f17f16a8fd7361b5f4435208b3ba32c226e52212a8c30 \
+                    size    135862
+
+python.versions     39 310 311 312
+python.pep517_backend hatch
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-hatch-vcs
+
+    depends_lib-append \
+                    port:py${python.version}-packaging \
+                    port:py${python.version}-tz \
+                    port:py${python.version}-sentinels
+}

--- a/python/py-mp-api/Portfile
+++ b/python/py-mp-api/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-mp-api
+version             0.43.0
+revision            0
+
+categories-append   science devel
+platforms           {darwin any}
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         API Client for the Materials Project
+long_description    {*}${description}
+
+homepage            https://github.com/materialsproject/api
+
+distname            mp_api-${version}
+
+checksums           rmd160  bfd74bf8d283f0d51603f872b6c93180551f5c31 \
+                    sha256  9bb7e97790f91c6ae082c73f1a43307b480247c0885772724b52eeba1b117afe \
+                    size    702889
+
+python.versions     39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-emmet-core \
+                    port:py${python.version}-maggma \
+                    port:py${python.version}-monty \
+                    port:py${python.version}-msgpack \
+                    port:py${python.version}-pymatgen \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-smart-open \
+                    port:py${python.version}-typing_extensions
+}

--- a/python/py-pycifrw/Portfile
+++ b/python/py-pycifrw/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pycifrw
+python.rootname     PyCifRW
+version             4.4.6
+revision            0
+
+categories-append   science
+license             Python-2.0
+maintainers         nomaintainer
+
+description         CIF/STAR file support for Python
+long_description    {*}${description}
+
+homepage            https://github.com/jamesrhester/pycifrw/blob/development/README.md
+
+checksums           rmd160  9483aa69524d260965d4639147e6dff3fc3855d5 \
+                    sha256  02bf5975e70ab71540bff62fbef3e8354ac707a0f0ab914a152047962891ef15 \
+                    size    1073183
+
+python.versions     39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-ply
+}

--- a/python/py-pydash/Portfile
+++ b/python/py-pydash/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pydash
+version             8.0.4
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         The kitchen sink of Python utility libraries for doing \
+                    "stuff" in a functional way. Based on the Lo-Dash \
+                    Javascript library.
+long_description    {*}${description}
+
+homepage            https://github.com/dgilland/pydash
+
+checksums           rmd160  3aaddfd18aa2d6deb922a748c98433f50febc895 \
+                    sha256  a33fb17b4b06c617da5c57c711605d2dc8723311ee5388c8371f87cd44bf4112 \
+                    size    164676
+
+python.versions     39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-typing_extensions
+}

--- a/python/py-pyqtgraph/Portfile
+++ b/python/py-pyqtgraph/Portfile
@@ -20,15 +20,15 @@ long_description    PyQtGraph is a pure-python graphics and GUI library \
                     for number crunching and Qt’s GraphicsView framework \
                     for fast display.
 
-version             0.13.1
-checksums           rmd160  684e82952133c5ed6d4b0b1a08658135eab55253 \
-                    sha256  698f87f59db965727b33602a0b29058de21291d8b143dea878b50578aec0dc08 \
-                    size    1364064
+version             0.13.7
+checksums           rmd160  dcc61a485d23320e58c7ff5a9b5a15035d0381fc \
+                    sha256  64f84f1935c6996d0e09b1ee66fe478a7771e3ca6f3aaa05f00f6e068321d9e3 \
+                    size    2343380
 revision            0
 
 homepage            https://pyqtgraph.org/
 
-python.versions     39 310
+python.versions     39 310 311 312
 
 if {${subport} ne ${name}} {
     if {[variant_isset pyqt4] || [variant_isset pyside]} {

--- a/python/py-sentinels/Portfile
+++ b/python/py-sentinels/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-sentinels
+version             1.0.0
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         Various objects to denote special meanings in python
+long_description    {*}${description}
+
+homepage            https://pypi.org/project/sentinels
+
+checksums           rmd160  67ed7e31d6e083d3edba67336e2d2567c7a616fd \
+                    sha256  7be0704d7fe1925e397e92d18669ace2f619c92b5d4eb21a89f31e026f9ff4b1 \
+                    size    4074
+
+python.versions     39 310 311 312

--- a/python/py-smart-open/Portfile
+++ b/python/py-smart-open/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-smart-open
+version             7.0.5
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         Utils for streaming large files (S3, HDFS, GCS, Azure Blob \
+                    Storage, gzip, bz2...)
+long_description    {*}${description}
+
+homepage            https://github.com/piskvorky/smart_open
+
+distname            smart_open-${version}
+
+checksums           rmd160  37c5bc096ab0c6b0b89d70c9f296430213372e04 \
+                    sha256  d3672003b1dbc85e2013e4983b88eb9a5ccfd389b0d4e5015f39a9ee5620ec18 \
+                    size    71693
+
+python.versions     39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-wrapt
+}

--- a/python/py-sqlalchemy-utils/Portfile
+++ b/python/py-sqlalchemy-utils/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-sqlalchemy-utils
+python.rootname     SQLAlchemy-Utils
+version             0.41.2
+revision            0
+
+categories-append   databases devel
+platforms           {darwin any}
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         Various utility functions for SQLAlchemy.
+long_description    {*}${description}
+
+homepage            https://github.com/kvesteri/sqlalchemy-utils
+
+checksums           rmd160  50c671662efef4842803dde5db3fa41eeaeaaab0 \
+                    sha256  bc599c8c3b3319e53ce6c5c3c471120bd325d0071fb6f38a10e924e3d07b9990 \
+                    size    138017
+
+python.versions     39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-sqlalchemy
+}

--- a/python/py-sshtunnel/Portfile
+++ b/python/py-sshtunnel/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-sshtunnel
+version             0.4.0
+revision            0
+
+categories-append   devel
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         Pure python SSH tunnels
+long_description    {*}${description}
+
+homepage            https://github.com/pahaz/sshtunnel
+
+checksums           rmd160  8e91de2f8cc6f2646df16ea9ed4439abd7ceb7c4 \
+                    sha256  e7cb0ea774db81bf91844db22de72a40aae8f7b0f9bb9ba0f666d474ef6bf9fc \
+                    size    62716
+
+python.versions     39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-paramiko
+}

--- a/python/py-xraylarch/Portfile
+++ b/python/py-xraylarch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-xraylarch
-version             0.9.62
+version             0.9.81
 revision            0
 
 categories-append   science
@@ -14,7 +14,6 @@ license             BSD
 maintainers         {nist.gov:joe.fowler @joefowler} openmaintainer
 
 description         Larch is a system for analyzing X-ray data from synchrotron beamlines.
-
 long_description    Larch is a open-source library and set of applications for processing and \
     analyzing X-ray absorption and fluorescence spectroscopy data and X-ray fluorescence and \
     diffraction image data from synchrotron beamlines. It aims to be a complete analysis \
@@ -26,61 +25,60 @@ long_description    Larch is a open-source library and set of applications for p
 
 homepage            https://xraypy.github.io/xraylarch
 
-# Find the latest at https://pypi.org/project/xraylarch/#files
-master_sites        https://files.pythonhosted.org/packages/ff/4a/cf7f494aaa3ea1ba15adf5806cef0ac5136affc7e8f7c2048999fa4e28d9/
-distname            xraylarch-${version}-py3-none-any
+checksums           rmd160  47733be47724c790e047f08e8332f02e6623476a \
+                    sha256  34ca8da369176d89ff89e1d969972c139cd6a2a8a8b602a5afaac1ca52425108 \
+                    size    21485459
 
-checksums           rmd160  0736ee2e7d6ba40c8c55dc7111cb3c3067454fd2 \
-                    sha256  92d558df4c8302a277ead4ad597920285abf3b7e69ca9ab13873e8dc319e452a \
-                    size    21056444
-
-python.versions     39 310
-python.pep517       yes
-python.pep517_backend
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
-
-    # Must build from wheel file, because PyPi distributes only that and no tarballs
-    # (starting with version 0.9.61 in May 2022).
-    # See discussion at https://github.com/xraypy/xraylarch/issues/380
-
-    extract.suffix  .whl
-    extract.only
-
-    build { }
-
-    depends_lib-append \
-                    port:py${python.version}-numpy
+    depends_build-append \
+                    port:py${python.version}-setuptools_scm
 
     depends_run-append \
                     port:py${python.version}-asteval \
+                    port:py${python.version}-charset-normalizer \
+                    port:py${python.version}-dill \
                     port:py${python.version}-h5py \
+                    port:py${python.version}-imageio \
                     port:py${python.version}-fabio \
-                    port:py${python.version}-importlib-metadata \
+                    port:py${python.version}-hdf5plugin \
                     port:py${python.version}-lmfit \
                     port:py${python.version}-matplotlib \
+                    port:py${python.version}-mp-api \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-numexpr \
                     port:py${python.version}-numdifftools \
+                    port:py${python.version}-pandas \
+                    port:py${python.version}-packaging \
                     port:py${python.version}-Pillow \
-                    port:py${python.version}-peakutils \
                     port:py${python.version}-psutil \
+                    port:py${python.version}-pycifrw \
+                    port:py${python.version}-pyFAI \
+                    port:py${python.version}-pymatgen \
                     port:py${python.version}-pyqt5 \
                     port:py${python.version}-pyqtgraph \
                     port:py${python.version}-pyqt5-webengine \
+                    port:py${python.version}-pyshortcuts \
                     port:py${python.version}-requests \
-                    port:py${python.version}-ruamel-yaml-clib \
                     port:py${python.version}-scikit-image \
                     port:py${python.version}-scikit-learn \
                     port:py${python.version}-scipy \
                     port:py${python.version}-silx \
                     port:py${python.version}-sqlalchemy \
+                    port:py${python.version}-sqlalchemy-utils \
+                    port:py${python.version}-tabulate \
                     port:py${python.version}-termcolor \
                     port:py${python.version}-toml \
                     port:py${python.version}-uncertainties \
                     port:py${python.version}-xraydb \
+                    port:py${python.version}-yaml
+
+    # currently pyXY-wxpython-4.0 fails to build on macOS 15; make it a variant for now
+    variant gui description "Build with wxPython GUI" {
+        depends_run-append \
                     port:py${python.version}-wxmplot \
                     port:py${python.version}-wxpython-4.0 \
                     port:py${python.version}-wxutils \
-                    port:py${python.version}-yaml
-
-    destroot.target ${distpath}/${distfiles}
+    }
 }


### PR DESCRIPTION
#### Description
This PR supersedes #25157. @joefowler this includes the update to the latest upstream version and adds (recursively) the required dependencies. 
I have no interest in maintaining these ports, but would be happy to add you as maintainer if you wish to do so and keep things up-to-date; please let me know.

I added a `gui` variant as on the latest macOS version the `py-wxpython-4.0` port does not build and would thus prohibit the port to be installed. There is/are Trac ticket(s) for that; I did take a quick look but couldn't fix it in the time I'm willing to spend on it...

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1.1 24B91 x86_64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
