### PR TITLE
ruby-build: Update to 20241225.2

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20241213 v
+github.setup        rbenv ruby-build 20241225.2 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  472587c7af068de051e3d6eb22ad6b91927ccf89 \
-                    sha256  029128f1e6f7955354064fa5338d3afc7a33dab529986792f219c2d5266ab261 \
-                    size    93348
+checksums           rmd160  b8b72b07f63537e0142620a5e055dde336fe3015 \
+                    sha256  ae43d89f54b8765d04673fa9da993143ac5269c1ae2671509c3d3fab73f06d20 \
+                    size    93369
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20241225.2

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.1 16B40

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
