### PR TITLE
meson: update to 1.6.1; includes important fix for ld

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                meson
-version             1.6.0
+version             1.6.1
 revision            0
 
 license             Apache-2

--- a/python/py-meson/Portfile
+++ b/python/py-meson/Portfile
@@ -6,13 +6,13 @@ PortGroup           github 1.0
 
 name                py-meson
 # update version and revision also in the meson port
-github.setup        mesonbuild meson 1.6.0
+github.setup        mesonbuild meson 1.6.1
 github.tarball_from releases
 revision            0
 
-checksums           rmd160  b3376a06163a378f4188a75d412d92f4cafcf1d8 \
-                    sha256  999b65f21c03541cf11365489c1fad22e2418bb0c3d50ca61139f2eec09d5496 \
-                    size    2277602
+checksums           rmd160  b7c38c2626e32a40c1989a54f7bffca1a4a01a28 \
+                    sha256  1eca49eb6c26d58bbee67fd3337d8ef557c0804e30a6d16bfdf269db997464de \
+                    size    2276144
 
 license             Apache-2
 categories-append   devel


### PR DESCRIPTION
### Description

* Update Meson to 1.6.1, as the latest release includes an important ld-related fix
* Fixes: [70386 - glib2 @2.78.4_0+x11: ld: unknown option: -export_dynamic](https://trac.macports.org/ticket/70386)