### PR TITLE
mise: Update to 2024.12.17

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.12.16 v
+github.setup        jdx mise 2024.12.17 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  24d51926ba2cb9a736a3a78ec1624833448497d6 \
-                    sha256  5df101845809e37daf7a5fae83326814923eff48156f35439e96aca76d08c67c \
-                    size    4171192
+                    rmd160  55c5894bb3a5a8644f109079c7ccf3a2c5a03a5f \
+                    sha256  8f29224ab72073d1da8d3c1527fe2c735d1b9f61a83e866d5af40d2327628543 \
+                    size    4173570
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -296,8 +296,8 @@ cargo.crates \
     idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
-    impl-tools                      0.10.2  b4739bc9af85c18969eba5e4db90dbf26be140ff2e5628593693f18559e9e5fe \
-    impl-tools-lib                  0.11.0  798fe18a7e727001b30a029ab9cdd485afd325801d4df846f0bb5338b2986a2c \
+    impl-tools                      0.10.3  0ae95c9095c2f1126d7db785955c73cdc5fc33e7c3fa911bd4a42931672029a7 \
+    impl-tools-lib                  0.11.1  2a391adcea096a89a593317881fb61ef4e68d3e7d9de9e2338e6e1557be29e10 \
     indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
     indexmap                         2.7.0  62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f \
@@ -529,7 +529,7 @@ cargo.crates \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
     time-macros                     0.2.19  2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
-    tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
+    tinyvec                          1.8.1  022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tokio                           1.42.0  5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551 \
     tokio-macros                     2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
@@ -570,7 +570,7 @@ cargo.crates \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                        1.7.2  f8e8e596b6aabf5e0f7589a08facfccb63ee1668d071c26c321f64d7c7050fd2 \
+    usage-lib                        1.7.4  ab923f719b3048bd1cd2fb738fca978ed2a60756ce15cdad639fc40645adad9c \
     utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \


### PR DESCRIPTION
#### Description

mise: Update to 2024.12.17

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
