### PR TITLE
qt5*: fix build with ICU 76

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -220,7 +220,7 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtcharts {
@@ -355,7 +355,7 @@ array set modules {
         {"Qt Location" "Qt Positioning"}
         ""
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtlottie  {
@@ -711,7 +711,7 @@ array set modules {
         {"Qt WebKit" "Qt WebKit Widgets"}
         "community support only (use Qt WebEngine)"
         "variant overrides: "
-        "revision 7"
+        "revision 8"
         "License: "
     }
     qtwebkit-examples {
@@ -1395,6 +1395,10 @@ foreach {module module_info} [array get modules] {
             configure.universal_cxxflags
             configure.universal_cppflags
 
+            # ICU requires C++17
+            compiler.cxx_standard   2017
+            configure.args-append   QMAKE_CXXFLAGS_GNUCXX11=-std=c++17
+
             # configure script looks for perl but doesn't seem to use it for our configuration
 
             # configure script uses gawk if it can find it,
@@ -1588,6 +1592,10 @@ foreach {module module_info} [array get modules] {
 
                 # avoid unnecessary dependency on OpenSSL
                 configure.args-append "QMAKE_LIBS_OPENSSL="
+
+                # ICU requires C++17
+                compiler.cxx_standard   2017
+                configure.args-append   QMAKE_CXXFLAGS_CXX14=-std=c++17
             }
 
             # special case
@@ -1658,7 +1666,13 @@ foreach {module module_info} [array get modules] {
                     foreach test { glx libXcomposite libXrender } {
                         reinplace "s|return 0;|return 0;\\\n#error turn off test|g" ${worksrcpath}/Tools/qmake/config.tests/${test}/${test}.cpp
                     }
+                    reinplace "s|icu-i18n|icu-i18n icu-uc|g" ${worksrcpath}/Source/WTF/WTF.pri
+                    reinplace "s|auto_ptr|unique_ptr|g" ${worksrcpath}/Source/ThirdParty/ANGLE/src/compiler/preprocessor/MacroExpander.h
                 }
+
+                # ICU requires C++17
+                compiler.cxx_standard   2017
+                configure.args-append   QMAKE_CXXFLAGS=-Wno-error=register
             }
 
             # special case


### PR DESCRIPTION
###### Type(s)

- [x] bugfix

###### Tested on
macOS 15.1.1 24B2091 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?