### PR TITLE
gallery-dl: update to 1.28.3 and bump python

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.28.2 v
+github.setup        mikf gallery-dl 1.28.3 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  89ee7dc1075f06800fc280ba65e202a9e7711f0e \
-                    sha256  f1e6f39b44af6c3d131ff61a3369dedb3eae77bf0c7e1ac978afb345c3ed9048 \
-                    size    518743
+checksums           rmd160  5a940d2c6849098885b68eda4f1c9ba92c705425 \
+                    sha256  5582704f1b1cc8cff30e983f115174fb57e28c08412160878bf2befdda091f19 \
+                    size    520004
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites
@@ -25,7 +25,7 @@ long_description    ${name} is a {*}${description}. It is a cross-platform tool 
 supported_archs     noarch
 platforms           {darwin any}
 license             GPL-2
-python.default_version 312
+python.default_version 313
 
 depends_build-append port:py${python.version}-setuptools
 


### PR DESCRIPTION
#### Description

- updated to 1.28.3
- changed default python to 3.13

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macorts-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
