### PR TITLE
py-xdg-base-dirs: update to 6.0.2, add Python 3.13 subport

### DIFF
--- a/python/py-xdg-base-dirs/Portfile
+++ b/python/py-xdg-base-dirs/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-xdg-base-dirs
-version                 6.0.1
+version                 6.0.2
 revision                0
 
 supported_archs         noarch
@@ -19,11 +19,11 @@ homepage                https://github.com/srstevenson/xdg-base-dirs
 
 distname                [string map {- _} ${python.rootname}]-${version}
 
-checksums               rmd160  0c8b0a2e1e5e35371d35db18de1dc1104ce605b6 \
-                        sha256  b4c8f4ba72d1286018b25eea374ec6fbf4fddda3d4137edf50de95de53e195a6 \
-                        size    4318
+checksums               rmd160  987d63bec56f32f12134910512ade5d783d159b5 \
+                        sha256  950504e14d27cf3c9cb37744680a43bf0ac42efefc4ef4acf98dc736cab2bced \
+                        size    4085
 
-python.versions         38 39 310 311 312
+python.versions         38 39 310 311 312 313
 
 python.pep517           yes
 python.pep517_backend   poetry


### PR DESCRIPTION
#### Description

Update to 6.0.2, add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?