### PR TITLE
py-uc-micro-py: add Python 3.13 subport

### DIFF
--- a/python/py-uc-micro-py/Portfile
+++ b/python/py-uc-micro-py/Portfile
@@ -21,4 +21,4 @@ checksums           rmd160  d24992ab03f9f3455eef0228cd47e6ecf56b1ce9 \
                     sha256  d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a \
                     size    6043
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?