### PR TITLE
py-tenacity: update to 9.0.0, add Python 3.13 subport

### DIFF
--- a/python/py-tenacity/Portfile
+++ b/python/py-tenacity/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-tenacity
-version             8.4.1
+version             9.0.0
 license             Apache-2
 platforms           {darwin any}
 supported_archs     noarch
@@ -15,11 +15,11 @@ long_description    {*}${description}
 
 homepage            https://github.com/jd/tenacity
 
-checksums           rmd160  cdf6efba91f8b264293317b39f629a2e2b5cf68a \
-                    sha256  54b1412b878ddf7e1f1577cd49527bad8cdef32421bd599beac0c6c3f10582fd \
-                    size    45426
+checksums           rmd160  26e11e48b9de19ea6e795fd36a24abdac2c293f8 \
+                    sha256  807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b \
+                    size    47421
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Update to 9.0.0, add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?