### PR TITLE
opencascade: Stop using DYLD_LIBRARY_PATH

### DIFF
--- a/science/opencascade/Portfile
+++ b/science/opencascade/Portfile
@@ -24,6 +24,7 @@ checksums                   rmd160  88033cfe653f3d18feb41c7e0225ec31fd613104 \
                             size    48431454
 
 patchfiles-append           patch-CMakeLists.txt.diff \
+                            patch-env.sh.diff \
                             patch-env.sh.in.diff
 
 # Remove at release 7.9.0 or later.  Was fixed upstream.

--- a/science/opencascade/files/patch-env.sh.diff
+++ b/science/opencascade/files/patch-env.sh.diff
@@ -1,0 +1,13 @@
+--- adm/templates/env.sh.orig	2023-12-26 01:37:59
++++ adm/templates/env.sh	2024-12-12 22:43:16
+@@ -206,10 +206,6 @@
+ fi
+ 
+ export PATH="${CSF_OCCTBinPath}:${PATH}"
+-export LD_LIBRARY_PATH="${CSF_OCCTLibPath}:${LD_LIBRARY_PATH}"
+-if [ "$WOKSTATION" == "mac" ]; then
+-  export DYLD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${DYLD_LIBRARY_PATH}"
+-fi
+ 
+ # Set envoronment variables used by OCCT
+ export CSF_LANGUAGE="us"


### PR DESCRIPTION
#### Description

* Stop using DYLD_LIBRARY_PATH
* Also stop using LD_LIBRARY_PATH.
* May fix builds on older systems.

Closes: https://trac.macports.org/ticket/70235

###### Type(s)

- [x] bugfix

###### Tested on

CI Only.  OS 13, 14, 15.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?