### PR TITLE
mise: Update to 2025.1.1

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.1.0 v
+github.setup        jdx mise 2025.1.1 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  9797bf2fa4622a4f84832b59bcc6157317cff639 \
-                    sha256  51e56a831cbedece92b1e3e5eaad92afae9d133503881ad18f229ea41e24a618 \
-                    size    4250709
+                    rmd160  77d97592cbce709a68dc670dd9262904a3757cbf \
+                    sha256  cf9277fa07ce77fec5df24f2c7bf892bb70387cf7a3333812123a849dda3462b \
+                    size    4252429
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -109,7 +109,7 @@ cargo.crates \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
     async-compression               0.4.18  df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522 \
-    async-trait                     0.1.83  721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd \
+    async-trait                     0.1.84  1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
@@ -124,7 +124,7 @@ cargo.crates \
     bit-vec                          0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
     bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    bstr                            1.11.1  786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8 \
+    bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
     built                            0.7.5  c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytecount                        0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
@@ -135,7 +135,7 @@ cargo.crates \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                               1.2.6  8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333 \
+    cc                               1.2.7  a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
@@ -218,14 +218,14 @@ cargo.crates \
     errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
     errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
     exec                             0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
-    expr-lang                        0.2.1  62d87141875739c4eb2b6a6e0c6dbd6f877ff3336953cdbf850b3dc920d3bf2f \
+    expr-lang                        0.2.2  bbf7d3d8b433d4dc8fe3e5383ad01f1cb2ffba8e999191af8bf7af1e9fa3e2ca \
     eyre                            0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
     fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     filetime_creation                0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
     find-crate                       0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
-    fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
+    fixedbitset                      0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
     flate2                          1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
     fluent                          0.16.1  bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a \
     fluent-bundle                   0.15.3  7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493 \
@@ -258,7 +258,6 @@ cargo.crates \
     h2                               0.4.7  ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
@@ -301,11 +300,11 @@ cargo.crates \
     impl-tools-lib                  0.11.1  2a391adcea096a89a593317881fb61ef4e68d3e7d9de9e2338e6e1557be29e10 \
     indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                         2.7.0  62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f \
+    indexmap                         2.5.0  68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5 \
     indicatif                       0.17.9  cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inout                            0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
-    insta                           1.41.1  7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8 \
+    insta                           1.42.0  6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5 \
     intl-memoizer                    0.5.2  fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda \
     intl_pluralrules                 7.0.2  078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972 \
     io_tee                           0.1.1  4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304 \
@@ -313,6 +312,7 @@ cargo.crates \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
+    itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     js-sys                          0.3.76  6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7 \
@@ -390,7 +390,7 @@ cargo.crates \
     pest_derive                     2.7.15  816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e \
     pest_generator                  2.7.15  7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b \
     pest_meta                       2.7.15  e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea \
-    petgraph                         0.6.5  b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db \
+    petgraph                         0.7.0  e2b1374ec32450264534c67d1ccb5ca09818c4db8fd87cf97478d0df2fa44c65 \
     phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
     phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
     phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
@@ -413,7 +413,7 @@ cargo.crates \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro2                     1.0.92  37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0 \
-    quick-xml                       0.23.1  11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea \
+    quick-xml                       0.37.2  165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003 \
     quinn                           0.11.6  62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef \
     quinn-proto                     0.11.9  a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d \
     quinn-udp                        0.5.9  1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904 \
@@ -466,7 +466,7 @@ cargo.crates \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     self_cell                       0.10.3  e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d \
     self_cell                        1.1.0  c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe \
-    self_update                     0.41.0  469a3970061380c19852269f393e74c0fe607a4e23d85267382cf25486aa8de5 \
+    self_update                     0.42.0  d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c \
     semver                          1.0.24  3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba \
     serde                          1.0.217  02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70 \
     serde-value                      0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
@@ -509,7 +509,7 @@ cargo.crates \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.93  9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058 \
+    syn                             2.0.95  46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
@@ -519,7 +519,7 @@ cargo.crates \
     tabled_derive                    0.9.0  931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1 \
     taplo                           0.13.2  010941ac4171eaf12f1e26dfc11dadaf78619ea2330940fef01fe6bb0442d14d \
     tar                             0.4.43  c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6 \
-    tempfile                        3.14.0  28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c \
+    tempfile                        3.15.0  9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704 \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                    0.4.1  5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9 \
@@ -637,12 +637,12 @@ cargo.crates \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                          0.6.21  e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68 \
+    winnow                          0.6.22  39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980 \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     x25519-dalek                     2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
-    xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
+    xattr                            1.4.0  e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909 \
     xx                               2.0.3  43e8a6586de03e05832a7e364b3b94fb86ae16bbaa881f3e7998c4e66c6b900f \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.1.1

##### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
