### PR TITLE
mvnd2: use rc version

### DIFF
--- a/java/mvnd2/Portfile
+++ b/java/mvnd2/Portfile
@@ -3,7 +3,9 @@
 PortSystem      1.0
 PortGroup select 1.0
 
-version         2.0.0-rc-1
+# Until 2.0.0 is released, use a version that sorts before 2.0.0
+version         1.9.9-rc1
+set real_version 2.0.0-rc-1
 revision        0
 name            mvnd2
 categories      java
@@ -33,7 +35,7 @@ long_description mvnd aims at providing faster Maven builds using techniques kno
 homepage        https://github.com/apache/maven-mvnd
 supported_archs x86_64 arm64
 
-master_sites    https://archive.apache.org/dist/maven/mvnd/${version}/
+master_sites    https://archive.apache.org/dist/maven/mvnd/${real_version}/
 
 depends_run     port:mvnd_select
 
@@ -43,12 +45,12 @@ select.group    mvnd
 select.file     ${filespath}/${name}
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname        maven-mvnd-${version}-darwin-amd64
+    distname        maven-mvnd-${real_version}-darwin-amd64
     checksums       rmd160  1bcfec599f9c73d709b53b36464e798d8f57eb4c \
                     sha256  4581214a672e649a2e5da55392911cd98f60d3e58d5763a953662696d06adf90 \
                     size    29864805
 } elseif {${configure.build_arch} eq "arm64"} {
-    distname        maven-mvnd-${version}-darwin-aarch64
+    distname        maven-mvnd-${real_version}-darwin-aarch64
     checksums       rmd160  7fcc2aa1ada75b6050a5417c31a47d9a064972be \
                     sha256  e0da84ae20d71af11c63846aeabb0ef134d575348613706fa17a26cfd8840004 \
                     size    29922827
@@ -78,4 +80,4 @@ destroot {
 }
 
 notes \
-"- To make mvnd $version the default, please run: sudo port select --set ${select.group} ${name}"
+"- To make mvnd ${real_version} the default, please run: sudo port select --set ${select.group} ${name}"


### PR DESCRIPTION
#### Description

Until 2.0.0 is out, use a version that sorts before 2.0.0.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a