### PR TITLE
mise: Update to 2024.12.11

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.12.10 v
+github.setup        jdx mise 2024.12.11 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f24dd0937b05dcb018639c808393e04f5dc9ec08 \
-                    sha256  f724379119f69b056aafec6eda5faf58db1d11c9ae333cdbcdbd4e7c556a965c \
-                    size    4116482
+                    rmd160  30da7ee9f1518fb2dad7b1170c8bfa21036111dc \
+                    sha256  059ae28e362993ea18df9edc0434c9bbda6abf3bab81b61447c462199acee63a \
+                    size    4128479
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -88,7 +88,11 @@ cargo.crates \
     addr2line                       0.21.0  8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
     adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
+    aead                             0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
     aes                              0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
+    aes-gcm                         0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
+    age                             0.10.0  edeef7d7b199195a2d7d7a8155d2d04aee736e60c5c7bdd7097d115369a8817d \
+    age-core                        0.10.0  a5f11899bc2bbddd135edbc30c36b1924fa59d0746bb45beb5933fafe3fe509b \
     ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
@@ -108,8 +112,11 @@ cargo.crates \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
+    base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     base64ct                         1.6.0  8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b \
+    basic-toml                       0.1.9  823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8 \
+    bech32                           0.9.1  d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445 \
     beef                             0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
     binstall-tar                    0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
     bit-set                          0.6.0  f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f \
@@ -130,6 +137,8 @@ cargo.crates \
     cc                               1.2.4  9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
+    chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
+    chacha20poly1305                0.10.1  10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35 \
     chrono                          0.4.39  7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825 \
     chrono-tz                        0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
@@ -152,6 +161,8 @@ cargo.crates \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     constant_time_eq                 0.3.1  7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6 \
     contracts                        0.6.3  f1d1429e3bd78171c65aa010eabcdf8f863ba3254728dbfb0ad4b1545beac15c \
+    convert_case                     0.4.0  6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e \
+    cookie-factory                   0.3.3  9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2 \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
     core-foundation                 0.10.0  b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
@@ -160,24 +171,32 @@ cargo.crates \
     crc                              3.2.1  69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636 \
     crc-catalog                      2.4.0  19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
-    crossbeam-channel               0.5.13  33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2 \
-    crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
+    crossbeam-channel               0.5.14  06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471 \
+    crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
+    crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
     crossterm                       0.28.1  829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6 \
     crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     ctor                             0.2.9  32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501 \
+    ctr                              0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
+    darling                        0.20.10  6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989 \
+    darling_core                   0.20.10  95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5 \
+    darling_macro                  0.20.10  d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806 \
+    dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
     demand                           1.5.0  32fc891cc4764e78af29352555c5b837c62a863ebde041f97bd232de926b552c \
     der                              0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
+    derive_more                    0.99.18  5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce \
     deunicode                        1.6.0  339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00 \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    directories                      5.0.1  9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35 \
+    dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     document-features               0.2.10  cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0 \
     dotenvy                         0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
@@ -203,23 +222,32 @@ cargo.crates \
     fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     filetime_creation                0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
+    find-crate                       0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
     flate2                          1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
+    fluent                          0.16.1  bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a \
+    fluent-bundle                   0.15.3  7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493 \
+    fluent-langneg                  0.13.0  2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94 \
+    fluent-syntax                   0.11.1  2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fsio                             0.4.0  dad0ce30be0cc441b325c5d705c8b613a0ca0d92b6a8953d41bd236dc09a36d0 \
     fslock                           0.2.1  04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb \
+    futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
     futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
     futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
+    futures-executor                0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
     futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
+    futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
     futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
     futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
     futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
     fuzzy-matcher                    0.3.7  54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
+    ghash                            0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
     git2                            0.19.0  b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724 \
     glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
@@ -232,6 +260,8 @@ cargo.crates \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
+    hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
+    hkdf                            0.12.4  7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7 \
     hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
     homedir                          0.3.4  5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2 \
@@ -245,6 +275,10 @@ cargo.crates \
     hyper-rustls                    0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
     hyper-tls                        0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                      0.1.10  df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4 \
+    i18n-config                      0.4.7  8e88074831c0be5b89181b05e6748c4915f77769ecc9a4c372f88b169a8509c9 \
+    i18n-embed                      0.14.1  94205d95764f5bb9db9ea98fa77f89653365ca748e27161f5bbea2ffd50e459c \
+    i18n-embed-fl                    0.7.0  9fc1f8715195dffc4caddcf1cf3128da15fe5d8a137606ea8856c9300047d5a2 \
+    i18n-embed-impl                  0.8.4  0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2 \
     iana-time-zone                  0.1.61  235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
@@ -257,9 +291,12 @@ cargo.crates \
     icu_properties_data              1.5.0  67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569 \
     icu_provider                     1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
     icu_provider_macros              1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
+    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
+    impl-tools                      0.10.2  b4739bc9af85c18969eba5e4db90dbf26be140ff2e5628593693f18559e9e5fe \
+    impl-tools-lib                  0.11.0  798fe18a7e727001b30a029ab9cdd485afd325801d4df846f0bb5338b2986a2c \
     indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
     indexmap                         2.7.0  62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f \
@@ -267,6 +304,9 @@ cargo.crates \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inout                            0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
     insta                           1.41.1  7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8 \
+    intl-memoizer                    0.5.2  fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda \
+    intl_pluralrules                 7.0.2  078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972 \
+    io_tee                           0.1.1  4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304 \
     ipnet                           2.10.1  ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
@@ -323,10 +363,12 @@ cargo.crates \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
     once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
+    opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
     openssl                        0.10.68  6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5 \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
     openssl-sys                    0.9.104  45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741 \
+    option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     os-release                       0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
     os_pipe                          1.2.1  5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982 \
@@ -350,15 +392,21 @@ cargo.crates \
     phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
     phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
     phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
+    pin-project                      1.1.7  be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95 \
+    pin-project-internal             1.1.7  3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c \
     pin-project-lite                0.2.15  915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
     platforms                        3.5.0  d43467300237085a4f9e864b937cf0bc012cef7740be12be1a48b10d2c8a3701 \
+    poly1305                         0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
+    polyval                          0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
     portable-atomic                 1.10.0  280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
+    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro2                     1.0.92  37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0 \
@@ -373,6 +421,7 @@ cargo.crates \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                    0.5.8  03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834 \
+    redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
@@ -383,7 +432,11 @@ cargo.crates \
     rmp                             0.8.14  228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4 \
     rmp-serde                        1.3.0  52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
+    rops                             0.1.4  cd8e93012c1b06c4e7b1582d5a86e64311c8347b7feaf406bbf04bc1235e792b \
     rowan                          0.15.16  0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d \
+    rust-embed                       8.5.0  fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0 \
+    rust-embed-impl                  8.5.0  6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478 \
+    rust-embed-utils                 8.5.0  2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                       2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
@@ -396,13 +449,18 @@ cargo.crates \
     rustls-webpki                  0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
     rustversion                     1.0.18  0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248 \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
+    salsa20                         0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    scrypt                          0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
+    secrecy                          0.8.0  9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework               3.0.1  e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8 \
     security-framework-sys          2.12.1  fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
+    self_cell                       0.10.3  e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d \
+    self_cell                        1.1.0  c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe \
     self_update                     0.41.0  469a3970061380c19852269f393e74c0fe607a4e23d85267382cf25486aa8de5 \
     semver                          1.0.24  3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba \
     serde                          1.0.216  0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e \
@@ -410,8 +468,11 @@ cargo.crates \
     serde_derive                   1.0.216  46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e \
     serde_ignored                   0.1.10  a8e319a36d1b52126a0d608f24e93b2d81297091818cd70625fcf50a15d84ddf \
     serde_json                     1.0.133  c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377 \
+    serde_regex                      1.1.0  a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
+    serde_with                      3.11.0  8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817 \
+    serde_with_macros               3.11.0  9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d \
     serde_yaml           0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     sevenz-rust                      0.6.1  26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
@@ -435,6 +496,7 @@ cargo.crates \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
@@ -473,6 +535,7 @@ cargo.crates \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                    0.26.1  5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37 \
     tokio-util                      0.7.13  d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078 \
+    toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
     toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                      0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
@@ -484,6 +547,7 @@ cargo.crates \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber              0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
+    type-map                         0.5.0  deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f \
     typeid                           1.0.2  0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
     ubi                              0.2.4  62cddbea2772c6d00b7d951dfd3fd8ba39f2479219769f36fec91d29f2ee602d \
@@ -491,6 +555,8 @@ cargo.crates \
     unic-char-property               0.9.0  a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221 \
     unic-char-range                  0.9.0  0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc \
     unic-common                      0.9.0  80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc \
+    unic-langid                      0.9.5  23dd9d1e72a73b25e07123a80776aae3e7b0ec461ef94f9151eed6ec88005a44 \
+    unic-langid-impl                 0.9.5  0a5422c1f65949306c99240b81de9f3f15929f5a8bfe05bb44b034cc8bf593e5 \
     unic-segment                     0.9.0  e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23 \
     unic-ucd-segment                 0.9.0  2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700 \
     unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
@@ -498,6 +564,7 @@ cargo.crates \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
+    universal-hash                   0.5.1  fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea \
     unsafe-libyaml                  0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
@@ -541,21 +608,31 @@ cargo.crates \
     windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
     windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
     windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
     windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
     windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
     windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
     windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
     windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
     windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     winnow                          0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
+    x25519-dalek                     2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
     xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
     xx                               2.0.3  43e8a6586de03e05832a7e364b3b94fb86ae16bbaa881f3e7998c4e66c6b900f \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \


### PR DESCRIPTION
#### Description

mise: Update to 2024.12.11

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
