### PR TITLE
nco: update to 5.3.0

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.2.9
-revision            2
+github.setup        nco nco 5.3.0
+revision            0
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
                     openmaintainer
@@ -20,9 +20,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  c8f3c750d9bc26814868993aeaab40a5667c9104 \
-                    sha256  a7ba0b5cf328c6a4a8d6c8edf5bfc04629109580fc56b80baa86c0dec82cd021 \
-                    size    6840905
+checksums           rmd160  dfbcbc17e6b573703aa844e8057ed1d6b72b4328 \
+                    sha256  a7a42d5d0cf51a9cc3501fcfd6ebce108a82598dcd615a57a6859cc0f1b17a4f \
+                    size    6854511
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Simple update to upstream version 5.3.0
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 x86_64
Command Line Tools 16.2.0.0.1.1733547573
###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
