### PR TITLE
legcord: new port

### DIFF
--- a/net/Legcord/Portfile
+++ b/net/Legcord/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        Legcord Legcord 1.0.6 v
+github.tarball_from archive
+
+categories          net
+maintainers         {@akierig fastmail.de:akierig} openmaintainer
+revision            0
+
+checksums           rmd160  9e8ea1cd293f26ab446d858b046f7f961d2bb412 \
+                    sha256  765238e63153268e1d5e14681fbb875abaf83c81aaf174beae8193411b09a540 \
+                    size    1601820
+
+description         lightweight alternative to the regular Discord application
+long_description    ${name} is a {*}${description}. It wraps the Discord web \
+                    client in a version of Chromium fully optimized for use \
+                    with Discord's web interface, blocks trackers by default,\
+                    and supports a variety of client plugin frameworks.
+
+supported_archs     arm64
+platforms           {darwin any}
+license             OSL-3.0
+
+depends_build       port:pnpm
+
+use_configure       no
+
+build {
+    system -W ${worksrcpath} "pnpm install"
+    system -W ${worksrcpath} "pnpm run build"
+    system -W ${worksrcpath} "node_modules/.bin/electron-builder -m zip"
+}
+
+destroot {
+    file copy ${worksrcpath}/dist/mac-${build_arch}/Legcord.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description

Legcord (originally Armcord) is a version of the Discord web client packaged for desktop. Unlike the Discord application or web client, it blocks Discord's trackers and consumes far fewer resources. It also supports all of the major Discord client plugin/theming frameworks.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
