### PR TITLE
py-thinc and friends: drop unneeded hardcoding of archs

### DIFF
--- a/python/py-blis/Portfile
+++ b/python/py-blis/Portfile
@@ -15,8 +15,6 @@ checksums           rmd160  94337b4032e0fb0d7ab49d622a9b42f5c53c7335 \
                     sha256  6b13374cd4fd6493d583db2a5139c973c90818c9b59bbb572eb207325c3e5542 \
                     size    3914839
 
-supported_archs     arm64 x86_64
-
 license             MIT
 
 maintainers         {jonesc @cjones051073} openmaintainer

--- a/python/py-cymem/Portfile
+++ b/python/py-cymem/Portfile
@@ -14,8 +14,6 @@ checksums           rmd160  a6e885cb3aa1f251292f2cf91df7bc78a8fd47d8 \
                     sha256  556b8138234392fb632af3f332d09777a526a105fd42d464272e334169ea645e \
                     size    8371
 
-supported_archs     arm64 x86_64
-
 license             MIT
 
 maintainers         {jonesc @cjones051073} openmaintainer

--- a/python/py-murmurhash/Portfile
+++ b/python/py-murmurhash/Portfile
@@ -13,8 +13,6 @@ checksums           rmd160  b31b30e3e349394069f90bd0f0f193f4f9484910 \
                     sha256  62254b101542f4f715fbc8219ed0e53c0daa800e80de35b5c2a7663a48a2d0fb \
                     size    12422
 
-supported_archs     arm64 x86_64
-
 license             MIT
 
 maintainers         {jonesc @cjones051073} openmaintainer
@@ -26,7 +24,7 @@ long_description    {*}${description}
 github.livecheck.regex {([0-9.]+)}
 
 # Supported python versions
-python.versions     38 39 310 311 312
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-preshed/Portfile
+++ b/python/py-preshed/Portfile
@@ -13,8 +13,6 @@ checksums           rmd160  3e2cbb41215cd3906384df2608a945bcbbf5a249 \
                     sha256  11bb5368a045a8acebb661d30b5012c725c1543f59b56fc017eb1fc2a9dc9a32 \
                     size    15942
 
-supported_archs     arm64 x86_64
-
 license             MIT
 
 maintainers         {jonesc @cjones051073} openmaintainer

--- a/python/py-srsly/Portfile
+++ b/python/py-srsly/Portfile
@@ -14,8 +14,6 @@ checksums           rmd160  7cd493af5fbfa3b7f33967f56472f655bba50a4f \
                     sha256  5f6231c8735e2c537ed5c13884df61596f00762ca88362048aedeaa7c342f823 \
                     size    235404
 
-supported_archs     arm64 x86_64
-
 license             MIT
 
 maintainers         {jonesc @cjones051073} openmaintainer
@@ -34,6 +32,10 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
         port:py${python.version}-numpy
+
+    # objToJSON.c:122: error: ‘TypeContext’ has no member named ‘longValue’
+    compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 }
 
 # Exclude pre-release candidates

--- a/python/py-thinc/Portfile
+++ b/python/py-thinc/Portfile
@@ -15,8 +15,6 @@ checksums           rmd160  e5027c99aa760844dc82af5f2823866f18592f37 \
                     sha256  4ceb2a4f345a68f15efdf3d49dff0f8ceafc5bec74cfc48fdea597f8dadf2b63 \
                     size    1704272
 
-supported_archs     arm64 x86_64
-
 license             MIT
 
 maintainers         {jonesc @cjones051073} openmaintainer


### PR DESCRIPTION
#### Description

Also for `py-srsly` blacklist Xcode gcc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
