### PR TITLE
libpixman: hold back to 0.43.4_1 on Tiger

### DIFF
--- a/graphics/libpixman/Portfile
+++ b/graphics/libpixman/Portfile
@@ -20,6 +20,17 @@ checksums               rmd160  4392f22e5dc1086b9708abd91677982332f2a702 \
                         sha256  50baf820dde0c5ff9714d03d2df4970f606a3d3b1024f5404c0398a9821cc4b0 \
                         size    650012
 
+# hold back on Tiger until meson is updated
+platform darwin 8 {
+
+version                 0.43.4
+revision                1
+checksums               rmd160  344d0e77ec49ac2bdf6cb2c5fe7595b44d07dea7 \
+                        sha256  48d8539f35488d694a2fef3ce17394d1153ed4e71c05d1e621904d574be5df19 \
+                        size    636900
+}
+
+
 categories              graphics
 maintainers             {ryandesign @ryandesign} {mascguy @mascguy}
 license                 X11


### PR DESCRIPTION
needs a new meson, at least, to build on Tiger

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

macOS 10.4

