### PR TITLE
py-strpdatetime: update to 0.4.0, add Python 3.13 subport

### DIFF
--- a/python/py-strpdatetime/Portfile
+++ b/python/py-strpdatetime/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-strpdatetime
-version                 0.3.0
+version                 0.4.0
 revision                0
 
 categories-append       devel
@@ -20,14 +20,14 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/strpdatetime
 
-checksums               rmd160  7bd2c54bf100e04c410d2ad2deff731b562b9324 \
-                        sha256  01b95a4841db31503f616b3ba545f0b548841598296b17000ba00fbe11e49264 \
-                        size    17242
+checksums               rmd160  303c957bc6a6fded64da1688ee0f383e95f8308e \
+                        sha256  bd05e902184f558484bfe9c162b50896d7c0dc935bdeb9a397c48df2029f008b \
+                        size    26211
 
-python.versions         38 39 310 311 312
+python.versions         39 310 311 312 313
 
 python.pep517           yes
-python.pep517_backend   poetry
+python.pep517_backend   hatch
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-textx


### PR DESCRIPTION
#### Description

Update to 0.4.0, add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?