### PR TITLE
py-blessed: add Python 3.13 subport

### DIFF
--- a/python/py-blessed/Portfile
+++ b/python/py-blessed/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  714f301601b0bc3bea74b810f08399f6a18e348c \
                     sha256  2cdd67f8746e048f00df47a2880f4d6acbcdb399031b604e34ba8f71d5787680 \
                     size    6655612
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?