### PR TITLE
tesseract-training: use_mp_libcxx on 10.13 and older

### DIFF
--- a/textproc/tesseract/Portfile
+++ b/textproc/tesseract/Portfile
@@ -3,15 +3,19 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
 
 name                tesseract
 
 if {${subport} in [list tesseract tesseract-training]} {
     github.setup    tesseract-ocr tesseract 5.4.1
-    revision        3
+    revision        4
     checksums       rmd160  d21bc77911627900ad32b084ffbd39d3d339aee3 \
                     sha256  37e38d561ebeadc24f1e0614f5213761e4c281a93e998978edcdefb5e2da5c98 \
                     size    1900262
+
+    legacysupport.newest_darwin_requires_legacy 17
+    legacysupport.use_mp_libcxx                 yes
 } elseif {[variant_isset best]} {
     github.setup    tesseract-ocr tessdata_best  4.1.0
     checksums       rmd160  753e227df9393d064a78d3243a5bc6fdce20f73c \


### PR DESCRIPTION
#### Description

tesseract-training uses `std::filesystem` from C++17. Xcode 11, which only runs on 10.14 and up, adds support for that. The newest version that needs to link MacPorts libc++ is therefore Darwin 17.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

`port lint` reports one warning, but it is not new and not related to my changes.

Binary files: tested running `/opt/local/bin/text2image --help` and verified using `otool -L` that it is linked against `/opt/local/lib/libcxx/libc++.1.0.dylib`.