### PR TITLE
llvm-devel: update to 20241219

### DIFF
--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -25,18 +25,18 @@ maintainers             {jeremyhu @jeremyhu} {jonesc @cjones051073} openmaintain
 # for devel
 PortGroup github        1.0
 
-set llvm-commit         6a0618a0289cb0c23ef3e5c820418650cc1d0fdc
-set date                20240308
+set llvm-commit         b0a4b5b35ab1951d0a4fa95ff58d96e902aa8b1e
+set date                20241219
 revision                0
 set llvm_version        devel
-set clang_exe_version   19
+set clang_exe_version   20
 github.setup            llvm llvm-project ${llvm-commit}
 version                 ${date}-[string range ${llvm-commit} 0 7]
 default_variants-append +assertions
 
-checksums               rmd160  004294eb7c8d2266a5198d542eaf0b7d6ae2a7b6 \
-                        sha256  742fb1f5aafd96d971a57055550b7e05c7cd9b58c6aced9e33b8bbd3f89eef75 \
-                        size    206891508
+checksums               rmd160  fc391a88985f8b67eaa5670f4ecfd7b919676221 \
+                        sha256  030a5b47c2423c660da726fbec1ce2d378d8d2b76ebd0935c8e5c7d2f1c767c2 \
+                        size    224499816
 
 # For release
 #set llvm_version        14

--- a/lang/llvm-devel/files/0002-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch
+++ b/lang/llvm-devel/files/0002-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch
@@ -1,22 +1,14 @@
 diff --git a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
-index 533f20535655..478232dc0ec8 100644
+index d2e60bb7f631..3b5366eb432f 100644
 --- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
 +++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
-@@ -287,12 +287,14 @@ bool AsmPrinter::doInitialization(Module &M) {
-   // alternative is duplicated code in each of the target asm printers that
+@@ -488,7 +488,8 @@ bool AsmPrinter::doInitialization(Module &M) {
    // use the directive, where it would need the same conditionalization
    // anyway.
--  const Triple &Target = TM.getTargetTriple();
--  Triple TVT(M.getDarwinTargetVariantTriple());
--  OutStreamer->emitVersionForTarget(
-+  if (MAI->useIntegratedAssembler()) {
-+    const Triple &Target = TM.getTargetTriple();
-+    Triple TVT(M.getDarwinTargetVariantTriple());
-+    OutStreamer->emitVersionForTarget(
-       Target, M.getSDKVersion(),
-       M.getDarwinTargetVariantTriple().empty() ? nullptr : &TVT,
-       M.getDarwinTargetVariantSDKVersion());
-+  }
- 
-   // Allow the target to emit any magic that it wants at the start of the file.
-   emitStartOfAsmFile(M);
+   const Triple &Target = TM.getTargetTriple();
+-  if (Target.isOSBinFormatMachO() && Target.isOSDarwin()) {
++  if (Target.isOSBinFormatMachO() && Target.isOSDarwin() &&
++      MAI->useIntegratedAssembler()) {
+     Triple TVT(M.getDarwinTargetVariantTriple());
+     OutStreamer->emitVersionForTarget(
+         Target, M.getSDKVersion(),

--- a/lang/llvm-devel/files/0007-Threading-Only-call-pthread_setname_np-if-we-have-it.patch
+++ b/lang/llvm-devel/files/0007-Threading-Only-call-pthread_setname_np-if-we-have-it.patch
@@ -1,26 +1,18 @@
-From af4b8f8987248e442faaad339261332e05e254b8 Mon Sep 17 00:00:00 2001
-Date: Sun, 16 May 2021 12:21:10 -0700
-Subject: [PATCH 07/24] Threading: Only call pthread_setname_np() if we have it
-
----
- llvm/lib/Support/Unix/Threading.inc | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/llvm/lib/Support/Unix/Threading.inc b/llvm/lib/Support/Unix/Threading.inc
-index 667d023fc134..8162c60b2cdd 100644
+index aedcd9aa34b9..8bdcedcfba08 100644
 --- a/llvm/lib/Support/Unix/Threading.inc
 +++ b/llvm/lib/Support/Unix/Threading.inc
-@@ -176,8 +176,10 @@ void llvm::set_thread_name(const Twine &Name) {
+@@ -193,11 +193,13 @@ void llvm::set_thread_name(const Twine &Name) {
    ::pthread_setname_np(::pthread_self(), "%s",
-     const_cast<char *>(NameStr.data()));
+                        const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
 +#if HAVE_PTHREAD_SETNAME_NP
    ::pthread_setname_np(NameStr.data());
+ #else
+   ::pthread_setname_np(::pthread_self(), NameStr.data());
+ #endif
  #endif
 +#endif
  }
  
  void llvm::get_thread_name(SmallVectorImpl<char> &Name) {
--- 
-2.21.1 (Apple Git-122.3)
-


### PR DESCRIPTION
#### Description

* update to commit b0a4b5b, date 20241219
* Changes patch 0002 because code has changed
* Changes patch 0007 because line numbers have changed

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
