### PR TITLE
qemu: disable meson compiler check

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -61,7 +61,8 @@ depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2 \
                         port:dtc
 
 # "error: unknown type name 'fpunchhole_t'" pre-10.12.4
-patchfiles-append       patch-qemu-punchhole.diff
+patchfiles-append       patch-qemu-punchhole.diff \
+                        patch-meson-disable-compiler-check.diff
 
 # IPPROTO workarounds
 patchfiles-append       patch-qemu-net-colo.diff

--- a/emulators/qemu/files/patch-meson-disable-compiler-check.diff
+++ b/emulators/qemu/files/patch-meson-disable-compiler-check.diff
@@ -1,0 +1,11 @@
+--- ./meson.build.orig	2024-12-12 13:47:17
++++ ./meson.build	2024-12-12 13:48:46
+@@ -325,7 +325,7 @@
+       #endif''')
+     # ok
+   else
+-    error('You either need GCC v7.4 or Clang v10.0 (or XCode Clang v15.0) to compile QEMU')
++    # error('You either need GCC v7.4 or Clang v10.0 (or XCode Clang v15.0) to compile QEMU')
+   endif
+ endforeach
+ 


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
