### PR TITLE
libvpx*: fix patch which fails to apply after update

### DIFF
--- a/multimedia/libvpx-devel/Portfile
+++ b/multimedia/libvpx-devel/Portfile
@@ -37,11 +37,9 @@ fetch.type          git
 git.url             https://chromium.googlesource.com/webm/${my_name}
 git.branch          v${version}
 
-# upstream support for non-intel archs removed in version 1.5.0
-supported_archs     x86_64 i386 arm64 ppc ppc64
-
 patchfiles-append   patch-Makefile.diff
 patchfiles-append   patch-configure.sh.diff
+patchfiles-append   patch-vpx_ports.diff
 
 # requires c++11 https://trac.macports.org/ticket/67038
 compiler.cxx_standard 2011
@@ -56,7 +54,7 @@ conflicts_build     gtest
 # Also blacklist clang 8, due to issues like:
 #   error: use of undeclared identifier 'abs'
 compiler.blacklist-append \
-                    {*gcc-[3-4].*} {clang < 900} {macports-clang-3.*}
+                    {clang < 900} {macports-clang-3.*}
 
 # As of 1.7.0: builds both static and shared libraries
 # doesn't install docs or examples correctly, so disable them.
@@ -74,19 +72,12 @@ configure.args-append \
                     --enable-vp9-highbitdepth
 
 platform darwin {
-    if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
-        # disable a wrong kind of abi
-        patchfiles-append      patch-vpx_ports.diff
-        # with shared enabled the build no longer fails
-        configure.args-append  --enable-shared
-    } else {
-        configure.args-append  --enable-shared
-    }
+    configure.args-append   --enable-shared
 }
 
 platform darwin 8 {
-    depends_build-append  port:gmake
-    build.cmd             ${prefix}/bin/gmake
+    depends_build-append    port:gmake
+    build.cmd               ${prefix}/bin/gmake
 
     # Tiger Intel has some unique restrictions https://trac.macports.org/ticket/67041
     if {${configure.build_arch} in {i386 x86_64}} {

--- a/multimedia/libvpx-devel/files/patch-vpx_ports.diff
+++ b/multimedia/libvpx-devel/files/patch-vpx_ports.diff
@@ -2,18 +2,17 @@
 
 --- vpx_ports/vpx_ports.mk.orig	2021-10-07 01:41:19.000000000 +0800
 +++ vpx_ports/vpx_ports.mk	2022-04-24 17:38:34.000000000 +0800
-@@ -39,8 +39,10 @@
- PORTS_SRCS-$(VPX_ARCH_ARM) += arm_cpudetect.c
+@@ -43,8 +43,8 @@
+ PORTS_SRCS-$(VPX_ARCH_ARM) += arm_cpudetect.h
  PORTS_SRCS-$(VPX_ARCH_ARM) += arm.h
  
-+ifeq ($(VPX_ARCH_PPC64LE),yes)
- PORTS_SRCS-$(VPX_ARCH_PPC) += ppc_cpudetect.c
- PORTS_SRCS-$(VPX_ARCH_PPC) += ppc.h
-+endif
+-PORTS_SRCS-$(VPX_ARCH_PPC) += ppc_cpudetect.c
+-PORTS_SRCS-$(VPX_ARCH_PPC) += ppc.h
++PORTS_SRCS-$(VPX_ARCH_PPC64LE) += ppc_cpudetect.c
++PORTS_SRCS-$(VPX_ARCH_PPC64LE) += ppc.h
  
  PORTS_SRCS-$(VPX_ARCH_MIPS) += mips_cpudetect.c
  PORTS_SRCS-$(VPX_ARCH_MIPS) += mips.h
-
 
 --- vp8/common/generic/systemdependent.c.orig	2021-10-07 01:41:19.000000000 +0800
 +++ vp8/common/generic/systemdependent.c	2022-04-24 18:03:19.000000000 +0800
@@ -26,13 +25,3 @@
  #include "vpx_ports/ppc.h"
  #elif VPX_ARCH_MIPS
  #include "vpx_ports/mips.h"
-@@ -96,7 +96,7 @@
-   ctx->cpu_caps = arm_cpu_caps();
- #elif VPX_ARCH_X86 || VPX_ARCH_X86_64
-   ctx->cpu_caps = x86_simd_caps();
--#elif VPX_ARCH_PPC
-+#elif VPX_ARCH_PPC64LE
-   ctx->cpu_caps = ppc_simd_caps();
- #elif VPX_ARCH_MIPS
-   ctx->cpu_caps = mips_cpu_caps();
-

--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -37,11 +37,9 @@ fetch.type          git
 git.url             https://chromium.googlesource.com/webm/${my_name}
 git.branch          v${version}
 
-# upstream support for non-intel archs removed in version 1.5.0
-supported_archs     x86_64 i386 arm64 ppc ppc64
-
 patchfiles-append   patch-Makefile.diff
 patchfiles-append   patch-configure.sh.diff
+patchfiles-append   patch-vpx_ports.diff
 
 # requires c++11 https://trac.macports.org/ticket/67038
 compiler.cxx_standard 2011
@@ -56,7 +54,7 @@ conflicts_build     gtest
 # Also blacklist clang 8, due to issues like:
 #   error: use of undeclared identifier 'abs'
 compiler.blacklist-append \
-                    {*gcc-[3-4].*} {clang < 900} {macports-clang-3.*}
+                    {clang < 900} {macports-clang-3.*}
 
 # As of 1.7.0: builds both static and shared libraries
 # doesn't install docs or examples correctly, so disable them.
@@ -74,19 +72,12 @@ configure.args-append \
                     --enable-vp9-highbitdepth
 
 platform darwin {
-    if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
-        # disable a wrong kind of abi
-        patchfiles-append      patch-vpx_ports.diff
-        # with shared enabled the build no longer fails
-        configure.args-append  --enable-shared
-    } else {
-        configure.args-append  --enable-shared
-    }
+    configure.args-append   --enable-shared
 }
 
 platform darwin 8 {
-    depends_build-append  port:gmake
-    build.cmd             ${prefix}/bin/gmake
+    depends_build-append    port:gmake
+    build.cmd               ${prefix}/bin/gmake
 
     # Tiger Intel has some unique restrictions https://trac.macports.org/ticket/67041
     if {${configure.build_arch} in {i386 x86_64}} {

--- a/multimedia/libvpx/files/patch-vpx_ports.diff
+++ b/multimedia/libvpx/files/patch-vpx_ports.diff
@@ -2,18 +2,17 @@
 
 --- vpx_ports/vpx_ports.mk.orig	2021-10-07 01:41:19.000000000 +0800
 +++ vpx_ports/vpx_ports.mk	2022-04-24 17:38:34.000000000 +0800
-@@ -39,8 +39,10 @@
- PORTS_SRCS-$(VPX_ARCH_ARM) += arm_cpudetect.c
+@@ -43,8 +43,8 @@
+ PORTS_SRCS-$(VPX_ARCH_ARM) += arm_cpudetect.h
  PORTS_SRCS-$(VPX_ARCH_ARM) += arm.h
  
-+ifeq ($(VPX_ARCH_PPC64LE),yes)
- PORTS_SRCS-$(VPX_ARCH_PPC) += ppc_cpudetect.c
- PORTS_SRCS-$(VPX_ARCH_PPC) += ppc.h
-+endif
+-PORTS_SRCS-$(VPX_ARCH_PPC) += ppc_cpudetect.c
+-PORTS_SRCS-$(VPX_ARCH_PPC) += ppc.h
++PORTS_SRCS-$(VPX_ARCH_PPC64LE) += ppc_cpudetect.c
++PORTS_SRCS-$(VPX_ARCH_PPC64LE) += ppc.h
  
  PORTS_SRCS-$(VPX_ARCH_MIPS) += mips_cpudetect.c
  PORTS_SRCS-$(VPX_ARCH_MIPS) += mips.h
-
 
 --- vp8/common/generic/systemdependent.c.orig	2021-10-07 01:41:19.000000000 +0800
 +++ vp8/common/generic/systemdependent.c	2022-04-24 18:03:19.000000000 +0800
@@ -26,13 +25,3 @@
  #include "vpx_ports/ppc.h"
  #elif VPX_ARCH_MIPS
  #include "vpx_ports/mips.h"
-@@ -96,7 +96,7 @@
-   ctx->cpu_caps = arm_cpu_caps();
- #elif VPX_ARCH_X86 || VPX_ARCH_X86_64
-   ctx->cpu_caps = x86_simd_caps();
--#elif VPX_ARCH_PPC
-+#elif VPX_ARCH_PPC64LE
-   ctx->cpu_caps = ppc_simd_caps();
- #elif VPX_ARCH_MIPS
-   ctx->cpu_caps = mips_cpu_caps();
-


### PR DESCRIPTION
#### Description

Fix the build broken by a patch not being rebased. Apply it unconditionally (it only deals with powerpc).
Drop some unneeded stuff in the portfile like redundant blacklisting and duplicate configure args.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
