### PR TITLE
qgis3: update to 3.40.2; qgis3-ltr: update to 3.34.14

### DIFF
--- a/devel/spatialindex/Portfile
+++ b/devel/spatialindex/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        libspatialindex libspatialindex 2.0.0
+github.setup        libspatialindex libspatialindex 2.1.0
 github.tarball_from releases
 name                spatialindex
 revision            0
@@ -24,9 +24,9 @@ homepage            https://libspatialindex.org/
 
 distname            ${name}-src-${version}
 
-checksums           rmd160  8894c66f8b99e0403835a25d51389ff1dd72e840 \
-                    sha256  f1d5a369681fa6ac3301a54db412ccf3180fc17163ebc3252f32c752f77345de \
-                    size    669866
+checksums           rmd160  38ed65a3db5571ba85bf2c6f198be9bc3ea69673 \
+                    sha256  b36e2f8ac4c91a6d292f11d5925d584e13674015afd2132ed2870f1b5ec7b9ad \
+                    size    668738
 
 compiler.cxx_standard   2011
 

--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -25,25 +25,25 @@ subport ${name-ltr} {}
 
 if {${subport} eq ${name}} {
     # Latest version
-    github.setup    qgis QGIS 3_40_1 final-
+    github.setup    qgis QGIS 3_40_2 final-
     revision        0
     set app_name    QGIS3
 
-    checksums       rmd160  fdd005787e7bea3c5eb64771c4d8eb177849cb13 \
-                    sha256  eee2f267240ed2d92e3209b6c2b4bb0bb4e909b958ab6ba21a8f559ef1cd9fbb \
-                    size    210895928
+    checksums       rmd160  f2fbf85fa549d19084525e7b956f7f4da4f603a6 \
+                    sha256  20d8f327739454fc10de345478cef5747cc8ef81d3c69a1eb1d5d85a73af9d63 \
+                    size    210797656
 
     set grass_utils_file grass_utils.py
 } else {
     # LTR version
-    github.setup    qgis QGIS 3_34_13 final-
+    github.setup    qgis QGIS 3_34_14 final-
     revision        0
     set app_name    QGIS3-LTR
     description     {*}${description} (LTR)
 
-    checksums       rmd160  f5448b99bc297fee4dfa929f17397e67e9cf3ffb \
-                    sha256  d6a296e8311bf75cb5f951ccbda21083c7908fdb839402a656d4b16311a4d6ed \
-                    size    198067959
+    checksums       rmd160  7e7d9aaf12bd06b003fb9499b482426ea6a017f7 \
+                    sha256  c1ba9f7b027a0568092b69c5bfe7dd8b195866eab3e6e6d41be864266efbeb50 \
+                    size    198070087
 
     set grass_utils_file Grass7Utils.py
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update:
- `qgis3`to 3.40.2
-  `qgis3-ltr`  to 3.34.14
-  `spatialindex` to 2.1.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
