### PR TITLE
py-pydantic: provide rust-free version for old systems

### DIFF
--- a/python/py-pydantic/Portfile
+++ b/python/py-pydantic/Portfile
@@ -9,8 +9,6 @@ revision            0
 
 categories-append   devel
 license             MIT
-supported_archs     noarch
-platforms           {darwin any}
 
 python.versions     38 39 310 311 312
 
@@ -28,15 +26,42 @@ checksums           rmd160  d9447947fa61d3965d805276182060ca4461a1cb \
                     sha256  0c84efd9548d545f63ac0060c1e4d39bb9b14db8b3c0652338aecc07b5adec52 \
                     size    714127
 
+set pydantic_darwin_min_ver 13
+
 if {${name} ne ${subport}} {
-    python.pep517_backend \
+    if {${os.platform} eq "darwin" && ${os.major} < ${pydantic_darwin_min_ver}} {
+        # Notice, this is not a version peg, as of now;
+        # branch 1.x is still being updated.
+        version     1.10.19
+        revision    0
+        checksums   rmd160  1c8d836cd6a55e6fe4f2262fe483cc7b47af4901 \
+                    sha256  fea36c2065b7a1d28c6819cc2e93387b43dd5d3cf5a1e82d8132ee23f36d1f10 \
+                    size    355208
+
+        depends_build-append \
+                    port:py${python.version}-cython-compat \
+                    port:py${python.version}-pythran
+
+        set compat_path     [string replace ${python.pkgd} 0 [string length ${python.prefix}]-1 ${prefix}/lib/py${python.version}-cython-compat]
+        build.env-append    PYTHONPATH=${compat_path}
+
+        livecheck.type      none
+
+    } else {
+        supported_archs     noarch
+        platforms           {darwin any}
+
+        python.pep517_backend \
                     hatch
 
-    depends_build-append \
+        depends_build-append \
                     port:py${python.version}-hatch-fancy-pypi-readme
 
-    depends_run-append \
+        depends_run-append \
                     port:py${python.version}-annotated_types \
-                    port:py${python.version}-pydantic_core \
+                    port:py${python.version}-pydantic_core
+    }
+
+    depends_run-append \
                     port:py${python.version}-typing_extensions
 }


### PR DESCRIPTION
#### Description

Provide rust-free version for legacy systems

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
