### PR TITLE
py-markdown-it-py: add Python 3.13 subport

### DIFF
--- a/python/py-markdown-it-py/Portfile
+++ b/python/py-markdown-it-py/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  2fe5b5a4d114b5097b8e0f60598f26c9dcff68d8 \
                     sha256  e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb \
                     size    74596
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 python.pep517_backend   flit
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?