### PR TITLE
tk: split into quartz and x11 subports

### DIFF
--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -1,19 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               active_variants 1.1
 
 name                    tkimg
 version                 1.4.16
-revision                0
+revision                1
 categories              graphics
 license                 Tcl/Tk
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} {gmx.us:chrischavez @chrstphrchvz} openmaintainer
 homepage                https://tkimg.sourceforge.net
 description             adds a lot of image formats to Tcl/Tk
 long_description        The \"Img\" package adds a lot of image formats to Tcl/Tk.
-
-platforms               darwin
 
 master_sites            sourceforge:tkimg/tkimg/[join [lrange [split ${version} .] 0 1] .]/tkimg%20${version}
 distname                Img-${version}-Source
@@ -39,20 +36,20 @@ patchfiles-append       patch-quartz.diff
 depends_build-append    port:tcllib
 
 depends_lib-append      port:tcl \
-                        port:tk \
                         port:zlib
 
-configure.args-append   --with-tcl=${prefix}/lib \
-                        --with-tk=${prefix}/lib
+configure.args-append   --with-tcl=${prefix}/lib
 
 destroot.destdir        INSTALL_ROOT=${destroot}
 
 variant quartz conflicts x11 {
-    require_active_variants tk quartz
+    depends_lib-append  port:tk-quartz
+    configure.args-append   --with-tk=${prefix}/lib/tk-quartz
 }
 
 variant x11 conflicts quartz {
-    require_active_variants tk x11
+    depends_lib-append  port:tk-x11
+    configure.args-append   --with-tk=${prefix}/lib/tk-x11
 }
 
 if {![variant_isset x11] && ![variant_isset quartz]} {

--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -255,12 +255,17 @@ variant latex description {build with LaTeX support and docs in PDF} {
 }
 
 variant tcltk description {enable use of tcltk} {
-    depends_lib-append      port:tcl \
-                            port:tk
+    depends_lib-append      port:tcl
+    if {[variant_isset quartz]} {
+        depends_lib-append      port:tk-quartz
+        configure.args-append   --with-tk-config=${prefix}/lib/tk-quartz/tkConfig.sh
+    } else {
+        depends_lib-append      port:tk-x11
+        configure.args-append   --with-tk-config=${prefix}/lib/tk-x11/tkConfig.sh
+    }
     configure.args-delete   --without-tcltk
     configure.args-append   --with-tcltk \
-                            --with-tcl-config=${prefix}/lib/tclConfig.sh \
-                            --with-tk-config=${prefix}/lib/tkConfig.sh
+                            --with-tcl-config=${prefix}/lib/tclConfig.sh
 }
 
 variant tests description {include tests of R installation} {
@@ -268,7 +273,6 @@ variant tests description {include tests of R installation} {
 }
 
 variant x11 conflicts quartz {
-    require_active_variants tk x11
     depends_lib-append      port:xorg-libice \
                             port:xorg-libsm \
                             port:xorg-libX11 \
@@ -285,7 +289,6 @@ variant aqua description {Enable native macOS graphics support, needed by R.app 
 }
 
 variant quartz requires aqua conflicts x11 {
-    require_active_variants tk quartz
     notes-append "
         Note that R with quartz variant will not work with R.app because\
         of conflicts over the macOS menu."

--- a/math/netgen/Portfile
+++ b/math/netgen/Portfile
@@ -9,7 +9,7 @@ PortGroup               github    1.0
 PortGroup               legacysupport 1.1
 
 github.setup            NGSolve netgen 6.2.2307 v
-revision                0
+revision                1
 categories              math
 license                 LGPL-2
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -60,7 +60,6 @@ patchfiles-append       patch-no-external.diff \
 
 depends_lib-append      port:zlib \
                         port:tcl \
-                        port:tk \
                         port:tkdnd \
                         port:Togl \
                         path:lib/libavcodec.dylib:ffmpeg \
@@ -70,7 +69,6 @@ configure.args-append   -DUSE_NATIVE_ARCH=OFF \
                         -DUSE_PYTHON=OFF \
                         -DPREFER_SYSTEM_PYBIND11=ON \
                         -DTCL_INCLUDE_PATH:PATH=${prefix}/include \
-                        -DTK_INCLUDE_PATH:PATH=${prefix}/include \
                         -DOPENGL_glu_LIBRARY="" \
                         -DNETGEN_VERSION_GIT="v${version}" \
                         -DUSE_JPEG=ON \
@@ -134,7 +132,7 @@ foreach pdv ${pythonversions} {
 }
 
 variant quartz conflicts x11 {
-    require_active_variants tk    quartz
+    depends_lib-append  port:tk-quartz
     require_active_variants tkdnd quartz
     require_active_variants Togl  quartz
 
@@ -145,10 +143,14 @@ variant quartz conflicts x11 {
         reinplace           "s|MACPORTS_NO_X11|TRUE|g" \
                             ${worksrcpath}/CMakeLists.txt
     }
+    configure.args-append   -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-quartz \
+                            -DTK_WISH:PATH=${prefix}/libexec/tk-quartz/wish \
+                            -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtkstub8.6.a \
+                            -DTK_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtk.dylib
 }
 
 variant x11 conflicts quartz {
-    require_active_variants tk    x11
+    depends_lib-append  port:tk-x11
     require_active_variants tkdnd x11
     require_active_variants Togl  x11
     depends_lib-append      port:xorg-libX11 \
@@ -159,7 +161,11 @@ variant x11 conflicts quartz {
     # Use appropriate headers:
     patchfiles-append       patch-x11-gl.diff
 
-    configure.args-append   -DOPENGL_gl_LIBRARY=${prefix}/lib/libGL.dylib
+    configure.args-append   -DOPENGL_gl_LIBRARY=${prefix}/lib/libGL.dylib \
+                            -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-x11 \
+                            -DTK_WISH:PATH=${prefix}/libexec/tk-x11/wish \
+                            -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-x11/libtkstub8.6.a \
+                            -DTK_LIBRARY:PATH=${prefix}/lib/tk-x11/libtk.dylib
 }
 
 if {![variant_isset quartz] && ![variant_isset x11]} {

--- a/science/gvemod-labeler/Portfile
+++ b/science/gvemod-labeler/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
-PortGroup                   active_variants 1.1
 
 name                        gvemod-labeler
 version                     0.4
+revision                    1
 categories                  science graphics x11
 maintainers                 {raphael @raphael-st} openmaintainer
 description                 An interactive tool for generating \
@@ -16,7 +16,6 @@ long_description            This is the Labeler emodule, an interactive tool \
                             interactive 3d viewing program).
 homepage                    http://www.geomview.org/
 license                     LGPL-2+
-platforms                   darwin
 master_sites                sourceforge:project/geomview/${name}:current \
                             sourceforge:project/geomview/${name}/0.2:old
 
@@ -35,9 +34,7 @@ checksums                   ${distname}${extract.suffix} \
                                 size    254354
 
 depends_lib                 port:geomview \
-                            port:tk
-
-require_active_variants     tk x11
+                            port:tk-x11
 
 # Use the Tcl script from version 0.2 and delete the "Labler" binary.
 # Work around case-insensitivity "Labeler" Tcl script <-> "labeler" module
@@ -47,6 +44,9 @@ post-extract {
     reinplace "s|module_tcl_DATA = Labeler|module_tcl_DATA = Labeler.tc|" \
         ${worksrcpath}/src/Makefile.in
 }
+
+configure.args              --with-tk-lib=${prefix}/lib/tk-x11 \
+                            --with-tk-headers=${prefix}/include/tk-x11
 
 post-destroot {
     move ${destroot}${prefix}/libexec/geomview/tcl/Labeler.tc \

--- a/science/magic/Portfile
+++ b/science/magic/Portfile
@@ -1,12 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           active_variants 1.1
 PortGroup           conflicts_build 1.0
 
 name                magic
 version             8.3.508
-revision            0
+revision            1
 checksums           rmd160  f034a75cb02e22b72cf0f5748029bb06e570a259 \
                     sha256  efd23c5b6de4da25868964f1f1e6e4e2229d8ee82f1bfa795e6c2cbfb48e46ab \
                     size    3762537
@@ -35,13 +34,11 @@ depends_lib         port:blt \
                     port:libGLU \
                     port:mesa \
                     port:tcl \
-                    port:tk \
+                    port:tk-x11 \
                     port:xorg-libice \
                     port:xorg-libXi \
                     port:xorg-libXmu \
                     port:zlib
-
-require_active_variants tk x11
 
 universal_variant   no
 
@@ -61,7 +58,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 19} {
 }
 
 configure.args-append \
-                    ac_cv_path_PYTHON3=${configure.python}
+                    ac_cv_path_PYTHON3=${configure.python} \
+                    --with-tk=${prefix}/lib/tk-x11 \
+                    --with-tkincls=${prefix}/include/tk-x11 \
+                    --with-tklibs=${prefix}/lib/tk-x11 \
+                    --with-wish=${prefix}/libexec/tk-x11/wish
 
 use_parallel_build  no
 

--- a/science/xcrysden/Portfile
+++ b/science/xcrysden/Portfile
@@ -1,13 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           active_variants 1.1
 PortGroup           compilers 1.0
 
 name                xcrysden
 version             1.6.2
+revision            1
 categories          science
-platforms           darwin
 license             GPL-2+
 
 # depends on mesa->py27-xml2->python27->openssl, but nothing from openssl is actually used in XCrySDen
@@ -32,9 +31,7 @@ checksums           rmd160  76d689c50dfc2207cf814b2edc4df36b2921e80b \
 compilers.choose    fc
 compilers.setup     require_fortran
 
-require_active_variants tk x11
-
-depends_lib         port:fftw-3 port:mesa port:libGLU port:tcl port:tk port:Togl-2.0 \
+depends_lib         port:fftw-3 port:mesa port:libGLU port:tcl port:tk-x11 port:Togl-2.0 \
                     port:xorg-libXmu port:xorg-libX11 port:xorg-libXext
 depends_run         port:BWidget
 
@@ -85,7 +82,8 @@ COMPILE_FFTW=no
 COMPILE_TOGL=no
 FFTW3_LIB=${prefix}/lib/libfftw3.dylib
 X_LIB=${prefix}/lib/libXmu.dylib ${prefix}/lib/libX11.dylib ${prefix}/lib/libXext.dylib
-TK_LIB=${prefix}/lib/libtk.dylib
+TK_INCDIR=-I${prefix}/include/tk-x11
+TK_LIB=${prefix}/lib/tk-x11/libtk.dylib
 TCL_LIB=${prefix}/lib/libtcl.dylib
 GL_LIB=${prefix}/lib/libGL.dylib
 GLU_LIB=${prefix}/lib/libGLU.dylib

--- a/science/xcrysden/files/patch-C-Makefile.diff
+++ b/science/xcrysden/files/patch-C-Makefile.diff
@@ -1,5 +1,14 @@
---- C/Makefile.orig	2020-06-05 21:44:48.000000000 -0700
-+++ C/Makefile	2020-06-05 21:45:10.000000000 -0700
+--- C/Makefile.orig	2019-10-29 22:37:45
++++ C/Makefile	2024-12-29 15:10:54
+@@ -6,7 +6,7 @@
+ # don't touch below this
+ #
+ 
+-INCS      = $(FFTW3_INCDIR) $(MESCHACH_INCDIR) $(TCL_INCDIR) $(TK_INCDIR) $(GL_INCDIR) $(X_INCDIR) $(EXTERNAL_INCDIR)
++INCS      = $(TK_INCDIR) $(FFTW3_INCDIR) $(MESCHACH_INCDIR) $(TCL_INCDIR) $(GL_INCDIR) $(X_INCDIR) $(EXTERNAL_INCDIR)
+ 
+ include make-objects
+ 
 @@ -38,7 +38,7 @@
  	$(CC) $(CFLAGS) $(XFS_OBJS) -o xsf2xsf $(MATH) $(LDLIB)
  

--- a/x11/Togl/Portfile
+++ b/x11/Togl/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
-PortGroup                       active_variants 1.1
 PortGroup                       github          1.0
 
 name                            Togl
@@ -11,7 +10,7 @@ name                            Togl
 # See https://github.com/NGSolve/netgen/tree/master/ng.
 github.setup                    NGSolve netgen 6.2.2307 v
 version                         2.1
-revision                        5
+revision                        6
 categories                      x11
 license                         permissive
 maintainers                     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -31,19 +30,19 @@ worksrcdir                      ${worksrcdir}/ng/Togl${version}
 
 conflicts                       Togl-2.0
 
-depends_lib-append              port:tcl \
-                                port:tk
+depends_lib-append              port:tcl
 
 # It does not build with Xcode gcc.
 compiler.blacklist-append       *gcc-4.0 *gcc-4.2
 
-configure.args-append           --with-tcl=${prefix}/lib \
-                                --with-tk=${prefix}/lib
+configure.args-append           --with-tcl=${prefix}/lib
 
 configure.universal_args-delete --disable-dependency-tracking
 
 variant quartz conflicts x11 {
-    require_active_variants     tk quartz
+    depends_lib-append  port:tk-quartz
+    configure.args-append       --with-tk=${prefix}/lib/tk-quartz \
+                                --with-tkinclude=${prefix}/include/tk-quartz
     # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L250
     configure.cppflags-append   -DTOGL_NSOPENGL
     # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L221
@@ -51,11 +50,13 @@ variant quartz conflicts x11 {
 }
 
 variant x11 conflicts quartz {
-    require_active_variants     tk x11
-    depends_lib-append          port:xorg-libX11 \
+    depends_lib-append          port:tk-x11 \
+                                port:xorg-libX11 \
                                 port:xorg-libXmu \
                                 port:mesa
-    configure.args-append       --with-Xmu
+    configure.args-append       --with-tk=${prefix}/lib/tk-x11 \
+                                --with-tkinclude=${prefix}/include/tk-x11 \
+                                --with-Xmu
     # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L252
     configure.cppflags-append   -DTOGL_X11
 }

--- a/x11/blt/Portfile
+++ b/x11/blt/Portfile
@@ -1,21 +1,19 @@
 #-*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               active_variants 1.1
 
 name                    blt
 version                 2.5.3
-revision                0
+revision                1
 categories              x11
 license                 MIT
 maintainers             nomaintainer
 
 description             BLT is an extension to the Tk toolkit, adding new widgets, \
                         geometry managers, and miscellaneous commands.
-long_description        ${description}
+long_description        {*}${description}
 
 homepage                http://blt.sourceforge.net/
-platforms               darwin
 
 master_sites            sourceforge:wize
 use_zip                 yes
@@ -27,15 +25,15 @@ checksums               rmd160  a0e0882e19003bbdb8a89d7c3d410bd32b12b685 \
                         size    2724036
 
 depends_build           port:tcl \
-                        port:tk \
+                        port:tk-x11 \
                         port:xorg-libX11
-
-require_active_variants tk x11
 
 use_parallel_build      no
 
 configure.args-append   --with-tcl=${prefix}/lib \
-                        --with-tk=${prefix}/lib
+                        --with-tk=${prefix}/lib/tk-x11 \
+                        --with-tkincls=${prefix}/include/tk-x11 \
+                        --with-tklibs=${prefix}/lib/tk-x11
 
 # prevent having to modify all of Debian patches
 patch.pre_args-replace  -p0 -p1

--- a/x11/tix/Portfile
+++ b/x11/tix/Portfile
@@ -1,12 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           active_variants 1.1
 
 name                tix
 version             8.4.3
-revision            5
-platforms           darwin
+revision            6
 categories          x11
 license             BSD
 maintainers         {gmx.us:chrischavez @chrstphrchvz} openmaintainer
@@ -30,8 +28,7 @@ checksums           rmd160  99249c4d7a19fcb8c27f11ab1b3ef6102911409d \
                     sha256  562f040ff7657e10b5cffc2c41935f1a53c6402eb3d5f3189113d734fd6c03cb \
                     size    1831503
 
-depends_lib         port:tcl \
-                    port:tk
+depends_lib         port:tcl
 patchfiles          patch-generic-tixGrSort.c.diff \
                     patch-tk_x11.diff \
                     patch-dyld_variable.diff \
@@ -42,20 +39,24 @@ patchfiles-append   patch-missing-headers.diff \
                     panic.patch
 
 configure.args      --mandir=${prefix}/share/man \
-                    --with-tcl=${prefix}/lib \
-                    --with-tk=${prefix}/lib
+                    --with-tcl=${prefix}/lib
 
 variant quartz conflicts x11 {
-    require_active_variants tk quartz
+    depends_lib-append  port:tk-quartz
+    configure.args-append \
+                    --with-tk=${prefix}/lib/tk-quartz
+    configure.cppflags-prepend  -I${prefix}/include/tk-quartz
 }
 
 variant x11 conflicts quartz {
-    require_active_variants tk x11
+    depends_lib-append  port:tk-x11
 
     configure.args-append \
                     --with-x \
                     --x-includes=${prefix}/include \
-                    --x-libraries=${prefix}/lib
+                    --x-libraries=${prefix}/lib \
+                    --with-tk=${prefix}/lib/tk-x11
+    configure.cppflags-prepend  -I${prefix}/include/tk-x11
 }
 
 if {![variant_isset quartz]} {

--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.1
 
 name                tk
 version             8.6.15
-revision            0
+revision            1
 categories          x11
 license             Tcl/Tk
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} {gmx.us:chrischavez @chrstphrchvz} openmaintainer
@@ -25,82 +25,130 @@ checksums           md5 6d64b6eb021062f378017d403fedcbe6 \
                     rmd160 3cb0ef6823829ed2f7ff0870c7754ea8be20b82a \
                     sha256 550969f35379f952b3020f3ab7b9dd5bfd11c1ef7c9b7c6a75f5c49aca793fec
 
-depends_build       port:pkgconfig
+if {$subport eq $name} {
+    distfiles
+    # Not noarch so arch checking works transitively
+    test.ignore_archs   yes
+    platforms       any
+    use_configure   no
+    build           {}
+    destroot {
+        if {[variant_exists quartz] && [variant_isset quartz]} {
+            set tkdepname tk-quartz
+        } else {
+            set tkdepname tk-x11
+        }
 
-# force usage of MacPorts Tcl
-depends_lib         port:fontconfig \
-                    port:tcl \
-                    port:Xft2 \
-                    port:xorg-libXScrnSaver
+        set bindir ${prefix}/libexec/${tkdepname}
+        ln -s {*}[glob -directory ${bindir} *] ${destroot}${prefix}/bin
 
-patchfiles          CGRect.patch
+        set incdir ${prefix}/include/${tkdepname}
+        ln -s {*}[glob -directory ${incdir} *] ${destroot}${prefix}/include
 
-configure.dir      ${worksrcpath}/unix
-build.dir          ${configure.dir}
+        set libdir ${prefix}/lib/${tkdepname}
+        ln -s {*}[glob -types f -directory ${libdir} *] ${destroot}${prefix}/lib
+        ln -s {*}[glob -types d -directory ${libdir} tk*] ${destroot}${prefix}/lib
+        ln -s ${libdir}/pkgconfig/tk.pc ${destroot}${prefix}/lib/pkgconfig
 
-configure.args      --mandir=${prefix}/share/man --with-tcl=${prefix}/lib
-# see https://trac.macports.org/ticket/58447
-configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
-configure.ldflags   -L${worksrcpath} -L${prefix}/lib -lfontconfig
+        set mandir ${prefix}/share/${tkdepname}/man
+        foreach sect {1 3 n} {
+            xinstall -d ${destroot}${prefix}/share/man/man${sect}
+            ln -s {*}[glob -directory ${mandir}/man${sect} *] ${destroot}${prefix}/share/man/man${sect}
+        }
+    }
+    if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
+        && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
+        variant quartz conflicts x11 {}
+        # The buildbot uses default variants, so binaries for ports
+        # that don't depend on a specific tk subport will be linked
+        # with tk-quartz, which is thus always needed.
+        depends_lib port:tk-quartz
 
-# see https://trac.macports.org/ticket/17189
-destroot.target-append \
-                    install-private-headers
-post-destroot {
-    ln -s wish8.6 ${destroot}${prefix}/bin/wish
-    ln -s libtk8.6.dylib ${destroot}${prefix}/lib/libtk.dylib
-}
+        variant x11 conflicts quartz {
+            depends_lib-append port:tk-x11
+        }
 
-configure.args.x86_64-append    --enable-64bit
-configure.args.ppc64-append     --enable-64bit
+        if {![variant_isset x11]} {
+            default_variants +quartz
+        }
+    } else {
+        depends_lib port:tk-x11
+    }
+    livecheck.type      regex
+    # Only check for 8.x versions - 9 will need to be a separate port.
+    livecheck.regex     {Tcl/Tk (8(?:\.\d+)*)</a>}
+} else {
+    depends_build       path:bin/pkg-config:pkgconfig
+    depends_lib         port:tcl
 
-if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx" && ${os.major} >= 10} {
-    variant quartz conflicts x11 {
-        depends_lib-delete \
-                    port:fontconfig \
-                    port:Xft2 \
-                    port:xorg-libXScrnSaver
-        configure.ldflags-delete \
-                    -lfontconfig
+    patchfiles          CGRect.patch
+
+    configure.dir       ${worksrcpath}/unix
+    build.dir           ${configure.dir}
+
+    set bindir          ${prefix}/libexec/${subport}
+    set incdir          ${prefix}/include/${subport}
+    set libdir          ${prefix}/lib/${subport}
+    set mandir          ${prefix}/share/${subport}/man
+
+    configure.args      --bindir=${bindir} \
+                        --includedir=${incdir} \
+                        --libdir=${libdir} \
+                        --mandir=${mandir} \
+                        --with-tcl=${prefix}/lib
+    configure.env       {TK_LIBRARY=$(libdir)/tk$(VERSION)}
+    platform darwin {
         configure.args-append \
-                    --enable-aqua
-        post-destroot {
-            move \
-                ${destroot}${prefix}/include/X11 \
-                ${destroot}${prefix}/include/X11_tk
-            fs-traverse fl ${destroot}${prefix}/include {
-                if {[file extension ${fl}] eq ".h"} {
-                    reinplace -q "s|include <X11/|include <X11_tk/|g" ${fl}
-                    reinplace -q "s|include \"X11/|include \"X11_tk/|g" ${fl}
-                }
-            }
+                        tcl_cv_type_64bit="long long"
+    }
+    # see https://trac.macports.org/ticket/58447
+    configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
+    configure.ldflags   -L${worksrcpath} -L${prefix}/lib
+
+    configure.args.arm64-append     --enable-64bit
+    configure.args.x86_64-append    --enable-64bit
+    configure.args.ppc64-append     --enable-64bit
+
+    # see https://trac.macports.org/ticket/17189
+    destroot.target-append \
+                        install-private-headers
+    post-destroot {
+        ln -s wish8.6 ${destroot}${bindir}/wish
+        ln -s libtk8.6.dylib ${destroot}${libdir}/libtk.dylib
+    
+        foreach fl {tk3d.h tkFont.h} {
+            xinstall -m 0644 ${workpath}/tk${version}/generic/${fl} ${destroot}${incdir}
         }
     }
 
-    variant x11 conflicts quartz {}
+    test.run            yes
 
-    if {![variant_isset x11]} {
-        default_variants +quartz
-    }
-} else {
-    # Even though X11 is the only option, make a variant so that other ports
-    # can check for it being set with require_active_variants.
-    variant x11 {}
-    default_variants +x11
+    livecheck.type      none
 }
 
-platform darwin {
+subport tk-quartz {
+    platforms       {macosx >= 10}
+    supported_archs arm64 i386 x86_64
     configure.args-append \
-                    tcl_cv_type_64bit="long long"
-}
-
-post-destroot {
-    foreach fl {tk3d.h tkFont.h} {
-        xinstall -m 0644 ${workpath}/tk${version}/generic/${fl} ${destroot}${prefix}/include/
+                    --enable-aqua
+    post-destroot {
+        move \
+            ${destroot}${incdir}/X11 \
+            ${destroot}${incdir}/X11_tk
+        fs-traverse fl [list ${destroot}${incdir}] {
+            if {[file extension ${fl}] eq ".h"} {
+                reinplace -q "s|include <X11/|include <X11_tk/|g" ${fl}
+                reinplace -q "s|include \"X11/|include \"X11_tk/|g" ${fl}
+            }
+        }
     }
 }
 
-test.run            yes
-
-livecheck.type      regex
-livecheck.regex     {Tcl/Tk (\d+(?:\.\d+)*)</a>}
+subport tk-x11 {
+    depends_lib-append \
+                    port:fontconfig \
+                    port:Xft2 \
+                    port:xorg-libXScrnSaver
+    configure.ldflags-append \
+                    -lfontconfig
+}

--- a/x11/tkdnd/Portfile
+++ b/x11/tkdnd/Portfile
@@ -2,12 +2,11 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           active_variants 1.1
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        petasis tkdnd 2.9.4 tkdnd-release-test-v
-platforms           darwin
+revision            1
 categories          x11
 license             BSD
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} {gmx.us:chrischavez @chrstphrchvz} openmaintainer
@@ -28,14 +27,17 @@ cmake.install_prefix ${prefix}/lib
 patchfiles-append   patch-CMakeLists.txt.diff
 
 configure.args-append \
-    -DTCL_INCLUDE_PATH:PATH=${prefix}/include \
-    -DTK_INCLUDE_PATH:PATH=${prefix}/include
+    -DTCL_INCLUDE_PATH:PATH=${prefix}/include
 
-depends_lib-append port:tcl \
-                   port:tk
+depends_lib-append port:tcl
 
 variant quartz conflicts x11 {
-    require_active_variants tk quartz
+    depends_lib-append  port:tk-quartz
+    configure.args-append \
+        -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-quartz \
+        -DTK_WISH:PATH=${prefix}/libexec/tk-quartz/wish \
+        -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtkstub8.6.a \
+        -DTK_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtk.dylib
     # garbage collection is still available for ${os.major} < 16
     # ARC is available for ${os.major} > 10
     # in Xcode < 10, ARC forbids Objective-C objects in struct
@@ -59,12 +61,18 @@ variant quartz conflicts x11 {
 }
 
 variant x11 conflicts quartz {
-    require_active_variants tk x11
     depends_lib-append \
+        port:tk-x11 \
         port:xorg-libX11 \
         port:xorg-libXext \
         port:xorg-libice \
         port:xorg-libsm
+
+    configure.args-append \
+        -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-x11 \
+        -DTK_WISH:PATH=${prefix}/libexec/tk-x11/wish \
+        -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-x11/libtkstub8.6.a \
+        -DTK_LIBRARY:PATH=${prefix}/lib/tk-x11/libtk.dylib
 }
 
 if {![variant_isset quartz] && ![variant_isset x11]} {

--- a/x11/tktable/Portfile
+++ b/x11/tktable/Portfile
@@ -1,18 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           active_variants 1.1
 
 name                tktable
 version             2.11
-revision            2
+revision            3
 categories          x11
 license             Tcl/Tk
 maintainers         {gmx.us:chrischavez @chrstphrchvz} openmaintainer
 description         A table/matrix widget extension to Tk/Tcl
-long_description    ${description}
+long_description    {*}${description}
 homepage            http://tktable.sourceforge.net/
-platforms           darwin
 
 # TkTable 2.11 was never posted to SourceForge.
 # A copy of the TkTable repository, owned by a Tcl/Tk developer,
@@ -36,23 +34,23 @@ patchfiles-append   patch-dyld_variable.diff \
                     patch-quartz.diff \
                     panic.patch
 
-depends_build       port:tcl \
-                    port:tk
+depends_build       port:tcl
 
 variant universal {}
 
 configure.args      --with-tcl=${prefix}/lib \
-                    --with-tk=${prefix}/lib \
                     CPPFLAGS="${configure.cppflags}" \
                     CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
                     LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
 
 variant quartz conflicts x11 {
-    require_active_variants tk quartz
+    depends_build-append    port:tk-quartz
+    configure.args-append   --with-tk=${prefix}/lib/tk-quartz
 }
 
 variant x11 conflicts quartz {
-    require_active_variants tk x11
+    depends_build-append    port:tk-x11
+    configure.args-append   --with-tk=${prefix}/lib/tk-x11
 }
 
 if {![variant_isset quartz]} {

--- a/x11/xcircuit/Portfile
+++ b/x11/xcircuit/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                xcircuit
 version             3.10.30
-revision            2
+revision            3
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          x11 cad
 maintainers         {khindenburg @kurthindenburg} openmaintainer
@@ -39,11 +39,10 @@ depends_build       port:autoconf \
 
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:ghostscript \
-                    port:tk \
+                    port:tk-x11 \
                     port:xpm
 
-# Currently, xcircuit crashes upon start if tk is built without +x11
-require_active_variants tk x11 quartz
+# Currently, xcircuit crashes upon start if tk is built without x11
 
 require_active_variants cairo x11
 
@@ -56,7 +55,7 @@ patchfiles-append   patch-xcircuit-implicit-udrawxat.diff
 configure.cflags-append -Wno-return-type
 
 configure.args      --with-tcl=${prefix}/lib \
-                    --with-tk=${prefix}/lib \
+                    --with-tk=${prefix}/lib/tk-x11 \
                     --with-gs=${prefix}/bin/gs \
                     --x-includes=${prefix}/include \
                     --x-libraries=${prefix}/lib


### PR DESCRIPTION
This allows ports that require an X11 version of tk to depend on tk-x11, and this is implemented in the second commit.