### PR TITLE
opencv4: add py313 bindings

### DIFF
--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -84,7 +84,7 @@ dist_subdir         ${my_name}
 # Python build support
 #------------------------------------------------------------------------------
 set default_python_branch \
-                    3.12
+                    3.13
 set default_python_version \
                     [join [lrange [split ${default_python_branch} .] 0 1] ""]
 set default_python_path \
@@ -398,7 +398,7 @@ platform darwin {
 }
 
 # Python Bindings
-set python_branches {3.9 3.10 3.11 3.12}
+set python_branches {3.9 3.10 3.11 3.12 3.13}
 foreach python_branch ${python_branches} {
     set python_version   [join [lrange [split ${python_branch} .] 0 1] ""]
     set python_path      ${prefix}/bin/python${python_branch}


### PR DESCRIPTION
#### Description



###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

No binary files. Tested by importing `cv2` into Python 3.13 and reading an image.

Linting returns:
```
Error: conflicts references unknown port: py313-opencv3
Error: conflicts references unknown port: py313-opencv3-devel
Error: conflicts references unknown port: py313-opencv4-devel
```
There are no Python 3.12 bindings for OpenCV 3 either, but bindings exist for the devel version of OpenCV 4. I did not add py313-opencv4-devel because I have not had the chance to test it. I am not sure what the difference actually is, since both are at version 4.9.0.