### PR TITLE
py-linkify-it-py: add Python 3.13 subport

### DIFF
--- a/python/py-linkify-it-py/Portfile
+++ b/python/py-linkify-it-py/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  78dcf83eac65ca3b341dc1ae16135883e813b4fc \
                     sha256  68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048 \
                     size    27946
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_run-append \


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?