### PR TITLE
dagger: update to 0.15.1

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.13.6 v
+github.setup        dagger dagger 0.15.1 v
 github.tarball_from releases
 revision            0
 
@@ -13,26 +13,26 @@ license             Apache-2
 
 description         A portable devkit for CI/CD pipelines
 long_description    \
-    Using Dagger, software teams can develop powerful CICD pipelines with \
+    Using Dagger, software teams can develop powerful CI/CD pipelines with \
     minimal effort, then run them anywhere. Benefits include: \
-    \n- Unify dev and CI environments. Write your pipeline once, Dagger will \
+    \n- Unified dev and CI environments. Write your pipeline once, Dagger will \
     run it the same everywhere. \
-    \n- Reduce CI lock-in. No more re-writing everything from scratch every \
+    \n- Reduced CI lock-in. No more re-writing everything from scratch every \
     6 months.
 homepage            https://dagger.io
 
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  52915a02835031d49ab70e368d1fff8d0fdd8f52 \
-                            sha256  d956d2def964f92f08814c891478fa587f4ec8d5267b0169a4b0525f19e1fdc3 \
-                            size    11005335
+        checksums           rmd160  cab99c5c0762f524e42df80051078e3dc619920a \
+                            sha256  759156895c2076036837049aba208d185682b6be9e7a75bf91984fa2cb91ffbd \
+                            size    11258422
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  14b036c47c53911d0d50864370f6df5a5431f58a \
-                            sha256  1ca89e66f9ede8ca57ddeea2802691d3edda4837bbbaa073532941bf11f7516f \
-                            size    10386619
+        checksums           rmd160  f7c397dbc7c826ddf98ffbe043d5fbc64eb7b6b7 \
+                            sha256  d5f0f95690941b5845c1a4f60be8a3c8f79be18a786b6bd31354a587118cafa6 \
+                            size    10619160
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

upgrade to the current version: https://github.com/dagger/dagger/releases/tag/v0.15.1

###### Tested on
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
