### PR TITLE
patchelf: Update to 0.18.0

### DIFF
--- a/devel/patchelf/Portfile
+++ b/devel/patchelf/Portfile
@@ -3,29 +3,24 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        NixOS patchelf 0.14.3
-github.tarball_from archive
+github.setup        NixOS patchelf 0.18.0
+github.tarball_from releases
 revision            0
 
 categories          devel
-platforms           darwin
 license             GPL-3+
 maintainers         {kollar.me:laszlo @lkollar} openmaintainer
 description         Modify dynamic ELF executables
 long_description    PatchELF is a simple utility for modifying existing ELF executables and libraries
 
-checksums           sha256  827a8ca914c69413f1ca0d967a637980a24edf000a938531a77e663317c853bb \
-                    rmd160  0eb1041c1684d829cf1bce93526884ff717559ab \
-                    size    123722
+checksums           sha256  1952b2a782ba576279c211ee942e341748fdb44997f704dd53def46cd055470b \
+                    rmd160  542cf448a6cd8f6177758d325c30be3299f37b09 \
+                    size    423290
 
 compiler.cxx_standard \
                     2011
 
-use_autoreconf      yes
-autoreconf.cmd      ./bootstrap.sh
-
-depends_build       port:autoconf \
-                    port:automake
+use_bzip2           yes
 
 configure.args      --disable-dependency-tracking \
                     --disable-silent-rules


### PR DESCRIPTION
#### Description

Update `patchelf` to its latest released version, 0.18.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
