### PR TITLE
libewf: do not force libfuse on archs where it is unsupported

### DIFF
--- a/security/libewf/Portfile
+++ b/security/libewf/Portfile
@@ -7,7 +7,6 @@ PortGroup           openssl 1.0
 github.setup        libyal libewf 20230212
 revision            0
 categories          security
-platforms           darwin
 maintainers         nomaintainer
 license             LGPL-3+
 
@@ -27,18 +26,14 @@ checksums           rmd160  2c23bdeb7f703c142d8b4412a952c08aace9500c \
                     sha256  d22eecbd962c3d7d646ccfba131fc3c07e6a07da37dc163b6ecbb1348db16101 \
                     size    2638562
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 
 openssl.branch      3
 
 depends_lib         port:bzip2 \
                     port:gettext \
                     port:libiconv \
-                    path:lib/pkgconfig/fuse.pc:macfuse \
                     port:zlib
-
-# osxfuse is not universal
-universal_variant   no
 
 platform linux {
     configure.env-append \
@@ -46,7 +41,6 @@ platform linux {
 }
 
 configure.args      --with-bzip2=${prefix} \
-                    --with-libfuse=${prefix} \
                     --with-openssl=[openssl::install_area] \
                     --with-zlib=${prefix} \
                     --without-libbfio \
@@ -62,6 +56,7 @@ configure.args      --with-bzip2=${prefix} \
                     --without-libcthreads \
                     --without-libfcache \
                     --without-libfdata \
+                    --without-libfuse \
                     --without-libfvalue \
                     --without-libhmac \
                     --without-libodraw \
@@ -69,3 +64,14 @@ configure.args      --with-bzip2=${prefix} \
                     --without-libsmraw \
                     --without-libuna \
                     --without-libuuid
+
+if {${configure.build_arch} in [list arm64 x86_64]} {
+    depends_lib-append \
+                    path:lib/pkgconfig/fuse.pc:macfuse
+
+    configure.args-replace \
+                   --without-libfuse --with-libfuse=${prefix}
+
+    # osxfuse is not universal
+    universal_variant   no
+}


### PR DESCRIPTION
#### Description

The port is completely unnecessarily broken on powerpc and i386 by forcing an optional dependency. Fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
