### PR TITLE
jenkins-cli: update to 0.0.44

### DIFF
--- a/devel/jenkins-cli/Portfile
+++ b/devel/jenkins-cli/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jenkins-zh/jenkins-cli 0.0.42 v
-set git_commit      c4a03f2
+go.setup            github.com/jenkins-zh/jenkins-cli 0.0.44 v
+set git_commit      4a589b1
 categories          devel
 license             MIT
 
@@ -20,10 +20,9 @@ set short           jcli
 homepage            https://${short}.jenkins-zh.cn
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  eb4c76c68d879ff97056c91a19197fc5adb94c0a \
-                        sha256  3b4cca2ebc76931d8464a2aef1590f989d03fa49ae04ed7072330ce298bf4d65 \
-                        size    223113
-
+                        rmd160  0a2153716e9d31d4824027a668860b21f650284f \
+                        sha256  1a28cbf9824dccb7775eb3010a577122b1481550487af4c6fbe0022fac07ba76 \
+                        size    221672
 
 # Allows for version number, last commit and build date in `jcli version`
 # Suppress build date for reproducible builds


### PR DESCRIPTION
#### Description
https://github.com/jenkins-zh/jenkins-cli/compare/v0.0.42...v0.0.44

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
