### PR TITLE
wireshark4: update to 4.4.2

### DIFF
--- a/net/wireshark4/Portfile
+++ b/net/wireshark4/Portfile
@@ -29,12 +29,12 @@ if { ${os.platform} eq "darwin" && ${os.major} < 16 } {
     }
 }
 
-version         4.4.1
+version         4.4.2
 revision        0
 
-checksums       sha256  2b9e96572a7002c3e53b79683cf92f8172217e64c17ecaaf612eb68c2a7556ec \
-                sha1    18672f1faaf5bdd878a45fc8af9d527fd034152e \
-                size    46748700
+checksums       sha256  6053d97499c83feb87ce1d7f732d9c889c6c18bb334de67e65dca11483b0514e \
+                sha1    95e8dbc57e19c52ec8b41a06e49cfd70298d0037 \
+                size    46763620
 
 livecheck.type  regex
 livecheck.url   ${homepage}download/src/
@@ -60,6 +60,7 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libgcrypt \
                     port:libpcap \
                     port:libssh \
+                    port:libxml2 \
                     port:lz4 \
                     port:nghttp2 \
                     port:nghttp3 \
@@ -73,7 +74,7 @@ configure.args-append \
                     -DENABLE_APPLICATION_BUNDLE=OFF \
                     -DENABLE_GNUTLS=OFF \
                     -DENABLE_KERBEROS=OFF \
-                    -DENABLE_LIBXML2=OFF \
+                    -DENABLE_LIBXML2=ON \
                     -DENABLE_LUA=OFF \
                     -DENABLE_LZ4=ON \
                     -DENABLE_MINIZIP=OFF \
@@ -160,7 +161,7 @@ variant chmodbpf description {Enable Wireshark to access macOS capture devices} 
     depends_run             port:wireshark-chmodbpf
 }
 
-set pythons_suffixes {38 39 310 311 312}
+set pythons_suffixes {39 310 311 312 313}
 
 set pythons_ports {}
 foreach py_ver_nodot ${pythons_suffixes} {
@@ -190,7 +191,7 @@ foreach py_ver_nodot ${pythons_suffixes} {
 ## if no python3* variant is specified, add +python311
 ## XYZZY: it would be better to detect which python3* is already installed and use that...
 if {!${python_isset}} {
-    default_variants-append +python312
+    default_variants-append +python313
 }
 
 


### PR DESCRIPTION
Add and default to python313, drop python38

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
