### PR TITLE
pacparser: fix build with Xcode gcc

### DIFF
--- a/net/pacparser/Portfile
+++ b/net/pacparser/Portfile
@@ -2,8 +2,9 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
-github.setup        pacparser pacparser 1.4.5 v
+github.setup        manugarg pacparser 1.4.5 v
 github.tarball_from archive
 revision            0
 
@@ -19,6 +20,12 @@ checksums           rmd160  941b9aa469ce95cd4da79f76ff306ca1e63762f1 \
                     sha256  fac205f41d000e245519244dc3e730e649a0ac1c61b5f2d1d0660056e1680b2d \
                     size    905331
 
-use_configure       no
 worksrcdir          ${worksrcpath}/src
+
+# https://github.com/manugarg/pacparser/issues/211
+if {[string match *gcc-4.* ${configure.compiler}]} {
+    build.cmd-prepend \
+                    CFLAGS=-std=c99
+}
+
 destroot.args       PREFIX=${destroot}${prefix}


### PR DESCRIPTION
#### Description

Fix build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
