### PR TITLE
weechat: fix libcjson dependency spec

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
 version             4.4.3
-revision            0
+revision            1
 checksums           rmd160  e4d6451236846719acf3e9e5805b9609ae7fcb51 \
                     sha256  295612f8dc24af28c918257d3014eb53342a5d077d5e3d9a3eadf303bd8febfa \
                     size    2730188
@@ -44,13 +44,13 @@ maintainers         {acm.org:cardi @cardi} openmaintainer
 depends_build-append \
                     port:asciidoctor \
                     port:docbook-xsl-nons \
-                    port:libcjson \
                     port:libxslt \
                     path:bin/pkg-config:pkgconfig
 
 depends_lib-append  port:curl \
                     port:gettext \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
+                    port:libcjson \
                     port:libgcrypt \
                     port:libiconv \
                     port:ncurses


### PR DESCRIPTION
#### Description
```
Could not open /opt/local/lib/libcjson.1.dylib: Error opening or reading file (referenced from /opt/local/lib/weechat/plugins/relay.so)
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2 24C101 x86_64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
