### PR TITLE
py-bpylist2: add Python 3.13 subport

### DIFF
--- a/python/py-bpylist2/Portfile
+++ b/python/py-bpylist2/Portfile
@@ -21,5 +21,5 @@ checksums                   rmd160  a1c03c7471ae71539392eb24049c01a5dc39f21c \
                             sha256  0cc63284aee42f5c7e0ec87f8f59cdd35aaed05ad12d866b1868ea0c0caaafe1 \
                             size    18000
 
-python.versions             39 310 311 312
+python.versions             39 310 311 312 313
 python.pep517_backend       poetry


### PR DESCRIPTION
#### Description

Add subport for Python 3.13.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?