### PR TITLE
py-mdit-py-plugins: update to 0.4.2, add Python 3.13 subport

### DIFF
--- a/python/py-mdit-py-plugins/Portfile
+++ b/python/py-mdit-py-plugins/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        executablebooks mdit-py-plugins 0.4.1 v
+github.setup        executablebooks mdit-py-plugins 0.4.2 v
 
 name                py-mdit-py-plugins
 revision            0
@@ -17,9 +17,9 @@ platforms           {darwin any}
 description         Collection of core plugins for markdown-it-py.
 long_description    {*}${description}
 
-checksums           rmd160  a088f564a078710eb23900750047ae3fd2f6e7c0 \
-                    sha256  9c8b9046a5de4ce1a6b019ed87198dce317547cd85a4a028c0bc16ec28edde9e \
-                    size    63330
+checksums           rmd160  66f262bdfd82cde780c4e9ec2a7c931d9ed4a07b \
+                    sha256  f17e3a9e44d2c497ffd1f9c68d44d446de0b2981fc9e66bf45668beccad70e7f \
+                    size    64563
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 python.pep517_backend flit


### PR DESCRIPTION
#### Description

Update to 0.4.2, add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?