### PR TITLE
py-pathvalidate: update to 3.2.1, add Python 3.13 subport

### DIFF
--- a/python/py-pathvalidate/Portfile
+++ b/python/py-pathvalidate/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pathvalidate
-version             3.2.0
+version             3.2.1
 revision            0
 
 categories-append   devel
@@ -18,9 +18,13 @@ long_description    {*}${description}
 
 homepage            https://github.com/thombashi/pathvalidate
 
-checksums           rmd160  4c1f00c7c899aa69f27e2bafcba844b54b9dd59b \
-                    sha256  5e8378cf6712bff67fbe7a8307d99fa8c1a0cb28aa477056f8fc374f0dff24ad \
-                    size    31246
+checksums           rmd160  8fe2c04f85e87cb34d94e6932f6d07fedb83c6d4 \
+                    sha256  f5d07b1e2374187040612a1fcd2bcb2919f8db180df254c9581bb90bf903377d \
+                    size    59263
 
 python.pep517       yes
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools_scm
+}


### PR DESCRIPTION
#### Description

Update to 3.2.1, add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?