### PR TITLE
nodejs{12,14,16,18,20,22}: Use configure.cxxflags-append correctly

### DIFF
--- a/devel/nodejs12/Portfile
+++ b/devel/nodejs12/Portfile
@@ -89,11 +89,11 @@ post-patch {
 
 # suppress a warning-as-error that shows up with newer clang compilers
 if {[string match *clang* ${configure.compiler}]} {
-    configure.cxx-append      -Wno-error=enum-constexpr-conversion
+    configure.cxxflags-append       -Wno-error=enum-constexpr-conversion
 
     #the ventura buildbot will fail because it doesn't recognise this flag
     #so we disable unknown warnings as errors for older compilers
-    configure.cxx-append      -Wno-error=unknown-warning-option
+    configure.cxxflags-append       -Wno-error=unknown-warning-option
 }
 
 # use the system libuv instead of the bundled version, as it is fixed for older systems
@@ -124,9 +124,6 @@ configure.args-append   --shared-zlib-libpath=${prefix}/lib
 supported_archs         i386 x86_64 arm64
 
 universal_variant       no
-
-# "V8 doesn't like cache."
-configure.ccache        no
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}

--- a/devel/nodejs14/Portfile
+++ b/devel/nodejs14/Portfile
@@ -89,18 +89,18 @@ if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
     configure.args-append --shared-libuv
 
     if {${configure.cxx_stdlib} eq "libc++"} {
-        depends_lib-append        port:macports-libcxx
-        configure.cxx-append      -Wl,-L${prefix}/lib/libcxx
+        depends_lib-append          port:macports-libcxx
+        configure.cxxflags-append   -Wl,-L${prefix}/lib/libcxx
     }
 }
 
 # suppress a warning-as-error that shows up with newer clang compilers
 if {[string match *clang* ${configure.compiler}]} {
-    configure.cxx-append      -Wno-error=enum-constexpr-conversion
+    configure.cxxflags-append       -Wno-error=enum-constexpr-conversion
 
     #the ventura buildbot will fail because it doesn't recognise this flag
     #so we disable unknown warnings as errors for older compilers
-    configure.cxx-append      -Wno-error=unknown-warning-option
+    configure.cxxflags-append       -Wno-error=unknown-warning-option
 }
 
 pre-configure {
@@ -125,9 +125,6 @@ configure.args-append   --shared-zlib-libpath=${prefix}/lib
 supported_archs         i386 x86_64 arm64
 
 universal_variant       no
-
-# "V8 doesn't like cache."
-configure.ccache        no
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}

--- a/devel/nodejs16/Portfile
+++ b/devel/nodejs16/Portfile
@@ -61,18 +61,18 @@ if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
     configure.args-append --shared-libuv
 
     if {${configure.cxx_stdlib} eq "libc++"} {
-        depends_lib-append        port:macports-libcxx
-        configure.cxx-append      -Wl,-L${prefix}/lib/libcxx
+        depends_lib-append          port:macports-libcxx
+        configure.cxxflags-append   -Wl,-L${prefix}/lib/libcxx
     }
 }
 
 # suppress a warning-as-error that shows up with newer clang compilers
 if {[string match *clang* ${configure.compiler}]} {
-    configure.cxx-append      -Wno-error=enum-constexpr-conversion
+    configure.cxxflags-append       -Wno-error=enum-constexpr-conversion
 
     #the ventura buildbot will fail because it doesn't recognise this flag
     #so we disable unknown warnings as errors for older compilers
-    configure.cxx-append      -Wno-error=unknown-warning-option
+    configure.cxxflags-append       -Wno-error=unknown-warning-option
 }
 
 proc rec_glob {basedir pattern} {
@@ -134,9 +134,6 @@ supported_archs         i386 x86_64 arm64
 
 universal_variant       no
 
-# "V8 doesn't like cache."
-configure.ccache        no
-
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}
 
@@ -155,7 +152,7 @@ switch $build_arch {
 compiler.blacklist-append {clang < 900}
 
 # error: integer value is outside the valid range of values for this enumeration type
-configure.cxx-append \
+configure.cxxflags-append \
                     -Wno-enum-constexpr-conversion \
                     -Wno-unknown-warning-option
 

--- a/devel/nodejs18/Portfile
+++ b/devel/nodejs18/Portfile
@@ -49,18 +49,18 @@ if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
     configure.args-append --shared-libuv
 
     if {${configure.cxx_stdlib} eq "libc++"} {
-        depends_lib-append        port:macports-libcxx
-        configure.cxx-append      -Wl,-L${prefix}/lib/libcxx
+        depends_lib-append          port:macports-libcxx
+        configure.cxxflags-append   -Wl,-L${prefix}/lib/libcxx
     }
 }
 
 # suppress a warning-as-error that shows up with newer clang compilers
 if {[string match *clang* ${configure.compiler}]} {
-    configure.cxx-append      -Wno-error=enum-constexpr-conversion
+    configure.cxxflags-append       -Wno-error=enum-constexpr-conversion
 
     #the ventura buildbot will fail because it doesn't recognise this flag
     #so we disable unknown warnings as errors for older compilers
-    configure.cxx-append      -Wno-error=unknown-warning-option
+    configure.cxxflags-append       -Wno-error=unknown-warning-option
 }
 
 proc rec_glob {basedir pattern} {
@@ -125,9 +125,6 @@ variant no_openssl3_with_quic description {use MacPort's OpenSSL rather than Nod
     configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
     configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
 }
-
-# "V8 doesn't like cache."
-configure.ccache        no
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}

--- a/devel/nodejs20/Portfile
+++ b/devel/nodejs20/Portfile
@@ -49,22 +49,22 @@ if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
     # unlike earlier versions. the flag below ensures the libuv
     # packaged with nodejs20+ can be used
     if {[string match *clang* ${configure.compiler}]} {
-        configure.cxx-append      -Wno-error=incompatible-function-pointer-types
+        configure.cxxflags-append   -Wno-error=incompatible-function-pointer-types
     }
 
     if {${configure.cxx_stdlib} eq "libc++"} {
-        depends_lib-append        port:macports-libcxx
-        configure.cxx-append      -Wl,-L${prefix}/lib/libcxx
+        depends_lib-append          port:macports-libcxx
+        configure.cxxflags-append   -Wl,-L${prefix}/lib/libcxx
     }
 }
 
 # suppress a warning-as-error that shows up with newer clang compilers
 if {[string match *clang* ${configure.compiler}]} {
-    configure.cxx-append      -Wno-error=enum-constexpr-conversion
+    configure.cxxflags-append       -Wno-error=enum-constexpr-conversion
 
     #the ventura buildbot will fail because it doesn't recognise this flag
     #so we disable unknown warnings as errors for older compilers
-    configure.cxx-append      -Wno-error=unknown-warning-option
+    configure.cxxflags-append       -Wno-error=unknown-warning-option
 }
 
 proc rec_glob {basedir pattern} {
@@ -129,9 +129,6 @@ variant no_openssl3_with_quic description {use MacPort's OpenSSL rather than Nod
     configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
     configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
 }
-
-# "V8 doesn't like cache."
-configure.ccache        no
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}

--- a/devel/nodejs22/Portfile
+++ b/devel/nodejs22/Portfile
@@ -49,12 +49,12 @@ if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
     # unlike earlier versions. the flag below ensures the libuv
     # packaged with nodejs20+ can be used
     if {[string match *clang* ${configure.compiler}]} {
-        configure.cxx-append      -Wno-error=incompatible-function-pointer-types
+        configure.cxxflags-append   -Wno-error=incompatible-function-pointer-types
     }
 
     if {${configure.cxx_stdlib} eq "libc++"} {
-        depends_lib-append        port:macports-libcxx
-        configure.cxx-append      -Wl,-L${prefix}/lib/libcxx
+        depends_lib-append          port:macports-libcxx
+        configure.cxxflags-append   -Wl,-L${prefix}/lib/libcxx
     }
 
     #we guard against using the pthread qos API for Yosemite (10.10) and lower,
@@ -66,11 +66,11 @@ if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
 
 # suppress a warning-as-error that shows up with newer clang compilers
 if {[string match *clang* ${configure.compiler}]} {
-    configure.cxx-append      -Wno-error=enum-constexpr-conversion
+    configure.cxxflags-append       -Wno-error=enum-constexpr-conversion
 
     #the ventura buildbot will fail because it doesn't recognise this flag
     #so we disable unknown warnings as errors for older compilers
-    configure.cxx-append      -Wno-error=unknown-warning-option
+    configure.cxxflags-append       -Wno-error=unknown-warning-option
 }
 
 proc rec_glob {basedir pattern} {
@@ -135,9 +135,6 @@ variant no_openssl3_with_quic description {use MacPort's OpenSSL rather than Nod
     configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
     configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
 }
-
-# "V8 doesn't like cache."
-configure.ccache        no
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}


### PR DESCRIPTION
#### Description

devel/nodejs* ports use `configure.cxx-append` to add C++ compiler flags. They also use `compiler.blacklist-append` to blacklist incompatible XCode versions. In such a situation, if `compiler.blacklist-append` is not placed before the first `configure.cxx-append`, on Mojave it results in `configure.cxx` not being set to the fallback compiler while `configure.cc` is correctly using the fallback compiler.

Failure logs (choose an OS version in the Port Health panel, look for `CXX=`, compare with `CC=`):
* [nodejs18 on Mojave](https://ports.macports.org/port/nodejs18/details/)
* [nodejs20 on Mojave](https://ports.macports.org/port/nodejs20/details/)
* [nodejs22 on Mojave, Catalina, and Big Sur](https://ports.macports.org/port/nodejs22/details/) 

Solution: use `configure.cxxflags-append` instead.

While I was looking at this, I also re-enabled ccache usage, as the reports on V8 not liking ccache seem to be really outdated.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
