### PR TITLE
tracker3: fix compiler choice

### DIFF
--- a/gnome/tracker3/Portfile
+++ b/gnome/tracker3/Portfile
@@ -70,7 +70,9 @@ depends_lib-append  port:avahi \
 # src/tracker/tracker-main.c:29:10: fatal error: 'gio/gdesktopappinfo.h' file not found
 require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 x11
 
-compiler.c_standard     1999
+# It does not build with C99 compiler.
+# tracker-sparql-grammar.h:496: error: redefinition of typedef ‘TrackerGrammarRule’
+compiler.c_standard 2011
 
 configure.args-append \
                     -Dbash_completion=false \


### PR DESCRIPTION
#### Description

Unbreak the build after https://github.com/macports/macports-ports/commit/49a25be1045bc2abc8857b953582c878756fcf04

The port does not need C++11, however it uses C11 features and fails to build with a C99 compiler.

P. S. @mohd-akram @kencu If you consider that the failure is not due to C11 being required, alternative fix would be to blacklist Xcode gcc, since MacPorts considers it to be C99-capable, and it fails to build this port. So what we have now is wrong in any case.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
