### PR TITLE
dcmtk: Bump linking dependents for 3.6.9

### DIFF
--- a/graphics/OpenSceneGraph/Portfile
+++ b/graphics/OpenSceneGraph/Portfile
@@ -6,7 +6,7 @@ PortGroup               cmake 1.1
 PortGroup               boost 1.0
 
 github.setup            openscenegraph OpenSceneGraph 3.6.5 OpenSceneGraph-
-revision                15
+revision                16
 conflicts               OpenSceneGraph-devel
 categories              graphics
 maintainers             nomaintainer

--- a/graphics/h3dutil/Portfile
+++ b/graphics/h3dutil/Portfile
@@ -6,7 +6,7 @@ PortGroup           conflicts_build 1.0
 
 name                h3dutil
 version             1.4.0
-revision            3
+revision            4
 categories          graphics
 platforms           darwin
 maintainers         {@SenseGraphics sensegraphics.com:support}

--- a/graphics/openimageio/Portfile
+++ b/graphics/openimageio/Portfile
@@ -20,13 +20,13 @@ set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
 
 if {${port_latest}} {
     github.setup        AcademySoftwareFoundation OpenImageIO 2.5.10.1 v
-    revision            1
+    revision            2
     checksums           rmd160  acca3794870850f6d39e41e62e9370bf6ff9565b \
                         sha256  8f6a547f6a5d510737ba436f867043db537def65f0fdb14ec30e5a185b619f93 \
                         size    52061055
 } else {
     github.setup        AcademySoftwareFoundation OpenImageIO 2.1.20.0 v
-    revision            15
+    revision            16
     checksums           rmd160  7f241baddcc6e731a29fb37090e4582953560f38 \
                         sha256  0ad46bda55d6357a3c474b8c8ccbb41d9732313247cffaf4a65fc50e6aad9e78 \
                         size    29116032


### PR DESCRIPTION
Bump ports which link against DCMTK.