### PR TITLE
uv: Update to 0.5.12

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.5.11
+github.setup            astral-sh uv 0.5.12
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -16,9 +16,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  4d45f726f57b785c2d9a9f882507fdfa18dba0ed \
-                        sha256  4f581e0903285e3228f55967f7094f3311a06aa3ec4e4ea3bf7438702fb776d6 \
-                        size    3145749
+                        rmd160  39019c47c325974dd30054125a87ca8f3a6a5c1c \
+                        sha256  445a1256295aff91542ba417a3107cb88f088ab2263892b14ec5e195d955a819 \
+                        size    3174790
 
 # Fix opportunistic linking with libiconv and xz
 #
@@ -82,7 +82,7 @@ cargo.crates \
     anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                   3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
-    anyhow                          1.0.94  c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7 \
+    anyhow                          1.0.95  34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04 \
     arrayref                         0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
@@ -94,10 +94,10 @@ cargo.crates \
     async_http_range_reader          0.9.1  2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
-    axoasset                         1.1.0  489aa74cfacfaf4cabcb0c2bb63da396b2a5aa70937050bc9dc0233bd7c9b85c \
+    axoasset                         1.2.0  5ba1098cfaa17f0973d2b766ee07bedb3e81a29b35c8d8b26de5074e37011443 \
     axoprocess                       0.2.0  4de46920588aef95658797996130bacd542436aee090084646521260a74bda7d \
     axotag                           0.2.0  d888fac0b73e64cbdf36a743fc5a25af5ae955c357535cb420b389bf1e1a6c54 \
-    axoupdater                       0.8.2  a70b7d3a9ea86ef8d17dada23f2c42518ed4b75dd6a8ff761f8988b448db8454 \
+    axoupdater                       0.9.0  bc194af960a8ddbc4f28be3fa14f8716aa22141fe40bf1762ae0948defadcce4 \
     backoff                          0.4.0  b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1 \
     backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
@@ -107,11 +107,11 @@ cargo.crates \
     bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     boxcar                           0.2.7  7f839cdf7e2d3198ac6ca003fd8ebc61715755f41c1cad15ff13df67531e00ed \
-    bstr                            1.11.0  1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22 \
+    bstr                            1.11.1  786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8 \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytecheck                        0.8.0  50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f \
     bytecheck_derive                 0.8.0  523363cbe1df49b68215efdf500b103ac3b0fb4836aed6d15689a076eadb8fff \
-    bytemuck                        1.20.0  8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a \
+    bytemuck                        1.21.0  ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3 \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     byteorder-lite                   0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
     bytes                            1.9.0  325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b \
@@ -121,7 +121,7 @@ cargo.crates \
     camino                           1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
     cargo-util                      0.2.16  0b15bbe49616ee353fadadf6de5a24136f3fe8fdbd5eb0894be9f8a42c905674 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
-    cc                               1.2.3  27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d \
+    cc                               1.2.5  c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     charset                          0.1.5  f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e \
@@ -130,7 +130,7 @@ cargo.crates \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
     clap                            4.5.23  3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84 \
     clap_builder                    4.5.23  30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838 \
-    clap_complete                   4.5.38  d9647a559c112175f17cf724dc72d3645680a883c58481332779192b0d8e7a01 \
+    clap_complete                   4.5.40  ac2e663e3e3bed2d32d065a8404024dad306e699a04263ec59919529f803aee9 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.4  315902e790cc6e5ddd20cbd313c1d0d49db77f191e149f96397230fb82a17677 \
     clap_derive                     4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
@@ -139,19 +139,19 @@ cargo.crates \
     codspeed-criterion-compat        2.7.2  8eb1a6cb9c20e177fde58cdef97c1c7c9264eb1424fe45c4fccedc2fb078a569 \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
-    colored                          2.1.0  cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8 \
+    colored                          2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
     concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     configparser                     3.1.0  e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b \
-    console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
+    console                        0.15.10  ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b \
     core-foundation                 0.10.0  b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     cpufeatures                     0.2.16  16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
     criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
     criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
-    crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
+    crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
+    crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     csv                              1.3.1  acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf \
@@ -173,23 +173,25 @@ cargo.crates \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.17  0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125 \
     either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
-    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     encoding_rs_io                   0.1.7  1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83 \
+    env_home                         0.1.0  c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     erased-serde                     0.4.5  24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d \
     errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
     etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
     event-listener                   5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
     event-listener-strategy          0.5.3  3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2 \
-    fastrand                         2.2.0  486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4 \
+    fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     fdeflate                         0.3.7  1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
     flate2                          1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
     float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
+    float-cmp                       0.10.0  b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    foldhash                         0.1.3  f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2 \
+    foldhash                         0.1.4  a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f \
     fontconfig-parser                0.5.7  c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7 \
     fontdb                          0.12.0  ff20bef7942a72af07104346154a70a70b089c572e454b41bef6eb6cb10e9c06 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
@@ -222,7 +224,7 @@ cargo.crates \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
+    home                            0.5.11  589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf \
     homedir                          0.3.4  5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2 \
     html-escape                     0.2.13  6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476 \
     http                             1.2.0  f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea \
@@ -231,8 +233,8 @@ cargo.crates \
     http-content-range               0.2.0  91314cc9d86f625097a3365cab4e4b6f190eac231650f8f41c1edd8080cea1d0 \
     httparse                         1.9.5  7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    hyper                            1.5.1  97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f \
-    hyper-rustls                    0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
+    hyper                            1.5.2  256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0 \
+    hyper-rustls                    0.27.5  2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2 \
     hyper-util                      0.1.10  df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4 \
     icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
     icu_locid                        1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
@@ -272,10 +274,10 @@ cargo.crates \
     kurbo                            0.8.3  7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449 \
     kurbo                            0.9.5  bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.167  09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc \
+    libc                           0.2.169  b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a \
     libmimalloc-sys                 0.1.39  23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    libz-rs-sys                      0.4.0  39cc71ac688c22a9f5730a38171ac94795c071ac81d1a0ab5537f6ef164fff30 \
+    libz-rs-sys                      0.4.1  a90e19106f1b2c93f1fa6cdeec2e56facbf2e403559c1e1c0ddcc6d46e979cdf \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
     litemap                          0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
@@ -294,7 +296,7 @@ cargo.crates \
     mimalloc                        0.1.43  68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     mime_guess                       2.0.5  f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e \
-    miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
+    miniz_oxide                      0.8.2  4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394 \
     mio                              1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
     miow                             0.6.0  359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044 \
     munge                            0.4.1  64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df \
@@ -307,7 +309,7 @@ cargo.crates \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
-    object                          0.36.5  aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e \
+    object                          0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
     once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
     oorandom                        11.1.4  b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
@@ -337,14 +339,14 @@ cargo.crates \
     pipeline                         0.5.0  d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0 \
     pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
     plain                            0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
-    platform-info                    2.0.4  91077ffd05d058d70d79eefcd7d7f6aac34980860a7519960f7913b6563a8c3a \
-    png                            0.17.15  b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d \
+    platform-info                    2.0.5  7539aeb3fdd8cb4f6a331307cf71a1039cee75e94e8a71725b9484f4a0d9451a \
+    png                            0.17.16  82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526 \
     poloto                          19.1.2  164dbd541c9832e92fa34452e9c2e98b515a548a3f8549fb2402fe1cd5e46b96 \
     portable-atomic                 1.10.0  280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6 \
     ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
-    predicates                       3.1.2  7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97 \
-    predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
-    predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
+    predicates                       3.1.3  a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573 \
+    predicates-core                  1.0.9  727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa \
+    predicates-tree                 1.0.12  72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     priority-queue                   2.1.1  714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d \
     proc-macro2                     1.0.92  37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0 \
@@ -354,8 +356,8 @@ cargo.crates \
     ptr_meta_derive                  0.3.0  ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1 \
     quinn                           0.11.6  62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef \
     quinn-proto                     0.11.9  a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d \
-    quinn-udp                        0.5.7  7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da \
-    quote                           1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
+    quinn-udp                        0.5.9  1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904 \
+    quote                           1.0.38  0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc \
     quoted_printable                 0.5.1  640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73 \
     rancor                           0.1.0  caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
@@ -366,7 +368,7 @@ cargo.crates \
     rctree                           0.5.0  3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f \
     redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
     redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
-    redox_syscall                    0.5.7  9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f \
+    redox_syscall                    0.5.8  03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834 \
     redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
     reflink-copy                    0.1.20  17400ed684c3a0615932f00c271ae3eea13e47056a1455821995122348ab6438 \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
@@ -375,7 +377,7 @@ cargo.crates \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     rend                             0.5.2  a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215 \
-    reqwest                         0.12.9  a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f \
+    reqwest                        0.12.10  3d3536321cfc54baa8cf3e273d5e1f63f889067829c4b410fcdbac8ca7b80994 \
     reqwest-middleware               0.4.0  d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3 \
     reqwest-retry                    0.7.0  29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178 \
     resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
@@ -393,10 +395,10 @@ cargo.crates \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
     rustix                         0.38.42  f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85 \
-    rustls                         0.23.19  934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1 \
+    rustls                         0.23.20  5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
-    rustls-pki-types                1.10.0  16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b \
+    rustls-pki-types                1.10.1  d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37 \
     rustls-webpki                  0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
     rustybuzz                        0.7.0  162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
@@ -408,15 +410,15 @@ cargo.crates \
     scroll                          0.12.0  6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6 \
     scroll_derive                   0.12.0  7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
-    security-framework               3.0.1  e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8 \
-    security-framework-sys          2.12.1  fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2 \
+    security-framework               3.1.0  81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc \
+    security-framework-sys          2.13.0  1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
-    semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
+    semver                          1.0.24  3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba \
     serde                          1.0.216  0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e \
     serde-untagged                   0.1.6  2676ba99bd82f75cae5cbd2c8eda6fa0b8760f18978ea840e980dd5567b5c5b6 \
     serde_derive                   1.0.216  46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                     1.0.133  c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377 \
+    serde_json                     1.0.134  d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
@@ -447,18 +449,18 @@ cargo.crates \
     svgfilters                       0.4.0  639abcebc15fdc2df179f37d6f5463d660c1c79cd552c12343a4600827a04bce \
     svgtypes                         0.9.0  c9ee29c1407a5b18ccfe5f6ac82ac11bab3b14407e09c209a6c1a32098b19734 \
     svgtypes                        0.10.0  98ffacedcdcf1da6579c907279b4f3c5492fbce99fbbf227f5ed270a589c2765 \
-    syn                             2.0.90  919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31 \
+    syn                             2.0.91  d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     tagu                             0.1.6  eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a \
     tar                             0.4.43  c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6 \
-    target-lexicon                  0.13.0  4ff4a4048091358129767b8a200d6927f58876c8b5ea16fb7b0222d43b79bfa8 \
+    target-lexicon                  0.13.1  dc12939a1c9b9d391e0b7135f72fd30508b73450753e28341fed159317582a77 \
     temp-env                         0.3.6  96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050 \
     tempfile                        3.14.0  28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
     terminal_size                    0.4.1  5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9 \
-    termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
+    termtree                         0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
     test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
@@ -466,9 +468,9 @@ cargo.crates \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
     textwrap                        0.16.1  23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                        2.0.7  93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767 \
+    thiserror                        2.0.9  f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                   2.0.7  e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36 \
+    thiserror-impl                   2.0.9  7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tikv-jemalloc-sys 0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d \
     tikv-jemallocator                0.6.0  4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865 \
@@ -476,7 +478,7 @@ cargo.crates \
     tiny-skia-path                   0.8.4  adbfb5d3f3dd57a0e11d12f4f13d4ebbbc1b5c15b7ab0a156d030b21da5f677c \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
-    tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
+    tinyvec                          1.8.1  022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tokio                           1.42.0  5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551 \
     tokio-macros                     2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
@@ -487,6 +489,8 @@ cargo.crates \
     toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                      0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
+    tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
+    tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-attributes              0.1.28  395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d \
@@ -503,8 +507,8 @@ cargo.crates \
     typeid                           1.0.2  0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
-    unicase                          2.8.0  7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df \
-    unicode-bidi                    0.3.17  5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893 \
+    unicase                          2.8.1  75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539 \
+    unicode-bidi                    0.3.18  5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5 \
     unicode-bidi-mirroring           0.1.0  56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694 \
     unicode-ccc                      0.1.2  cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1 \
     unicode-general-category         0.6.0  2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7 \
@@ -543,7 +547,7 @@ cargo.crates \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                    0.26.7  5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e \
     weezl                            0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
-    which                            7.0.0  c9cad3279ade7346b96e38731a641d7343dd6a53d55083dd54eadfa5a1b38c6b \
+    which                            7.0.1  fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028 \
     widestring                       1.1.0  7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -604,7 +608,7 @@ cargo.crates \
     zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
     zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
     zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
-    zlib-rs                          0.4.0  2ca4a9dc6566c9224cc161dedc5577bd81f4a9ee0f9fbe80592756d096b07ee5 \
+    zlib-rs                          0.4.1  aada01553a9312bad4b9569035a1f12b05e5ec9770a1a4b323757356928944f8 \
     zstd                            0.13.2  fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9 \
     zstd-safe                        7.2.1  54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059 \
     zstd-sys             2.0.13+zstd.1.5.6  38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.5.12

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
