### PR TITLE
rebels-in-the-sky: Update to 1.0.26

### DIFF
--- a/games/rebels-in-the-sky/Portfile
+++ b/games/rebels-in-the-sky/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        ricott1 rebels-in-the-sky 1.0.25 v
+github.setup        ricott1 rebels-in-the-sky 1.0.26 v
 revision            0
 
 categories          games
@@ -29,9 +29,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix}  \
-                    rmd160  bd700e0a7a56c8456878bd8840ac946f6372d744 \
-                    sha256  5811167ae2ac31d7bb48d421a8a838c6d4fdf265c08cde9d1e27f117fa0f8aeb \
-                    size    9758280
+                    rmd160  b9e349a741c6d4db3c86d51e010fa253323773a9 \
+                    sha256  f8fb6e67845842d88319db11e5d7020a8d7fa98fd14f30ca7dda149dddfe05f6 \
+                    size    9721823
 
 cargo.crates \
     ab_glyph                           0.2.29  ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0 \
@@ -44,7 +44,7 @@ cargo.crates \
     ahash                              0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                        1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     aligned-vec                         0.5.0  4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1 \
-    allocator-api2                     0.2.20  45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9 \
+    allocator-api2                     0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     alsa                                0.9.1  ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43 \
     alsa-sys                            0.3.1  db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527 \
     android-tzdata                      0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
@@ -54,7 +54,7 @@ cargo.crates \
     anstyle-parse                       0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                       1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                      3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
-    anyhow                             1.0.93  4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775 \
+    anyhow                             1.0.94  c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7 \
     approx                              0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
     arbitrary                           1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arc-swap                            1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
@@ -97,7 +97,7 @@ cargo.crates \
     cassowary                           0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     castaway                            0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
     cbc                                 0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.2  f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc \
+    cc                                  1.2.3  27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d \
     cesu8                               1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cexpr                               0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-expr                           0.15.8  d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02 \
@@ -108,10 +108,10 @@ cargo.crates \
     chrono                             0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
     cipher                              0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     clang-sys                           1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    clap                               4.5.21  fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f \
-    clap_builder                       4.5.21  b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec \
+    clap                               4.5.23  3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84 \
+    clap_builder                       4.5.23  30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838 \
     clap_derive                        4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
-    clap_lex                            0.7.3  afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7 \
+    clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     claxon                              0.4.3  4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688 \
     cmake                              0.1.52  c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e \
     color_quant                         1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
@@ -149,6 +149,7 @@ cargo.crates \
     data-encoding-macro                0.1.15  f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639 \
     data-encoding-macro-internal       0.1.13  332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f \
     delegate                           0.12.0  4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b \
+    delegate                           0.13.1  bc2323e10c92e1cf4d86e11538512e6dc03ceb586842970b6332af3d4046a046 \
     der                                 0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     der-parser                          9.0.0  5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553 \
     deranged                           0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
@@ -174,10 +175,10 @@ cargo.crates \
     equivalent                          1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                              0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
     event-listener                      5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
-    event-listener-strategy             0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
+    event-listener-strategy             0.5.3  3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2 \
     exr                                1.73.0  f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0 \
-    fastrand                            2.2.0  486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4 \
-    fdeflate                            0.3.6  07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb \
+    fastrand                            2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
+    fdeflate                            0.3.7  1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c \
     ff                                 0.13.0  ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449 \
     fiat-crypto                         0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     flate2                             1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
@@ -224,7 +225,7 @@ cargo.crates \
     hostname                            0.3.1  3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867 \
     hound                               3.5.1  62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f \
     http                               0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
-    http                                1.1.0  21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258 \
+    http                                1.2.0  f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea \
     http-body                           0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-body                           1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                      0.1.2  793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f \
@@ -260,7 +261,7 @@ cargo.crates \
     imgref                             1.11.0  d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408 \
     include_dir                         0.7.4  923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd \
     include_dir_macros                  0.7.4  7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75 \
-    indexmap                            2.6.0  707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da \
+    indexmap                            2.7.0  62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f \
     indoc                               2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inout                               0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
     instability                         0.3.3  b829f37dead9dc39df40c2d3376c179fdfd2ac771f53f55d3c30dc096a3c0c6e \
@@ -276,7 +277,7 @@ cargo.crates \
     jni-sys                             0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
     jobserver                          0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jpeg-decoder                        0.3.1  f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0 \
-    js-sys                             0.3.73  fb15147158e79fd8b8afd0252522769c4f48725460b37338544d8379d94fc8f9 \
+    js-sys                             0.3.76  6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7 \
     lazy_static                         1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     lebe                                0.5.2  03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8 \
     lewton                             0.10.2  777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030 \
@@ -328,7 +329,7 @@ cargo.crates \
     mio                                 1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
     multiaddr                          0.18.2  fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961 \
     multibase                           0.9.1  9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404 \
-    multihash                          0.19.2  cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2 \
+    multihash                          0.19.3  6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d \
     multistream-select                 0.13.0  ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19 \
     nalgebra                           0.32.6  7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4 \
     ndk                                 0.8.0  2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7 \
@@ -387,7 +388,7 @@ cargo.crates \
     pkcs5                               0.7.1  e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6 \
     pkcs8                              0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                         0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
-    png                               0.17.14  52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0 \
+    png                               0.17.15  b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d \
     polling                             3.7.4  a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f \
     poly1305                            0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
     polyval                             0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
@@ -436,14 +437,14 @@ cargo.crates \
     rodio                              0.20.1  e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1 \
     rsa                                 0.9.7  47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519 \
     rtnetlink                          0.13.1  7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0 \
-    russh                              0.46.0  c536b90d8e2468d8dedc8de2369383c101325e23fffa3a30de713032862a11d4 \
-    russh-cryptovec                     0.7.3  fadd2c0ab350e21c66556f94ee06f766d8bdae3213857ba7610bfd8e10e51880 \
-    russh-keys                         0.46.0  6e3db166c8678c824627c2c46f619ed5ce4ae33f38a35403c62f6ab8f3985867 \
+    russh                              0.48.2  5c086efe0c429fa0b4e448c67147366d0319ed1c9a051d91b8f38e93fef25cc7 \
+    russh-cryptovec                    0.48.0  4d8e7e854e1a87e4be00fa287c98cad23faa064d0464434beaa9f014ec3baa98 \
+    russh-keys                         0.48.1  fed9bf3da16ad2892a44b840e40483010295bfc8fda8134650c381654cb1ef36 \
     russh-sftp                          2.0.6  c2a72c8afe2041c17435eecd85d0b7291841486fd3d1c4082e0b212e5437ca42 \
-    russh-util                         0.46.0  63aeb9d2b74f8f38befdc0c5172d5ffcf58f3d2ffcb423f3b6cdfe2c2d747b80 \
+    russh-util                         0.48.0  92c7dd577958c0cefbc8f8a2c05c48c88c42e2fdb760dbe9b96ae31d4de97a1f \
     rustc-demangle                     0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                          1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
-    rustc-hash                          2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
+    rustc-hash                          2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
     rustc_version                       0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rusticata-macros                    4.1.0  faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632 \
     rustix                            0.38.41  d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6 \
@@ -493,7 +494,7 @@ cargo.crates \
     ssh-key                             0.6.7  3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3 \
     stable_deref_trait                  1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     static_assertions                   1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
-    stream-download                    0.13.1  81221d0a002314782fac02988a87198110f462e995cea349508e22b993554ee6 \
+    stream-download                    0.13.2  569eda55a5072a746dd143a76a15a8395366b8814652e4ef8cc13fefd3be0cab \
     strsim                             0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                              0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
     strum_macros                       0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
@@ -513,23 +514,23 @@ cargo.crates \
     target-lexicon                    0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
     tempfile                           3.14.0  28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c \
     thiserror                          1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                           2.0.3  c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa \
+    thiserror                           2.0.6  8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47 \
     thiserror-impl                     1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                      2.0.3  f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568 \
+    thiserror-impl                      2.0.6  d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312 \
     thread-id                           4.2.2  cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea \
     tiff                                0.9.1  ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e \
-    time                               0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
+    time                               0.3.37  35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21 \
     time-core                           0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
-    time-macros                        0.2.18  3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf \
+    time-macros                        0.2.19  2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de \
     tiny-keccak                         2.0.2  2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237 \
     tinystr                             0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                             1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                      0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                              1.41.1  22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33 \
+    tokio                              1.42.0  5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551 \
     tokio-macros                        2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
-    tokio-rustls                       0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
-    tokio-stream                       0.1.16  4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1 \
-    tokio-util                         0.7.12  61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a \
+    tokio-rustls                       0.26.1  5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37 \
+    tokio-stream                       0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
+    tokio-util                         0.7.13  d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078 \
     toml                               0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
     toml_datetime                       0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                         0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
@@ -569,14 +570,14 @@ cargo.crates \
     walkdir                             2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                                0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi        0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                       0.2.96  21d3b25c3ea1126a2ad5f4f9068483c2af1e64168f847abe863a526b8dbfe00b \
-    wasm-bindgen-backend               0.2.96  52857d4c32e496dc6537646b5b117081e71fd2ff06de792e3577a150627db283 \
-    wasm-bindgen-futures               0.4.46  951fe82312ed48443ac78b66fa43eded9999f738f6022e67aead7b708659e49a \
-    wasm-bindgen-macro                 0.2.96  920b0ffe069571ebbfc9ddc0b36ba305ef65577c94b06262ed793716a1afd981 \
-    wasm-bindgen-macro-support         0.2.96  bf59002391099644be3524e23b781fa43d2be0c5aa0719a18c0731b9d195cab6 \
-    wasm-bindgen-shared                0.2.96  e5047c5392700766601942795a436d7d2599af60dcc3cc1248c9120bfb0827b0 \
+    wasm-bindgen                       0.2.99  a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396 \
+    wasm-bindgen-backend               0.2.99  5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79 \
+    wasm-bindgen-futures               0.4.49  38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2 \
+    wasm-bindgen-macro                 0.2.99  2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe \
+    wasm-bindgen-macro-support         0.2.99  30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2 \
+    wasm-bindgen-shared                0.2.99  943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6 \
     wasm-streams                        0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
-    web-sys                            0.3.73  476364ff87d0ae6bfb661053a9104ab312542658c3d8f963b7ace80b6f9b26b9 \
+    web-sys                            0.3.76  04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc \
     web-time                            1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                       0.26.7  5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e \
     weezl                               0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
@@ -634,7 +635,7 @@ cargo.crates \
     writeable                           0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     x25519-dalek                        2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
     x509-parser                        0.16.0  fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69 \
-    xml-rs                             0.8.23  af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f \
+    xml-rs                             0.8.24  ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432 \
     xmltree                            0.10.3  d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb \
     yamux                              0.12.1  9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776 \
     yamux                              0.13.4  17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4 \


### PR DESCRIPTION
#### Description

rebels-in-the-sky: Update to 1.0.26

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
