### PR TITLE
lima: Update to 1.0.3

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 1.0.2 v
+go.setup            github.com/lima-vm/lima 1.0.3 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 depends_run         port:qemu
 
-checksums           rmd160  e89a2e641f9a73e393716badea02bf6e4c72ed80 \
-                    sha256  f1f69d38998ca4e08b1dadbb3e3e5140feaecf8b49105a99a18be0e7a27ce90d \
-                    size    7378648
+checksums           rmd160  60a71868460fe544be7e44f0ec10bc3d66198a10 \
+                    sha256  c36e803f4faf41607220df4c1d7a61977a7d492facf03e0b67f1f69390840a90 \
+                    size    7381537
 
 build.cmd           make
 


### PR DESCRIPTION
#### Description

lima: Update to 1.0.3

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
