### PR TITLE
appstream-glib: fix missing ossp-uuid dependency

### DIFF
--- a/devel/appstream-glib/Portfile
+++ b/devel/appstream-glib/Portfile
@@ -8,7 +8,7 @@ PortGroup           muniversal 1.0
 
 github.setup        hughsie appstream-glib 0_8_3 appstream_glib_
 version             [string map {_ .} ${version}]
-revision            0
+revision            1
 epoch               1
 
 categories          devel
@@ -44,7 +44,8 @@ depends_lib-append \
                     port:json-glib \
                     port:libarchive \
                     port:libxslt \
-                    port:libyaml
+                    port:libyaml \
+                    port:ossp-uuid
 
 patchfiles-append   use-system-uuid.patch
 


### PR DESCRIPTION
Even though upsteam doesn't declare uuid as a dependency in appstream-glib, it won't start without ossp-uuid being installed.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Even though upstream doesn't declare uuid as a dependency in `appstream-glib`, it won't start without `ossp-uuid` being installed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.10 20G1427 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
