### PR TITLE
mlton: Fix environment variable that specifies gmp directory

### DIFF
--- a/lang/mlton/Portfile
+++ b/lang/mlton/Portfile
@@ -8,7 +8,7 @@ PortGroup           openssl 1.0
 
 github.setup        MLton mlton 475cf2b14993869711f1a93a15a9fa854b5126ed
 version             20240519
-revision            1
+revision            2
 categories          lang ml
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             HPND
@@ -55,7 +55,7 @@ compiler.blacklist-append {clang < 900}
 compiler.blacklist-append {macports-clang-1[7-9]} {macports-gcc-1[4-9]}
 
 build.args-append   CC=${configure.cc} \
-                    GMP_DIR=${prefix}
+                    WITH_GMP_DIR=${prefix}
 
 platform darwin 10 {
     if {${configure.build_arch} eq "ppc"} {


### PR DESCRIPTION
#### Description

When MLton compiles an SML program that uses IntInf, MLton generates code that depends on libgmp.  With the MLton port 20240519_1, compilation fails with the error `'gmp.h' file not found`.  For example, compiling with MLton as follows:
```
cat - > test1.sml << ++++
val a : IntInf.int = 2
val b : IntInf.int = 3
val () = print (String.concat ["a + b = ", IntInf.toString (a + b), "\n"])
;
++++
mlton test1.sml
```
produces the following error:
```
In file included from /var/folders/yb/t772rqcn1wnbb55qtm22rjjh0000gn/T/filejEBSzz.1.c:2:
In file included from /opt/local/lib/mlton/include/c-main.h:13:
In file included from /opt/local/lib/mlton/include/common-main.h:17:
In file included from /opt/local/lib/mlton/include/platform.h:13:
/opt/local/lib/mlton/include/cenv.h:49:10: fatal error: 'gmp.h' file not found
#include <gmp.h>
         ^~~~~~~
1 error generated.
MLton 20240519 raised: Fail: call to system failed with Fail: exit status 1:
/usr/bin/clang -c -I/opt/local/lib/mlton/targets/self/include -std=gnu11 -fno-common -O1 -fno-strict-aliasing -foptimize-sibling-calls -w -I/opt/local/lib/mlton/include -arch 
arm64 -o /var/folders/yb/t772rqcn1wnbb55qtm22rjjh0000gn/T/filebBwrkG.o /var/folders/yb/t772rqcn1wnbb55qtm22rjjh0000gn/T/filejEBSzz.1.c
```
This can be worked around by giving the required flags explicitly as follows:
```
mlton -cc-opt "$(pkg-config --cflags gmp)" -link-opt "$(pkg-config --libs gmp)" test1.sml
```
but this should not be necessary.

###### Type(s)
- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.5 21G72 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?  See note 1 below.
- [ ] tested basic functionality of all binary files?  See note 2 below.

1. I can't get `sudo port -vst install` to work due to trace mode (`-t`).  It seems that the MLton source cannot even be extracted in to the sandbox:
```
:info:extract Executing:  cd "/opt/local/var/macports/build/_Users_guest_Phil_MacPorts_devel_lang_mlton/mlton/work" && /usr/bin/gzip -dc 
'/opt/local/var/macports/distfiles/mlton/mlton-475cf2b14993869711f1a93a15a9fa854b5126ed.tar.gz' | /usr/bin/tar -xf - 
:debug:extract system:  cd "/opt/local/var/macports/build/_Users_guest_Phil_MacPorts_devel_lang_mlton/mlton/work" && /usr/bin/gzip -dc 
'/opt/local/var/macports/distfiles/mlton/mlton-475cf2b14993869711f1a93a15a9fa854b5126ed.tar.gz' | /usr/bin/tar -xf - 
:info:extract Command failed:  cd "/opt/local/var/macports/build/_Users_guest_Phil_MacPorts_devel_lang_mlton/mlton/work" && /usr/bin/gzip -dc 
'/opt/local/var/macports/distfiles/mlton/mlton-475cf2b14993869711f1a93a15a9fa854b5126ed.tar.gz' | /usr/bin/tar -xf - 
:info:extract Killed by signal: 9
:error:extract Failed to extract mlton: command execution failed
:debug:extract Error code: NONE
:debug:extract Backtrace: command execution failed
:debug:extract     while executing
:debug:extract "$procedure $targetname"
:error:extract See /opt/local/var/macports/logs/_Users_guest_Phil_MacPorts_devel_lang_mlton/mlton/main.log for details.
```

2. I have tested only the main MLton binary.
