### PR TITLE
spring-boot-cli: update to 3.4.1

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.4.0
+version         3.4.1
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  a15fcb0eb5a3a7feef4c2521c64e9b9da0003f45 \
-                sha256  cc73b59ff7db67c45af07f6f2266bc1317f6deeea725083338f01984b2f01b3e \
-                size    5720567
+checksums       rmd160  f77ce3c4a6ff92c8ef812ca24dae9fa91ed08f32 \
+                sha256  fc2d75a11bed64cd63b6c3bd7be727c4a781cd1348855e17f76ade516448ee38 \
+                size    5721870
 
 worksrcdir      spring-${version}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.4.1.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?