### PR TITLE
google-cloud-sdk: update to 503.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             502.0.0
+version             503.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  b614224ee9d01c484a561e5e42f5c147564ec3bd \
-                    sha256  64b69f1948e53cf84333f38b4f8dd6dc41c6ec726380ceb080c4880aac93a009 \
-                    size    52593724
+    checksums       rmd160  0115f86debd3610281a3265bd80d0ed12b1da58e \
+                    sha256  88e2800164a4cce08aba6f55dfac8a02fbcd0bbe3079b17373f0247f133174ca \
+                    size    53196393
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  472c2ee8983cc8ab7665093ce589787e1df9cce1 \
-                    sha256  9d8543f742cd02b50e3a7553495b9dfcdb6c6b690b4e02c7c73f85780cc3d330 \
-                    size    53943066
+    checksums       rmd160  099dc7c030511e596a012b61c2dad538c20e57e6 \
+                    sha256  e4f9e2235889d489df512c1fec99dce19dacac2c1a72ff5021049f18dd652953 \
+                    size    54552005
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  1598fd5451b470f24236802262b68555e9122081 \
-                    sha256  903b01237a2147f0bc550109a1085d6d713e9803374faa8fcd3f7a0ed81581e5 \
-                    size    53889708
+    checksums       rmd160  72e9e09658f28872b4fcdd0810af0edb83f92993 \
+                    sha256  e879d56b20890e9ead5864c7b04fd55d5ed55de47b2e018cfb13b6736bb7191f \
+                    size    54497857
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -44,7 +44,7 @@ worksrcdir          ${name}
 # Most recent supported Python version according to both
 # https://cloud.google.com/sdk/docs/install#mac and
 # https://cloud.google.com/storage/docs/gsutil_install#specifications
-python.default_version 311
+python.default_version 312
 
 post-patch {
     # Default to the MacPorts Python binary


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 503.0.0.

###### Tested on

macOS 15.1.1 24B91 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?