### PR TITLE
mise: Update to 2024.12.3

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.12.1 v
+github.setup        jdx mise 2024.12.3 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  c250b0a0d30f93bd4e33362d422052aeba4e8810 \
-                    sha256  0763599841970d9a60630fbd97301d7a06d9ce5c61d9da657fda432f2204cfae \
-                    size    3257804
+                    rmd160  464d45bf855139410a0834a3316a1e1c47c0b7bd \
+                    sha256  954b3f017a958d9c55843a4deb529d87b7afa3cf8f639b1246e42697c617d85d \
+                    size    3260638
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -123,7 +123,7 @@ cargo.crates \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                               1.2.2  f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc \
+    cc                               1.2.3  27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
@@ -262,7 +262,7 @@ cargo.crates \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
-    js-sys                          0.3.74  a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705 \
+    js-sys                          0.3.76  6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7 \
     junction                         1.2.0  72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16 \
     kdl                              4.6.0  062c875482ccb676fd40c804a40e3824d4464c18c364547456d1c8e8e951ae47 \
     lazy-regex                       3.3.0  8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda \
@@ -328,10 +328,10 @@ cargo.crates \
     path-dedot                       3.1.1  07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397 \
     pbkdf2                          0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    pest                            2.7.14  879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442 \
-    pest_derive                     2.7.14  d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd \
-    pest_generator                  2.7.14  eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e \
-    pest_meta                       2.7.14  b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d \
+    pest                            2.7.15  8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc \
+    pest_derive                     2.7.15  816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e \
+    pest_generator                  2.7.15  7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b \
+    pest_meta                       2.7.15  e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea \
     petgraph                         0.6.5  b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db \
     phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
     phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
@@ -441,9 +441,9 @@ cargo.crates \
     test-log                        0.2.16  3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93 \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                        2.0.4  2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490 \
+    thiserror                        2.0.5  643caef17e3128658ff44d85923ef2d28af81bb71e0d67bbfe1d76f19a73e053 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                   2.0.4  8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061 \
+    thiserror-impl                   2.0.5  995d0bbc9995d1f19d28b7215a9352b0fc3cd3a2d2ec95c2cadc485cdedbcdde \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     time                            0.3.37  35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
@@ -498,13 +498,13 @@ cargo.crates \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.97  d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c \
-    wasm-bindgen-backend            0.2.97  8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd \
-    wasm-bindgen-futures            0.4.47  9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d \
-    wasm-bindgen-macro              0.2.97  705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051 \
-    wasm-bindgen-macro-support      0.2.97  98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d \
-    wasm-bindgen-shared             0.2.97  6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49 \
-    web-sys                         0.3.74  a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c \
+    wasm-bindgen                    0.2.99  a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396 \
+    wasm-bindgen-backend            0.2.99  5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79 \
+    wasm-bindgen-futures            0.4.49  38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2 \
+    wasm-bindgen-macro              0.2.99  2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe \
+    wasm-bindgen-macro-support      0.2.99  30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2 \
+    wasm-bindgen-shared             0.2.99  943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6 \
+    web-sys                         0.3.76  04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                    0.26.7  5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e \
     which                            6.0.3  b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f \


### PR DESCRIPTION
#### Description

mise: Update to 2024.12.3

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
