### PR TITLE
py-lesscpy: Update to 0.15.1

### DIFF
--- a/python/py-lesscpy/Portfile
+++ b/python/py-lesscpy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-lesscpy
-version             0.15.0
+version             0.15.1
 revision            0
 
 categories-append   lang devel
@@ -18,11 +18,11 @@ long_description    {*}${description}
 
 homepage            https://github.com/lesscpy/lesscpy
 
-checksums           rmd160  f6d130c23e996db1896e1f92e9afac5bbe336e75 \
-                    sha256  ef058fb3fca077f0136222c415bc6d20fe256e92648ccbf4b3de874ba03b9b9d \
-                    size    176879
+checksums           rmd160  4bd2acb756eb4f5a77412a9e38e429adf28b724c \
+                    sha256  1045d17a98f688646ca758dff254e6e9c03745648e051a081b0395c3b77c824c \
+                    size    177240
 
-python.versions     39 310
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Update `lesscpy` to its latest released version, 0.15.1, adding subports for Python 3.11 and 3.12

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
