### PR TITLE
libvmime: fix for old systems

### DIFF
--- a/mail/libvmime/Portfile
+++ b/mail/libvmime/Portfile
@@ -43,7 +43,8 @@ patchfiles          expected-value-in-expression.patch \
                     use-of-undeclared-identifier-FALSE.patch \
                     patch-unbreak-arm64-powerpc.diff \
                     patch-cxx17.diff \
-                    patch-icu.diff
+                    patch-icu.diff \
+                    patch-AI_NUMERICSERV.diff
 
 # Required for ICU
 compiler.cxx_standard   2017

--- a/mail/libvmime/files/patch-AI_NUMERICSERV.diff
+++ b/mail/libvmime/files/patch-AI_NUMERICSERV.diff
@@ -1,0 +1,16 @@
+From https://github.com/macports/macports-legacy-support/blob/0f1292b4734aac30188ee03561ecd1430a255062/include/netdb.h#L23
+
+--- src/vmime/platforms/posix/posixSocket.cpp	2024-12-08 09:04:25.000000000 +0800
++++ src/vmime/platforms/posix/posixSocket.cpp	2024-12-08 09:19:54.000000000 +0800
+@@ -59,6 +59,11 @@
+ #endif
+ 
+ 
++#ifndef AI_NUMERICSERV
++#define AI_NUMERICSERV 0x00001000
++#endif
++
++
+ // Workaround for detection of strerror_r variants
+ #if VMIME_HAVE_STRERROR_R
+ 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/71487

#### Description

Minor fix for old systems

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
