### PR TITLE
qbs: Fix building on 10.14

### DIFF
--- a/devel/qbs/Portfile
+++ b/devel/qbs/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           qt6 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
 
 name                qbs
 version             2.5.0
@@ -27,9 +28,12 @@ checksums           rmd160  a6348223ed91c7e514be37d1beac5baedf54ef1b \
 qt6.depends_lib qt5compat
 
 compiler.cxx_standard 2017
-# requires std::optional, above is not enough :(
-# https://github.com/macports/macports-base/pull/179
-compiler.blacklist-append {clang < 1001}
+# requires at least what qt64 requires
+compiler.blacklist-append {clang < 1100}
+
+# requires std::filesystem
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
 
 configure.args-append -DQBS_ENABLE_RPATH=NO
 


### PR DESCRIPTION
#### Description

Now that qt64 is allowed on 10.14, we can build qbs. It [requires using the same compiler toolchain Qt was built with](https://qbs.io//docs/building-qbs/#system-requirements) and also requires std::filesystem.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
