### PR TITLE
librsvg, librsvg-devel: use fallback version on Snow Leopard

### DIFF
--- a/graphics/librsvg-devel/Portfile
+++ b/graphics/librsvg-devel/Portfile
@@ -32,7 +32,10 @@ license_noconflict \
                     rust \
                     vala
 
-set min_darwin_for_rust 10
+# https://trac.macports.org/ticket/70693
+# new releases of librsvg depend on cargo and its libraries,
+# which became unbuildable on macOS <10.7
+set min_darwin_for_rust 11
 
 #----------------------------------------------------------------------------------------
 # Developer-only override, allowing easy testing of desired behavior:

--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -32,7 +32,10 @@ license_noconflict \
                     rust \
                     vala
 
-set min_darwin_for_rust 10
+# https://trac.macports.org/ticket/70693
+# new releases of librsvg depend on cargo and its libraries,
+# which became unbuildable on macOS <10.7
+set min_darwin_for_rust 11
 
 #----------------------------------------------------------------------------------------
 # Developer-only override, allowing easy testing of desired behavior:


### PR DESCRIPTION
See: https://trac.macports.org/ticket/70693

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
