### PR TITLE
google-cloud-sdk: update to 504.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             504.0.0
+version             504.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  067f1c013d206a27868cfdeee3e70cfda5009a8d \
-                    sha256  fcb1f2dc7cbce5d009ebb0911c93777046978c31f01bbd8796dd5abdaa7eac9c \
-                    size    53223908
+    checksums       rmd160  8136d720042f1feac9009d39ecb665aa6d3c638a \
+                    sha256  0c4515a3fc3983f7214e55fcd5b0d6fb0a2933a25f57c773ee94e145d1df8884 \
+                    size    53240119
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  5c36a9297934f4cc935d68d3b619b0510899b69d \
-                    sha256  224b91085d4c5b35d9ca0e4158a73008ea18c7944f4c13ae4901f8a9fceddcf7 \
-                    size    54572129
+    checksums       rmd160  8f322d5389247fe0a3d4fe0ef2968ff6a4c7ee33 \
+                    sha256  87fd436a6fbe556b472d1467130825cf6f0f64448070f5644228219b92771001 \
+                    size    54590053
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  66e6aa90fedd05cc8d82593f1eceb9b480711fd7 \
-                    sha256  a07991f255e6c47527f8aeefa3f29988eab4c0dfd32a7d8cde11075189bba95d \
-                    size    54518201
+    checksums       rmd160  70267be0838ea3793d36d9ad910067c78a8ccf3b \
+                    sha256  d73664d78308386aa1a480ccbebaf0d805241ed27cbce8fb2c24677bcb5edac9 \
+                    size    54536494
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 504.0.1.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?