### PR TITLE
fitpack: update to 0.2.0

### DIFF
--- a/_resources/port1.0/group/fortran-1.0.tcl
+++ b/_resources/port1.0/group/fortran-1.0.tcl
@@ -17,7 +17,7 @@ depends_build-append \
 global os.platform os.arch os.major
 if {${os.major} < 14} {
 	# FPM uses Git to fetch modules. Put it here so that we do not keep getting failures.
-	depends_build-append    port:git
+	depends_build-append    path:bin/git:git
 	git.cmd                 ${prefix}/bin/git
 }
 

--- a/fortran/fitpack/Portfile
+++ b/fortran/fitpack/Portfile
@@ -3,9 +3,7 @@
 PortSystem          1.0
 PortGroup           fortran 1.0
 
-# Release tarball is incomplete
-github.setup        perazz fitpack 6b8e9c06d3123cfb9cf85a804c870a6701a583bb
-version             0.1.0
+github.setup        perazz fitpack 0.2.0
 revision            0
 categories-append   math
 license             BSD
@@ -15,9 +13,10 @@ long_description    This is a modern Fortran translation of the FITPACK package 
                     The functions are modernized and translated from the original Fortran 77 code FITPACK by Paul Dierckx. \
                     The starting code used the double precision version of FITPACK distributed with scipy. \
                     An object-oriented interface wrapper is also being built.
-checksums           rmd160  6ddff5e38965de9b59fec27160ce09c61360ffb6 \
-                    sha256  8959921abc2c9ea4b9ee0a1c07fe143e5dcc0b30e877d55c85df6fc5698375a5 \
-                    size    201478
+checksums           rmd160  840725a13aa7a4b3b76b3df4ecaedc62e02fb085 \
+                    sha256  0a3ff76a29bc0493c212c2ee4a016340af6a32933e5b29480b5dba851bf7135a \
+                    size    214508
+github.tarball_from archive
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Also allow git-devel.

_This PG uses gcc-13 presently, so it will fail on macOS 14, like in a case of R._

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
