### PR TITLE
mdate: Update to 1.7.0.3

### DIFF
--- a/sysutils/mdate/Portfile
+++ b/sysutils/mdate/Portfile
@@ -1,29 +1,23 @@
-PortSystem              1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name                    mdate
-version                 1.5.6
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               makefile 1.0
+
+github.setup            ewe2 mdate 1.7.0.3
+github.tarball_from     archive
+revision                0
 categories              sysutils
 license                 GPL-2
 platforms               darwin freebsd
 maintainers             nomaintainer
 
-description             utility that converts Gregorian dates to Mayan Long Count dates
+description             Utility that converts Gregorian dates to Mayan Long Count dates
+long_description        {*}${description}.
 
-long_description        ${description}
-
-homepage                http://mdate.sourceforge.net/
-master_sites            sourceforge
-distname                Mdate-${version}
-
-checksums               md5     813edcde16cac96afddcf4be9342a82d \
-                        sha1    3a79e550e34774c247c792cc268f8c65f59fcee1 \
-                        rmd160  8af75f2c45944c612f9330e42c9d29b77d44a924
-
-use_configure           no
-
-variant universal {}
-
-build.args              CXX="${configure.cxx} [get_canonical_archflags cxx]"
+checksums               rmd160  e723dd342ca482b72c16a7efe0e95737ce85cf2e \
+                        sha256  6d58a8cf63c25b2b4b5b8904ba7c982f18608e8fa65436c555280699a020bcf8 \
+                        size    123892
 
 platform darwin {
     build.target        target=osx
@@ -34,10 +28,10 @@ platform freebsd {
 }
 
 destroot {
-    xinstall -s -m 755 ${worksrcpath}/mdate ${destroot}${prefix}/bin
-    xinstall -m 644 ${worksrcpath}/mdate.1 ${destroot}${prefix}/share/man/man1
-    
-    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 644 ${worksrcpath}/doc/${name}.1 ${destroot}${prefix}/share/man/man1/
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 644 -W ${worksrcpath} \
         API \
         AUTHORS \
@@ -46,10 +40,6 @@ destroot {
         NEWS \
         README \
         Translators \
-        mdate-1.html \
-        mdate-2.html \
-        mdate-3.html \
-        mdate-4.html \
-        mdate.html \
-        ${destroot}${prefix}/share/doc/${name}
+        doc/${name}.html \
+        ${destroot}${prefix}/share/doc/${name}/
 }


### PR DESCRIPTION
#### Description

Update `mdate` to 1.7.0.3. This change demands a new upstream change, evident by the use of the `github` PG

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
