### PR TITLE
mise: Update to 2024.12.12

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.12.11 v
+github.setup        jdx mise 2024.12.12 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  30da7ee9f1518fb2dad7b1170c8bfa21036111dc \
-                    sha256  059ae28e362993ea18df9edc0434c9bbda6abf3bab81b61447c462199acee63a \
-                    size    4128479
+                    rmd160  6716cfa5b3d8ce8fd714af0a4dc6d30a4392bd62 \
+                    sha256  0eeab8fbf1b25517d050776be89de35826ced39311596c8a09abec6d89fa1f4f \
+                    size    4133347
 
 patchfiles          patch-src_cli_self_update.diff
 


### PR DESCRIPTION
#### Description

mise: Update to 2024.12.12

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
