### PR TITLE
inkscape: Fix dependency on libsoup 2.4

### DIFF
--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -14,7 +14,7 @@ set ver_date        2023-11-25
 set ver_hash        091e20ef0f
 set ver_gal_item    44615
 version             ${ver_num}
-revision            2
+revision            3
 epoch               0
 
 categories          graphics gnome
@@ -117,7 +117,7 @@ depends_lib-append \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
                     port:libsigcxx2 \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup-2.4 \
                     port:libvisio-0.1 \
                     port:libwpg-0.3 \
                     port:libxml2 \


### PR DESCRIPTION
#### Description

Since a5bed96ea30dd136434b63fc7e5a885d3a393086, installing the libsoup port no longer automatically pulls in libsoup-2.4, but inkscape requires the latter. Adjust the dependency spec to match.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
