### PR TITLE
samba4: fix build with gcc14 and on older OS

### DIFF
--- a/net/samba4/Portfile
+++ b/net/samba4/Portfile
@@ -10,7 +10,8 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 name                samba4
-conflicts           samba3
+# With sbsat due to /opt/local/bin/gentest
+conflicts           samba3 sbsat
 version             4.21.2
 revision            0
 checksums           rmd160  f8b0751600bb857aadc37767c8edf0afd57bf3c1 \

--- a/net/samba4/Portfile
+++ b/net/samba4/Portfile
@@ -30,7 +30,7 @@ distname            samba-${version}
 
 perl5.major         5.34
 
-depends_build       port:pkgconfig \
+depends_build       path:bin/pkg-config:pkgconfig \
                     port:gettext \
                     port:bison
 
@@ -81,6 +81,9 @@ patchfiles-append patch-samba-install.diff
 # https://bugzilla.samba.org/show_bug.cgi?id=15763
 patchfiles-append   patch-ldb-wscript.diff
 
+# Add a missing header for renameat.
+patchfiles-append   patch-vfs_default.c.diff
+
 configure.perl      ${perl5.bin}
 configure.python    ${prefix}/bin/python3.12
 configure.env-append \
@@ -97,6 +100,12 @@ configure.args      -C \
                     --disable-avahi \
                     --with-gpgme \
                     --disable-spotlight
+
+# https://trac.macports.org/ticket/71494
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.cflags-append \
+                    -Wno-error=incompatible-pointer-types
+}
 
 build.pre_args
 build.env-append    PYTHON=${configure.python} DESTDIR=${destroot}

--- a/net/samba4/files/patch-vfs_default.c.diff
+++ b/net/samba4/files/patch-vfs_default.c.diff
@@ -1,0 +1,10 @@
+--- source3/modules/vfs_default.c
++++ source3/modules/vfs_default.c	2024-12-09 15:33:36.000000000 +0800
+@@ -37,6 +37,7 @@
+ #include "offload_token.h"
+ #include "util_reparse.h"
+ #include "lib/util/string_wrappers.h"
++#include <sys/stdio.h> /* renameat */
+ 
+ #undef DBGC_CLASS
+ #define DBGC_CLASS DBGC_VFS


### PR DESCRIPTION
#### Description

Fix build with gcc14 and on older systems

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
