### PR TITLE
py-photoscript: update to 0.4.0, add Python 3.13 subport

### DIFF
--- a/python/py-photoscript/Portfile
+++ b/python/py-photoscript/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-photoscript
-version                 0.3.1
+version                 0.4.0
 revision                0
 
 supported_archs         noarch
@@ -17,16 +17,18 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/photoscript
 
-checksums               rmd160  81f83f571f14d7da05df338a4396f8065879ae9f \
-                        sha256  fbd07e7d64467ffd0498b5fa09208c125024f8960641b15ca1e5ae65af33edab \
-                        size    24728
+checksums               rmd160  00a57f45662aed7249a3ab21a500412babed3d12 \
+                        sha256  5b00d663b7b2c2450d54fbba8a9d4864be5beb9396eac47e1dd3aeaecdc34366 \
+                        size    26315
 
-python.versions         38 39 310 311 312
+python.versions         38 39 310 311 312 313
 
 python.pep517           yes
 python.pep517_backend   poetry
 
 if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-wheel
+
     depends_lib-append  port:py${python.version}-applescript \
                         port:py${python.version}-pyobjc
 }


### PR DESCRIPTION
#### Description

Update to 0.4.0, add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?