### PR TITLE
tre: Update to 0.9.0

### DIFF
--- a/devel/tre/Portfile
+++ b/devel/tre/Portfile
@@ -1,25 +1,29 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                tre
-version             0.8.0
-revision            1
+github.setup        laurikari tre 0.9.0 v
+github.tarball_from releases
+revision            0
 categories          devel
-platforms           darwin
 maintainers         nomaintainer
 license             BSD
 conflicts           agrep glimpse
+
 description         TRE is a lightweight POSIX compliant regular expression library
-long_description    TRE is a lightweight POSIX compliant regular expression library
-homepage            http://laurikari.net/tre/
-master_sites        ${homepage}
-use_bzip2           yes
-checksums           md5     b4d3232593dadf6746f4727bdda20b41 \
-                    sha1    a41692e64b40ebae3cffe83931ddbf8420a10ae3 \
-                    rmd160  8031cc0c421dd0f473b4c98f49aef9805fa65b64
-depends_lib         port:gettext \
+long_description    {*}${description}.
+
+homepage            https://laurikari.net/tre/
+
+checksums           rmd160  5679f091936a3fee894f2feb95211aa8f5047386 \
+                    sha256  f57f5698cafdfe516d11fb0b71705916fe1162f14b08cf69d7cf86923b5a2477 \
+                    size    579986
+
+# See: https://lists.macports.org/pipermail/macports-dev/2021-December/044042.html
+depends_lib-append  port:gettext-runtime \
                     port:libiconv
+
 test.run            yes
 test.target         check
 
@@ -32,15 +36,10 @@ post-destroot {
     xinstall -d ${docdir}
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS \
-        ChangeLog \
         LICENSE \
         NEWS \
-        README \
+        README.md \
         THANKS \
         TODO \
         ${docdir}
 }
-
-livecheck.type      regex
-livecheck.url       [lindex ${master_sites} 0]download
-livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}


### PR DESCRIPTION
#### Description

Update `tre` to its latest released version, 0.9.0. This change dictatest an upstream change, [per this blog post by the author](https://laurikari.net/tre/tre-on-github/).

Before this update, this port didn't ship a statically-linked library along with a dynamically linked one. Unsure if that should be the case now (since its possible)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
