### PR TITLE
scamper: Define AI_NUMERICSERV where needed

### DIFF
--- a/net/scamper/Portfile
+++ b/net/scamper/Portfile
@@ -31,3 +31,4 @@ depends_lib-append  path:lib/liblzma.dylib:xz \
                     path:lib/libbz2.dylib:bzip2
 
 patchfiles          opt.patch
+patchfiles-append   define-ai-numericserv.patch

--- a/net/scamper/files/define-ai-numericserv.patch
+++ b/net/scamper/files/define-ai-numericserv.patch
@@ -1,0 +1,19 @@
+Fix:
+
+scamper_control.c:3801: error: ‘AI_NUMERICSERV’ undeclared (first use in this function)
+
+From: https://github.com/macports/macports-legacy-support/blob/v1.3.0/include/netdb.h#L23
+===================================================================
+--- scamper/scamper_control.c	2024-08-17 22:11:05.000000000 +0000
++++ scamper/scamper_control.c	2024-12-14 05:01:54.867327356 +0000
+@@ -65,6 +65,10 @@
+ #include "host/scamper_host_do.h"
+ #endif
+ 
++#ifndef AI_NUMERICSERV
++#define AI_NUMERICSERV 0x00001000
++#endif
++
+ #define REMOTE_HDRLEN 10
+ 
+ /*


### PR DESCRIPTION
#### Description

Define `AI_NUMERICSERV` where needed to fix building on < 10.7. Originally, this PR addressed  [this Trac ticket](https://trac.macports.org/ticket/71519), but was rudely superseeded.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
