### PR TITLE
jpeg-quantsmooth: fix build with gcc and for ppc

### DIFF
--- a/graphics/jpeg-quantsmooth/Portfile
+++ b/graphics/jpeg-quantsmooth/Portfile
@@ -27,6 +27,10 @@ compiler.blacklist-append \
 depends_lib-append  port:libjpeg-turbo
 
 patchfiles-append   patch-dynamic.patch
+
+# See: https://github.com/ilyakurdyukov/jpeg-quantsmooth/pull/31
+patchfiles-append   patch-Makefile.patch
+
 post-patch {
     reinplace "s|LDFLAGS :=|LDFLAGS ?=|g" Makefile
     reinplace "s|CFLAGS :=|CFLAGS ?=|g" Makefile
@@ -35,10 +39,12 @@ post-patch {
     }
 }
 
-configure.cflags-append \
+if {[string match *clang* ${configure.compiler}]} {
+    configure.cflags-append \
                     -I${prefix}/include/libomp
-configure.ldflags-append \
+    configure.ldflags-append \
                     -L${prefix}/lib/libomp
+}
 
 destroot {
     xinstall -m 755 ${worksrcpath}/jpegqs ${destroot}${prefix}/bin

--- a/graphics/jpeg-quantsmooth/files/patch-Makefile.patch
+++ b/graphics/jpeg-quantsmooth/files/patch-Makefile.patch
@@ -1,0 +1,40 @@
+diff --git a/Makefile b/Makefile
+index 97c9461..cbc7c4e 100644
+--- Makefile
++++ Makefile
+@@ -25,10 +25,10 @@ SIMDOBJ := jpegqs_base.o jpegqs_sse2.o jpegqs_avx2.o jpegqs_avx512.o
+ else ifeq ($(SIMD),none)
+ SIMDFLG := -DNO_SIMD
+ else ifeq ($(SIMD),native)
+-ifneq (,$(filter arm% aarch64,$(ARCH)))
+-SIMDFLG := -mcpu=native
++ifneq (,$(filter arm% aarch64 ppc% Power\ Macintosh,$(ARCH)))
++SIMDFLG := -mcpu=native -mtune=native
+ else
+-SIMDFLG := -march=native
++SIMDFLG := -march=native -mtune=native
+ endif
+ else ifeq ($(SIMD),avx512)
+ SIMDFLG := $(SIMD_AVX512)
+@@ -49,14 +49,20 @@ CFLAGS := -Wall -O2
+ ifneq (,$(filter e2k,$(ARCH)))
+ CFLAGS := $(filter-out -O2,$(CFLAGS)) -O3
+ endif
++OMPLINK :=
+ ifeq ($(OS),Darwin)
+ LDFLAGS := -Wl,-dead_strip
+ ifeq ($(LIBMINIOMP),)
+-LDFLAGS += -lomp
++ifneq (,$(filter gcc%,$(notdir $(CC))))
++OMPLINK := -lgomp
++else
++OMPLINK := -lomp
++endif
+ endif
+ else
+ LDFLAGS := -Wl,--gc-sections -s
+ endif
++LDFLAGS += $(OMPLINK)
+ 
+ CFLAGS_LIB := $(CFLAGS) $(MFLAGS) $(SIMDFLG)
+ CFLAGS_APP := $(CFLAGS_LIB) -Wextra -pedantic $(MTOPTS)


### PR DESCRIPTION
#### Description

Fix the build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
