### PR TITLE
xaos: restrict compilers to supported by qt64

### DIFF
--- a/graphics/xaos/Portfile
+++ b/graphics/xaos/Portfile
@@ -5,6 +5,7 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               qt6 1.0
 PortGroup               legacysupport 1.1
+PortGroup               compiler_blacklist_versions 1.0
 
 github.setup            xaos-project XaoS 4.3.3 release-
 revision                0
@@ -46,6 +47,9 @@ qt6.depends_build       qttools
 compiler.thread_local_storage yes
 
 compiler.cxx_standard   2017
+
+# Same as qt64
+compiler.blacklist-append   {clang < 1100}
 
 cmake.module_path-append \
                         ${qt6.dir}/lib/cmake/Qt6LinguistTools


### PR DESCRIPTION
#### Description

Building xaos on Mojave fails, as it tries to use the unsupported XCode 10.3 compiler.
Add the needed `compiler.blacklist-append` directive.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
