### PR TITLE
kakoune: fix install prefix, revbump

### DIFF
--- a/editors/kakoune/Portfile
+++ b/editors/kakoune/Portfile
@@ -7,7 +7,7 @@ PortGroup           makefile        1.0
 
 github.setup        mawww kakoune 2024.05.18 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://kakoune.org
 
@@ -43,6 +43,8 @@ platforms           darwin linux freebsd
 checksums           rmd160  9700c43f525a5b174368e0abe1f5ca2884456869 \
                     sha256  50f2920db8ab8f71556b73dfd6d53fb924f67d1c60b9882050cfecfaa3aed31f \
                     size    720073
+
+patchfiles-append   patch-fix-prefix.diff
 
 # error: 'uncaught_exceptions' is unavailable: introduced in macOS 10.12
 if {${os.platform} eq "darwin" && ${os.major} < 16} {

--- a/editors/kakoune/files/patch-fix-prefix.diff
+++ b/editors/kakoune/files/patch-fix-prefix.diff
@@ -1,0 +1,11 @@
+--- Makefile	2024-05-18 12:43:06.000000000 +0800
++++ Makefile	2024-12-18 20:48:21.000000000 +0800
+@@ -33,7 +33,7 @@
+ version = $(shell cat .version 2>/dev/null || git describe --tags HEAD 2>/dev/null | sed s/^v// || echo unknown)
+ version != cat .version 2>/dev/null || ( git describe --tags HEAD 2>/dev/null | sed s/^v// ) || echo unknown
+ 
+-PREFIX = /usr/local
++PREFIX ?= /usr/local
+ DESTDIR = # root dir
+ 
+ bindir = $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/71584

#### Description

Fix installation

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
