### PR TITLE
micronaut: update to 4.7.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.7.1 v
+github.setup    micronaut-projects micronaut-starter 4.7.2 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  73d1a43860d3cc452df9741b201c2811ffe448a6 \
-                 sha256  5f674fb70129322dbf39d2bbe959510bf4c83568220b726e1d2a138068a7c090 \
-                 size    27586407
+    checksums    rmd160  ed8789eb62cf906c498792bb2842e6b64863b4b1 \
+                 sha256  b233d7b43daa8f7507cc671706f41b2b8a8447747da64907210d288b0d1ccd20 \
+                 size    27808583
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  1f86ced15c68870598a5f7c629a4cfdcb426a2d2 \
-                 sha256  c7ec0ca510d507cd2eb64d392e0d88f87ae08c8cdfe1c11a79b70607f82d24ba \
-                 size    27586978
+    checksums    rmd160  3672a9c1b6b864ca565e8d39f211e51ac473c6f1 \
+                 sha256  32d49afec4306a8cbe2f70dfeae3a3791daeec8ac8f702523370774da657b1b5 \
+                 size    27587409
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.7.2.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?