### PR TITLE
osxphotos: update to 0.69.2

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.69.1
+version                 0.69.2
 revision                0
 
 categories              graphics python
@@ -25,9 +25,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  20e8f6147c6920942cb61a2e7f8a6c9f75b2e4d0 \
-                        sha256  27f066eee63cd08640445edc86b2a38deea2c17d0ff7c4ef52964473cfeba08b \
-                        size    2234560
+checksums               rmd160  93f49070fa4ff370101fcbb4da450acfcf431ee3 \
+                        sha256  ea6d431b9cea6ea4eede6079419e48a586149daca88937db121073e73306d47f \
+                        size    2234555
 
 python.default_version  313
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.69.2.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?