### PR TITLE
cmark-gfm: new port

### DIFF
--- a/devel/cmark-gfm/Portfile
+++ b/devel/cmark-gfm/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+# Any version update requires revbumping all ports that link with the library
+# because the full version number is in the library's install name.
+# See https://github.com/commonmark/cmark/issues/474
+github.setup        github cmark-gfm 0.29.0.gfm.13
+revision            0
+
+checksums           rmd160  4d46836c6a151360b0feac74c3f4c5b07a4ec2d1 \
+                    sha256  a95a166edd854f8c5206229d3848639eba438e0edba499b0575a9075545a7a30 \
+                    size    300099
+
+categories          devel
+maintainers         {wyuenho @wyuenho} openmaintainer
+license             BSD
+
+description         GitHub's fork of cmark
+long_description    cmark-gfm is an extended version of the C reference \
+                    implementation of CommonMark, a rationalized version of \
+                    Markdown syntax with a spec. This repository adds GitHub \
+                    Flavored Markdown extensions to the upstream \
+                    implementation, as defined in the spec.
+
+configure.args-append \
+                    -DCMARK_TESTS=OFF \
+                    -DCMARK_STATIC=OFF
+                    
+variant buildtests description "Build Tests" {
+    depends_lib-append        port:python313
+    configure.args-replace    -DCMARK_TESTS=OFF -DCMARK_TESTS=ON
+    configure.args-append     -DPYTHON_EXECUTABLE=${prefix}/bin/python3.13
+    test.run                  yes
+
+}


### PR DESCRIPTION
#### Description

[cmark-gfm](https://github.com/github/cmark-gfm) is an extended version of the C reference implementation of CommonMark, a rationalized version of Markdown syntax with a spec. This repository adds GitHub Flavored Markdown extensions to the upstream implementation, as defined in the spec.

The rest of the README is preserved as-is from the upstream source. Note that the library and binaries produced by this fork are suffixed with -gfm in order to distinguish them from the upstream.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2
Xcode 16.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
