### PR TITLE
nxcomp: Reorganize so patch.dir is top-level dir

### DIFF
--- a/net/nxcomp/Portfile
+++ b/net/nxcomp/Portfile
@@ -24,9 +24,13 @@ long_description        nxcomp is a library compressing X commands to be passed 
 homepage                https://wiki.x2go.org/doku.php/wiki:libs:nx-libs
 master_sites            https://code.x2go.org/releases/source/nx-libs/
 distname                nx-libs-${version}-lite
+worksrcdir              nx-libs-${version}
+patch.dir               ${workpath}/${worksrcdir}
+worksrcdir              ${worksrcdir}/${subport}
 
 universal_variant       yes
 
+# We are patching Makefile.am.
 use_autoreconf          yes
 # https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
 configure.checks.implicit_function_declaration.whitelist-append strchr
@@ -40,6 +44,8 @@ post-patch {
     # In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/ostream:142:
     # ../version:1:1: error: expected unqualified-id
     # 3.5.99.22
+    # https://github.com/ArcticaProject/nx-libs/issues/1086
+    # The VERSION file must not be moved until after the configure phase.
     move ${worksrcpath}/VERSION ${worksrcpath}/VERSION.txt
 }
 
@@ -51,8 +57,6 @@ if {${name} eq ${subport}} {
                         path:include/turbojpeg.h:libjpeg-turbo \
                         port:zlib \
                         port:xorg-xorgproto
-
-    worksrcdir          nx-libs-${version}/nxcomp
 
     patchfiles-append   bind.patch
 
@@ -72,8 +76,6 @@ subport nxproxy {
     installs_libs       no
 
     depends_lib-append  port:nxcomp
-
-    worksrcdir          nx-libs-${version}/nxproxy
 
     patchfiles-append   patch-nxproxy_src_Makefile.am-use-system-libXcomp.diff
 

--- a/net/nxcomp/files/bind.patch
+++ b/net/nxcomp/files/bind.patch
@@ -3,8 +3,8 @@ Fix:
 Loop.cpp:4224:34: error: invalid operands to binary expression ('__bind<int &, sockaddr *&, unsigned int &>' and 'int')
 
 https://github.com/ArcticaProject/nx-libs/issues/1044
---- src/Loop.cpp.orig	2019-08-27 08:46:39.000000000 -0500
-+++ src/Loop.cpp	2024-11-22 20:22:54.000000000 -0600
+--- nxcomp/src/Loop.cpp.orig	2019-08-27 08:46:39.000000000 -0500
++++ nxcomp/src/Loop.cpp	2024-11-22 20:22:54.000000000 -0600
 @@ -4221,7 +4221,7 @@
        goto SetupSocketError;
      }

--- a/net/nxcomp/files/patch-nxproxy_src_Makefile.am-use-system-libXcomp.diff
+++ b/net/nxcomp/files/patch-nxproxy_src_Makefile.am-use-system-libXcomp.diff
@@ -1,5 +1,5 @@
---- src/Makefile.am.old	2019-04-23 12:04:41.000000000 +0200
-+++ src/Makefile.am	2019-04-23 12:08:02.000000000 +0200
+--- nxproxy/src/Makefile.am.orig	2019-04-23 12:04:41.000000000 +0200
++++ nxproxy/src/Makefile.am	2019-04-23 12:08:02.000000000 +0200
 @@ -9,7 +9,7 @@ nxproxy_SOURCES =					\
      $(NULL)
  


### PR DESCRIPTION
#### Description

This allows files in the top-level dir, like version.sh, to be patched, should the need arise.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
