### PR TITLE
rage: update to 0.11.1

### DIFF
--- a/security/rage/Portfile
+++ b/security/rage/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        str4d rage 0.11.0 v
+github.setup        str4d rage 0.11.1 v
 github.tarball_from archive
 revision            0
 categories          security
@@ -369,9 +369,9 @@ cargo.crates \
     zstd-sys                      2.0.13+zstd.1.5.6  38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  1860b8d8958c1f1ea43d32afd15ae0e0f7f5cb4c \
-                    sha256  f5c37b27428ad2b9ed91f0c691612dd0f91044d17565edf177fb676be4af1d35 \
-                    size    1659004
+                    rmd160  e6ef8afeba024bb2b2534e1b673bb0f1073429e0 \
+                    sha256  b00559285c9fa5779b2908726d7a952cbf7cb629008e4c4c23a5c137c98f3f09 \
+                    size    1660381
 
 set cargo_builddir ${worksrcpath}/target/[cargo.rust_platform]/release
 


### PR DESCRIPTION
#### Description

Updates rage to [0.11.1](https://github.com/str4d/rage/releases/tag/v0.11.1). 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 15.1.1 24B2091 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
