### PR TITLE
mise: Update to 2024.12.4

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.12.3 v
+github.setup        jdx mise 2024.12.4 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  464d45bf855139410a0834a3316a1e1c47c0b7bd \
-                    sha256  954b3f017a958d9c55843a4deb529d87b7afa3cf8f639b1246e42697c617d85d \
-                    size    3260638
+                    rmd160  1c72dc17d0dfddf386e5d606723e3b0822fa0678 \
+                    sha256  bda1dc53b8cd459ec452ff8846a09dfb7559bf50bb2d67b4bfd25aede9f022de \
+                    size    4056309
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -126,7 +126,7 @@ cargo.crates \
     cc                               1.2.3  27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
+    chrono                          0.4.39  7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825 \
     chrono-tz                        0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
@@ -163,7 +163,7 @@ cargo.crates \
     curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
-    demand                           1.2.4  911255fd44dad0c6b5675764410acef128715644cbb68e5fad6a503ead70db0a \
+    demand                           1.3.0  3f411dff701b92f8dd5169b550e256f6cffbb8b90b047c77c32efa3d9fa61d66 \
     der                              0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
@@ -191,7 +191,7 @@ cargo.crates \
     exec                             0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
     expr-lang                        0.2.1  62d87141875739c4eb2b6a6e0c6dbd6f877ff3336953cdbf850b3dc920d3bf2f \
     eyre                            0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
-    fastrand                         2.2.0  486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4 \
+    fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     filetime_creation                0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
@@ -264,11 +264,11 @@ cargo.crates \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     js-sys                          0.3.76  6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7 \
     junction                         1.2.0  72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16 \
-    kdl                              4.6.0  062c875482ccb676fd40c804a40e3824d4464c18c364547456d1c8e8e951ae47 \
+    kdl                              4.7.0  3a18038fbecda667e7ea2101bdd02af754da5e17ca2887a7649b8f3fa809d8b8 \
     lazy-regex                       3.3.0  8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda \
     lazy-regex-proc_macros           3.3.0  76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.167  09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc \
+    libc                           0.2.168  5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d \
     libgit2-sys               0.17.0+1.8.1  10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224 \
     libm                            0.2.11  8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
@@ -289,8 +289,8 @@ cargo.crates \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
-    miette                          5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
-    miette-derive                   5.10.0  49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c \
+    miette                           7.4.0  317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64 \
+    miette-derive                    7.4.0  23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.7.4  b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08 \
@@ -352,7 +352,7 @@ cargo.crates \
     quick-xml                       0.23.1  11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea \
     quinn                           0.11.6  62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef \
     quinn-proto                     0.11.9  a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d \
-    quinn-udp                        0.5.7  7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da \
+    quinn-udp                        0.5.8  52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527 \
     quote                           1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
@@ -373,7 +373,7 @@ cargo.crates \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
-    rustix                         0.38.41  d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6 \
+    rustix                         0.38.42  f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85 \
     rustls                         0.23.19  934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
@@ -441,9 +441,9 @@ cargo.crates \
     test-log                        0.2.16  3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93 \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                        2.0.5  643caef17e3128658ff44d85923ef2d28af81bb71e0d67bbfe1d76f19a73e053 \
+    thiserror                        2.0.6  8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                   2.0.5  995d0bbc9995d1f19d28b7215a9352b0fc3cd3a2d2ec95c2cadc485cdedbcdde \
+    thiserror-impl                   2.0.6  d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     time                            0.3.37  35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
@@ -484,7 +484,7 @@ cargo.crates \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                        1.3.4  d43de343a2409b44516220610d6686e765fc3701e82ed4829d5f5e5faa431967 \
+    usage-lib                        1.4.0  9e94c6959099cfbc672b68392f9b9fe7fde12447c4550f5a36af1516a0277807 \
     utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -492,7 +492,7 @@ cargo.crates \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
-    vfox                             0.3.3  5a909ee4afc8dccf80dae7b73581198b1204a0dbf7b22615f95bddd3e306a439 \
+    vfox                             0.3.4  d4c44e4ec114bba1eeed55bc3a47ced72545cd2ffa04ce0ec0bdba1fb535807d \
     vte                             0.10.1  6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983 \
     vte_generate_state_changes       0.1.2  2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
@@ -539,7 +539,7 @@ cargo.crates \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
-    xx                               1.1.9  cf77a847b8a88b00563bb61a1041c90a8697bc23f0382eb1ecbe852098df351c \
+    xx                               2.0.0  f2c507cfdc3944bf23d0ef0fc39894bd05b566828bb961dbd1dc42e013d99f99 \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \


### PR DESCRIPTION
#### Description

mise: Update to 2024.12.4

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
