### PR TITLE
tree: Require C11

### DIFF
--- a/sysutils/tree/Portfile
+++ b/sysutils/tree/Portfile
@@ -24,6 +24,9 @@ checksums           rmd160  4e7d927b44a771bb1bc408aec95d749faa3f2e2f \
                     sha256  68ac45dc78c0c311ada06200ffc3c285e74223ba208061f8d15ffac25e44b2ec \
                     size    65505
 
+compiler.c_standard \
+                    2011
+
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
     xinstall -m 0644 ${worksrcpath}/doc/${name}.1 ${destroot}${prefix}/share/man/man1/


### PR DESCRIPTION
#### Description

Since #27143, `tree` requires C11 to fix the build on (assuming) OSX 10.6 and below, [per this commit comment](https://github.com/macports/macports-ports/commit/557810f916f6c41c2121ea9fdd7faa238de999ed#commitcomment-150776961)

cc @barracuda156 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
