### PR TITLE
wget: make metalink support a variant

### DIFF
--- a/net/wget/Portfile
+++ b/net/wget/Portfile
@@ -51,6 +51,7 @@ configure.args          --enable-option-checking \
                         --enable-xattr \
                         --without-ssl \
                         --with-zlib \
+                        --without-metalink \
                         --without-cares \
                         --with-libiconv-prefix=${prefix} \
                         --with-libintl-prefix=${prefix} \
@@ -114,7 +115,7 @@ variant ssl conflicts gnutls description {SSL support via OpenSSL} {
 }
 
 variant metalink description {Metalink support} {
-    configure.args-append   --with-metalink
+    configure.args-replace  --without-metalink --with-metalink
     depends_lib-append      port:gpgme \
                             port:libmetalink
 }

--- a/net/wget/Portfile
+++ b/net/wget/Portfile
@@ -7,7 +7,7 @@ PortGroup               perl5 1.0
 
 name                    wget
 version                 1.25.0
-revision                0
+revision                1
 
 checksums               rmd160  39e268af49675a252706ca972b42b75cc73260fe \
                         sha256  19225cc756b0a088fc81148dc6a40a0c8f329af7fd8483f1c7b2fe50f4e08a1f \
@@ -51,7 +51,6 @@ configure.args          --enable-option-checking \
                         --enable-xattr \
                         --without-ssl \
                         --with-zlib \
-                        --with-metalink \
                         --without-cares \
                         --with-libiconv-prefix=${prefix} \
                         --with-libintl-prefix=${prefix} \
@@ -72,10 +71,8 @@ depends_test            port:p${perl5.major}-libwww-perl \
                         port:p${perl5.major}-io-socket-ssl
 
 depends_lib             port:gettext-runtime \
-                        port:gpgme \
                         port:libiconv \
                         port:libidn2 \
-                        port:libmetalink \
                         port:libproxy \
                         port:libpsl \
                         port:libunistring \
@@ -114,6 +111,12 @@ variant ssl conflicts gnutls description {SSL support via OpenSSL} {
 
     configure.args-replace  --without-ssl --with-ssl=openssl
     configure.args-append   --with-libssl-prefix=[openssl::install_area]
+}
+
+variant metalink description {Metalink support} {
+    configure.args-append   --with-metalink
+    depends_lib-append      port:gpgme \
+                            port:libmetalink
 }
 
 if {![variant_isset ssl]} {


### PR DESCRIPTION
In order to reduce the dependencies of wget, make metalink support optional via a variant. Currently, wget is the only port that depends on libmetalink and metalink support is disable on most Linux distributions in wget and curl.

Re: https://trac.macports.org/ticket/69601

Closes: https://trac.macports.org/ticket/71523

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1.1 24B91 x86_64
Command Line Tools 16.1.0.0.1.1729049160

macOS 15.0.1 24A348 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
