### PR TITLE
Critical: Update dotnetcli domain

### DIFF
--- a/dotnet/aspnetcore-runtime-2.1/Portfile
+++ b/dotnet/aspnetcore-runtime-2.1/Portfile
@@ -26,7 +26,7 @@ homepage            https://dotnet.microsoft.com/
 platforms           {darwin any} {darwin >= 16}
 supported_archs     x86_64
 distname            aspnetcore-runtime-${version}-osx-x64
-master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${version}/
 
 checksums           rmd160  81ab5d19c9214c28e332548bc24ed5aa13c12331 \
                     sha256  ce0128b83be40489ec6d4a31064f124dd03eeb7be3702807968ccdbed83964dd \

--- a/dotnet/aspnetcore-runtime-3.1/Portfile
+++ b/dotnet/aspnetcore-runtime-3.1/Portfile
@@ -26,7 +26,7 @@ homepage            https://dotnet.microsoft.com/
 platforms           {darwin any} {darwin >= 19}
 supported_archs     x86_64
 distname            aspnetcore-runtime-${version}-osx-x64
-master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${version}/
 
 checksums           rmd160  d9c4da94b1e6a8a1c3f60d15667359a5d580d9e5 \
                     sha256  cc853a95232ce6b8c4443d5d9dd71927c24cc18931589709aedad7d94fa5baff \

--- a/dotnet/aspnetcore-runtime-6/Portfile
+++ b/dotnet/aspnetcore-runtime-6/Portfile
@@ -45,7 +45,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/aspnetcore-runtime-7/Portfile
+++ b/dotnet/aspnetcore-runtime-7/Portfile
@@ -45,7 +45,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/aspnetcore-runtime-8/Portfile
+++ b/dotnet/aspnetcore-runtime-8/Portfile
@@ -45,7 +45,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/aspnetcore-runtime-devel/Portfile
+++ b/dotnet/aspnetcore-runtime-devel/Portfile
@@ -48,7 +48,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/dotnet-cli/Portfile
+++ b/dotnet/dotnet-cli/Portfile
@@ -47,7 +47,7 @@ homepage            https://dotnet.microsoft.com/
 platforms           {darwin any} {darwin >= 19}
 supported_archs     x86_64 arm64
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Runtime/${version}/
 
 switch ${build_arch} {
     x86_64 {

--- a/dotnet/dotnet-runtime-2.1/Portfile
+++ b/dotnet/dotnet-runtime-2.1/Portfile
@@ -25,7 +25,7 @@ homepage            https://dotnet.microsoft.com/
 platforms           {darwin any} {darwin >= 16}
 supported_archs     x86_64
 distname            dotnet-runtime-${version}-osx-x64
-master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Runtime/${version}/
 
 checksums           rmd160  2bc893e18d51ff6ea8ee0aa964a6fbc5e8abb8ec \
                     sha256  e69d62789c0ebc690ab4a67ade35f7251939c9d24e7e0d4752ac89ba34ed2df2 \

--- a/dotnet/dotnet-runtime-3.1/Portfile
+++ b/dotnet/dotnet-runtime-3.1/Portfile
@@ -25,7 +25,7 @@ homepage            https://dotnet.microsoft.com/
 platforms           {darwin any} {darwin >= 19}
 supported_archs     x86_64
 distname            dotnet-runtime-${version}-osx-x64
-master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Runtime/${version}/
 
 checksums           rmd160  838f44918ef9d5675ced0ded97b81b515b31d485 \
                     sha256  2d577720fc956c34ebd4e2c5bd910c96333ae263865359e89c7fb50264205774 \

--- a/dotnet/dotnet-runtime-6/Portfile
+++ b/dotnet/dotnet-runtime-6/Portfile
@@ -44,7 +44,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Runtime/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/dotnet-runtime-7/Portfile
+++ b/dotnet/dotnet-runtime-7/Portfile
@@ -44,7 +44,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Runtime/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/dotnet-runtime-8/Portfile
+++ b/dotnet/dotnet-runtime-8/Portfile
@@ -44,7 +44,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Runtime/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/dotnet-runtime-devel/Portfile
+++ b/dotnet/dotnet-runtime-devel/Portfile
@@ -47,7 +47,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Runtime/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/dotnet-sdk-2.1/Portfile
+++ b/dotnet/dotnet-sdk-2.1/Portfile
@@ -25,7 +25,7 @@ long_description    .NET is a free, cross-platform, open source developer platfo
 homepage            https://dotnet.microsoft.com/
 platforms           {darwin any} {darwin >= 16}
 distname            dotnet-sdk-${version}-osx-x64
-master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Sdk/${version}/
 
 checksums           rmd160  f013b7b489627ad0df00a0afe4496d06e7d03e80 \
                     sha256  eceea62b5ae716fa149ceabfd9de66f89fd91f48e701be3ea498d7f3cbc8a988 \

--- a/dotnet/dotnet-sdk-3.1/Portfile
+++ b/dotnet/dotnet-sdk-3.1/Portfile
@@ -26,7 +26,7 @@ homepage            https://dotnet.microsoft.com/
 platforms           {darwin any} {darwin >= 19}
 supported_archs     x86_64
 distname            dotnet-sdk-${version}-osx-x64
-master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Sdk/${version}/
 
 checksums           rmd160  1b0a834ae33a55f14721b53121f05b1b336d0e6c \
                     sha256  6b0792f2be40a279ebbee284b6bc4e955c8242401f2b254a9a975ff477c7e535 \

--- a/dotnet/dotnet-sdk-6/Portfile
+++ b/dotnet/dotnet-sdk-6/Portfile
@@ -47,7 +47,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Sdk/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/dotnet-sdk-7/Portfile
+++ b/dotnet/dotnet-sdk-7/Portfile
@@ -47,7 +47,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Sdk/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/dotnet-sdk-8/Portfile
+++ b/dotnet/dotnet-sdk-8/Portfile
@@ -47,7 +47,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Sdk/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes

--- a/dotnet/dotnet-sdk-devel/Portfile
+++ b/dotnet/dotnet-sdk-devel/Portfile
@@ -50,7 +50,7 @@ switch ${build_arch} {
     }
 }
 
-master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+master_sites        https://builds.dotnet.microsoft.com/dotnet/Sdk/${version}/
 
 worksrcdir          ${name}-${version}
 extract.mkdir       yes


### PR DESCRIPTION
`dotnetcli.azureedge.net` may fail soon.

Related: https://github.com/dotnet/core/issues/9671