### PR TITLE
google-benchmark: new package

### DIFF
--- a/devel/google-benchmark/Portfile
+++ b/devel/google-benchmark/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       cmake 1.1
+PortGroup       github 1.0
+
+github.setup    google benchmark 1.9.1 v
+name            google-benchmark
+revision        0
+checksums       rmd160  3d598796c611d25267358246f9af9bd1e9e394b3 \
+                sha256  6e8bd8a610ad0c6814af4b3ae930517dd00fa69caf6f6f4667270fae8d47b53d \
+                size    255170
+
+categories      devel
+maintainers     nomaintainer
+license         Apache-2
+
+description     Google's microbenchmark support library for C++
+long_description \
+                Google's microbenchmark support library for C++.
+homepage        https://google.github.io/benchmark/
+
+compiler.cxx_standard   2017
+
+# Clear optflags; controlled by project, via cmake build type
+configure.optflags
+
+if {[variant_isset debug]} {
+    cmake.build_type Debug
+} else {
+    cmake.build_type RelWithDebInfo
+}
+
+configure.args-append \
+                    -DBENCHMARK_ENABLE_TESTING=OFF \
+                    -DBUILD_SHARED_LIBS=ON
+
+variant static description "Build static library" {
+  configure.args-replace \
+                    -DBUILD_SHARED_LIBS=ON \
+                    -DBUILD_SHARED_LIBS=OFF
+}
+
+# Disable warnings to work around the following:
+#
+# src/benchmark_api_internal.cc:46:29: error: ISO C++11 does not support the 'q' gnu_printf length modifier [-Wno-error=format]
+# 46 |     name_.args += StrFormat("%" PRId64, arg);
+configure.args-append \
+                    -DBENCHMARK_ENABLE_WERROR=OFF \
+                    -DBENCHMARK_FORCE_WERROR=OFF
+
+# Ignore prerelease versions
+github.livecheck.regex  {([^"-]+)}


### PR DESCRIPTION
#### Description

Adds a package for https://github.com/google/benchmark

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

/cc @AJenbo
