### PR TITLE
py-rich-theme-manager: add Python 3.13 subport

### DIFF
--- a/python/py-rich-theme-manager/Portfile
+++ b/python/py-rich-theme-manager/Portfile
@@ -22,7 +22,7 @@ checksums                   rmd160  ef39eff71d0b66f67716ec8b409486c45999aa93 \
                             sha256  3bc1effa4b6c42f72994b73c8b3c391b1c6e803deccc2fc3932da31b00f1a112 \
                             size    17416
 
-python.versions             38 39 310 311 312
+python.versions             38 39 310 311 312 313
 
 python.pep517               yes
 python.pep517_backend       poetry


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?