### PR TITLE
py-cgmetadata: update to 0.2.0, add Python 3.13 subport

### DIFF
--- a/python/py-cgmetadata/Portfile
+++ b/python/py-cgmetadata/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cgmetadata
-version             0.1.6
+version             0.2.0
 revision            0
 
 supported_archs     noarch
@@ -34,10 +34,10 @@ long_description    {*}${description} \
 
 homepage            https://pypi.org/project/cgmetadata/
 
-checksums           rmd160  d68d8cf24e4d83f4236422346282089e86ce14db \
-                    sha256  e9c16e3e905947ba0b54978bf04cb3f8c5fa9dadf56467f1e559a25b8e00c359 \
-                    size    20669
+checksums           rmd160  cf06af82c8cd788a9081d879e43770c385535bd0 \
+                    sha256  f6805dcb107bed1c736b3f0869c043637ffd8f8956b9bc7b4de6aa6e2876f5cf \
+                    size    20583
 
-python.versions     312
+python.versions     312 313
 
-depends_build-append    port:py312-flit
+python.pep517_backend flit


### PR DESCRIPTION
#### Description

Update to 0.2.0, add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?