### PR TITLE
opencascade: Fix build, initialization error

### DIFF
--- a/science/opencascade/Portfile
+++ b/science/opencascade/Portfile
@@ -26,6 +26,10 @@ checksums                   rmd160  88033cfe653f3d18feb41c7e0225ec31fd613104 \
 patchfiles-append           patch-CMakeLists.txt.diff \
                             patch-env.sh.in.diff
 
+# Remove at release 7.9.0 or later.  Was fixed upstream.
+# https://trac.macports.org/ticket/71233
+patchfiles-append           patch-StdPrs_BRepFont.cxx.diff
+
 compiler.cxx_standard       2011
 configure.args-append       -DCMAKE_CXX_STANDARD=11 \
                             -DCMAKE_CXX_STANDARD_REQUIRED=ON

--- a/science/opencascade/files/patch-StdPrs_BRepFont.cxx.diff
+++ b/science/opencascade/files/patch-StdPrs_BRepFont.cxx.diff
@@ -1,0 +1,31 @@
+# Macports issue: https://trac.macports.org/ticket/71233
+# Upstream issue: https://github.com/Open-Cascade-SAS/OCCT/discussions/48
+
+# StdPrs_BRepFont.cxx: error: cannot initialize a variable of type 'const char *'
+#   with an rvalue of type 'unsigned char *'
+
+From: dpasukhi <dpasukhi@opencascade.com>
+Date: Tue, 27 Aug 2024 10:33:29 +0000 (+0100)
+Subject: 0033808: Coding - FreeType Use unsigned point and contour indexing in `FT_Outline`
+X-Git-Url: http://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff_plain;h=7236e83dcc1e7284e66dc61e612154617ef715d6;hp=099e0d25243925da349d43e6e1ee0528763cdabe
+
+0033808: Coding - FreeType Use unsigned point and contour indexing in `FT_Outline`
+
+Changes to auto instead of specific type
+---
+
+# Fixed paths here, to make compatible with MacPorts patch command.
+
+diff --git src/StdPrs/StdPrs_BRepFont.cxx.orig src/StdPrs/StdPrs_BRepFont.cxx
+index ab2d9b3c9f..cd701879b1 100644
+--- src/StdPrs/StdPrs_BRepFont.cxx.orig
++++ src/StdPrs/StdPrs_BRepFont.cxx
+@@ -457,7 +457,7 @@ Standard_Boolean StdPrs_BRepFont::renderGlyph (const Standard_Utf32Char theChar,
+   for (short aContour = 0, aStartIndex = 0; aContour < anOutline->n_contours; ++aContour)
+   {
+     const FT_Vector* aPntList = &anOutline->points[aStartIndex];
+-    const char* aTags      = &anOutline->tags[aStartIndex];
++    const auto* aTags      = &anOutline->tags[aStartIndex];
+     const short anEndIndex = anOutline->contours[aContour];
+     const short aPntsNb    = (anEndIndex - aStartIndex) + 1;
+     aStartIndex = anEndIndex + 1;


### PR DESCRIPTION
#### Description

* Closes: https://trac.macports.org/ticket/71233
* Fixes "error: cannot initialize a variable of type 'const char *' with an rvalue of type 'unsigned char *'"
* See:  https://github.com/Open-Cascade-SAS/OCCT/discussions/48
* Apply upstream patch.
* https://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff;h=7236e83dcc1e7284e66dc61e612154617ef715d6;hp=099e0d25243925da349d43e6e1ee0528763cdabe#patch1

###### Type(s)

- [x] bugfix

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?