### PR TITLE
cmake: update 3.31.2

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -36,10 +36,10 @@ homepage            https://cmake.org
 platforms           darwin freebsd
 gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup        cmake   cmake 3.29.5 v
-checksums           rmd160  1b00eb2691fff51f513df9cbc27395a3ba5d2b74 \
-                    sha256  18817b7bfb80ec5bfc92adeb01bbf806a52e1bb9fe811989055a48169f8ad78a \
-                    size    8584045
+gitlab.setup        cmake   cmake 3.31.2 v
+checksums           rmd160  4d02eac86512b831f1830e8c6b9f2ae0ed21fb28 \
+                    sha256  5eb84fd2441a9319698928c6935894593df3a3a37b10d6d2a64544f9d2a3203b \
+                    size    8941814
 revision            0
 
 dist_subdir         ${my_name}


### PR DESCRIPTION
#### Description

* Bumps the version to 3.31.2 and updates the hashes.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
