### PR TITLE
lua: add legacy-support for Tiger

### DIFF
--- a/lang/lua/Portfile
+++ b/lang/lua/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
+PortGroup                   legacysupport 1.1
 PortGroup                   makefile    1.0
 
 # each version of Lua can (and does) break backwards compatibility
@@ -36,6 +37,9 @@ master_sites                ${homepage}/ftp
 checksums                   rmd160  cc715df991bccaec75a022404902200d984b002e \
                             sha256  fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60 \
                             size    303770
+
+# localtime_r gmtime_r
+legacysupport.newest_darwin_requires_legacy 8
 
 # Semantic Versioning uses x.y.z as the "version"
 # in the Lua nomenclature, x.y is the version and z is the release


### PR DESCRIPTION
#### Description

Lua uses `localtime_r` and `gmtime_r`, which require legacy-support on Tiger.

Fixes Lua on Tiger (tested with lua54).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

/cc @AJenbo
