### PR TITLE
wxWidgets-3.0: set c++ standards

### DIFF
--- a/graphics/wxWidgets-3.0/Portfile
+++ b/graphics/wxWidgets-3.0/Portfile
@@ -8,7 +8,7 @@ PortGroup           wxWidgets       1.0
 
 github.setup        wxWidgets wxWidgets 3.0.5.1 v
 github.tarball_from releases
-revision            4
+revision            5
 
 # macOS 15 Requirement: CGDisplayCreateImage fails as it's been removed
 platform darwin 24 {
@@ -40,7 +40,7 @@ if {${subport} eq ${name}} {
 } elseif {${subport} eq "wxPython-3.0"} {
     wxWidgets.use   wxPython-3.0
     version         3.0.2
-    revision        8
+    revision        9
 } elseif {${subport} eq "wxgtk-3.0"} {
     # wxgtk-3.0 is need to support older systems where wxWidgets-3.0
     # do not work correctly (they do build, but are unusable).
@@ -145,7 +145,11 @@ platform darwin powerpc {
 }
 
 
-if {${subport} eq "wxPython-3.0"} {
+if {${subport} eq ${name}} {
+    configure.cxxflags-append -std=c++03
+
+} elseif {${subport} eq "wxPython-3.0"} {
+
     master_sites            sourceforge:project/wxwindows/${version} \
                             http://biolpc22.york.ac.uk/pub/${version}/ \
                             http://trac.macports.org/raw-attachment/ticket/19190/:trac
@@ -178,6 +182,8 @@ if {${subport} eq "wxPython-3.0"} {
                             patch-upstream-src-stc-scintilla-src-Editor.cxx.diff \
                             patch-upstream-strvararg.diff \
                             patch-upstream-webkit-proper-types.diff
+
+    configure.cxxflags-append -std=c++03
 
     # https://trac.macports.org/ticket/52069
     if {${os.platform} eq "darwin" && ${os.major} >= 16} {
@@ -214,6 +220,8 @@ if {${subport} eq "wxPython-3.0"} {
     configure.args-delete   --with-cocoa \
                             --without-sdl
     configure.args-append   --with-sdl
+
+    configure.cxxflags-append -std=c++03
 
     #variant gtk2 conflicts gtk3 description {} {
     #    depends_lib-append      path:lib/pkgconfig/gtk+-2.0.pc:gtk2
@@ -272,11 +280,18 @@ if {${subport} eq "wxPython-3.0"} {
 
     configure.args-replace  --with-cocoa --with-gtk=3 \
                             --without-sdl --with-sdl
-}
 
-if {${subport} eq "wxgtk-3.0" || ${subport} eq "wxgtk-3.0-cxx11"} {
+    configure.cxxflags-append -std=c++11
+
+} elseif {${subport} eq "wxgtk-3.0"} {
     # Address this bug: https://trac.macports.org/ticket/70124
     patchfiles-append       patch-no-osx-evtloopsrc.h.diff
+    configure.cxxflags-append -std=c++03
+
+} elseif {${subport} eq "wxgtk-3.0-cxx11"} {
+    # Address this bug: https://trac.macports.org/ticket/70124
+    patchfiles-append       patch-no-osx-evtloopsrc.h.diff
+    configure.cxxflags-append -std=c++11
 }
 
 post-destroot {


### PR DESCRIPTION
The builds of the wx30 ports are failing on 10.7, at least.

This appears to be because 10.7 is building them with clang-16, and clang-16 defaults to a too-new c++ standard, which causes all the builds to error out.

We have two versions of most of the wx30 ports, one a "standard" build, which up to now was defaulting to something pre-c++-11 in almost all cases, and one a "*-cxx11" build, where a c++11 compiler was used.

If we set the c++ standards as such in each of the subports, this fixes the builds of the wx30 ports on 10.7, at least.

I have not tested wxPython as yet, nor any other systems beyond 10.7 as yet.