### PR TITLE
qmake5 PortGroup: do not include unneeded legacysupport

### DIFF
--- a/_resources/port1.0/group/qmake5-1.0.tcl
+++ b/_resources/port1.0/group/qmake5-1.0.tcl
@@ -7,7 +7,6 @@
 
 PortGroup                       qt5 1.0
 PortGroup                       active_variants 1.1
-PortGroup                       legacysupport 1.1
 
 options qt5.add_spec qt5.debug_variant qt5.top_level qt5.cxxflags qt5.ldflags qt5.frameworkpaths qt5.spec_cmd
 default qt5.add_spec yes


### PR DESCRIPTION
#### Description

Building qt5-qttools fails ([ticket](https://trac.macports.org/ticket/70682), [logs](https://ports.macports.org/port/qt5-qttools/details/)) on Mojave and High Sierra with a cryptic message:
````
Undefined symbols for architecture x86_64:
  "vtable for ApplicationEventFilter", referenced from:
      _main in main.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
````
It looks like the problem goes away when I remove `-isystem/opt/local/include/LegacySupport` from the compiler invocation. qt5-qttools does not use legacysupport itself. legacysupport is [brought in by qmake5-1.0.tcl, which does not seem to make any use of it](https://github.com/macports/macports-ports/commit/51ad9d1e539d33e7eaa717da62c933f79ee03778). Removing legacysupport from qmake5-1.0.tcl fixes the build, at least on Mojave.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
