### PR TITLE
ruby-build: Update to 20241213

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20241105 v
+github.setup        rbenv ruby-build 20241213 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  abccf0fabbb1d847eb30182fc574e4b814ef736c \
-                    sha256  5023c0225249b409e5936c70ae5c7cebe731566da686d6fbe3f7f5b09d6323ef \
-                    size    93112
+checksums           rmd160  472587c7af068de051e3d6eb22ad6b91927ccf89 \
+                    sha256  029128f1e6f7955354064fa5338d3afc7a33dab529986792f219c2d5266ab261 \
+                    size    93348
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20241213

##### Tested on

macOS 15.1.1 24B2091 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
