### PR TITLE
py-textx: update to 4.1.0, add Python 3.13 subport

### DIFF
--- a/python/py-textx/Portfile
+++ b/python/py-textx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-textx
-version             4.0.1
+version             4.1.0
 revision            0
 
 categories-append   devel
@@ -18,11 +18,11 @@ long_description    {*}${description}
 
 homepage            https://github.com/textX/textX
 
-checksums           rmd160  75d14baafe36b66cd10fd089f75cb4b7bce44f93 \
-                    sha256  84aff5c95fd2c947402fcbe83eeeddc23aabcfed3464ab84184ef193c52d831a \
-                    size    1820595
+checksums           rmd160  476e4d128f8bf72c5d212d490d3cd1f0378aa26c \
+                    sha256  37b4f0c455452e27cc0f13d40777b5d20549eaa871311b26e2ed83c019456692 \
+                    size    2136296
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 python.pep517       yes
 python.pep517_backend \


### PR DESCRIPTION
#### Description

Update to 4.1.0, add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?