### PR TITLE
lagrange: update to 1.18.4

### DIFF
--- a/devel/sealcurses/Portfile
+++ b/devel/sealcurses/Portfile
@@ -5,8 +5,8 @@ PortGroup           cmake 1.1
 PortGroup           gitea 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         skyjake sealcurses e11026ca34b03c5ab546512f82a6f705d0c29e95
-version             2023-02-06
+gitea.setup         skyjake sealcurses 310348a6b88678a47d371c7edfcc1e8c76ca1677
+version             2024-12-02
 revision            0
 categories          devel
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         SDL Emulation and Adaptation Layer for Curses (ncursesw)
 long_description    {*}${description}
 
-checksums           rmd160  cd0d2f2d9a9852ee59f582984dfec9c52eb76c8a \
-                    sha256  797efa8fcfea3d69383c493b4fc29305c72fdc5f3586063e84e89da601739d2c \
-                    size    22432
+checksums           rmd160  f201aaad223879c49795c2446b2214c857277ae4 \
+                    sha256  627758f50cc2b744fd2ab29cf9140562224136d37c40670b643ababa2d46812b \
+                    size    23008
 
 worksrcdir          ${name}
 

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.18.3 v
+gitea.setup         gemini lagrange 1.18.4 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  ca2c96d3ad9b78b0b99380c0e2c6ae439211db1f \
-                    sha256  0b476be2bf8dd577cd88082e7ad1cbfde195e083f53a59093d2a6cfc27436bbe \
-                    size    7798444
+checksums           rmd160  a8bcda9363b31e2b8a50cb687015c486aca03196 \
+                    sha256  cacaa34eb4ad8181bb492dabff89f3f035f0546576305cea819d246bed5d9ee6 \
+                    size    8828673
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://github.com/skyjake/lagrange/releases/tag/v1.18.4

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
