### PR TITLE
micronaut: update to 4.7.3

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.7.2 v
+github.setup    micronaut-projects micronaut-starter 4.7.3 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  ed8789eb62cf906c498792bb2842e6b64863b4b1 \
-                 sha256  b233d7b43daa8f7507cc671706f41b2b8a8447747da64907210d288b0d1ccd20 \
-                 size    27808583
+    checksums    rmd160  04832766055e6821056c012ccd82ebb33c0c10cc \
+                 sha256  870c7839460cc153a0c8b4f1fe5c32fecf510aebb602c537cca47fad34dde848 \
+                 size    27808338
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  3672a9c1b6b864ca565e8d39f211e51ac473c6f1 \
-                 sha256  32d49afec4306a8cbe2f70dfeae3a3791daeec8ac8f702523370774da657b1b5 \
-                 size    27587409
+    checksums    rmd160  87b3b9a5f18386f2741732d56bf5232098f9ce4a \
+                 sha256  d927685d269e8736769e1cb6d959382ca80ae086ce000fa01f2b3ac6ca0563c1 \
+                 size    27590069
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.7.3.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?