### PR TITLE
qmmp: update to 0.12.20 for qt4

### DIFF
--- a/audio/qmmp/Portfile
+++ b/audio/qmmp/Portfile
@@ -15,13 +15,13 @@ long_description    {*}${description}
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     PortGroup       qt4 1.0
 
-    version         0.12.18
-    revision        1
+    version         0.12.20
+    revision        0
     set branch      [join [lrange [split ${version} .] 0 1] .]
 
-    checksums       rmd160  52f494a9df2dded4fbdd25a297b7247da847b792 \
-                    sha256  cd778a945ee0c5f334ef79aa3333354ff14492ffbf6aa9bc2848c6ee341a7f69 \
-                    size    1466561
+    checksums       rmd160  328cf0056717542c0bd94eea3a3872a77be7fc06 \
+                    sha256  b26192e7ed11df8aa6c2b86bc1a8d220e2a5a16e9f9cbc569ec97e89c6de5e4c \
+                    size    1461567
 
     patchfiles-append \
                     patch-CMakeLists.diff


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
