### PR TITLE
libplist-devel: update to a more recent commit.

### DIFF
--- a/textproc/libplist/Portfile
+++ b/textproc/libplist/Portfile
@@ -30,16 +30,16 @@ configure.args      --disable-silent-rules \
                     --without-cython
 
 subport libplist-devel {
-    github.setup    libimobiledevice libplist 2cd858c679d25633077ca78b67182a9b77653816
-    version         20231003
+    github.setup    libimobiledevice libplist 44099d4b79c8d6a7d599d652ebef62db8dae6696
+    version         20241203
     revision        0
 
     github.tarball_from \
                     archive
 
-    checksums       rmd160  7767978d612aecc5fe7cb8ad9cfd19f5648c39e4 \
-                    sha256  7bc3aae8a451c83569e21a2d3c2b13e9496d20808559e9cde02cee7f4b846460 \
-                    size    219091
+    checksums       rmd160  4d33204b564220fc839a2cfeb40d514fd7e7a0e2 \
+                    sha256  8aee958bf4039c8864f8b8cce822708f7e5d44b8214ed4e7f8e2ae1dd9e14b7b \
+                    size    225046
 
     conflicts       libplist
 


### PR DESCRIPTION
#### Description

Updates `libplist-devel` to a more recent commit.

This will unblock #27258.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
