### PR TITLE
py-pytimeparse2: add Python 3.13 subport

### DIFF
--- a/python/py-pytimeparse2/Portfile
+++ b/python/py-pytimeparse2/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  7ee2bc6aae54b69e634d51c37c60017d93ce1eb8 \
                     sha256  98668cdcba4890e1789e432e8ea0059ccf72402f13f5d52be15bdfaeb3a8b253 \
                     size    10431
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?