### PR TITLE
py-makelive: add Python 3.13 support

### DIFF
--- a/python/py-makelive/Portfile
+++ b/python/py-makelive/Portfile
@@ -31,6 +31,6 @@ checksums           rmd160  12440ba7928fed3d1da24d5986cdfc305eb06ba0 \
                     sha256  df02b715116e462a3e7316517eb91b8f9a1dbad1d6d41352fd562f44a168e858 \
                     size    18723
 
-python.versions     312
+python.versions     312 313
 
 python.pep517_backend flit


### PR DESCRIPTION
#### Description

Add Python 3.13 support.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?