### PR TITLE
python(12,13,14-devel): Depend on openssl3 instead of openssl

### DIFF
--- a/lang/python312/Portfile
+++ b/lang/python312/Portfile
@@ -6,6 +6,7 @@ name                python312
 
 # Remember to keep py312-tkinter and py312-gdbm's versions sync'd with this
 version             3.12.8
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang
@@ -47,7 +48,7 @@ depends_lib         port:bzip2 \
                     port:libedit \
                     port:libffi \
                     port:ncurses \
-                    port:openssl \
+                    port:openssl3 \
                     port:sqlite3 \
                     port:xz \
                     port:zlib
@@ -66,7 +67,8 @@ configure.args      --enable-framework=${frameworks_dir} \
                     --with-ensurepip=no \
                     --with-readline=editline \
                     --with-system-expat \
-                    --with-dbmliborder=ndbm:bdb
+                    --with-dbmliborder=ndbm:bdb \
+                    --with-openssl=${prefix}/libexec/openssl3
 
 configure.ccache    no
 # pkg-config removes -I flags for paths in CPATH, which confuses python.

--- a/lang/python313/Portfile
+++ b/lang/python313/Portfile
@@ -6,6 +6,7 @@ name                python313
 
 # Remember to keep py313-tkinter and py313-gdbm's versions sync'd with this
 version             3.13.1
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang
@@ -46,7 +47,7 @@ depends_lib         port:bzip2 \
                     port:libffi \
                     port:mpdecimal \
                     port:ncurses \
-                    path:lib/libssl.dylib:openssl \
+                    port:openssl3 \
                     port:sqlite3 \
                     port:xz \
                     port:zlib
@@ -64,7 +65,8 @@ configure.args      --enable-framework=${frameworks_dir} \
                     --with-ensurepip=no \
                     --with-readline=editline \
                     --with-system-expat \
-                    --with-dbmliborder=ndbm:bdb
+                    --with-dbmliborder=ndbm:bdb \
+                    --with-openssl=${prefix}/libexec/openssl3
 
 configure.ccache    no
 # pkg-config removes -I flags for paths in CPATH, which confuses python.

--- a/lang/python314-devel/Portfile
+++ b/lang/python314-devel/Portfile
@@ -6,6 +6,7 @@ name                python314-devel
 
 # Remember to keep py314-tkinter and py314-gdbm's versions sync'd with this
 version             3.14.0a2
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang
@@ -46,7 +47,7 @@ depends_lib         port:bzip2 \
                     port:libffi \
                     port:mpdecimal \
                     port:ncurses \
-                    path:lib/libssl.dylib:openssl \
+                    port:openssl3 \
                     port:sqlite3 \
                     port:xz \
                     port:zlib
@@ -64,7 +65,8 @@ configure.args      --enable-framework=${frameworks_dir} \
                     --with-ensurepip=no \
                     --with-readline=editline \
                     --with-system-expat \
-                    --with-dbmliborder=ndbm:bdb
+                    --with-dbmliborder=ndbm:bdb \
+                    --with-openssl=${prefix}/libexec/openssl3
 
 configure.ccache    no
 # pkg-config removes -I flags for paths in CPATH, which confuses python.


### PR DESCRIPTION
openssl is just a shim port that installs a few sym links into the primary install prefix for the files installed by the openssl3 port. As such, openssl (but not openssl3) conflicts with libressl so removing this dependency removes the conflict between the python ports and libressl.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

