### PR TITLE
postgis3, pgrouting, saga, pdal: updates

### DIFF
--- a/databases/postgis3/Portfile
+++ b/databases/postgis3/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 name                postgis3
 categories          databases gis
 license             GPL-2+
-version             3.5.0
-revision            2
+version             3.5.1
+revision            0
 maintainers         {vince @Veence} {yahoo.com:n_larsson @nilason} openmaintainer
 
 description         PostGIS is the spatial extension to the\
@@ -21,9 +21,9 @@ homepage            https://postgis.net/
 master_sites        https://download.osgeo.org/postgis/source
 distname            postgis-${version}
 
-checksums           rmd160  a2b158d3a03ab7fc9e224a141a97464fa2e1a6e8 \
-                    sha256  ca698a22cc2b2b3467ac4e063b43a28413f3004ddd505bdccdd74c56a647f510 \
-                    size    15031829
+checksums           rmd160  120d83c35ed0f5814471dde1d915317a105cd66a \
+                    sha256  23706abc117fb1bab45a27a263b589f52fc08ebaff318c0bc0bdc940905306b5 \
+                    size    15044755
 
 patchfiles          patch-configure.diff
 

--- a/gis/pdal/Portfile
+++ b/gis/pdal/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake         1.1
 PortGroup           github        1.0
 PortGroup           legacysupport 1.1
 
-github.setup        PDAL PDAL 2.8.2
+github.setup        PDAL PDAL 2.8.3
 revision            0
 
 name                pdal
@@ -32,9 +32,9 @@ compiler.thread_local_storage yes
 
 github.tarball_from releases
 
-checksums           rmd160  010d189af37f2e4ffa5eda16ca8efa11e2e240c5 \
-                    sha256  f2b091543d12109311bbec0ca5424295d737d5be170e27ebe7509b2abb0d49c8 \
-                    size    90049190
+checksums           rmd160  d4047ae041b33dcd36e3c3a0791281d340e71232 \
+                    sha256  d6c67c14f6042afbcc9d3c4d43b9887cf743e0ea12c8fbb7ef1686d1463ee440 \
+                    size    89516499
 
 depends_build-append \
                     port:pkgconfig \

--- a/gis/pgrouting/Portfile
+++ b/gis/pgrouting/Portfile
@@ -17,12 +17,12 @@ license             LGPL-2
 
 homepage            http://www.pgrouting.org/
 
-github.setup        pgRouting pgrouting 3.7.0 v
+github.setup        pgRouting pgrouting 3.7.1 v
 revision            0
 
-checksums           rmd160  b9ea17ecfe21baf20781e47908062894b464ff12 \
-                    sha256  02f94c5150c8165fa8272e0edab7ee2dbb8bbfa32ac0812dbfa59c55d1ab7ec8 \
-                    size    3870837
+checksums           rmd160  603cf21469a6d3e5fc2a5e6e73d5fda5d34212f5 \
+                    sha256  7d34c3b70bc612120c7cd87c89c1e9dc8dacc2f355d9cecd1327f7c928ed55f4 \
+                    size    3874346
 
 compiler.cxx_standard   2014
 compiler.c_standard     1999

--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -10,7 +10,7 @@ wxWidgets.use       wxWidgets-3.2
 name                saga
 categories          gis
 license             GPL
-version             9.6.2
+version             9.7.0
 revision            0
 maintainers         {vince @Veence} {yahoo.com:n_larsson @nilason} openmaintainer
 
@@ -26,9 +26,9 @@ homepage            https://saga-gis.sourceforge.io/en/index.html
 set master_sites_in sourceforge:project/saga-gis/SAGA%20-%20[lindex [split ${version} "."] 0]/SAGA%20-%20${version}
 master_sites        ${master_sites_in}
 
-checksums           rmd160  6b7e6fbbf0ea698a9e2c96e9b323c2762deaccc9 \
-                    sha256  4d79c148895e51da137a4f06a49a91ff5d0eb95bd5ed4c47c61a397d7afc8e09 \
-                    size    9818613
+checksums           rmd160  43e0b1c8faa656bae29f31c8012fcdf5fed4ec00 \
+                    sha256  c148f44ef6682fff66882c159377988a5617a9cce46e0b12b42adb280a1ebb1c \
+                    size    9851336
 
 cmake.source_dir    ${worksrcpath}/saga-gis
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

postgis3: update to 3.5.1
pgrouting: update to 3.7.1
saga: update to 9.7.0
pdal: update to 2.8.3


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
