### PR TITLE
xmms2: another go with fixing opportunistic linking

### DIFF
--- a/audio/xmms2/Portfile
+++ b/audio/xmms2/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               legacysupport 1.1
+PortGroup               openssl 1.0
 PortGroup               waf 1.0
 
 # strndup
@@ -11,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 10
 name                    xmms2
 github.setup            xmms2 xmms2-devel 0.9.5
 github.tarball_from     releases
-revision                1
+revision                2
 categories              audio
 # Mostly LGPL, some plugins and clients are GPL
 license                 LGPL-2.1+ GPL-2+ GPL-2
@@ -30,18 +31,23 @@ checksums               rmd160  ec8beae90b455e6af7311fb37c2382705e8843e9 \
 depends_build-append    path:bin/pkg-config:pkgconfig
 
 set ffmpeg_ver          6
-depends_lib-append      port:faad2 \
+depends_lib-append      port:curl \
+                        port:faad2 \
                         port:ffmpeg${ffmpeg_ver} \
                         port:fftw-3-single \
                         port:flac \
                         port:fluidsynth \
+                        port:gettext-runtime \
                         path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                        port:libao \
                         port:libcdio-paranoia \
                         port:libdiscid \
                         port:libmad \
                         port:libmms \
                         port:libmodplug \
                         port:libmpcdec \
+                        port:libofa \
+                        port:libogg \
                         port:libsamplerate \
                         port:libshout2 \
                         port:libsndfile \
@@ -83,7 +89,7 @@ compiler.blacklist-append   *gcc-4.0 *gcc-4.2
 options optionals
 
 options disabled_plugins
-default disabled_plugins {jack pulse}
+default disabled_plugins {daap jack pulse samba}
 
 # not supported
 configure.post_args-delete  --nocache
@@ -109,9 +115,18 @@ variant cpp description {C++ development support} {
     optionals-append    xmmsclient++ xmmsclient++-glib
 }
 
-variant mdns description {MDNS backend support using avahi} {
+# These two introduce a dependency on avahi.
+variant avahi description {MDNS and DAAP using avahi} {
     depends_lib-append  port:avahi
+    
+    disabled_plugins-delete daap
     optionals-append    mdns
+}
+
+variant samba description {Enable smbclient support} {
+    depends_lib-append  port:samba3
+
+    disabled_plugins-delete samba
 }
 
 variant perl description {Perl development support} {


### PR DESCRIPTION
#### Description

Fix dependencies further.

Samba in a variant, since samba3 conflicts with samba4, we do not want that by default.
Disabling only `mdns` but leaving `daap` enabled in meaningless, since both use `avahi`. Join them together in one variant.
Add other dependencies which the port links to via plugins.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
