### PR TITLE
py-imagecodecs: unbreak build

### DIFF
--- a/python/py-imagecodecs/Portfile
+++ b/python/py-imagecodecs/Portfile
@@ -48,4 +48,8 @@ if {${name} ne ${subport}} {
                     port:webp \
                     port:zopfli \
                     port:zstd
+
+    post-patch {
+        reinplace "s|%PREFIX%|${prefix}|g" ${worksrcpath}/setup.py
+    }
 }


### PR DESCRIPTION
#### Description

Log before patch:
```
:info:build /usr/bin/clang -fno-strict-overflow -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -O3 -Wall -pipe -Os -arch x86_64 -isysroot/ -DNPY_NO_DEPRECATED_API=NPY_1_20_API_VERSION -Iimagecodecs -I%PREFIX%/lib/libaec/include -I/opt/local/Library/Frameworks/Python.framework/Versions/3.12/include/python3.12 -I/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/numpy/core/include -c imagecodecs/_aec.c -o build/temp.macosx-10.9-x86_64-cpython-312/imagecodecs/_aec.o
:info:build imagecodecs/_aec.c:1267:10: fatal error: 'libaec.h' file not found
:info:build #include "libaec.h"
:info:build          ^
:info:build 1 error generated.
:info:build error: command '/usr/bin/clang' failed with exit code 1
```

Note the include: `-I%PREFIX%/lib/libaec/include`.

To fix this I copied `reinplace "s|%PREFIX%|${prefix}|g" ${worksrcpath}/setup.py` from py-pivy.

There are no patches in this port, but this I put this line in the `post-patch` step, as in all other Python ports that use this replacement.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
