### PR TITLE
lima: drop dependency on QEMU from macOS 14 onwards

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/lima-vm/lima 1.0.3 v
 go.offline_build    no
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://lima-vm.io
 
@@ -18,7 +18,8 @@ long_description    {*}{
     was to promote containerd including nerdctl (contaiNERD ctl) to
     Mac users, but Lima can be used for non-container applications as
     well. Lima also supports other container engines, such as Docker,
-    Podman, Kubernetes, etc.
+    Podman, Kubernetes, etc. Lima can also emulate other architectures
+    if QEMU is installed.
 }
 
 categories          sysutils
@@ -28,8 +29,6 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-depends_run         port:qemu
-
 checksums           rmd160  60a71868460fe544be7e44f0ec10bc3d66198a10 \
                     sha256  c36e803f4faf41607220df4c1d7a61977a7d492facf03e0b67f1f69390840a90 \
                     size    7381537
@@ -37,6 +36,23 @@ checksums           rmd160  60a71868460fe544be7e44f0ec10bc3d66198a10 \
 build.cmd           make
 
 patchfiles          patch-Makefile.diff
+
+platform darwin {
+    # Lima defaults to VZ with macOS 13.5 and later; drop dependency from 14 onwards
+    if {${os.major} < 23} {
+        depends_run-append port:qemu
+    } else {
+        # added January 2025
+        notes {
+            Please note that the Lima now defaults to native\
+            virtualization support and not QEMU. If you rely on it,\
+            such as for emulating other architectures, you can install\
+            it explicitly:
+
+            port install qemu
+        }
+    }
+}
 
 post-patch {
     reinplace "s|@@VERSION@@|${version}|g" ${worksrcpath}/Makefile


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

As of [Lima 1.0.0](https://github.com/lima-vm/lima/releases/tag/v1.0.0), it no longer defaults to using QEMU. Since QEMU is a rather large dependency, we should not depend on needless, so I've dropped it from 14 onwards.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
