### PR TITLE
py-scikit-image: update to 0.25.0, add py313 subport

### DIFF
--- a/python/py-scikit-image/Portfile
+++ b/python/py-scikit-image/Portfile
@@ -5,12 +5,12 @@ PortGroup           python 1.0
 
 name                py-scikit-image
 python.rootname     scikit_image
-version             0.22.0
+version             0.25.0
 revision            0
 categories-append   science
 license             BSD
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 python.pep517_backend   meson
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -23,13 +23,26 @@ long_description    Image processing algorithms for SciPy, including IO, \
 
 homepage            https://scikit-image.org/
 
-checksums           md5 91dbff8962b4231ca0a9666f43c0d71f \
-                    rmd160 fb8347226da3f17fd149414ce0aeaf93d43993e9 \
-                    sha256 018d734df1d2da2719087d15f679d19285fce97cd37695103deadfaef2873236 \
-                    size   22685018
+checksums           md5 bdddc9565fd64fb6ac6984a5a31f51b8 \
+                    rmd160 df0ea1ddf1dee7fe8bc79b00ccf5003686d26267 \
+                    sha256 58d94fea11b6b3306b3770417dc1cbca7fa9bcbd6a13945d7910399c88c2018c \
+                    size   22696477
 
 if {${name} ne ${subport}} {
     compiler.openmp_version 2.5
+
+    if {${python.version} == 39} {
+        version             0.24.0
+        revision            0
+        checksums           md5 c91af89808e4aa0d485f62072c81670a \
+                            rmd160 b02c21901ca7ad16a8c5504375120608e71a6868 \
+                            sha256 5d16efe95da8edbeb363e0c4157b99becbd650a60b77f6e3af5768b66cf007ab \
+                            size   22693928
+
+        patchfiles-append   patch-pyproject.toml-0.24.0.diff
+    } else {
+        patchfiles-append   patch-pyproject.toml.diff
+    }
 
     depends_build-append \
                         path:bin/cython-${python.branch}:py${python.version}-cython \
@@ -47,10 +60,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-pywavelets \
                         port:py${python.version}-tifffile
 
-    patchfiles-append   patch-pyproject.toml.diff
-
     post-patch {
-        reinplace "s|#!/usr/bin/env python|#!/usr/bin/env python3|" \
+        reinplace "s|#!/usr/bin/env python.*|#!${python.bin}|" \
             {*}[glob -directory ${worksrcpath}/skimage/_build_utils {[a-z]*.py}]
     }
 

--- a/python/py-scikit-image/files/patch-pyproject.toml-0.24.0.diff
+++ b/python/py-scikit-image/files/patch-pyproject.toml-0.24.0.diff
@@ -1,0 +1,16 @@
+--- pyproject.toml
++++ pyproject.toml
+@@ -120,13 +120,10 @@
+ build-backend = 'mesonpy'
+ requires = [
+     'meson-python>=0.15',
+-    'wheel',
+-    'setuptools>=67',
+     'packaging>=21',
+     'Cython>=3.0.4',
+     'pythran',
+     'lazy_loader>=0.3',
+-    'numpy>=2.0.0rc1',
+ ]
+
+ [tool.spin]

--- a/python/py-scikit-image/files/patch-pyproject.toml.diff
+++ b/python/py-scikit-image/files/patch-pyproject.toml.diff
@@ -1,22 +1,14 @@
---- pyproject.toml.orig	2023-10-04 07:14:28
-+++ pyproject.toml	2023-12-27 14:16:12
-@@ -118,18 +118,11 @@
+--- pyproject.toml
++++ pyproject.toml
+@@ -118,11 +118,9 @@
  build-backend = 'mesonpy'
  requires = [
-     'meson-python>=0.14',
--    'wheel',
--    'setuptools>=67',
-     'packaging>=21',
-     'Cython>=0.29.32',
-     'pythran',
-     'lazy_loader>=0.3',
--    "numpy==1.22.4; python_version=='3.9' and platform_python_implementation != 'PyPy'",
--    "numpy==1.22.4; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
--    "numpy==1.22.4; python_version=='3.10' and platform_system != 'Windows' and platform_python_implementation != 'PyPy'",
--    "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
--    "numpy; python_version>='3.12'",
--    "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
-+    "numpy",
+     'meson-python>=0.16',
+-    'setuptools>=68',
+     'Cython>=3.0.8',
+     'pythran>=0.16',
+     'lazy_loader>=0.4',
+-    'numpy>=2.0',
  ]
- 
+
  [tool.spin]


### PR DESCRIPTION
#### Description

* Update to 0.25.0 for Python >= 3.10
* Pin to 0.24.0 for Python 3.9
* Add py313 subport

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

No binary files. Tested by importing the module and testing a function (`skimage.morphology.remove_small_objects`).