### PR TITLE
py-rich: add Python 3.13 subport

### DIFF
--- a/python/py-rich/Portfile
+++ b/python/py-rich/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  33cf9aec01fba72196886e0683d7e34f6fbde3f5 \
                     sha256  439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098 \
                     size    223149
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 python.pep517_backend   poetry
 


### PR DESCRIPTION
#### Description

Add Python 3.13 subport.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?