### PR TITLE
isync: Fix crash on 0-size messages on IMAP

### DIFF
--- a/mail/isync/Portfile
+++ b/mail/isync/Portfile
@@ -4,9 +4,8 @@ PortSystem              1.0
 
 name                    isync
 version                 1.5.0
-revision                0
+revision                1
 categories              mail
-platforms               darwin
 license                 GPL-2
 maintainers             {gmail.com:emanuele.giaquinta @exg} openmaintainer
 description             command line utility to synchronize mailboxes
@@ -38,7 +37,8 @@ startupitem.name        mbsync
 # Patch the sample configuration to use MacPorts certificates and
 # drv_proxy_gen.pl to use MacPorts perl for building on OS X 10.8 and
 # earlier: https://sourceforge.net/p/isync/bugs/37/
-patchfiles          patch-paths.diff
+patchfiles          patch-paths.diff \
+                    0001-accept-zero-sized-messages-from-IMAP.patch
 
 post-extract {
     xinstall -m 644 -W ${filespath} mbsync.plist ${worksrcpath}

--- a/mail/isync/files/0001-accept-zero-sized-messages-from-IMAP.patch
+++ b/mail/isync/files/0001-accept-zero-sized-messages-from-IMAP.patch
@@ -1,0 +1,77 @@
+From 15c7e02e4a5fe127bd55bce2b9aa63a5da8eb228 Mon Sep 17 00:00:00 2001
+From: Oswald Buddenhagen <ossi@users.sf.net>
+Date: Sun, 24 Nov 2024 13:11:32 +0100
+Subject: [PATCH] accept zero-sized messages from IMAP
+
+while such a thing is rather pointless, completely empty messages are
+not forbidden. consequently, we should be able to deal with them, and
+above all not crash.
+
+Upstream-Status: Backport [https://sourceforge.net/p/isync/isync/ci/15c7e02e4a5fe127bd55bce2b9aa63a5da8eb228/]
+---
+ src/drv_imap.c | 5 ++++-
+ src/socket.c   | 1 -
+ src/util.c     | 5 +++++
+ 3 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/src/drv_imap.c b/src/drv_imap.c
+index 1280e3c..b0be1fd 100644
+--- ./src/drv_imap.c
++++ ./src/drv_imap.c
+@@ -780,6 +780,8 @@ parse_imap_list( imap_store_t *ctx, char **sp, parse_list_state_t *sts )
+ 				if (sts->callback->atom( ctx, NULL, bytes, AtomChunkedLiteral ) != LIST_OK)
+ 					goto bail;
+ 				sts->in_literal = ChunkedLiteral;
++				if (!bytes)
++					goto nobytes;
+ 				sts->big_literal = 1;
+ 			  get_chunked:
+ 				n = 1;
+@@ -806,7 +808,7 @@ parse_imap_list( imap_store_t *ctx, char **sp, parse_list_state_t *sts )
+ 				} else if (DFlags & DEBUG_NET_ALL) {
+ 					printf( "%s=========\n", ctx->label );
+ 					fwrite( p, n, 1, stdout );
+-					if (p[n - 1] != '\n')
++					if (n && p[n - 1] != '\n')
+ 						fputs( "\n(no-nl) ", stdout );
+ 					printf( "%s=========\n", ctx->label );
+ 				} else {
+@@ -819,6 +821,7 @@ parse_imap_list( imap_store_t *ctx, char **sp, parse_list_state_t *sts )
+ 			bytes -= n;
+ 			if (bytes > 0)
+ 				goto postpone;
++		  nobytes:
+ 			if (sts->in_literal == ChunkedLiteral && sts->callback->atom( ctx, NULL, 0, AtomLiteral ) != LIST_OK)
+ 				goto bail;
+ 		  getline:
+diff --git a/src/socket.c b/src/socket.c
+index afd3f18..1ef0e95 100644
+--- ./src/socket.c
++++ ./src/socket.c
+@@ -952,7 +952,6 @@ socket_expect_bytes( conn_t *conn, uint len )
+ char *
+ socket_read( conn_t *conn, uint min_len, uint max_len, uint *out_len )
+ {
+-	assert( min_len > 0 );
+ 	assert( min_len <= sizeof(conn->buf) );
+ 	assert( min_len <= max_len );
+ 
+diff --git a/src/util.c b/src/util.c
+index e697cfb..121ab0a 100644
+--- ./src/util.c
++++ ./src/util.c
+@@ -637,6 +637,11 @@ nfmalloc( size_t sz )
+ {
+ 	void *ret;
+ 
++#ifndef __GLIBC__
++	// The C standard allows NULL returns for zero-sized allocations.
++	if (!sz)
++		sz = 1;
++#endif
+ 	if (!(ret = malloc( sz )))
+ 		oom();
+ 	return ret;
+-- 
+2.47.1
+


### PR DESCRIPTION
#### Description

Backport a patch already applied upstream that fixes this. Notably, attempting to sync a [Gmail]/Chats folder from GMail triggers this.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
