### PR TITLE
py-mdurl: add Python 3.13 subport

### DIFF
--- a/python/py-mdurl/Portfile
+++ b/python/py-mdurl/Portfile
@@ -23,6 +23,6 @@ checksums           rmd160  6f33deff9cca04f30ff7693c56ce1fda1d4b19e0 \
                     sha256  bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba \
                     size    8729
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 python.pep517_backend   flit


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?