### PR TITLE
py-ptpython: update to 3.0.29, add Python 3.13 subport

### DIFF
--- a/python/py-ptpython/Portfile
+++ b/python/py-ptpython/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 PortGroup               select 1.0
 
 name                    py-ptpython
-version                 3.0.27
+version                 3.0.29
 revision                0
 
 supported_archs         noarch
@@ -18,11 +18,11 @@ long_description        {*}${description}
 
 homepage                https://github.com/prompt-toolkit/ptpython
 
-checksums               rmd160  547159b244219870e31905d68e22199bed1ec67a \
-                        sha256  24b0fda94b73d1c99a27e6fd0d08be6f2e7cda79a2db995c7e3c7b8b1254bad9 \
-                        size    72022
+checksums               rmd160  2000308a2904de3d52420cb984825166f3757ff0 \
+                        sha256  b9d625183aef93a673fc32cbe1c1fcaf51412e7a4f19590521cdaccadf25186e \
+                        size    72622
 
-python.versions         38 39 310 311 312
+python.versions         38 39 310 311 312 313
 
 python.pep517           yes
 

--- a/python/py-ptpython/files/py313-ptpython
+++ b/python/py-ptpython/files/py313-ptpython
@@ -1,0 +1,4 @@
+${frameworks_dir}/Python.framework/Versions/3.13/bin/ptipython
+${frameworks_dir}/Python.framework/Versions/3.13/bin/ptipython3
+${frameworks_dir}/Python.framework/Versions/3.13/bin/ptpython
+${frameworks_dir}/Python.framework/Versions/3.13/bin/ptpython3


### PR DESCRIPTION
#### Description

Update to 3.0.29, add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?