### PR TITLE
vtk: Update to 9.4.1

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -18,7 +18,7 @@ compiler.cxx_standard 2011
 compiler.blacklist-append {clang < 900}
 
 name                vtk
-version             9.4.0
+version             9.4.1
 revision            0
 categories          graphics devel
 license             BSD
@@ -39,9 +39,9 @@ master_sites        ${homepage}/files/release/${branch}
 
 distname            VTK-${version}
 
-checksums           rmd160  b265f1752ab0be2687ada62e2376177f54ccbbf0 \
-                    sha256  16f3ffd65fafd68fab469bcb091395bf5432617c7db27cbce86a737bf09ec5b0 \
-                    size    118611659
+checksums           rmd160  7165ecf0a7c79776033fb1fdb30c1380be3170e4 \
+                    sha256  c253b0c8d002aaf98871c6d0cb76afc4936c301b72358a08d5f3f72ef8bc4529 \
+                    size    118618515
 
 mpi.setup
 


### PR DESCRIPTION
#### Description

vtk: Update 9.4.0 --> 9.4.1

###### Type(s)

###### Tested on

CI only.  OS 13, 14 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?