### PR TITLE
dcm2niix: Fix openjpeg usage; add batch tool.

### DIFF
--- a/science/dcm2niix/Portfile
+++ b/science/dcm2niix/Portfile
@@ -18,7 +18,6 @@ long_description    dcm2niix is a designed to convert neuroimaging data from \
                     the DICOM format to the NIfTI format
 
 license             BSD MIT
-platforms           darwin
 
 checksums \
     rmd160  a103c5c64b6e33a01734ca8ee7a622bbb3e3e52f \

--- a/science/dcm2niix/Portfile
+++ b/science/dcm2niix/Portfile
@@ -53,10 +53,9 @@ compiler.cxx_standard   2011
 # Linking with yaml-cpp currently broken; haven't chased down; revisit later.
 # Disabling BATCH_VERSION until this is resolved.
 configure.args-append   -DUSE_OPENJPEG=System \
+                        -DBATCH_VERSION=ON \
                         -DZLIB_IMPLEMENTATION=System \
-                        -DYAML-CPP_IMPLEMENTATION=System \
-                        -DBATCH_VERSION=ON
-
+                        -DYAML-CPP_IMPLEMENTATION=System
 
 # cmake re-runs during build; retain configured CC and CXX (Only an issue in
 # the default configuration on <= 10.6 where we are not using system clang.)

--- a/science/dcm2niix/Portfile
+++ b/science/dcm2niix/Portfile
@@ -38,8 +38,8 @@ variant docs description {Install man pages} {
 
 default_variants        +docs
 
-depends_lib-append      port:yaml-cpp \
-                        port:openjpeg \
+depends_lib-append      port:openjpeg \
+                        port:yaml-cpp \
                         port:zlib
 
 depends_build-append    port:pkgconfig
@@ -54,7 +54,6 @@ compiler.cxx_standard   2011
 # Linking with yaml-cpp currently broken; haven't chased down; revisit later.
 # Disabling BATCH_VERSION until this is resolved.
 configure.args-append   -DUSE_OPENJPEG=System \
-                        -DBATCH_VERSION=OFF \
                         -DZLIB_IMPLEMENTATION=System \
                         -DYAML-CPP_IMPLEMENTATION=System \
                         -DBATCH_VERSION=ON

--- a/science/dcm2niix/Portfile
+++ b/science/dcm2niix/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        rordenlab dcm2niix 1.0.20241208 v
 version             ${github.version}
 
-revision            0
+revision            1
 
 categories          science
 maintainers         {eborisch @eborisch} openmaintainer
@@ -38,7 +38,8 @@ variant docs description {Install man pages} {
 
 default_variants        +docs
 
-depends_lib-append      port:openjpeg \
+depends_lib-append      port:yaml-cpp \
+                        port:openjpeg \
                         port:zlib
 
 depends_build-append    port:pkgconfig
@@ -52,10 +53,11 @@ compiler.cxx_standard   2011
 
 # Linking with yaml-cpp currently broken; haven't chased down; revisit later.
 # Disabling BATCH_VERSION until this is resolved.
-configure.args-append   -DUSE_OPENJPEG=ON \
+configure.args-append   -DUSE_OPENJPEG=System \
                         -DBATCH_VERSION=OFF \
-                        -DZLIB_IMPLEMENTATION=custom \
-                        -DZLIB_ROOT=${prefix}
+                        -DZLIB_IMPLEMENTATION=System \
+                        -DYAML-CPP_IMPLEMENTATION=System \
+                        -DBATCH_VERSION=ON
 
 
 # cmake re-runs during build; retain configured CC and CXX (Only an issue in


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/71509