### PR TITLE
py-bitstring: update to 4.2.3, add subport for Python 3.13

### DIFF
--- a/python/py-bitstring/Portfile
+++ b/python/py-bitstring/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        scott-griffiths bitstring 4.1.4 bitstring-
+github.setup        scott-griffiths bitstring 4.2.3 bitstring-
 name                py-bitstring
 revision            0
 
@@ -19,11 +19,11 @@ long_description    bitstring is a pure Python module that makes the \
                     creation, manipulation and analysis of binary data \
                     as simple and natural as possible.
 
-checksums           rmd160  1cc74279cafd10aa635df85266f614e32e22c691 \
-                    sha256  645a3742d2c3ed4b3a468bfe96509d7fdcc0490d1a7945e0b68d28396c6ec0e2 \
-                    size    420174
+checksums           rmd160  1975a158384d88dcef14da0071c19db7b39f82bc \
+                    sha256  33cc5014bcce5cfee26cbd82855424b922530cd58a179ca46c9f296d498c59c2 \
+                    size    443138
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append \
@@ -31,7 +31,7 @@ if {${name} ne ${subport}} {
 
     post-destroot {
         xinstall -d ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 0644 -W ${worksrcpath} README.md release_notes.txt \
+        xinstall -m 0644 -W ${worksrcpath} README.md release_notes.md \
             LICENSE ${destroot}${prefix}/share/doc/${subport}
    }
 


### PR DESCRIPTION
#### Description

Update to 4.2.3, add subport for Python 3.13.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?