### PR TITLE
ffmpeg-devel: don't install in separate prefix

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -15,10 +15,10 @@ PortGroup           xcode_workaround 1.0
 
 name                ffmpeg-devel
 set my_name         ffmpeg
-conflicts           ffmpeg7
+conflicts           ffmpeg
 
 version             7.1
-revision            1
+revision            2
 epoch               2
 
 license             LGPL-2.1+
@@ -164,22 +164,11 @@ configure.cflags-append \
                     -Wno-deprecated-declarations \
                     ${configure.cppflags}
 
-set port_ver_major  [lindex [split ${version} .] 0]
-set port_alias      ${my_name}${port_ver_major}
-set port_prefix     ${prefix}/libexec/${port_alias}
-set port_bindir     ${port_prefix}/bin
-set port_sharedir   ${port_prefix}/share
+set port_sharedir   ${prefix}/share
 set port_docdir     ${port_sharedir}/doc
-set port_datadir    ${port_sharedir}/data
 
-configure.pre_args-delete \
-                    --prefix=${prefix}
 configure.pre_args-append \
-                    --cc="${configure.cc}" \
-                    --datadir=${port_datadir} \
-                    --docdir=${port_docdir} \
-                    --progs-suffix=${port_ver_major} \
-                    --prefix=${port_prefix}
+                    --cc="${configure.cc}"
 
 configure.args-append \
                     --disable-audiotoolbox \
@@ -411,22 +400,6 @@ post-destroot {
     foreach f [glob ${worksrcpath}/doc/*.txt] {
         file copy $f ${destroot}${port_docdir}
     }
-
-    # Create bin symlinks
-    if {![variant_isset no_symlink]} {
-        set port_bin_list \
-            [glob -type f -directory ${destroot}${port_bindir} *]
-        foreach f ${port_bin_list} {
-            set fname [file tail ${f}]
-            ui_info "Symlinking bin: ${prefix}/bin/${fname} -> ${port_bindir}/${fname}"
-            ln -s ${port_bindir}/${fname} ${destroot}${prefix}/bin/${fname}
-        }
-    }
-}
-
-variant no_symlink description {Disable binary suffices and symlinks} {
-    configure.pre_args-delete \
-                    --progs-suffix=${port_ver_major}
 }
 
 variant x11 {
@@ -581,22 +554,6 @@ This build of ${name} includes no GPLed or nonfree code and is therefore license
 "
 }
 
-notes-append ""
-if {[variant_isset no_symlink]} {
-    notes-append "
-    To use the ${name} command-line programs, add\
-    ${prefix}/libexec/ffmpeg${port_ver_major}/bin to your \$PATH,\
-    in front of the normal ${prefix}/bin; or else use full paths.
-    "
-}
-notes-append "
-To compile and link with ${name}, add\
--I${prefix}/libexec/ffmpeg${port_ver_major}/include and\
--L${prefix}/libexec/ffmpeg${port_ver_major}/lib to your compile command.
-For builds using pkg-config, add\
-${prefix}/libexec/ffmpeg${port_ver_major}/lib/pkgconfig to \$PKG_CONFIG_PATH.
-"
-
 livecheck.type      regex
 livecheck.url       ${master_sites}
-livecheck.regex     "${my_name}-(${port_ver_major}(?:\\.\\d+)*)${extract.suffix}"
+livecheck.regex     "${my_name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
#### Description

This restores the previous behavior of ffmpeg-devel.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?