### PR TITLE
py-lazy_loader: update to 0.4, add py313 subport

### DIFF
--- a/python/py-lazy_loader/Portfile
+++ b/python/py-lazy_loader/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-lazy_loader
-version             0.3
+version             0.4
 revision            0
 
 platforms           {darwin any}
@@ -19,12 +19,11 @@ long_description    ${python.rootname} makes it easy to load \
 
 homepage            https://scientific-python.org/specs/spec-0001/
 
-checksums           md5 6b0f19ab63de5d00b862325bbeca7ea7 \
-                    rmd160 e80499d84d692de89011de5658465b75320dd54c \
-                    sha256 3b68898e34f5b2a29daaaac172c6555512d0f32074f147e2254e4a6d9d838f37
+checksums           md5 0ed9a697d30fbe5b7f24106b448d634d \
+                    rmd160 70da70209cec9d0702b609bef3709c2f3267a402 \
+                    sha256 47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1
 
-python.versions     39 310 311 312
-python.pep517_backend   flit
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     test.run        yes
@@ -35,4 +34,6 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} LICENSE.md README.md \
             ${destroot}${docdir}
     }
+
+    depends_lib-append  port:py${python.version}-packaging
 }


### PR DESCRIPTION
#### Description

Note: Python 3.13 is not in the list of supported Python versions on PyPI, but [this PR](https://github.com/scientific-python/lazy-loader/pull/139), which adds 3.13 support, only updates the documentation and makes no changes to the source code. Development versions of 3.13 have been included in their tests for months, and I verified that the package is compatible with 3.13 by testing that it works.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Tested by importing the module and caling `lazy_loader.load()` for both modules that exist and modules that do not exist.