### PR TITLE
ocrmypdf: rework python variants, default to 3.13; enable english by default

### DIFF
--- a/textproc/ocrmypdf/Portfile
+++ b/textproc/ocrmypdf/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                ocrmypdf
 version             16.7.0
-revision            0
+revision            1
 categories          textproc
 
 homepage            https://github.com/ocrmypdf/OCRmyPDF
@@ -70,8 +70,11 @@ depends_lib-append  port:ghostscript \
                     port:py${python.version}-pyheif \
                     port:py${python.version}-rich
 
-notes "
-You will need to install the tesseract language ports of your choice.
-e.g., to add English and German support:
+depends_run-append  port:tesseract-eng
 
-    port install tesseract-eng tesseract-deu"
+notes "
+English support is enabled by default.
+To enable support for other languages you will need to install corresponding tesseract language ports.
+e.g., to add and German support:
+
+    port install tesseract-deu"

--- a/textproc/ocrmypdf/Portfile
+++ b/textproc/ocrmypdf/Portfile
@@ -27,17 +27,24 @@ supported_archs     noarch
 platforms           {darwin any}
 license             MPL-2
 
-variant python310 conflicts python311 python312 description "Use Python 3.10" {}
-variant python311 conflicts python310 python312 description "Use Python 3.11" {}
-variant python312 conflicts python310 python311 description "Use Python 3.12" {}
-
-if {[variant_isset python310]} {
+variant python310 conflicts python311 python312 python313 description "Use Python 3.10" {
     python.default_version 310
-} elseif {[variant_isset python311]} {
+}
+
+variant python311 conflicts python310 python312 python313 description "Use Python 3.11" {
     python.default_version 311
-} else {
-    default_variants +python312
+}
+
+variant python312 conflicts python310 python311 python313 description "Use Python 3.12" {
     python.default_version 312
+}
+
+variant python313 conflicts python310 python311 python312 description "Use Python 3.13" {
+    python.default_version 313
+}
+
+if {![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312]} {
+    default_variants +python313
 }
 
 depends_build-append \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
