### PR TITLE
py-utitools: new submission

### DIFF
--- a/python/py-utitools/Portfile
+++ b/python/py-utitools/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-utitools
+version             0.2.0
+revision            0
+
+maintainers         nomaintainer
+license             MIT
+supported_archs     noarch
+platforms           {darwin any}
+
+description         Uniform Type Identifier (UTI) tools
+long_description    {*}${description}
+
+homepage            https://github.com/RhetTbull/utitools
+
+checksums           rmd160  b1758bca4e9c29266ad569fb58500ab268a486fa \
+                    sha256  4385e74bb3064b5cb142026546ef02af6fe7aeb07042e3b0144fde53b77d2e00 \
+                    size    27131
+
+python.versions     313
+python.pep517_backend   flit


### PR DESCRIPTION
#### Description

New port for utitools, which is a dependency for the latest osxphotos versions.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?