### PR TITLE
libgeotiff: update to 1.7.3 and use latest PROJ

### DIFF
--- a/graphics/libgeotiff/Portfile
+++ b/graphics/libgeotiff/Portfile
@@ -3,10 +3,9 @@
 PortSystem          1.0
 
 name                libgeotiff
-version             1.7.1
-revision            3
+version             1.7.3
+revision            0
 categories          graphics
-platforms           darwin
 license             X11
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -19,9 +18,9 @@ long_description    This software provides support for the Tag Image File \
 homepage            https://geotiff.osgeo.org/
 master_sites        https://download.osgeo.org/geotiff/libgeotiff/
 
-checksums           rmd160  221970a969e613acb1034634eda70a7ab7fc22f7 \
-                    sha256  05ab1347aaa471fc97347d8d4269ff0c00f30fa666d956baba37948ec87e55d6 \
-                    size    542779
+checksums           rmd160  ff504fcff8f2dfb427ea339411c95a33fe1809fd \
+                    sha256  ba23a3a35980ed3de916e125c739251f8e3266be07540200125a307d7cf5a704 \
+                    size    547548
 
 # Set PROJ
 set proj_versions {7 8 9}

--- a/graphics/libgeotiff/Portfile
+++ b/graphics/libgeotiff/Portfile
@@ -22,37 +22,15 @@ checksums           rmd160  ff504fcff8f2dfb427ea339411c95a33fe1809fd \
                     sha256  ba23a3a35980ed3de916e125c739251f8e3266be07540200125a307d7cf5a704 \
                     size    547548
 
-# Set PROJ
-set proj_versions {7 8 9}
-set proj_variants {}
-foreach pjver ${proj_versions} {
-    lappend proj_variants proj${pjver}
-}
-foreach proj_ver ${proj_versions} {
-
-    set index [lsearch -exact ${proj_variants} proj${proj_ver}]
-    set cflcts [lreplace ${proj_variants} ${index} ${index}]
-
-        variant proj${proj_ver} description "Use Proj${proj_ver}" conflicts {*}${cflcts} "
-            depends_lib-append      port:proj${proj_ver}
-            configure.args-append   --with-proj=${prefix}/lib/proj${proj_ver}
-        "
-}
-set projdf "if {"
-foreach pv ${proj_versions} {
-    set projdf "${projdf}!\[variant_isset proj${pv}\] && "
-}
-set projdf [string range ${projdf} 0 end-4]
-set projdf "${projdf}} { default_variants +proj${pv} }"
-eval ${projdf}
-
-depends_lib         port:tiff \
+depends_lib         port:proj \
+                    port:tiff \
                     port:zlib \
                     path:include/turbojpeg.h:libjpeg-turbo
 
 configure.args-append \
                     --with-zip=${prefix} \
-                    --with-jpeg=${prefix}
+                    --with-jpeg=${prefix} \
+                    --with-proj=${prefix}/lib/proj9
 
 use_parallel_build  no
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- libgeotiff: update to 1.7.3
- libgeotiff: use latest version of PROJ (drop proj variants)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
