### PR TITLE
wcurl: Update to 2024.12.08

### DIFF
--- a/net/wcurl/Portfile
+++ b/net/wcurl/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        debian wcurl 2024.07.10
+github.setup        curl wcurl 2024.12.08 v
 revision            0
-checksums           rmd160  ddb1e0860073f813979eb2c80fe1f5caa5fad543 \
-                    sha256  962bb72e36e6f6cedbd21c8ca3af50e7dadd587a49d2482ab3226e76cf6dcc97 \
-                    size    5791
+checksums           rmd160  135d8d07a86bd63acee6aad1dc31f3aff27659b8 \
+                    sha256  9c0615b2c5d6b21da79ff559e75452197330d18449085a18e05f4b623b144a94 \
+                    size    9940
 
 categories          net www
 license             Curl
@@ -22,7 +22,7 @@ long_description    ${name} is a simple curl wrapper which lets you use curl \
                     parameters. Simply call wcurl with a list of URLs you want \
                     to download and wcurl will pick sane defaults.
 
-homepage            https://samueloph.dev/blog/announcing-wcurl-a-curl-wrapper-to-download-files/
+homepage            https://curl.se/wcurl/
 github.tarball_from archive
 
 depends_test        port:shunit2


### PR DESCRIPTION
#### Description

Update `wcurl` to its latest released version, 2024.12.08

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
