### PR TITLE
ruby33: Add a patch for Tiger

### DIFF
--- a/lang/ruby33/Portfile
+++ b/lang/ruby33/Portfile
@@ -188,6 +188,7 @@ platform darwin {
     }
 
     if {${os.major} == 8} {
+        patchfiles-append tiger-patch.diff
         configure.cppflags-append -DCPU_SUBTYPE_MASK=0xff000000
     }
 }

--- a/lang/ruby33/files/tiger-patch.diff
+++ b/lang/ruby33/files/tiger-patch.diff
@@ -1,0 +1,93 @@
+From 1a3f66633849bb949dd58a409772497623bb2143 Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Tue, 10 Dec 2024 12:20:40 +0000
+Subject: [PATCH] Support OSX 10.4
+
+1. OSX 10.4 does not have `CFStringCreateWithBytesNoCopy`.
+
+   There are two places that use it:
+
+   1. `rb_CFString_class_initialize_before_fork`.
+       This is only needed on macOS 13+, so we avoid calling
+       it for OSX 10.4. See e3cc1a6cae0e6c88c04cd54c3afa3c022bb6772c
+
+   2. `rb_CFString_class_initialize_before_fork`.
+       Uses `CFStringCreateWithBytes` instead.
+
+2. OSX 10.4 does not have `pthread_mach_thread_np`.
+
+   There doesn't seem to be away to get a thread ID at all.
+   Disables native thread ID functionality on OSX 10.4
+---
+ file.c           | 14 ++++++++++++--
+ thread_pthread.c |  4 +++-
+ 2 files changed, 15 insertions(+), 3 deletions(-)
+
+diff --git file.c file.c
+index 373788b206..c9bd9b6e19 100644
+--- file.c
++++ file.c
+@@ -28,6 +28,8 @@
+ #endif
+ 
+ #ifdef __APPLE__
++# include <AvailabilityMacros.h>
++
+ # if !(defined(__has_feature) && defined(__has_attribute))
+ /* Maybe a bug in SDK of Xcode 10.2.1 */
+ /* In this condition, <os/availability.h> does not define
+@@ -270,7 +272,8 @@ rb_str_encode_ospath(VALUE path)
+ #ifdef __APPLE__
+ # define NORMALIZE_UTF8PATH 1
+ 
+-# ifdef HAVE_WORKING_FORK
++# if defined(HAVE_WORKING_FORK) && \
++    defined(MAC_OS_X_VERSION_10_5) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_5
+ static void
+ rb_CFString_class_initialize_before_fork(void)
+ {
+@@ -314,10 +317,16 @@ rb_str_append_normalized_ospath(VALUE str, const char *ptr, long len)
+ {
+     CFIndex buflen = 0;
+     CFRange all;
++#if defined(MAC_OS_X_VERSION_10_5) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_5
+     CFStringRef s = CFStringCreateWithBytesNoCopy(kCFAllocatorDefault,
+                                                   (const UInt8 *)ptr, len,
+                                                   kCFStringEncodingUTF8, FALSE,
+                                                   kCFAllocatorNull);
++#else
++    CFStringRef s = CFStringCreateWithBytes(kCFAllocatorDefault,
++                                            (const UInt8 *)ptr, len,
++                                            kCFStringEncodingUTF8, FALSE);
++#endif
+     CFMutableStringRef m = CFStringCreateMutableCopy(kCFAllocatorDefault, len, s);
+     long oldlen = RSTRING_LEN(str);
+ 
+@@ -7341,7 +7350,8 @@ const char ruby_null_device[] =
+ void
+ Init_File(void)
+ {
+-#if defined(__APPLE__) && defined(HAVE_WORKING_FORK)
++#if defined(__APPLE__) && defined(HAVE_WORKING_FORK) && \
++    defined(MAC_OS_X_VERSION_10_5) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_5
+     rb_CFString_class_initialize_before_fork();
+ #endif
+ 
+diff --git thread_pthread.c thread_pthread.c
+index 305cbdbec1..cab0e90eb7 100644
+--- thread_pthread.c
++++ thread_pthread.c
+@@ -2743,7 +2743,9 @@ native_set_another_thread_name(rb_nativethread_id_t thread_id, VALUE name)
+ #endif
+ }
+ 
+-#if defined(RB_THREAD_T_HAS_NATIVE_ID) || defined(__APPLE__)
++#if defined(RB_THREAD_T_HAS_NATIVE_ID) || \
++    (defined(__APPLE__) && defined(MAC_OS_XS_VERSION_10_5) && \
++     MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_XS_VERSION_10_5)
+ static VALUE
+ native_thread_native_thread_id(rb_thread_t *target_th)
+ {
+-- 
+2.43.0
+


### PR DESCRIPTION
#### Description

Ruby officially only supports 10.5+ but it turned out to be quite easy to patch it for 10.4 support.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.4.11 8S165 Power Macintosh
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
