### PR TITLE
jenkins-cli: update to 0.0.46

### DIFF
--- a/devel/jenkins-cli/Portfile
+++ b/devel/jenkins-cli/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jenkins-zh/jenkins-cli 0.0.44 v
-set git_commit      4a589b1
+go.setup            github.com/jenkins-zh/jenkins-cli 0.0.46 v
+set git_commit      bd33a1b
 categories          devel
 license             MIT
 
@@ -20,9 +20,9 @@ set short           jcli
 homepage            https://${short}.jenkins-zh.cn
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  0a2153716e9d31d4824027a668860b21f650284f \
-                        sha256  1a28cbf9824dccb7775eb3010a577122b1481550487af4c6fbe0022fac07ba76 \
-                        size    221672
+                        rmd160  6ecfe78efa3c764cb2ae29dfb758f4f2a46c3a86 \
+                        sha256  084e721ef9edd6880dfbdbad9f0224f29a06dd42252c9768e0847c94061deab0 \
+                        size    224132
 
 # Allows for version number, last commit and build date in `jcli version`
 # Suppress build date for reproducible builds
@@ -52,9 +52,14 @@ post-destroot {
     }
 
     # bash completion
-    set bash_completion_dir ${destroot}${prefix}/etc/bash_completion.d
+    set bash_completion_dir ${destroot}${prefix}/share/bash-completion/completions
     xinstall -d ${bash_completion_dir}
     system -W ${worksrcpath} "${worksrcpath}/${name} completion --type bash > ${bash_completion_dir}/${short}"
+
+    # fish completion
+    set fish_completion_dir ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${fish_completion_dir}
+    system -W ${worksrcpath} "${worksrcpath}/${name} completion --type fish > ${fish_completion_dir}/${short}.fish"
 
     # zsh completion
     set zsh_completion_dir ${destroot}${prefix}/share/zsh/site-functions


### PR DESCRIPTION
#### Description
https://github.com/jenkins-zh/jenkins-cli/releases/tag/v0.0.45
https://github.com/jenkins-zh/jenkins-cli/releases/tag/v0.0.46

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
