### PR TITLE
hurl: fix stealth update (6.0.0)

### DIFF
--- a/www/hurl/Portfile
+++ b/www/hurl/Portfile
@@ -21,9 +21,11 @@ long_description    \
     used for both fetching data and testing HTTP sessions.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fb01a2ec3bb8fe39184eb183b6d560efb8b32709 \
-                    sha256  9e0fba34f591a0880276d899c97d73d5c1f32f146f34ecca6135c0ec94952303 \
-                    size    8076670
+                    rmd160  fc76b72a313f2295716f3d8387a0f4f9ddf2773a \
+                    sha256  3f21c9e2a4e86e1a5913e211d890b07e9388871e3d6ed526668487f56b11b925 \
+                    size    8076615
+
+dist_subdir         ${name}/${version}_${revision}
 
 categories          www
 installs_libs       no
@@ -71,8 +73,8 @@ cargo.crates \
     cc                               1.2.2  f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
-    clap                            4.5.21  fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f \
-    clap_builder                    4.5.21  b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec \
+    clap                            4.5.22  69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b \
+    clap_builder                    4.5.22  6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1 \
     clap_lex                         0.7.3  afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7 \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     colored                          2.1.0  cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8 \
@@ -218,7 +220,7 @@ cargo.crates \
     winres                          0.1.12  b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
-    xml-rs                          0.8.23  af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f \
+    xml-rs                          0.8.24  ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432 \
     yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
