### PR TITLE
colima: Update to 0.8.1

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.8.0 v
+go.setup            github.com/abiosoft/colima 0.8.1 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  6a9fcf6fd103b8cc7a3514b7a94bdf9cb4914424 \
-                    sha256  0040a1832a1e89cbffec9311382344546cb5965384bede079325dac8b2cbf4f0 \
-                    size    616094
+checksums           rmd160  d6e6900adee3c1bedf6cfc92efc7811cf2f35123 \
+                    sha256  9af9e1de6adc3590d852857e10c2846a167c331c40b6704fe71ac97b8bcda6ab \
+                    size    616994
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

colima: Update to 0.8.1

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
