### PR TITLE
hackrf: Update to 2024.02.1; hackrf-devel: Update to 20241205-db884152

### DIFF
--- a/science/hackrf/Portfile
+++ b/science/hackrf/Portfile
@@ -19,12 +19,12 @@ subport hackrf-devel {}
 if {${subport} eq ${name}} {
 
     # release
-    github.setup    greatscottgadgets hackrf 2021.03.1 v
+    github.setup    greatscottgadgets hackrf 2024.02.1 v
     github.tarball_from releases
     use_xz          yes
-    checksums       rmd160 d8c454803cad3ae966192dc3668eceac534d60ab \
-                    sha256 a43e5080c11efdfe69ddebcc35a02b018e30e820de0e0ebdc7948cf7b0cd93a3 \
-                    size   13661964
+    checksums       rmd160 8d6d45362224971ce7cfaa534f11ad04f3d7980d \
+                    sha256 d9ced67e6b801cd02c18d0c4654ed18a4bcb36c24a64330c347dfccbd859ad16 \
+                    size   21734672
     revision        0
 
     epoch           1

--- a/science/hackrf/Portfile
+++ b/science/hackrf/Portfile
@@ -27,7 +27,6 @@ if {${subport} eq ${name}} {
                     size   13661964
     revision        0
 
-    # bump the epoch because I moved the version from 20170219 to 2017.02.1
     epoch           1
 
     conflicts       hackrf-devel
@@ -35,22 +34,20 @@ if {${subport} eq ${name}} {
 } else {
 
     # devel
-    github.setup    greatscottgadgets hackrf d94295edcf2b3bda84f2c1e2a442f695a41e24b3
-    version         20211108-[string range ${github.version} 0 7]
+    github.setup    greatscottgadgets hackrf db884152dc4e2021c3f134cbd21392e958380c14
+    version         20241205-[string range ${git.branch} 0 7]
     github.tarball_from archive
-    checksums       rmd160 619b8a4ea1275bc9dd129512a6e02b592b07c3ec \
-                    sha256 2e0158b07ec2f8a520749723378e42ab0b65bcc37cb99e94d537b42c89e8832f \
-                    size   11718520
+    checksums       rmd160  ca1f0b179184c41889d7ae0f6dbe922681469232 \
+                    sha256  9c84505ccc9ce6a13b0a3b88715ed7c2289a190d15cbf99bf570120b392e854d \
+                    size    13248842
     revision        0
 
     conflicts       hackrf
 
-    # Handle stealth update; remove with next version update
-    dist_subdir     ${name}/${version}_1
-
 }
 
-depends_build-append port:pkgconfig
+depends_build-append path:bin/pkg-config:pkgconfig
+
 depends_lib-append   path:lib/pkgconfig/libusb-1.0.pc:libusb \
                      port:fftw-3-single
 
@@ -59,10 +56,7 @@ depends_lib-append   path:lib/pkgconfig/libusb-1.0.pc:libusb \
 
 patchfiles-append   patch-no-gnu90.diff
 
-# set last configure argument to the reletive path
-# to the top-level cmake source
-
-configure.post_args ../${worksrcdir}/host
+cmake.source_dir    ${worksrcpath}/host
 
 # remove top-level library and includes paths, such that internal
 # libraries and headers are used instead of any already-installed ones.


### PR DESCRIPTION
#### Description

hackrf: Update to 2024.02.1

hackrf-devel: Update to 20241205-db884152

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
