### PR TITLE
osxphotos: update to 0.69.1

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.68.6
+version                 0.69.1
 revision                0
 
 categories              graphics python
@@ -25,11 +25,11 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  980a7e9a7031c7c0ded012956c048fe0d25ba1a0 \
-                        sha256  2b501749e209398f2c0b7a9d2be6538822dd359539dd90f37db56f24c879282c \
-                        size    2185193
+checksums               rmd160  20e8f6147c6920942cb61a2e7f8a6c9f75b2e4d0 \
+                        sha256  27f066eee63cd08640445edc86b2a38deea2c17d0ff7c4ef52964473cfeba08b \
+                        size    2234560
 
-python.default_version  312
+python.default_version  313
 
 depends_build-append    port:py${python.version}-setuptools
 
@@ -61,6 +61,8 @@ depends_lib-append      port:py${python.version}-bitmath \
                         port:py${python.version}-wurlitzer \
                         port:py${python.version}-xdg-base-dirs \
                         port:py${python.version}-yaml
+
+depends_run-append      port:py${python.version}-utitools
 
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description

Update to 0.69.1.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?