### PR TITLE
age: install manpages

### DIFF
--- a/security/age/Portfile
+++ b/security/age/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/FiloSottile/age 1.2.1 v
 go.package          filippo.io/age
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://age-encryption.org
 
@@ -35,6 +35,9 @@ pre-build {
 destroot {
     foreach age_bin [glob ${worksrcpath}/_dist/*] {
         xinstall -m 0755 ${age_bin} ${destroot}${prefix}/bin/
+    }
+    foreach doc [glob ${worksrcpath}/doc/*.1] {
+        copy ${doc} ${destroot}${prefix}/share/man/man1
     }
 }
 


### PR DESCRIPTION
#### Description

Add installation of manpages to the age port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
