### PR TITLE
openbabel2: fix C++ standard, fix opportunistic usage of wxWidgets

### DIFF
--- a/python/py-openbabel2/Portfile
+++ b/python/py-openbabel2/Portfile
@@ -44,6 +44,9 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:openbabel2
 
+    # reaction.h: error: ‘shared_ptr’ is not a member of ‘std’
+    compiler.cxx_standard 2011
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}

--- a/science/openbabel2/Portfile
+++ b/science/openbabel2/Portfile
@@ -8,7 +8,7 @@ github.setup        openbabel openbabel 2-4-1 openbabel-
 name                openbabel2
 conflicts           openbabel
 version             [string map {- .} ${github.version}]
-revision            0
+revision            1
 
 categories          science devel chemistry
 license             GPL-2
@@ -31,12 +31,19 @@ checksums           rmd160  0587a3d3dd24c485ff9a680ff83145f052b504f4 \
 
 depends_build-append \
                     path:share/pkgconfig/eigen3.pc:eigen3 \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append  path:lib/pkgconfig/cairo.pc:cairo \
                     port:libiconv \
                     port:libxml2 \
                     port:zlib
+
+# Build behaves incoherently, ignoring -DBUILD_GUI=OFF.
+# https://trac.macports.org/ticket/71480
+patchfiles-append   patch-fix-wxWidgets-search.diff
+
+# eigen3-devel needs C++14 though.
+compiler.cxx_standard   2011
 
 configure.args-append \
                     -DBUILD_GUI=OFF \

--- a/science/openbabel2/files/patch-fix-wxWidgets-search.diff
+++ b/science/openbabel2/files/patch-fix-wxWidgets-search.diff
@@ -1,0 +1,32 @@
+--- CMakeLists.txt	2016-10-10 23:56:17.000000000 +0800
++++ CMakeLists.txt	2024-12-08 00:28:25.000000000 +0800
+@@ -178,15 +178,6 @@
+   endif()
+ endif()
+ 
+-# wxWidgets instructions based on http://wiki.wxwidgets.org/CMake
+-#find_package(wxWidgets COMPONENTS base core REQUIRED)
+-find_package(wxWidgets COMPONENTS base core adv)
+-if(wxWidgets_FOUND)
+-  include(${wxWidgets_USE_FILE})
+-  add_definitions(-DHAVE_WXWIDGETS)
+-  include_directories(${wxWidgets_INCLUDE_DIRS})
+-endif()
+-
+ if(MSVC)
+   # Ensure that CharacterSet="0" in the project files
+   add_definitions(-D_SBCS) # Single-Byte Character Set (requires CMake 2.8.8)
+@@ -494,6 +485,13 @@
+ 
+ if(BUILD_GUI)
+   message(STATUS "Attempting to build the GUI")
++  # wxWidgets instructions based on http://wiki.wxwidgets.org/CMake
++  find_package(wxWidgets COMPONENTS base core adv)
++  if(wxWidgets_FOUND)
++    include(${wxWidgets_USE_FILE})
++    add_definitions(-DHAVE_WXWIDGETS)
++    include_directories(${wxWidgets_INCLUDE_DIRS})
++  endif()
+   if(wxWidgets_FOUND)
+     message(STATUS "   wxWidgets found => GUI will be built")
+     add_subdirectory(src/GUI)


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/71480

#### Description

Fix this finally.

(Revbump due to opportunistic usage of wxWidgets, not due to C++ standard.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
