### PR TITLE
ddev: update to 1.24.1

### DIFF
--- a/devel/ddev/Portfile
+++ b/devel/ddev/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ddev/ddev 1.24.0 v
+go.setup            github.com/ddev/ddev 1.24.1 v
 go.offline_build    no
 fetch.type          git
 


### PR DESCRIPTION
Update ddev to version 1.24.1

- Fix for PHP < 8.1 in environments with additional SSL certificates
- Restore SQLite 3.45.1 only for Drupal 11
- Add more default locales
- Other minor improvements