### PR TITLE
ksh93-devel: update to version 1.0.10

### DIFF
--- a/shells/ksh93-devel/Portfile
+++ b/shells/ksh93-devel/Portfile
@@ -5,11 +5,11 @@ PortGroup           github 1.0
 
 # Please keep the ksh93 and ksh93-devel ports as similar as possible.
 
-github.setup        ksh93 ksh 1.0.8 v
+github.setup        ksh93 ksh 1.0.10 v
 revision            0
-checksums           rmd160  8d0b56c14bec573d8d1a50b502cef4d58b16e381 \
-                    sha256  b46565045d0eb376d3e6448be6dbc214af454efc405d527f92cb81c244106c8e \
-                    size    2114262
+checksums           rmd160  29d8965318c8a3fc3bcb142380a515208ecd16fd \
+                    sha256  9f4c7a9531cec6941d6a9fd7fb70a4aeda24ea32800f578fd4099083f98b4e8a\
+                    size    2019536
 
 name                ksh93-devel
 version             93u+m-${github.version}
@@ -47,6 +47,19 @@ destroot {
         ${destroot}${prefix}/bin
     xinstall -m 0444 ${build.dir}/src/cmd/ksh93/sh.1 \
         ${destroot}${prefix}/share/man/man1/ksh.1
+    xinstall -m 0755 -d ${destroot}${prefix}/share/${name}
+    xinstall -m 0755 ${build.dir}/src/cmd/ksh93/fun/autocd \
+        ${destroot}${prefix}/share/${name}
+    xinstall -m 0755 ${build.dir}/src/cmd/ksh93/fun/cd \
+        ${destroot}${prefix}/share/${name}
+    xinstall -m 0755 ${build.dir}/src/cmd/ksh93/fun/dirs \
+        ${destroot}${prefix}/share/${name}
+    xinstall -m 0755 ${build.dir}/src/cmd/ksh93/fun/mcd \
+        ${destroot}${prefix}/share/${name}
+    xinstall -m 0755 ${build.dir}/src/cmd/ksh93/fun/popd \
+        ${destroot}${prefix}/share/${name}
+    xinstall -m 0755 ${build.dir}/src/cmd/ksh93/fun/pushd \
+        ${destroot}${prefix}/share/${name}
 }
 
 options ksharch


### PR DESCRIPTION
#### Description

Update ksh93-devel to version 1.0.10

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.7.1 22H221 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
