### PR TITLE
py-blis, py-thinc: unblacklist modern gcc

### DIFF
--- a/python/py-blis/Portfile
+++ b/python/py-blis/Portfile
@@ -32,7 +32,7 @@ python.versions        39 310 311 312
 # Compiler selection
 compiler.c_standard    1999
 compiler.cxx_standard  2011
-compiler.blacklist-append *gcc* {clang < 999} macports-clang-3.* {macports-clang-[4-6].0}
+compiler.blacklist-append *gcc-4.* {clang < 999} macports-clang-3.* {macports-clang-[4-6].0}
 
 # Pass selected compiler to BLIS
 build.env-append    BLIS_COMPILER=${configure.cc}

--- a/python/py-thinc/Portfile
+++ b/python/py-thinc/Portfile
@@ -30,7 +30,7 @@ python.versions     39 310 311 312
 
 # Compiler selection
 compiler.cxx_standard 2011
-compiler.blacklist-append *gcc* {clang < 900} {macports-clang-3.[0-9]} macports-clang-4.0
+compiler.blacklist-append *gcc-4.* {clang < 900} {macports-clang-3.[0-9]} macports-clang-4.0
 
 if {${name} ne ${subport}} {
     # diff -NaurdwB ./py-thinc-orig/pyproject.toml ./py-thinc-new/pyproject.toml | sed -E -e 's/\.\/py-thinc-(orig|new)/\.\//' | sed -E -e 's|/opt/local|@@PREFIX@@|g' > ~/Downloads/patch-pyproject_toml.diff


### PR DESCRIPTION
#### Description

Forgot to add this in the original PR. No reason to prohibit modern GCC here.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
