### PR TITLE
py-feedparser: correct python 27; use pypi instead of github

### DIFF
--- a/python/py-feedparser/Portfile
+++ b/python/py-feedparser/Portfile
@@ -5,7 +5,11 @@ PortGroup           python 1.0
 
 name                py-feedparser
 version             6.0.11
-revision            0
+revision            1
+
+# remove next update
+dist_subdir   ${name}/${version}_1
+
 license             BSD
 supported_archs     noarch
 platforms           {darwin any}
@@ -19,20 +23,22 @@ long_description    Universal Feed Parser is a Python module for downloading \
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 
-checksums           rmd160  b3df488d869882a31f2c1b71511339682aa1ea27 \
-                    sha256  7474d23c879a4a7a2367801b417e2797c4abf25449e516d1b9139a3873af7ade \
-                    size    253205
+checksums           rmd160  64627d6e92f894a35f6c3073e6add86887c9f9c6 \
+                    sha256  c9d0407b64c6f2a065d0ebb292c2b35c01050cc0dc33757461aaabdc4c4184d5 \
+                    size    286197
 
 python.versions     27 39 310 311 312
 
 if {${name} ne ${subport}} {
     if {${python.version} eq 27} {
         version             5.2.1
-        revision            0
+        revision            1
+        dist_subdir   ${name}/${version}_1
 
         checksums           rmd160  d48648b794bdd8af38e77b8337ac2241d79bca4c \
                             sha256  bd030652c2d08532c034c27fcd7c85868e7fa3cb2b17f230a44a6bbc92519bf9 \
                             size    252956
+
 
         depends_build-append \
                             port:py${python.version}-setuptools

--- a/python/py-feedparser/Portfile
+++ b/python/py-feedparser/Portfile
@@ -2,12 +2,10 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
 
-github.setup        kurtmckee feedparser 6.0.11
-github.tarball_from archive
+name                py-feedparser
+version             6.0.11
 revision            0
-name                py-${name}
 license             BSD
 supported_archs     noarch
 platforms           {darwin any}
@@ -19,23 +17,22 @@ long_description    Universal Feed Parser is a Python module for downloading \
     Userland RSS 0.91, RSS 0.92, RSS 0.93, RSS 0.94, RSS 1.0, RSS 2.0, Atom, \
     and CDF feeds.
 
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+
 checksums           rmd160  b3df488d869882a31f2c1b71511339682aa1ea27 \
                     sha256  7474d23c879a4a7a2367801b417e2797c4abf25449e516d1b9139a3873af7ade \
                     size    253205
 
 python.versions     27 39 310 311 312
 
-# Skip beta versions
-github.livecheck.regex  {([0-9.]+)}
-
 if {${name} ne ${subport}} {
     if {${python.version} eq 27} {
-        github.setup        kurtmckee feedparser 5.2.1
+        version             5.2.1
         revision            0
 
-        checksums           rmd160  22f74a36800fc02a57a69a16f3b793c23b863375 \
-                            sha256  53a133aed63977066b772b44e8b4d7e2d9c3e1ab80a6a549a8f587db4bc8956f \
-                            size    249223
+        checksums           rmd160  d48648b794bdd8af38e77b8337ac2241d79bca4c \
+                            sha256  bd030652c2d08532c034c27fcd7c85868e7fa3cb2b17f230a44a6bbc92519bf9 \
+                            size    252956
 
         depends_build-append \
                             port:py${python.version}-setuptools


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/70091
closes: https://trac.macports.org/ticket/70520

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
