### PR TITLE
bash: update to 5.2 patch 37, bash-devel: new port

### DIFF
--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -12,6 +12,14 @@ subport bash50 {
     set bash_patchlevel 18
 }
 version             ${bash_version}.${bash_patchlevel}
+subport bash-devel {
+    version             20241126
+    set bash_patchlevel 0
+
+    fetch.type          git
+    git.url             git://git.savannah.gnu.org/bash.git
+    git.branch          49c2670226b045746d66765b23af37c1c7ba5597
+}
 distname            ${name}-${bash_version}
 categories          shells
 platforms           darwin freebsd
@@ -27,9 +35,11 @@ long_description    \
     sh scripts can be run by Bash without modification.
 homepage            https://www.gnu.org/software/bash/bash.html
 if {${subport} eq ${name}} {
-   conflicts        bash50
+   conflicts        bash50 bash-devel
 } elseif {${subport} eq "bash50"} {
-   conflicts        bash
+   conflicts        bash bash-devel
+} elseif {${subport} eq "bash-devel"} {
+   conflicts        bash bash50
 }
 
 if {${subport} eq "bash50"} {
@@ -284,7 +294,7 @@ if {${subport} eq ${name}} {
     patchfiles-append  patch-configure.diff
 }
 
-depends_build           bin:bison:bison \
+depends_build           port:bison \
                         port:gettext
 # ar: internal ranlib command failed
 depends_build-append    port:cctools

--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                bash
 set bash_version    5.2
-set bash_patchlevel 32
+set bash_patchlevel 37
 subport bash50 {
     # used by bashdb port
     set bash_version    5.0
@@ -181,7 +181,27 @@ if {${subport} eq ${name}} {
                         bash52-032 \
                         rmd160  2ec870b706258160f24334b82faf264dbcd2633a \
                         sha256  7b9c77daeca93ff711781d7537234166e83ed9835ce1ee7dcd5742319c372a16 \
-                        size    1529
+                        size    1529 \
+                        bash52-033 \
+                        rmd160  4897a12d2ff129c2bb9d42d14cf74533bbb15882 \
+                        sha256  013ec6cc10ad98060a7c34ed5c11187bcc5bf4510f32de0d545db89a9a52a2e2 \
+                        size    2131 \
+                        bash52-034 \
+                        rmd160  0f1b8abb53d1318a9b2ee26bd118718c30324772 \
+                        sha256  899fbb3b338048fe52a9c8252bf65ef1194cdff4f7a3fb3316f5f2396143232e \
+                        size    4134 \
+                        bash52-035 \
+                        rmd160  c28e4f772d5486f4e60fe16d6e71bdb08efcfd7f \
+                        sha256  821a0a47fa692bb0a39482728b1b396bf951e2912768fea6f3026c813c1913e5 \
+                        size    3413 \
+                        bash52-036 \
+                        rmd160  af62b1bf1d062d5ef016b89d91c0c227d31fc070 \
+                        sha256  15c93f4936a5e5b88301f3ede767a23d3dd19635af2f3a91fb4cc0e560ca9057 \
+                        size    5941 \
+                        bash52-037 \
+                        rmd160  137255087bccdc8eb4eae5791383c35a758078e1 \
+                        sha256  8a2c1c3b5125d9ae5b47882f7d2ddf9648805f8c67c13aa5ea7efeac475cda94 \
+                        size    2835
 } elseif {${subport} eq "bash50"} {
    checksums           ${distname}${extract.suffix} \
                        rmd160  a081428a896d617855499376b670eca3433a27c1 \


### PR DESCRIPTION
#### Description

This doesn't have a fix for https://trac.macports.org/ticket/68638 . I made an initial attempt to cherry-pick that patch but it seemed hairy enough it's probably not worth maintaining.

But, to throw the affected a bone, I have added the bash-devel port that pulls in the latest devel branch. The fix is not in the 5.3-alpha release.

I didn't put this in as a Closes: because it doesn't really close the issue but can be persuaded if anyone feels strongly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.6.1 23G93 x86_64
Xcode 16.1 16B40
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
