### PR TITLE
rebels-in-the-sky: Update to 1.0.27

### DIFF
--- a/games/rebels-in-the-sky/Portfile
+++ b/games/rebels-in-the-sky/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        ricott1 rebels-in-the-sky 1.0.26 v
+github.setup        ricott1 rebels-in-the-sky 1.0.27 v
 revision            0
 
 categories          games
@@ -29,9 +29,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix}  \
-                    rmd160  b9e349a741c6d4db3c86d51e010fa253323773a9 \
-                    sha256  f8fb6e67845842d88319db11e5d7020a8d7fa98fd14f30ca7dda149dddfe05f6 \
-                    size    9721823
+                    rmd160  9b57f1a6a1ac3935d6dcfe46074935db9fe4152f \
+                    sha256  60123dea3aada5ce87b6801bab0aee8cc2f40c20737a96abd947f12810040128 \
+                    size    9768745
 
 cargo.crates \
     ab_glyph                           0.2.29  ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0 \
@@ -54,7 +54,7 @@ cargo.crates \
     anstyle-parse                       0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                       1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                      3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
-    anyhow                             1.0.94  c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7 \
+    anyhow                             1.0.95  34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04 \
     approx                              0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
     arbitrary                           1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arc-swap                            1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
@@ -64,10 +64,21 @@ cargo.crates \
     asn1-rs                             0.6.2  5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048 \
     asn1-rs-derive                      0.5.1  965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490 \
     asn1-rs-impl                        0.2.0  7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7 \
+    async-channel                       1.9.0  81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35 \
+    async-channel                       2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
+    async-executor                     1.13.1  30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec \
+    async-fs                            2.1.2  ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a \
+    async-global-executor               2.4.1  05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c \
     async-io                            2.4.0  43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059 \
     async-lock                          3.4.0  ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18 \
+    async-net                           2.0.0  b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7 \
+    async-process                       2.3.0  63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb \
+    async-signal                       0.2.10  637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3 \
+    async-std                          1.13.0  c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615 \
+    async-task                          4.7.1  8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de \
     async-trait                        0.1.83  721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd \
     asynchronous-codec                  0.7.0  a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233 \
+    atomic-waker                        1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     attohttpc                          0.24.1  8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2 \
     autocfg                             1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     av1-grain                           0.2.3  6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf \
@@ -86,18 +97,19 @@ cargo.crates \
     blake2                             0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
     block-buffer                       0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block-padding                       0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
+    blocking                            1.6.1  703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea \
     blowfish                            0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
     bs58                                0.5.1  bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4 \
     built                               0.7.5  c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b \
     bumpalo                            3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
-    bytemuck                           1.20.0  8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a \
+    bytemuck                           1.21.0  ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3 \
     byteorder                           1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     byteorder-lite                      0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
     bytes                               1.9.0  325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b \
     cassowary                           0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     castaway                            0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
     cbc                                 0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.3  27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d \
+    cc                                  1.2.6  8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333 \
     cesu8                               1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cexpr                               0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-expr                           0.15.8  d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02 \
@@ -105,7 +117,7 @@ cargo.crates \
     cfg_aliases                         0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                            0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
     chacha20poly1305                   0.10.1  10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35 \
-    chrono                             0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
+    chrono                             0.4.39  7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825 \
     cipher                              0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     clang-sys                           1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
     clap                               4.5.23  3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84 \
@@ -130,9 +142,9 @@ cargo.crates \
     cpal                               0.15.3  873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779 \
     cpufeatures                        0.2.16  16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3 \
     crc32fast                           1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
-    crossbeam-deque                     0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
+    crossbeam-deque                     0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                    0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                    0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
+    crossbeam-utils                    0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
     crossterm                          0.28.1  829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6 \
     crossterm_winapi                    0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crunchy                             0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
@@ -148,7 +160,6 @@ cargo.crates \
     data-encoding                       2.6.0  e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2 \
     data-encoding-macro                0.1.15  f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639 \
     data-encoding-macro-internal       0.1.13  332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f \
-    delegate                           0.12.0  4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b \
     delegate                           0.13.1  bc2323e10c92e1cf4d86e11538512e6dc03ceb586842970b6332af3d4046a046 \
     der                                 0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     der-parser                          9.0.0  5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553 \
@@ -174,6 +185,7 @@ cargo.crates \
     enum-ordinalize-derive              4.3.1  0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff \
     equivalent                          1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                              0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
+    event-listener                      2.5.3  0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0 \
     event-listener                      5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
     event-listener-strategy             0.5.3  3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2 \
     exr                                1.73.0  f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0 \
@@ -184,7 +196,7 @@ cargo.crates \
     flate2                             1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
     flurry                              0.5.2  cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9 \
     fnv                                 1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    foldhash                            0.1.3  f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2 \
+    foldhash                            0.1.4  a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f \
     form_urlencoded                     1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     futures                            0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
     futures-bounded                     0.2.4  91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e \
@@ -207,6 +219,7 @@ cargo.crates \
     gimli                              0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     glam                               0.29.2  dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677 \
     glob                                0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
+    gloo-timers                         0.3.0  bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994 \
     group                              0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
     h2                                 0.3.26  81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8 \
     half                                2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
@@ -217,11 +230,11 @@ cargo.crates \
     hex                                 0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hex-literal                         0.4.1  6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46 \
     hex_fmt                             0.3.0  b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f \
-    hickory-proto                      0.24.1  07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512 \
-    hickory-resolver                   0.24.1  28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243 \
+    hickory-proto                      0.24.2  447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5 \
+    hickory-resolver                   0.24.2  0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4 \
     hkdf                               0.12.4  7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7 \
     hmac                               0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
-    home                                0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
+    home                               0.5.11  589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf \
     hostname                            0.3.1  3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867 \
     hound                               3.5.1  62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f \
     http                               0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
@@ -232,9 +245,9 @@ cargo.crates \
     httparse                            1.9.5  7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946 \
     httpdate                            1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     humantime                           2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
-    hyper                             0.14.31  8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85 \
-    hyper                               1.5.1  97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f \
-    hyper-rustls                       0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
+    hyper                             0.14.32  41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7 \
+    hyper                               1.5.2  256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0 \
+    hyper-rustls                       0.27.5  2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2 \
     hyper-util                         0.1.10  df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4 \
     iana-time-zone                     0.1.61  235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220 \
     iana-time-zone-haiku                0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
@@ -249,7 +262,6 @@ cargo.crates \
     icu_provider                        1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
     icu_provider_macros                 1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
     ident_case                          1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
-    idna                                0.4.0  7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c \
     idna                                1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                        1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     if-addrs                           0.10.2  cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a \
@@ -264,7 +276,7 @@ cargo.crates \
     indexmap                            2.7.0  62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f \
     indoc                               2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inout                               0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
-    instability                         0.3.3  b829f37dead9dc39df40c2d3376c179fdfd2ac771f53f55d3c30dc096a3c0c6e \
+    instability                         0.3.5  898e106451f7335950c9cc64f8ec67b5f65698679ac67ed00619aeef14e1cf75 \
     instant                            0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
     interpolate_name                    0.2.4  c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60 \
     ipconfig                            0.3.2  b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f \
@@ -278,10 +290,11 @@ cargo.crates \
     jobserver                          0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jpeg-decoder                        0.3.1  f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0 \
     js-sys                             0.3.76  6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7 \
+    kv-log-macro                        1.0.7  0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f \
     lazy_static                         1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     lebe                                0.5.2  03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8 \
     lewton                             0.10.2  777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030 \
-    libc                              0.2.167  09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc \
+    libc                              0.2.169  b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a \
     libfuzzer-sys                       0.4.8  9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa \
     libloading                          0.8.6  fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34 \
     libm                               0.2.11  8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa \
@@ -297,9 +310,11 @@ cargo.crates \
     libp2p-metrics                     0.15.0  77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566 \
     libp2p-noise                       0.45.0  36b137cb1ae86ee39f8e5d6245a296518912014eaa87427d24e6ff58cfc1b28c \
     libp2p-ping                        0.45.0  005a34420359223b974ee344457095f027e51346e992d1e0dcd35173f4cdd422 \
+    libp2p-plaintext                   0.42.0  5b63d926c6be56a2489e0e7316b17fe95a70bc5c4f3e85740bb3e67c0f3c6a44 \
     libp2p-quic                        0.11.1  46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e \
     libp2p-swarm                       0.45.1  d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a \
     libp2p-swarm-derive                0.35.0  206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8 \
+    libp2p-swarm-test                   0.4.0  ea4e1d1d92421dc4c90cad42e3cd24f50fd210191c9f126d41bd483a09567f67 \
     libp2p-tcp                         0.42.0  ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314 \
     libp2p-tls                          0.5.0  47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847 \
     libp2p-upnp                         0.3.0  01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f \
@@ -325,7 +340,7 @@ cargo.crates \
     memchr                              2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     mime                               0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                     0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
-    miniz_oxide                         0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
+    miniz_oxide                         0.8.2  4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394 \
     mio                                 1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
     multiaddr                          0.18.2  fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961 \
     multibase                           0.9.1  9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404 \
@@ -339,7 +354,7 @@ cargo.crates \
     netlink-packet-route               0.17.1  053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66 \
     netlink-packet-utils                0.5.2  0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34 \
     netlink-proto                      0.11.3  86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21 \
-    netlink-sys                         0.8.6  416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307 \
+    netlink-sys                         0.8.7  16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23 \
     new_debug_unreachable               1.0.6  650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086 \
     nix                                0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
     nohash-hasher                       0.2.0  2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451 \
@@ -358,7 +373,7 @@ cargo.crates \
     num_cpus                           1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
     num_enum                            0.7.3  4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179 \
     num_enum_derive                     0.7.3  af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56 \
-    object                             0.36.5  aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e \
+    object                             0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
     oboe                                0.6.1  e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb \
     oboe-sys                            0.6.1  6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d \
     ogg                                 0.8.0  6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e \
@@ -371,7 +386,7 @@ cargo.crates \
     p256                               0.13.2  c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b \
     p384                               0.13.0  70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209 \
     p521                               0.13.3  0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2 \
-    pageant                      0.0.1-beta.3  2c8ca7f786256e4d89f369656546b1f504cfd2d5ec796f0b99600919dd993723 \
+    pageant                             0.0.1  032d6201d2fb765158455ae0d5a510c016bb6da7232e5040e39e9c8db12b0afc \
     parking                             2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                        0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                   0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
@@ -384,11 +399,12 @@ cargo.crates \
     pin-project-internal                1.1.7  3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c \
     pin-project-lite                   0.2.15  915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff \
     pin-utils                           0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    piper                               0.2.4  96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066 \
     pkcs1                               0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
     pkcs5                               0.7.1  e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6 \
     pkcs8                              0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                         0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
-    png                               0.17.15  b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d \
+    png                               0.17.16  82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526 \
     polling                             3.7.4  a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f \
     poly1305                            0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
     polyval                             0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
@@ -409,8 +425,8 @@ cargo.crates \
     quick-protobuf-codec                0.3.1  15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474 \
     quinn                              0.11.6  62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef \
     quinn-proto                        0.11.9  a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d \
-    quinn-udp                           0.5.7  7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da \
-    quote                              1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
+    quinn-udp                           0.5.9  1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904 \
+    quote                              1.0.38  0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc \
     rand                                0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                         0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                           0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
@@ -423,12 +439,12 @@ cargo.crates \
     rayon                              1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                         1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     rcgen                              0.11.3  52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6 \
-    redox_syscall                       0.5.7  9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f \
+    redox_syscall                       0.5.8  03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834 \
     redox_users                         0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
     regex                              1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                      0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                        0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    reqwest                            0.12.9  a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f \
+    reqwest                           0.12.11  7fe060fe50f524be480214aba758c71f99f90ee8c83c5a36b5e9e1d568eb4eb3 \
     resolv-conf                         0.7.0  52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00 \
     rfc6979                             0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
     rgb                                0.8.50  57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a \
@@ -437,9 +453,9 @@ cargo.crates \
     rodio                              0.20.1  e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1 \
     rsa                                 0.9.7  47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519 \
     rtnetlink                          0.13.1  7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0 \
-    russh                              0.48.2  5c086efe0c429fa0b4e448c67147366d0319ed1c9a051d91b8f38e93fef25cc7 \
+    russh                              0.49.2  2b206640a622d63529540fc48036aa39f211b2b71432a451156004f40655cdb4 \
     russh-cryptovec                    0.48.0  4d8e7e854e1a87e4be00fa287c98cad23faa064d0464434beaa9f014ec3baa98 \
-    russh-keys                         0.48.1  fed9bf3da16ad2892a44b840e40483010295bfc8fda8134650c381654cb1ef36 \
+    russh-keys                         0.49.2  788a2439ce385856585346beb37c48e7c9eb5de5f4f00736720a19ffdb3f5bb5 \
     russh-sftp                          2.0.6  c2a72c8afe2041c17435eecd85d0b7291841486fd3d1c4082e0b212e5437ca42 \
     russh-util                         0.48.0  92c7dd577958c0cefbc8f8a2c05c48c88c42e2fdb760dbe9b96ae31d4de97a1f \
     rustc-demangle                     0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
@@ -447,27 +463,27 @@ cargo.crates \
     rustc-hash                          2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
     rustc_version                       0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rusticata-macros                    4.1.0  faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632 \
-    rustix                            0.38.41  d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6 \
-    rustls                            0.23.19  934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1 \
+    rustix                            0.38.42  f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85 \
+    rustls                            0.23.20  5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b \
     rustls-pemfile                      2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
-    rustls-pki-types                   1.10.0  16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b \
+    rustls-pki-types                   1.10.1  d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37 \
     rustls-webpki                     0.101.7  8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765 \
     rustls-webpki                     0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
-    rustversion                        1.0.18  0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248 \
+    rustversion                        1.0.19  f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4 \
     rw-stream-sink                      0.4.0  d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1 \
     ryu                                1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
-    safe_arch                           0.7.2  c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a \
+    safe_arch                           0.7.4  96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323 \
     salsa20                            0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                           1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scopeguard                          1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scrypt                             0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
     sec1                                0.7.3  d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc \
     seize                               0.3.3  689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3 \
-    semver                             1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
-    serde                             1.0.215  6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f \
+    semver                             1.0.24  3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba \
+    serde                             1.0.216  0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e \
     serde-value                         0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
-    serde_derive                      1.0.215  ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0 \
-    serde_json                        1.0.133  c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377 \
+    serde_derive                      1.0.216  46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e \
+    serde_json                        1.0.134  d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d \
     serde_repr                         0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
     serde_spanned                       0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                    0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
@@ -484,6 +500,7 @@ cargo.crates \
     simd_helpers                        0.1.0  95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6 \
     slab                                0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     smallvec                           1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
+    smol                                2.0.2  a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f \
     snow                                0.9.6  850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85 \
     socket2                             0.5.8  c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8 \
     spin                                0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
@@ -494,7 +511,7 @@ cargo.crates \
     ssh-key                             0.6.7  3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3 \
     stable_deref_trait                  1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     static_assertions                   1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
-    stream-download                    0.13.2  569eda55a5072a746dd143a76a15a8395366b8814652e4ef8cc13fefd3be0cab \
+    stream-download                    0.14.0  12805df2636c863ea4ab01c288faf6589e8e8d4c9eac8b308d799ed3ac2bbf15 \
     strsim                             0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                              0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
     strum_macros                       0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
@@ -504,7 +521,7 @@ cargo.crates \
     symphonia-core                      0.5.4  798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3 \
     symphonia-metadata                  0.5.4  bc622b9841a10089c5b18e99eb904f4341615d5aa55bbf4eedde1be721a4023c \
     syn                               1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                                2.0.90  919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31 \
+    syn                                2.0.92  70ae51629bf965c5c098cc9e87908a3df5301051a9e087d6f9bef5c9771ed126 \
     sync_wrapper                        1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                       0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     system-configuration                0.6.1  3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b \
@@ -514,9 +531,9 @@ cargo.crates \
     target-lexicon                    0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
     tempfile                           3.14.0  28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c \
     thiserror                          1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                           2.0.6  8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47 \
+    thiserror                           2.0.9  f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc \
     thiserror-impl                     1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                      2.0.6  d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312 \
+    thiserror-impl                      2.0.9  7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4 \
     thread-id                           4.2.2  cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea \
     tiff                                0.9.1  ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e \
     time                               0.3.37  35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21 \
@@ -524,7 +541,7 @@ cargo.crates \
     time-macros                        0.2.19  2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de \
     tiny-keccak                         2.0.2  2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237 \
     tinystr                             0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
-    tinyvec                             1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
+    tinyvec                             1.8.1  022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8 \
     tinyvec_macros                      0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tokio                              1.42.0  5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551 \
     tokio-macros                        2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
@@ -534,6 +551,8 @@ cargo.crates \
     toml                               0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
     toml_datetime                       0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                         0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
+    tower                               0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
+    tower-layer                         0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                       0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                            0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-attributes                 0.1.28  395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d \
@@ -544,9 +563,7 @@ cargo.crates \
     typemap-ors                         1.0.0  a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867 \
     typenum                            1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
     uint                                0.9.5  76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52 \
-    unicode-bidi                       0.3.17  5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893 \
     unicode-ident                      1.0.14  adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83 \
-    unicode-normalization              0.1.24  5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956 \
     unicode-segmentation               1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-truncate                    1.1.0  b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf \
     unicode-width                      0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
@@ -564,6 +581,7 @@ cargo.crates \
     utf8parse                           0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     uuid                               1.11.0  f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a \
     v_frame                             0.3.8  d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b \
+    value-bag                          1.10.0  3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2 \
     version-compare                     0.2.0  852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b \
     version_check                       0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     void                                1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
@@ -653,4 +671,4 @@ cargo.crates \
     zerovec-derive                     0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
     zune-core                          0.4.12  3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a \
     zune-inflate                       0.2.54  73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02 \
-    zune-jpeg                          0.4.13  16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768
+    zune-jpeg                          0.4.14  99a5bab8d7dedf81405c4bb1f2b83ea057643d9cb28778cea9eecddeedd2e028


### PR DESCRIPTION
#### Description

rebels-in-the-sky: Update to 1.0.27

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
