### PR TITLE
lrzsz: update to support clang 16

### DIFF
--- a/comms/lrzsz/Portfile
+++ b/comms/lrzsz/Portfile
@@ -5,16 +5,13 @@ PortSystem          1.0
 name                lrzsz
 version             0.12.20
 revision            4
+
 categories          comms
 license             GPL-2+
 maintainers         nomaintainer
-platforms           darwin
-
 description         free XMODEM/YMODEM/ZMODEM implementation
-
 long_description    ${name} is a Unix communication package providing the \
                     XMODEM, YMODEM, and ZMODEM file transfer protocols.
-
 homepage            https://ohse.de/uwe/software/lrzsz.html
 master_sites        https://ohse.de/uwe/releases/
 
@@ -25,6 +22,14 @@ checksums           rmd160  1b1776143afaff8bc7447ce998f9d3a958d51f25 \
 configure.args      --program-transform-name=s/l// \
                     --mandir=${prefix}/share/man \
                     --disable-nls
+
+# workaround for clang 16+
+if {[string match *clang* ${configure.cc}]} {
+    configure.cflags-append \
+                    -Wno-implicit-int \
+                    -Wno-error=unknown-warning-option \
+                    -Wno-unknown-warning-option
+}
 
 patchfiles          implicit.patch \
                     patch-man-lrz.diff \


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/70755

#### Description

Resovles clang 16 breaking change that affects C functions with no declared return type.

The clang 16 change broke the lrzsz configure script. This change detects the clang version
and adds -Wno-implicit-int for clang version >= 16.

Note that addition of the -Wno-implicit-int clang flag is the same resolution as that was
used by homebrew to resolve this lrzsz problem.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.1.1 24B91 x86_64
Xcode 16.1 16B40

macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there arXen't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
