### PR TITLE
py-imageio: update to 2.36.1, add py313 subport

### DIFF
--- a/python/py-imageio/Portfile
+++ b/python/py-imageio/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-imageio
-version             2.34.1
+version             2.36.1
 revision            0
 categories-append   graphics
 license             BSD
 platforms           {darwin any}
 supported_archs     noarch
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -20,9 +20,9 @@ long_description    {*}${description}
 
 homepage            https://imageio.github.io/
 
-checksums           rmd160  a3c5950052e776ef6527eadfb9aa2f7f4eb25292 \
-                    sha256  f13eb76e4922f936ac4a7fec77ce8a783e63b93543d4ea3e40793a6cabd9ac7d \
-                    size    387557
+checksums           rmd160  fe07f3280929e44c86b527f76fa4edd748b0453a \
+                    sha256  e4e1d231f47f9a9e16100b0f7ce1a86e8856fb4d1c0fa2c4365a316f1746be62 \
+                    size    389522
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-numpy \


### PR DESCRIPTION
#### Description

Update to 2.36.1 and add subport for Python 3.13, which is officially supported. This package still supports Python 3.9, so no need to pin that version to a specific package version.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Tested by importing the module and reading an image.