### PR TITLE
ruff: Update to 0.8.4

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.8.3
+github.setup        astral-sh ruff 0.8.4
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  4a733eb38b3e57cd4f13df9f59d24de69a2cba55 \
-                    sha256  ff00bb1ca1a9de60aed3965d671c6a3d448a87a9016ba6d6b3a396760422bc25 \
-                    size    5548947
+                    rmd160  a29219042427d043de258de2342420672e48aedd \
+                    sha256  f48c9e2479e72957ce5dfd3d0cc9d27f5aeb36d15ae2f97c9c116fc5c742dc5d \
+                    size    5583531
 
 cargo.offline_cmd
 
@@ -90,7 +90,7 @@ cargo.crates \
     bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     boxcar                           0.2.7  7f839cdf7e2d3198ac6ca003fd8ebc61715755f41c1cad15ff13df67531e00ed \
-    bstr                            1.11.0  1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22 \
+    bstr                            1.11.1  786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8 \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
@@ -102,7 +102,7 @@ cargo.crates \
     cfg_aliases                      0.1.1  fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chic                             1.2.2  a5b5db619f3556839cb2223ae86ff3f9a09da2c5013be42bc9af08c9589bf70c \
-    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
+    chrono                          0.4.39  7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825 \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
@@ -117,7 +117,7 @@ cargo.crates \
     codspeed                         2.7.2  450a0e9df9df1c154156f4344f99d8f6f6e69d0fc4de96ef6e2e68b2ec3bce97 \
     codspeed-criterion-compat        2.7.2  8eb1a6cb9c20e177fde58cdef97c1c7c9264eb1424fe45c4fccedc2fb078a569 \
     colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
-    colored                          2.1.0  cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8 \
+    colored                          2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
     compact_str                      0.8.0  6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644 \
     console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
     console_error_panic_hook         0.1.7  a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc \
@@ -164,7 +164,7 @@ cargo.crates \
     errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
     etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
     fastrand                         2.1.1  e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6 \
-    fern                             0.7.0  69ff9c9d5fb3e6da8ac2f77ab76fe7e8087d512ce095200f8f29ac5b656cf6dc \
+    fern                             0.7.1  4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29 \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     flate2                          1.0.28  46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
@@ -224,7 +224,7 @@ cargo.crates \
     kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
     kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.167  09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc \
+    libc                           0.2.168  5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d \
     libcst                           1.5.1  fa3e60579a8cba3d86aa4a5f7fc98973cc0fd2ac270bf02f85a9bef09700b075 \
     libcst_derive                    1.4.0  a2ae40017ac09cd2c6a53504cb3c871c7f2b41466eac5bc66ba63f39073b467b \
     libmimalloc-sys                 0.1.39  23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44 \
@@ -327,9 +327,9 @@ cargo.crates \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
-    serde                          1.0.215  6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f \
+    serde                          1.0.216  0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e \
     serde-wasm-bindgen               0.6.5  8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b \
-    serde_derive                   1.0.215  ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0 \
+    serde_derive                   1.0.216  46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e \
     serde_derive_internals          0.29.0  330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3 \
     serde_json                     1.0.133  c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377 \
     serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
@@ -364,9 +364,9 @@ cargo.crates \
     test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
     thiserror                       1.0.67  3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd \
-    thiserror                        2.0.6  8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47 \
+    thiserror                        2.0.7  93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767 \
     thiserror-impl                  1.0.67  b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6 \
-    thiserror-impl                   2.0.6  d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312 \
+    thiserror-impl                   2.0.7  e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tikv-jemalloc-sys 0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d \
     tikv-jemallocator                0.6.0  4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865 \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.8.4

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
