### PR TITLE
symfony-cli: update to 5.10.6

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.10.5
+version             5.10.6
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  37514f48b649bb6b7b7a5b5ec3e5c0c4f1bac9db \
-                        sha256  36d4f06c126255adab1b51610c8a86577ab1bfb61dec71e313ab1bc6356db11f \
-                        size    273649
+    checksums           rmd160  10251c98e25675209fb25c9f2a4e2b4e5a1ad8bb \
+                        sha256  3bec4c11bee6776113ddc55b72238541ab558524b0ad10ad7d1d21c5c35b2409 \
+                        size    274053
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  66e3bb2a96dd5a196f6f16baefb2692734b38c92 \
-                        sha256  345a4dacde39b448cb8f6ac4089e264b086e94649950c603ecf74eb6dc0766b3 \
-                        size    11674956
+    checksums           rmd160  4442a8f30f81e88769369eced910a1cae29016bd \
+                        sha256  c9f5fe5996f8ea68629c72cd3297b3514654cbc4be42e2ac682292de041c652e \
+                        size    11676254
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.10.6

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
