### PR TITLE
weechat: fix linking to correct libs

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -5,12 +5,12 @@ PortGroup           cmake 1.1
 PortGroup           conflicts_build 1.0
 
 # Need strndup()
-PortGroup           legacysupport 1.0
+PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
 version             4.5.0
-revision            0
+revision            1
 checksums           rmd160  322aba1c2fffc882ceb34c21c08183d1ef6139c5 \
                     sha256  b85e800af0f7c9f2d60d72c0f7e56abbaa60274a4d47be17407907292da30398 \
                     size    2745516
@@ -62,6 +62,9 @@ depends_test-append port:cpputest
 license_noconflict  asciidoctor
 
 patchfiles          no-extra-gcc-warnings.patch
+
+# https://github.com/weechat/weechat/pull/2221
+patchfiles-append   fix-linking.patch
 
 configure.args-append \
                     -DENABLE_GUILE=OFF \

--- a/irc/weechat/files/fix-linking.patch
+++ b/irc/weechat/files/fix-linking.patch
@@ -1,0 +1,57 @@
+From a776fb1867b92dee37c1a6c58de499087c98050c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9bastien=20Helleu?= <flashcode@flashtux.org>
+Date: Sat, 21 Dec 2024 15:03:21 +0100
+Subject: [PATCH] core: fix detection of dl library
+
+This fixes the linking to curl and ncurses on macOS.
+---
+ CMakeLists.txt | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5d15a35489f..d235060983a 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -247,9 +247,7 @@ find_library(DL_LIBRARY
+   PATHS /lib /usr/lib /usr/libexec /usr/local/lib /usr/local/libexec
+ )
+ if(DL_LIBRARY)
+-  string(REGEX REPLACE "/[^/]*$" "" DL_LIBRARY_PATH "${DL_LIBRARY}")
+-  set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -L${DL_LIBRARY_PATH}")
+-  list(APPEND EXTRA_LIBS dl)
++  list(APPEND EXTRA_LIBS ${DL_LIBRARY})
+ endif()
+ 
+ add_subdirectory(icons)
+
+From c73fcbfd3310998c4488af6bdd1fbc4b72604d76 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9bastien=20Helleu?= <flashcode@flashtux.org>
+Date: Sat, 21 Dec 2024 14:42:12 +0100
+Subject: [PATCH] core: add option POST_BUILD in add_custom_command
+
+This fixes the following CMake warning:
+
+CMake Warning (dev) at src/gui/curses/normal/CMakeLists.txt:73 (add_custom_command):
+  Exactly one of PRE_BUILD, PRE_LINK, or POST_BUILD must be given.  Assuming
+  POST_BUILD to preserve backward compatibility.
+
+  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
+  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
+  command to set the policy and suppress this warning.
+This warning is for project developers.  Use -Wno-dev to suppress it.
+---
+ src/gui/curses/normal/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/gui/curses/normal/CMakeLists.txt b/src/gui/curses/normal/CMakeLists.txt
+index 1716905a809..43c48de74c8 100644
+--- src/gui/curses/normal/CMakeLists.txt
++++ src/gui/curses/normal/CMakeLists.txt
+@@ -72,6 +72,7 @@ target_link_libraries(${EXECUTABLE}
+ # It may be removed in future.
+ add_custom_command(
+   TARGET ${EXECUTABLE}
++  POST_BUILD
+   COMMAND ${CMAKE_COMMAND} -E remove -f "weechat-curses${CMAKE_EXECUTABLE_SUFFIX}"
+   COMMAND ${CMAKE_COMMAND} -E create_symlink "weechat${CMAKE_EXECUTABLE_SUFFIX}" "weechat-curses${CMAKE_EXECUTABLE_SUFFIX}"
+   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"


### PR DESCRIPTION
#### Description

Fix broken linking. Revbump, because all systems were affected.
Also switch to `legacysupport` 1.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
