### PR TITLE
py-arpeggio: add Python 3.13 subport

### DIFF
--- a/python/py-arpeggio/Portfile
+++ b/python/py-arpeggio/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  9384ca40412f52d7efdc28470fdd15c030056a10 \
                     sha256  c790b2b06e226d2dd468e4fbfb5b7f506cec66416031fde1441cf1de2a0ba700 \
                     size    766643
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?