### PR TITLE
libressl-devel: re-fix build on macOS < 10.14

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.1
 
 # error: 'TARGET_OS_OSX' is not defined
@@ -14,7 +13,6 @@ revision            0
 distname            libressl-${version}
 
 categories          security devel
-platforms           darwin
 license             OpenSSL SSLeay
 maintainers         {@artkiver gmail.com:artkiver} {cal @neverpanic} openmaintainer
 
@@ -45,11 +43,26 @@ post-patch {
     reinplace "s|@OPENSSLDIR@|${prefix}/etc/ssl|" ${worksrcpath}/include/openssl/opensslconf.h
 }
 
-# aesni-macosx-x86_64.S:890:2: error: invalid
-# instruction mnemonic 'endbr64'
-# uses newer assembly features on Intel
-compiler.blacklist-append \
-                     {clang < 1001}
+# https://github.com/macports/macports-ports/pull/26250#issuecomment-2437709579
+# https://trac.macports.org/ticket/69490
+# LibreSSL 3.8 (and later in OpenSSL 3.4) implements new intrinsic code
+# that increases compiler requirements. We can only use bootstrap Clang
+# because the newer one depends on openssl and causes a dependency cycle.
+if {${os.platform} eq "darwin" && ${os.major} < 18 && ${os.major} > 8} {
+    if {${configure.build_arch} in {"x86_64" "i386"}} {
+        depends_build-append port:clang-11-bootstrap
+        depends_skip_archcheck-append clang-11-bootstrap
+        configure.cc ${prefix}/libexec/clang-11-bootstrap/bin/clang
+        configure.cxx ${prefix}/libexec/clang-11-bootstrap/bin/clang++
+        # https://trac.macports.org/ticket/71201
+        # https://trac.macports.org/ticket/71246
+        # cctools is only needed for Snow Leopard i386/x86_64 and older.
+        # On Yosemite and newer systems it triggers the dependency cycle again.
+        if {${os.major} < 11} {
+            depends_build-append port:cctools
+        }
+    }
+}
 
 # HOST_ASM_MACOSX_X86_64 gets set when building i386 on x86_64
 set merger_configure_args(i386)     --disable-asm


### PR DESCRIPTION
Backport of the fix added in #26827. Once again, it fails to test correctly due to a conflict with OpenSSL.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
