### PR TITLE
Update dotnet links to be global

### DIFF
--- a/dotnet/aspnetcore-runtime-2.1/Portfile
+++ b/dotnet/aspnetcore-runtime-2.1/Portfile
@@ -54,5 +54,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/2.1
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/2.1
 livecheck.regex     "ASP.NET Core Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/aspnetcore-runtime-3.1/Portfile
+++ b/dotnet/aspnetcore-runtime-3.1/Portfile
@@ -51,5 +51,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/3.1
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/3.1
 livecheck.regex     "ASP.NET Core Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/aspnetcore-runtime-6/Portfile
+++ b/dotnet/aspnetcore-runtime-6/Portfile
@@ -66,5 +66,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/6.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/6.0
 livecheck.regex     "ASP.NET Core Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/aspnetcore-runtime-7/Portfile
+++ b/dotnet/aspnetcore-runtime-7/Portfile
@@ -66,5 +66,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/7.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/7.0
 livecheck.regex     "ASP.NET Core Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/aspnetcore-runtime-8/Portfile
+++ b/dotnet/aspnetcore-runtime-8/Portfile
@@ -66,5 +66,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/8.0
 livecheck.regex     "ASP.NET Core Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/aspnetcore-runtime-devel/Portfile
+++ b/dotnet/aspnetcore-runtime-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                aspnetcore-runtime-devel
 set main_version    9.0.0
-# See patch version in https://dotnet.microsoft.com/en-us/download/dotnet/9.0
+# See patch version in https://dotnet.microsoft.com/download/dotnet/9.0
 set patch_version   6.24328.4
 version             ${main_version}-preview.${patch_version}
 revision            0
@@ -70,5 +70,5 @@ destroot {
 
 livecheck.version   [join [lrange [split ${patch_version} .] 0 0] .]
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/9.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/9.0
 livecheck.regex     "ASP.NET Core Runtime ${main_version}-preview.(\\d)"

--- a/dotnet/dotnet-cli/Portfile
+++ b/dotnet/dotnet-cli/Portfile
@@ -97,5 +97,5 @@ destroot {
 
 set major_ver       [join [lrange [split ${version} .] 0 1] .]
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/${major_ver}
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/${major_ver}
 livecheck.regex     ".NET Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-runtime-2.1/Portfile
+++ b/dotnet/dotnet-runtime-2.1/Portfile
@@ -52,5 +52,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/2.1
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/2.1
 livecheck.regex     ".NET Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-runtime-3.1/Portfile
+++ b/dotnet/dotnet-runtime-3.1/Portfile
@@ -52,5 +52,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/3.1
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/3.1
 livecheck.regex     ".NET Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-runtime-6/Portfile
+++ b/dotnet/dotnet-runtime-6/Portfile
@@ -67,5 +67,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/6.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/6.0
 livecheck.regex     ".NET Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-runtime-7/Portfile
+++ b/dotnet/dotnet-runtime-7/Portfile
@@ -67,5 +67,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/7.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/7.0
 livecheck.regex     ".NET Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-runtime-8/Portfile
+++ b/dotnet/dotnet-runtime-8/Portfile
@@ -67,5 +67,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/8.0
 livecheck.regex     ".NET Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-runtime-devel/Portfile
+++ b/dotnet/dotnet-runtime-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                dotnet-runtime-devel
 set main_version    9.0.0
-# See patch version in https://dotnet.microsoft.com/en-us/download/dotnet/9.0
+# See patch version in https://dotnet.microsoft.com/download/dotnet/9.0
 set patch_version   6.24327.7
 version             ${main_version}-preview.${patch_version}
 revision            0
@@ -71,5 +71,5 @@ destroot {
 
 livecheck.version   [join [lrange [split ${patch_version} .] 0 0] .]
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/9.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/9.0
 livecheck.regex     ".NET Runtime ${main_version}-preview.(\\d)"

--- a/dotnet/dotnet-sdk-2.1/Portfile
+++ b/dotnet/dotnet-sdk-2.1/Portfile
@@ -52,5 +52,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/2.1
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/2.1
 livecheck.regex     "SDK (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-sdk-3.1/Portfile
+++ b/dotnet/dotnet-sdk-3.1/Portfile
@@ -75,5 +75,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/3.1
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/3.1
 livecheck.regex     "SDK (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-sdk-6/Portfile
+++ b/dotnet/dotnet-sdk-6/Portfile
@@ -98,5 +98,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/6.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/6.0
 livecheck.regex     "SDK (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-sdk-7/Portfile
+++ b/dotnet/dotnet-sdk-7/Portfile
@@ -98,5 +98,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/7.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/7.0
 livecheck.regex     "SDK (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-sdk-8/Portfile
+++ b/dotnet/dotnet-sdk-8/Portfile
@@ -98,5 +98,5 @@ destroot {
 }
 
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/8.0
 livecheck.regex     "SDK (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-sdk-devel/Portfile
+++ b/dotnet/dotnet-sdk-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                dotnet-sdk-devel
 set main_version    9.0.100
-# See patch version in https://dotnet.microsoft.com/en-us/download/dotnet/9.0
+# See patch version in https://dotnet.microsoft.com/download/dotnet/9.0
 set patch_version   6.24328.19
 version             ${main_version}-preview.${patch_version}
 revision            0
@@ -105,5 +105,5 @@ destroot {
 
 livecheck.version   [join [lrange [split ${patch_version} .] 0 0] .]
 livecheck.type      regex
-livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/9.0
+livecheck.url       https://dotnet.microsoft.com/download/dotnet/9.0
 livecheck.regex     "SDK ${main_version}-preview.(\\d)"


### PR DESCRIPTION
Many Microsoft links (A) offer localized content if the locale is removed, and (B) still work even if there is only English content.