### PR TITLE
py-osxmetadata: update to 1.4.0

### DIFF
--- a/python/py-osxmetadata/Portfile
+++ b/python/py-osxmetadata/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   python 1.0
 
 name                        py-osxmetadata
-version                     1.3.4
+version                     1.4.0
 revision                    0
 
 supported_archs             noarch
@@ -18,13 +18,13 @@ long_description            {*}${description}
 
 homepage                    https://github.com/RhetTbull/osxmetadata
 
-checksums                   rmd160  8ba0ff53e1135c8cdfcdf6268fcabffbe2df1c8b \
-                            sha256  e9512c7adf80e8ceff30ae608b88a2045ad04e3074b4f342bd03937b847611c8 \
-                            size    62655
+checksums                   rmd160  ff5ffd9daba42a9561a7f0dca53b91e9b66d0ad4 \
+                            sha256  979bf075ab5e5b0e96287df88d8bf7bb9806d858d1b2a52b5e4b72d89e50a6f3 \
+                            size    2452955
 
-python.versions             39 310 311 312
+python.versions             39 310 311 312 313
 
-python.pep517_backend       poetry
+python.pep517_backend       hatch
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-wheel \


### PR DESCRIPTION
#### Description

Update to 1.4.0, added subport for Python 3.13.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?