### PR TITLE
jsoncons: update to 1.0.0

### DIFF
--- a/devel/jsoncons/Portfile
+++ b/devel/jsoncons/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            danielaparker jsoncons 0.177.0 v
+github.setup            danielaparker jsoncons 1.0.0 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -15,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             A C++, header-only library for constructing JSON and JSON-like data formats
 long_description        {*}${description}
 
-checksums               rmd160  56b2ec602b91ad25f34840ac6ecb78a9457df4ca \
-                        sha256  a381d58489f143a3a515484f4ad6e32ae4d977033e1a455fecf8cdc4e2c9a49e \
-                        size    1468307
+checksums               rmd160  75d319d6e519493a3a0c18ce354b596c32d36d63 \
+                        sha256  5b602e131761a3eb0fc85043a67e8006f04fa0ce2f2012aeca48371cd99ec85f \
+                        size    1486549
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description
https://github.com/danielaparker/jsoncons/releases/tag/v1.0.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
