### PR TITLE
uptimed: Update to 0.4.6

### DIFF
--- a/sysutils/uptimed/Portfile
+++ b/sysutils/uptimed/Portfile
@@ -3,15 +3,14 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rpodgorny uptimed 0.4.3 v
+github.setup        rpodgorny uptimed 0.4.6 v
 revision            0
-checksums           rmd160  98ac756015f49ac8ef1ea9801412efab8deba7e0 \
-                    sha256  11add61c39cb2a50f604266104c5ceb291ab830939ed7c84659c309be1e1e715 \
-                    size    55396
+checksums           rmd160  6ee71ef925584e97c00eac9b176fb505888774af \
+                    sha256  48656498ac30c59b902e98dc5e411e97cbb96278a01946bdf0941d8da72b2ae1 \
+                    size    56796
 
 categories          sysutils
 license             GPL-2
-platforms           darwin
 maintainers         nomaintainer
 
 description         uptime record daemon

--- a/sysutils/uptimed/files/patch-libuptimed-urec.h.diff
+++ b/sysutils/uptimed/files/patch-libuptimed-urec.h.diff
@@ -1,6 +1,6 @@
---- libuptimed/urec.h	2020-08-31 03:17:55.000000000 -0500
-+++ libuptimed/urec.h	2021-07-30 12:06:57.000000000 -0500
-@@ -58,8 +58,8 @@
+--- libuptimed/urec.h	2021-11-14 23:45:03.000000000 +0000
++++ libuptimed/urec.h	2024-12-20 22:41:29.065160960 +0000
+@@ -65,8 +65,8 @@
  #define FILE_BOOTID "/data/uptimed/bootid"
  #define FILE_RECORDS "/data/uptimed/records"
  #else
@@ -11,13 +11,3 @@
  #endif
  
  typedef struct urec {
-@@ -81,9 +81,7 @@
- void calculate_downtime(void);
- void read_records(time_t);
- void save_records(int, time_t);
--#ifndef PLATFORM_BSD
- int createbootid(void);
--#endif
- int compare_urecs(Urec *, Urec *, int);
- Urec *sort_urec(Urec *, int);
- time_t readbootid(void);


### PR DESCRIPTION
#### Description

Update `uptimed` to its latest released version, 0.4.6

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
