### PR TITLE
py-bitmath: add support for Python 3.13

### DIFF
--- a/python/py-bitmath/Portfile
+++ b/python/py-bitmath/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  c195d27c3268fe5a669e4c2b743ed7f12fb40e2b \
                     sha256  293325f01e65defe966853111df11d39215eb705a967cb115851da8c4cfa3eb8 \
                     size    88519
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

Add support for Python 3.13.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?