### PR TITLE
google-cloud-sdk: update to 504.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             503.0.0
+version             504.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  0115f86debd3610281a3265bd80d0ed12b1da58e \
-                    sha256  88e2800164a4cce08aba6f55dfac8a02fbcd0bbe3079b17373f0247f133174ca \
-                    size    53196393
+    checksums       rmd160  067f1c013d206a27868cfdeee3e70cfda5009a8d \
+                    sha256  fcb1f2dc7cbce5d009ebb0911c93777046978c31f01bbd8796dd5abdaa7eac9c \
+                    size    53223908
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  099dc7c030511e596a012b61c2dad538c20e57e6 \
-                    sha256  e4f9e2235889d489df512c1fec99dce19dacac2c1a72ff5021049f18dd652953 \
-                    size    54552005
+    checksums       rmd160  5c36a9297934f4cc935d68d3b619b0510899b69d \
+                    sha256  224b91085d4c5b35d9ca0e4158a73008ea18c7944f4c13ae4901f8a9fceddcf7 \
+                    size    54572129
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  72e9e09658f28872b4fcdd0810af0edb83f92993 \
-                    sha256  e879d56b20890e9ead5864c7b04fd55d5ed55de47b2e018cfb13b6736bb7191f \
-                    size    54497857
+    checksums       rmd160  66e6aa90fedd05cc8d82593f1eceb9b480711fd7 \
+                    sha256  a07991f255e6c47527f8aeefa3f29988eab4c0dfd32a7d8cde11075189bba95d \
+                    size    54518201
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -41,9 +41,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 
 worksrcdir          ${name}
 
-# Most recent supported Python version according to both
-# https://cloud.google.com/sdk/docs/install#mac and
-# https://cloud.google.com/storage/docs/gsutil_install#specifications
+# Most recent Python version that supports to both
+# glcoud (https://cloud.google.com/sdk/docs/install#mac) and
+# gsutil (https://cloud.google.com/storage/docs/gsutil_install#specifications)
 python.default_version 312
 
 post-patch {


### PR DESCRIPTION
#### Description

Update to Google Cloud 504.0.0.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?