### PR TITLE
mise: Update to 2025.1.0

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2024.12.24 v
+github.setup        jdx mise 2025.1.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  c0a82156bb7432afd59fb4385179a72e532df036 \
-                    sha256  82b96daf3df808f0c08af1d9f3b9dee700c3634191f8669a21b9d45905ad566b \
-                    size    4249222
+                    rmd160  9797bf2fa4622a4f84832b59bcc6157317cff639 \
+                    sha256  51e56a831cbedece92b1e3e5eaad92afae9d133503881ad18f229ea41e24a618 \
+                    size    4250709
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -225,7 +225,7 @@ cargo.crates \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     filetime_creation                0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
     find-crate                       0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
-    fixedbitset                      0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
+    fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
     flate2                          1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
     fluent                          0.16.1  bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a \
     fluent-bundle                   0.15.3  7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493 \
@@ -258,6 +258,7 @@ cargo.crates \
     h2                               0.4.7  ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
+    hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
@@ -300,7 +301,7 @@ cargo.crates \
     impl-tools-lib                  0.11.1  2a391adcea096a89a593317881fb61ef4e68d3e7d9de9e2338e6e1557be29e10 \
     indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                         2.5.0  68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5 \
+    indexmap                         2.7.0  62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f \
     indicatif                       0.17.9  cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inout                            0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
@@ -389,7 +390,7 @@ cargo.crates \
     pest_derive                     2.7.15  816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e \
     pest_generator                  2.7.15  7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b \
     pest_meta                       2.7.15  e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea \
-    petgraph                         0.6.6  c94eb96835f05ec51384814c9b2daef83f68486f67a0e2e9680e0f698dca808e \
+    petgraph                         0.6.5  b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db \
     phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
     phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
     phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
@@ -429,7 +430,7 @@ cargo.crates \
     regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    reqwest                        0.12.11  7fe060fe50f524be480214aba758c71f99f90ee8c83c5a36b5e9e1d568eb4eb3 \
+    reqwest                        0.12.12  43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da \
     ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
     rmp                             0.8.14  228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4 \
     rmp-serde                        1.3.0  52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db \
@@ -636,7 +637,7 @@ cargo.crates \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                          0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
+    winnow                          0.6.21  e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68 \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.1.0

##### Tested on

macOS 14.7.1 23H222 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
