### PR TITLE
nxcomp: Restore old 'VERSION' move behavior

### DIFF
--- a/net/nxcomp/Portfile
+++ b/net/nxcomp/Portfile
@@ -35,7 +35,7 @@ depends_build-append    path:bin/pkg-config:pkgconfig
 
 configure.args-append   --disable-silent-rules
 
-post-patch {
+post-configure {
     # Avoid errors like
     # In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/ostream:142:
     # ../version:1:1: error: expected unqualified-id
@@ -45,7 +45,7 @@ post-patch {
 
 
 if {${name} eq ${subport}} {
-    revision            2
+    revision            3
 
     depends_lib-append  port:libpng \
                         path:include/turbojpeg.h:libjpeg-turbo \
@@ -63,7 +63,7 @@ if {${name} eq ${subport}} {
 }
 
 subport nxproxy {
-    revision            0
+    revision            1
 
     description         nxproxy is a compressing proxy for X
     long_description    nxproxy is a library compressing X commands to be passed over network \


### PR DESCRIPTION
#### Description

This restores old behavior where VERSION file was move at "pre-build" time, rather than "post-patch". VERSION is used to fill in version number. It's currently broken and version ends up being "0.0.0.0".

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.7.2 23H311 arm64

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
