### PR TITLE
py-mac-alias: add Python 3.13 support

### DIFF
--- a/python/py-mac-alias/Portfile
+++ b/python/py-mac-alias/Portfile
@@ -25,4 +25,4 @@ checksums           rmd160  8d46ee63eb8cd89e6ac896a988f62f4d1ed70b03 \
                     sha256  c99c728eb512e955c11f1a6203a0ffa8883b26549e8afe68804031aa5da856b7 \
                     size    34073
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313


### PR DESCRIPTION
#### Description

Add Python 3.13 support.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?