### PR TITLE
pipx: change default variant to python313

### DIFF
--- a/python/pipx/Portfile
+++ b/python/pipx/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        pypa pipx 1.7.1
-revision            0
+revision            1
 checksums           rmd160  ca10741d99a51760aa7f18bdf7cb5e2fe4e4767c \
                     sha256  28354a7085e0e0e4e2ef0930f8fb77eeb2e0851d00f089bb382d63e0be77c97f \
                     size    391902
@@ -29,7 +29,7 @@ if {
     ![variant_isset python312] &&
     ![variant_isset python313]
 } {
-    default_variants +python312
+    default_variants +python313
 }
 
 variant python39 conflicts python310 python311 python312 python313 description {Use Python 3.9} {}


### PR DESCRIPTION
#### Description

pipx: change default variant to python313

This PR replaces #26990: resubmitting after January 1, 2025 per @reneeotten.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 x86_64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
