### PR TITLE
Bear: Update to 3.1.5

### DIFF
--- a/devel/Bear/Portfile
+++ b/devel/Bear/Portfile
@@ -9,16 +9,15 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 19
 legacysupport.use_mp_libcxx                 yes
 
-github.setup        rizsotto Bear 3.1.3
-revision            5
+github.setup        rizsotto Bear 3.1.5
+revision            0
 
-checksums           rmd160  909b90269b3528c4960a634c47b76a534e389a87 \
-                    sha256  389a5251a835cd156fad4f4e598d0bf8c66783a0d5835eba7f113ab5f26637f5 \
-                    size    127777
+checksums           rmd160  15a2c3369693c1ec3b14f82cf483fbc0a214c100 \
+                    sha256  2b3ac2fe04f76999083db604fbe25743c95548ce73e3148036e50e80d3d1026b \
+                    size    152222
 
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-3+
-platforms           darwin
 
 categories          devel
 description         \


### PR DESCRIPTION
#### Description

Drop platforms line, which re-specifies the default.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
