### PR TITLE
py-shortuuid: add Python 3.13 subport

### DIFF
--- a/python/py-shortuuid/Portfile
+++ b/python/py-shortuuid/Portfile
@@ -22,7 +22,7 @@ checksums               rmd160  2981d77a92ea19cd23773cfa33141f23778f2f3d \
                         sha256  3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72 \
                         size    9662
 
-python.versions         38 39 310 311 312
+python.versions         38 39 310 311 312 313
 
 python.pep517           yes
 python.pep517_backend   poetry


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?