### PR TITLE
rsgain: fix the build after legacysupport added

### DIFF
--- a/audio/rsgain/Portfile
+++ b/audio/rsgain/Portfile
@@ -43,6 +43,9 @@ depends_lib-append              port:ffmpeg \
                                 port:libebur128 \
                                 port:taglib
 
+# https://github.com/complexlogic/rsgain/pull/140
+patchfiles-append               0001-rsgain.cpp-use-C-cmath.patch
+
 configure.args-append           -DUSE_STD_FORMAT=ON
 
 compiler.cxx_standard           2020

--- a/audio/rsgain/files/0001-rsgain.cpp-use-C-cmath.patch
+++ b/audio/rsgain/files/0001-rsgain.cpp-use-C-cmath.patch
@@ -1,0 +1,32 @@
+From b9611ea0679919cbc0ea241eb8b3de2d45a3b007 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Sat, 7 Dec 2024 06:48:57 +0800
+Subject: [PATCH] rsgain.cpp: use C++ cmath
+
+---
+ src/rsgain.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git src/rsgain.cpp src/rsgain.cpp
+index 54f377f..b30ee6d 100644
+--- src/rsgain.cpp
++++ src/rsgain.cpp
+@@ -33,8 +33,8 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <math.h>
+ #include <getopt.h>
++#include <cmath>
+ #include <string>
+ #include <locale>
+ 
+@@ -150,7 +150,7 @@ bool parse_max_peak_level(const char *value, double &peak)
+ {
+     char *rest = nullptr;
+     double max_peak = strtod(value, &rest);
+-    if (rest == value || !isfinite(max_peak)) {
++    if (rest == value || !std::isfinite(max_peak)) {
+         output_error("Invalid max peak level '{}'", value);
+         return false;
+     }


### PR DESCRIPTION
#### Description

The last update has broken build with gcc (upstream bug). Fix that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
