### PR TITLE
xfig and fig2dev: update to 3.2.9a

### DIFF
--- a/graphics/xfig/Portfile
+++ b/graphics/xfig/Portfile
@@ -7,11 +7,12 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                xfig
-version             3.2.9
-revision            2
+version             3.2.9a
+revision            0
 categories          graphics x11
 license             Permissive
-maintainers         nomaintainer
+maintainers         {me.com:remko.scharroo @remkos} \
+                    openmaintainer
 
 description         Facility for Interactive Generation of figures under X11
 long_description    \
@@ -25,9 +26,9 @@ homepage            https://mcj.sourceforge.net
 master_sites        sourceforge:project/mcj
 use_xz              yes
 
-checksums           rmd160  e31e95f5d4da6c4e03d01f4df3d7f3371155f7a0 \
-                    sha256  13ed9d04d1bbc2dec09da7ef49ceec278382d290f6cd926474c2f2d016fec2f7 \
-                    size    5368544
+checksums           rmd160  b01373b2c37ef54e3894033112227f0be7b9dd8f \
+                    sha256  bc572a1881e5e20987ac590158b041ab7803845a9691036d3ba5e982f66d9ca3 \
+                    size    5366180
 
 depends_lib         port:ghostscript \
                     path:include/turbojpeg.h:libjpeg-turbo \

--- a/print/fig2dev/Portfile
+++ b/print/fig2dev/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 
 name                fig2dev
-version             3.2.9
+version             3.2.9a
 revision            0
 categories          print graphics
-platforms           darwin
 license             Permissive
-maintainers         nomaintainer
+maintainers         {me.com:remko.scharroo @remkos} \
+                    openmaintainer
 
 description         Translates Fig code to various graphics languages
 
@@ -26,9 +26,9 @@ homepage            https://mcj.sourceforge.net
 master_sites        sourceforge:project/mcj
 use_xz              yes
 
-checksums           rmd160  b7afc99d61fba9372336e34f5530e587ab5de7cb \
-                    sha256  15e246c8d13cc72de25e08314038ad50ce7d2defa9cf1afc172fd7f5932090b1 \
-                    size    529892
+checksums           rmd160  eb9bac3262c7d872d49d8d3d7cc85ff6ceae097b \
+                    sha256  61e185393176852f03b901b3b05b19fbc5ad8258ff142f3da6e70b1b83513326 \
+                    size    536560
 
 depends_lib         port:ghostscript \
                     port:libpng \


### PR DESCRIPTION
#### Description

Simple update to upstream version 3.2.9a for both `xfig` and `fig2dev`
I combined the two, since they are intrinsically linked.

I also replaced `nomaintainer` with myself and `openmaintainer`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 x86_64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
