### PR TITLE
uv: Update to 0.5.11

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.5.10
+github.setup            astral-sh uv 0.5.11
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,11 +16,19 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  ac1713733193bc4a46e78e3ebc3cd86a98fd0e44 \
-                        sha256  493bd38750b397ed5c361fdb28a007186d13e5fa7d46bc997b3a1eff12a839f5 \
-                        size    3139617
+                        rmd160  4d45f726f57b785c2d9a9f882507fdfa18dba0ed \
+                        sha256  4f581e0903285e3228f55967f7094f3311a06aa3ec4e4ea3bf7438702fb776d6 \
+                        size    3145749
 
+# Fix opportunistic linking with libiconv and xz
+#
+# Ideally, the rust PG should handle any opportunistic linking with
+# MacPorts' libiconv, but that's a ticket that someone else should
+# open. Almost any Rust port links with libiconv, so it should be a
+# depends_lib, not a depends_build.
 depends_build-append    path:bin/pkg-config:pkgconfig
+depends_lib-append      port:xz \
+                        port:libiconv
 
 # Disable --frozen to workaround dependencies from Git
 cargo.offline_cmd


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.5.11. Additonally, fix any opportunistic linking with `xz` and MacPort's `libiconv`

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
