### PR TITLE
gcc10: use correct triples on powerpc*

### DIFF
--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -95,8 +95,18 @@ license_noconflict  gmp mpfr ppl libmpc zlib
 
 set major           [lindex [split ${version} .-] 0]
 
+proc gcc_arch {arch} {
+    switch ${arch} {
+        arm64       {return aarch64}
+        ppc64       {return powerpc64}
+        ppc         {return powerpc}
+        default     {return ${arch}}
+    }
+}
+
 platform darwin {
-    configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+    set gcc_triple [gcc_arch ${build_arch}]-apple-darwin${os.major}
+    configure.pre_args-append --build=${gcc_triple}
 }
 
 set gcc_configure_langs {c c++ objc obj-c++ lto fortran}


### PR DESCRIPTION
#### Description

@kencu No need revbump, given that no one could have built it yet in 10 min, right?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
