### PR TITLE
cdo: update to 2.5.0

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,7 +5,7 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.0
 
 name                        cdo
-version                     2.4.4
+version                     2.5.0
 revision                    0
 maintainers                 {takeshi @tenomoto} \
                             {me.com:remko.scharroo @remkos} \
@@ -14,11 +14,11 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/29649
+master_sites                https://code.mpimet.mpg.de/attachments/download/29786
 
-checksums           rmd160  af0ce66796ebcc5a7cace1db9fe38dad26d24fc9 \
-                    sha256  49f50bd18dacd585e9518cfd4f55548f692426edfb3b27ddcd1c653eab53d063 \
-                    size    13551047
+checksums           rmd160  c135c339eb6902e0ccd1d777b9d22a94fb2bbe97 \
+                    sha256  e865c05c1b52fd76b80e33421554db81b38b75210820bdc40e8690f4552f68e2 \
+                    size    13553301
 
 long_description \
     CDO is a collection of command line Operators               \


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.5.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 x86_64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
