### PR TITLE
termscp: update to 0.16.1

### DIFF
--- a/sysutils/termscp/Portfile
+++ b/sysutils/termscp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        veeso termscp 0.16.0 v
+github.setup        veeso termscp 0.16.1 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {@sikmir disroot.org:sikmir} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  7c41992125138a1e20a95219c7c971239735bfb4 \
-                    sha256  58f3b4770c5d1c5d7998af88b6df8c6a53dee4409f2cf6ea676caccec79cdb7f \
-                    size    11915056
+                    rmd160  179742dbd5b906a596e7129be5247bc5bca6eca3 \
+                    sha256  318673db7d4c8b580f8f6a2b4e305fed3e7afc151217be5e16cf1a8f33fc2af4 \
+                    size    11914664
 
 destroot {
     xinstall -m 0755 \


### PR DESCRIPTION
#### Description
https://github.com/veeso/termscp/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
