### PR TITLE
multiple ports: fix libsoup dependency

### DIFF
--- a/audio/easytag/Portfile
+++ b/audio/easytag/Portfile
@@ -82,7 +82,7 @@ subport easytag-devel {
                     size    1483172
 
     depends_lib-append \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+                    port:libsoup-2.4
 }
 
 post-activate {

--- a/audio/gmpc/Portfile
+++ b/audio/gmpc/Portfile
@@ -38,7 +38,7 @@ depends_lib     port:libmpd \
                 port:zlib \
                 path:lib/libssl.dylib:openssl \
                 port:curl \
-                path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                port:libsoup-2.4 \
                 port:libxspf
 
 patchfiles      implicit.patch

--- a/comms/telepathy-gabble/Portfile
+++ b/comms/telepathy-gabble/Portfile
@@ -10,7 +10,6 @@ long_description    Gabble is a Jabber/XMPP connection manager that handles sing
                     chats and voice/video calls.
 maintainers         {devans @dbevans} openmaintainer
 categories          comms
-platforms           darwin
 homepage            https://telepathy.freedesktop.org/wiki/
 master_sites        https://telepathy.freedesktop.org/releases/${name}/
 
@@ -22,7 +21,7 @@ depends_build       port:pkgconfig
 depends_lib         path:lib/pkgconfig/gnutls.pc:gnutls \
                     port:telepathy-glib \
                     port:libxslt \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:libnice \
                     port:cyrus-sasl2 \
                     port:py27-twisted

--- a/comms/telepathy-salut/Portfile
+++ b/comms/telepathy-salut/Portfile
@@ -12,7 +12,6 @@ long_description \
                 Salut implements the Telepathy D-Bus specification for link-local XMPP (XEP-0174, often called \"Bonjour\")
 maintainers     {devans @dbevans} openmaintainer
 categories      comms
-platforms       darwin
 homepage        https://telepathy.freedesktop.org/wiki/
 master_sites    https://telepathy.freedesktop.org/releases/${name}/
 
@@ -24,7 +23,7 @@ depends_build   port:pkgconfig
 depends_lib     port:telepathy-glib \
                 path:lib/pkgconfig/gnutls.pc:gnutls \
                 port:avahi \
-                path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                port:libsoup-2.4 \
                 port:ossp-uuid \
                 port:py27-twisted
 

--- a/devel/cutter/Portfile
+++ b/devel/cutter/Portfile
@@ -16,7 +16,6 @@ long_description    Cutter is a xUnit family Unit Testing Framework for C and C+
                     and so on.
 
 homepage            https://cutter.sourceforge.net/
-platforms           darwin
 license             LGPL-3+
 
 master_sites        https://osdn.dl.osdn.net/cutter/73761/ \
@@ -32,4 +31,4 @@ depends_build       port:intltool \
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:gtk-doc \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+                    port:libsoup-2.4

--- a/devel/geany-plugins/Portfile
+++ b/devel/geany-plugins/Portfile
@@ -43,7 +43,7 @@ depends_lib         port:geany \
                     port:gpgme \
                     port:gtkspell3 \
                     path:lib/pkgconfig/libgit2.pc:libgit2 \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:libxml2 \
                     port:lua51 \
                     port:vte \

--- a/devel/geoclue/Portfile
+++ b/devel/geoclue/Portfile
@@ -7,7 +7,6 @@ version             0.12.99
 revision            5
 categories          devel net
 license             LGPL-2.1+
-platforms           darwin
 maintainers         nomaintainer
 description         Geolocation library
 long_description    Geoclue is a modular geoinformation service built on top of the D-Bus messaging system. The goal of the Geoclue project is to make creating location-aware applications as simple as possible.
@@ -28,7 +27,7 @@ depends_build   \
 depends_lib     \
         path:lib/pkgconfig/gtk+-2.0.pc:gtk2 \
         port:dbus-glib \
-        path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+        port:libsoup-2.4
 
 # this old version of geoclue will not build with gpsd API 6.0+ (gpsd 3.12+)
 # current geoclue2 versions no longer support gpsd, drop gpsd support here as well
@@ -39,7 +38,7 @@ configure.args      --disable-gpsd \
                     --disable-silent-rules
 
 post-activate {
-	system "${prefix}/bin/glib-compile-schemas ${prefix}/share/glib-2.0/schemas" 
+    system "${prefix}/bin/glib-compile-schemas ${prefix}/share/glib-2.0/schemas"
 }
 
 livecheck.type      regex

--- a/devel/geoclue2/Portfile
+++ b/devel/geoclue2/Portfile
@@ -30,7 +30,7 @@ depends_build       port:intltool \
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:json-glib \
                     port:libnotify \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+                    port:libsoup-2.4
 
 gobject_introspection yes
 

--- a/devel/gvfs/Portfile
+++ b/devel/gvfs/Portfile
@@ -52,7 +52,7 @@ depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:libgcrypt \
                     port:libgdata \
                     port:openssh \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:libxml2 \
                     port:libsecret
 

--- a/gnome/frogr/Portfile
+++ b/gnome/frogr/Portfile
@@ -16,7 +16,6 @@ long_description    Frogr is a small application for the GNOME desktop that allo
 
 maintainers         {devans @dbevans} openmaintainer
 categories          gnome
-platforms           darwin
 homepage            https://wiki.gnome.org/Apps/Frogr
 master_sites        gnome:sources/${name}/${branch}/
 
@@ -38,7 +37,7 @@ depends_lib         port:desktop-file-utils \
                     port:libxml2 \
                     port:json-glib \
                     port:libgcrypt \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:gstreamer1
 
 depends_run         port:adwaita-icon-theme \

--- a/gnome/geocode-glib/Portfile
+++ b/gnome/geocode-glib/Portfile
@@ -17,7 +17,6 @@ long_description    geocode-glib is a convenience library for geocoding (finding
 
 maintainers         {devans @dbevans} openmaintainer
 categories          gnome devel
-platforms           darwin
 homepage            https://developer.gnome.org/geocode-glib/
 master_sites        gnome:sources/${name}/${branch}/
 
@@ -35,7 +34,7 @@ depends_lib         port:gettext-runtime \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     port:json-glib \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+                    port:libsoup-2.4
 
 # Work around lack of @rpath on Tiger, i.e. this error:
 # dyld: Library not loaded: @loader_path/libgeocode-glib.0.dylib

--- a/gnome/gfbgraph/Portfile
+++ b/gnome/gfbgraph/Portfile
@@ -13,7 +13,6 @@ long_description    ${description}
 
 maintainers         {devans @dbevans} openmaintainer
 categories          gnome
-platforms           darwin
 homepage            https://www.gnome.org
 master_sites        gnome:sources/${name}/${branch}/
 
@@ -29,7 +28,7 @@ depends_build       port:pkgconfig \
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:gnome-online-accounts \
                     port:json-glib \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:rest
 
 patchfiles          patch-Makefile.am.diff

--- a/gnome/grilo/Portfile
+++ b/gnome/grilo/Portfile
@@ -31,7 +31,7 @@ depends_build-append \
 depends_lib         path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:liboauth \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:libxml2 \
                     port:totem-pl-parser
 

--- a/gnome/gstreamer010-gst-plugins-good/Portfile
+++ b/gnome/gstreamer010-gst-plugins-good/Portfile
@@ -45,7 +45,7 @@ depends_lib     \
     port:libdv \
     path:include/turbojpeg.h:libjpeg-turbo \
     port:libshout2 \
-    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+    port:libsoup-2.4 \
     path:lib/libspeex.dylib:speex \
     port:taglib \
     port:wavpack

--- a/gnome/gthumb/Portfile
+++ b/gnome/gthumb/Portfile
@@ -12,7 +12,6 @@ description         Image viewer and browser for the GNOME desktop.
 long_description    ${description}
 maintainers         nomaintainer
 categories          gnome
-platforms           darwin
 homepage            https://wiki.gnome.org/Apps/gthumb
 master_sites        gnome:sources/gthumb/${branch}
 use_xz              yes
@@ -35,7 +34,7 @@ depends_lib         port:desktop-file-utils \
                     port:gstreamer1-gst-plugins-base \
                     port:lcms2 \
                     port:libraw \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:libsecret \
                     path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
                     port:webp \

--- a/gnome/libchamplain/Portfile
+++ b/gnome/libchamplain/Portfile
@@ -31,7 +31,7 @@ depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:clutter-gtk \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:sqlite3
 
 configure.args      -Dgtk_doc=true

--- a/gnome/libepc/Portfile
+++ b/gnome/libepc/Portfile
@@ -41,7 +41,7 @@ depends_build       port:pkgconfig \
 depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:avahi \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:ossp-uuid
 
 patchfiles          patch-configure.ac.diff \

--- a/gnome/libgdata/Portfile
+++ b/gnome/libgdata/Portfile
@@ -34,7 +34,7 @@ depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     port:json-glib \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:libxml2 \
                     port:uhttpmock
 

--- a/gnome/libsocialweb/Portfile
+++ b/gnome/libsocialweb/Portfile
@@ -32,7 +32,7 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:gconf \
                     port:dbus-glib \
                     port:json-glib \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:libgnome-keyring \
                     port:rest
 

--- a/gnome/polari/Portfile
+++ b/gnome/polari/Portfile
@@ -15,7 +15,6 @@ long_description    Polari is an IRC chat client designed to integrate \
                     popular IRC servers
 maintainers         {devans @dbevans} openmaintainer
 categories          gnome
-platforms           darwin
 
 homepage            https://wiki.gnome.org/Apps/Polari
 master_sites        gnome:sources/${name}/${branch}/
@@ -36,7 +35,7 @@ depends_lib         port:desktop-file-utils \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:libiconv \
                     port:libsecret \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:telepathy-glib \
                     port:telepathy-idle \
                     port:telepathy-logger \

--- a/gnome/rest/Portfile
+++ b/gnome/rest/Portfile
@@ -13,7 +13,6 @@ description         A library that makes it easier to access web services that \
 long_description    ${description}
 maintainers         {devans @dbevans} openmaintainer
 categories          gnome devel
-platforms           darwin
 homepage            https://wiki.gnome.org/Projects/Librest
 master_sites        gnome:sources/${name}/${branch}/
 
@@ -27,7 +26,7 @@ depends_build       port:pkgconfig
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libxml2 \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+                    port:libsoup-2.4
 
 depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 

--- a/gnome/tracker3/Portfile
+++ b/gnome/tracker3/Portfile
@@ -61,7 +61,7 @@ depends_lib-append  port:avahi \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     path:lib/pkgconfig/icu-uc.pc:icu \
                     port:json-glib \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:libxml2 \
                     port:ossp-uuid \
                     port:py${py_ver_nodot}-gobject3 \

--- a/gnome/uhttpmock/Portfile
+++ b/gnome/uhttpmock/Portfile
@@ -26,7 +26,7 @@ depends_build       port:pkgconfig \
                     path:bin/vala:vala
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+                    port:libsoup-2.4
 
 gobject_introspection yes
 

--- a/graphics/osm-gps-map-gtk2/Portfile
+++ b/graphics/osm-gps-map-gtk2/Portfile
@@ -10,7 +10,6 @@ revision        1
 license         GPL-3
 categories      graphics
 maintainers     {devans @dbevans} openmaintainer
-platforms       darwin
 homepage        http://nzjrs.github.io/${github.project}/
 
 description     A GTK+ 2 widget for displaying OpenStreetMap tiles.
@@ -30,7 +29,7 @@ depends_build   port:pkgconfig \
                 port:gnome-common \
                 port:gtk-doc
 
-depends_lib     path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+depends_lib     port:libsoup-2.4 \
                 path:lib/pkgconfig/gtk+-2.0.pc:gtk2
 
 patchfiles      patch-Makefile.am.diff

--- a/net/libgrss/Portfile
+++ b/net/libgrss/Portfile
@@ -13,7 +13,6 @@ long_description    ${description}
 
 maintainers         {devans @dbevans} openmaintainer
 categories          net gnome
-platforms           darwin
 homepage            https://wiki.gnome.org/Projects/Libgrss
 master_sites        gnome:sources/${name}/${branch}/
 
@@ -32,7 +31,7 @@ depends_build       port:pkgconfig \
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libxml2 \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+                    port:libsoup-2.4
 
 gobject_introspection yes
 

--- a/net/libgweather/Portfile
+++ b/net/libgweather/Portfile
@@ -36,7 +36,7 @@ depends_lib         port:geocode-glib \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:libxml2 \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+                    port:libsoup-2.4
 
 post-patch {
     reinplace -W ${worksrcpath} "s|^#!.*python3|#!${prefix}/bin/python3.10|" \

--- a/www/libhttpseverywhere/Portfile
+++ b/www/libhttpseverywhere/Portfile
@@ -55,7 +55,7 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     port:libarchive \
                     port:libgee \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:libxml2
 
 patchfiles          patch-vala-0.42.diff \

--- a/www/midori/Portfile
+++ b/www/midori/Portfile
@@ -35,7 +35,7 @@ depends_lib         port:desktop-file-utils \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:gcr \
                     port:libpeas \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:sqlite3 \
                     path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk
 

--- a/www/webkit-gtk/Portfile
+++ b/www/webkit-gtk/Portfile
@@ -46,7 +46,7 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libxslt \
                     port:libpng \
                     port:libsecret \
-                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libsoup-2.4 \
                     port:mesa \
                     port:sqlite3 \
                     port:webp \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)

- [x] bugfix

###### Tested on
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?