### PR TITLE
py-progressbar: add support for Python 3.13

### DIFF
--- a/python/py-progressbar/Portfile
+++ b/python/py-progressbar/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  fe6d08f7d30314d2d77acfc867a0587af1e3d8e3 \
                     sha256  f4ac55c2f4bee572f7219d6208adfeadf011c1e610fe03f56ba1109dbf750ccf \
                     size    10528
 
-python.versions     27 38 39 310 311 312
+python.versions     27 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Add Python 3.13 support.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?