### PR TITLE
tk dependents: default to +quartz when tk does

### DIFF
--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -42,20 +42,27 @@ configure.args-append   --with-tcl=${prefix}/lib
 
 destroot.destdir        INSTALL_ROOT=${destroot}
 
-variant quartz conflicts x11 {
-    depends_lib-append  port:tk-quartz
-    configure.args-append   --with-tk=${prefix}/lib/tk-quartz \
-                            --with-tkinclude=${prefix}/include/tk-quartz
+if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
+    && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
+
+    variant quartz conflicts x11 {
+        depends_lib-append  port:tk-quartz
+        configure.args-append   --with-tk=${prefix}/lib/tk-quartz \
+                                --with-tkinclude=${prefix}/include/tk-quartz
+    }
+    if {![variant_isset x11]} {
+        default_variants +quartz
+    }
+    set x11conflicts quartz
+} else {
+    default_variants +x11
+    set x11conflicts {}
 }
 
-variant x11 conflicts quartz {
+variant x11 conflicts {*}${x11conflicts} {
     depends_lib-append  port:tk-x11
     configure.args-append   --with-tk=${prefix}/lib/tk-x11 \
                             --with-tkinclude=${prefix}/include/tk-x11
-}
-
-if {![variant_isset x11] && ![variant_isset quartz]} {
-    default_variants +x11
 }
 
 livecheck.url           https://wiki.tcl-lang.org/page/Img

--- a/math/netgen/Portfile
+++ b/math/netgen/Portfile
@@ -131,25 +131,36 @@ foreach pdv ${pythonversions} {
     }
 }
 
-variant quartz conflicts x11 {
-    depends_lib-append  port:tk-quartz
-    require_active_variants tkdnd quartz
-    require_active_variants Togl  quartz
+if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
+    && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
 
-    # OpenGL/gl3.h does not exist prior to 10.7.
-    # https://github.com/NGSolve/netgen/issues/173
-    patchfiles-append       patch-opengl.diff
-    post-patch {
-        reinplace           "s|MACPORTS_NO_X11|TRUE|g" \
-                            ${worksrcpath}/CMakeLists.txt
+    variant quartz conflicts x11 {
+        depends_lib-append  port:tk-quartz
+        require_active_variants tkdnd quartz
+        require_active_variants Togl  quartz
+    
+        # OpenGL/gl3.h does not exist prior to 10.7.
+        # https://github.com/NGSolve/netgen/issues/173
+        patchfiles-append       patch-opengl.diff
+        post-patch {
+            reinplace           "s|MACPORTS_NO_X11|TRUE|g" \
+                                ${worksrcpath}/CMakeLists.txt
+        }
+        configure.args-append   -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-quartz \
+                                -DTK_WISH:PATH=${prefix}/libexec/tk-quartz/wish \
+                                -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtkstub8.6.a \
+                                -DTK_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtk.dylib
     }
-    configure.args-append   -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-quartz \
-                            -DTK_WISH:PATH=${prefix}/libexec/tk-quartz/wish \
-                            -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtkstub8.6.a \
-                            -DTK_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtk.dylib
+    if {![variant_isset x11]} {
+        default_variants +quartz
+    }
+    set x11conflicts quartz
+} else {
+    default_variants +x11
+    set x11conflicts {}
 }
 
-variant x11 conflicts quartz {
+variant x11 conflicts {*}${x11conflicts} {
     depends_lib-append  port:tk-x11
     require_active_variants tkdnd x11
     require_active_variants Togl  x11
@@ -168,12 +179,8 @@ variant x11 conflicts quartz {
                             -DTK_LIBRARY:PATH=${prefix}/lib/tk-x11/libtk.dylib
 }
 
-if {![variant_isset quartz] && ![variant_isset x11]} {
-    default_variants        +x11
-}
-
 pre-configure {
-    if {![variant_isset quartz] && ![variant_isset x11]} {
+    if {!([variant_exists quartz] && [variant_isset quartz]) && ![variant_isset x11]} {
         error "Either +x11 or +quartz is required"
     }
 }

--- a/x11/Togl/Portfile
+++ b/x11/Togl/Portfile
@@ -39,17 +39,29 @@ configure.args-append           --with-tcl=${prefix}/lib
 
 configure.universal_args-delete --disable-dependency-tracking
 
-variant quartz conflicts x11 {
-    depends_lib-append  port:tk-quartz
-    configure.args-append       --with-tk=${prefix}/lib/tk-quartz \
-                                --with-tkinclude=${prefix}/include/tk-quartz
-    # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L250
-    configure.cppflags-append   -DTOGL_NSOPENGL
-    # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L221
-    configure.ldflags-append    -undefined dynamic_lookup
+if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
+    && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
+
+    variant quartz conflicts x11 {
+        depends_lib-append  port:tk-quartz
+        configure.args-append       --with-tk=${prefix}/lib/tk-quartz \
+                                    --with-tkinclude=${prefix}/include/tk-quartz
+        configure.cppflags-prepend  -I${prefix}/include/tk-quartz
+        # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L250
+        configure.cppflags-append   -DTOGL_NSOPENGL
+        # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L221
+        configure.ldflags-append    -undefined dynamic_lookup
+    }
+    if {![variant_isset x11]} {
+        default_variants +quartz
+    }
+    set x11conflicts quartz
+} else {
+    default_variants +x11
+    set x11conflicts {}
 }
 
-variant x11 conflicts quartz {
+variant x11 conflicts {*}${x11conflicts} {
     depends_lib-append          port:tk-x11 \
                                 port:xorg-libX11 \
                                 port:xorg-libXmu \
@@ -57,16 +69,13 @@ variant x11 conflicts quartz {
     configure.args-append       --with-tk=${prefix}/lib/tk-x11 \
                                 --with-tkinclude=${prefix}/include/tk-x11 \
                                 --with-Xmu
+    configure.cppflags-prepend  -I${prefix}/include/tk-x11
     # see https://github.com/NGSolve/netgen/blob/master/CMakeLists.txt#L252
     configure.cppflags-append   -DTOGL_X11
 }
 
-if {![variant_isset quartz]} {
-    default_variants +x11
-}
-
 pre-configure {
-    if {![variant_isset quartz] && ![variant_isset x11]} {
+    if {!([variant_exists quartz] && [variant_isset quartz]) && ![variant_isset x11]} {
         error "Either +x11 or +quartz is required"
     }
 }

--- a/x11/tix/Portfile
+++ b/x11/tix/Portfile
@@ -41,14 +41,25 @@ patchfiles-append   patch-missing-headers.diff \
 configure.args      --mandir=${prefix}/share/man \
                     --with-tcl=${prefix}/lib
 
-variant quartz conflicts x11 {
-    depends_lib-append  port:tk-quartz
-    configure.args-append \
-                    --with-tk=${prefix}/lib/tk-quartz
-    configure.cppflags-prepend  -I${prefix}/include/tk-quartz
+if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
+    && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
+
+    variant quartz conflicts x11 {
+        depends_lib-append  port:tk-quartz
+        configure.args-append \
+                        --with-tk=${prefix}/lib/tk-quartz
+        configure.cppflags-prepend  -I${prefix}/include/tk-quartz
+    }
+    if {![variant_isset x11]} {
+        default_variants +quartz
+    }
+    set x11conflicts quartz
+} else {
+    default_variants +x11
+    set x11conflicts {}
 }
 
-variant x11 conflicts quartz {
+variant x11 conflicts {*}${x11conflicts} {
     depends_lib-append  port:tk-x11
 
     configure.args-append \
@@ -57,10 +68,6 @@ variant x11 conflicts quartz {
                     --x-libraries=${prefix}/lib \
                     --with-tk=${prefix}/lib/tk-x11
     configure.cppflags-prepend  -I${prefix}/include/tk-x11
-}
-
-if {![variant_isset quartz]} {
-    default_variants +x11
 }
 
 test.run            yes

--- a/x11/tkdnd/Portfile
+++ b/x11/tkdnd/Portfile
@@ -31,36 +31,47 @@ configure.args-append \
 
 depends_lib-append port:tcl
 
-variant quartz conflicts x11 {
-    depends_lib-append  port:tk-quartz
-    configure.args-append \
-        -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-quartz \
-        -DTK_WISH:PATH=${prefix}/libexec/tk-quartz/wish \
-        -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtkstub8.6.a \
-        -DTK_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtk.dylib
-    # garbage collection is still available for ${os.major} < 16
-    # ARC is available for ${os.major} > 10
-    # in Xcode < 10, ARC forbids Objective-C objects in struct
-    #     see https://developer.apple.com/videos/play/wwdc2018/409/?time=229
-    #     see https://trac.macports.org/ticket/59058
-    if {${os.major} >= 16} {
-        compiler.blacklist-append {clang < 1000}
-    }
-    post-patch {
-        reinplace "s|MACPORTS_APPLE|APPLE|g" \
-            ${worksrcpath}/CMakeLists.txt
-        if {${os.major} < 16} {
-            reinplace "s|#MACPORTS_DO_NOT_USE_GC||g" \
-                ${worksrcpath}/CMakeLists.txt
-        } else {
-            reinplace "s|#MACPORTS_DO_NOT_USE_ARC||g" \
-                ${worksrcpath}/CMakeLists.txt
+if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"
+    && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
 
+    variant quartz conflicts x11 {
+        depends_lib-append  port:tk-quartz
+        configure.args-append \
+            -DTK_INCLUDE_PATH:PATH=${prefix}/include/tk-quartz \
+            -DTK_WISH:PATH=${prefix}/libexec/tk-quartz/wish \
+            -DTK_STUB_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtkstub8.6.a \
+            -DTK_LIBRARY:PATH=${prefix}/lib/tk-quartz/libtk.dylib
+        # garbage collection is still available for ${os.major} < 16
+        # ARC is available for ${os.major} > 10
+        # in Xcode < 10, ARC forbids Objective-C objects in struct
+        #     see https://developer.apple.com/videos/play/wwdc2018/409/?time=229
+        #     see https://trac.macports.org/ticket/59058
+        if {${os.major} >= 16} {
+            compiler.blacklist-append {clang < 1000}
+        }
+        post-patch {
+            reinplace "s|MACPORTS_APPLE|APPLE|g" \
+                ${worksrcpath}/CMakeLists.txt
+            if {${os.major} < 16} {
+                reinplace "s|#MACPORTS_DO_NOT_USE_GC||g" \
+                    ${worksrcpath}/CMakeLists.txt
+            } else {
+                reinplace "s|#MACPORTS_DO_NOT_USE_ARC||g" \
+                    ${worksrcpath}/CMakeLists.txt
+    
+            }
         }
     }
+    if {![variant_isset x11]} {
+        default_variants +quartz
+    }
+    set x11conflicts quartz
+} else {
+    default_variants +x11
+    set x11conflicts {}
 }
 
-variant x11 conflicts quartz {
+variant x11 conflicts {*}${x11conflicts} {
     depends_lib-append \
         port:tk-x11 \
         port:xorg-libX11 \
@@ -75,12 +86,8 @@ variant x11 conflicts quartz {
         -DTK_LIBRARY:PATH=${prefix}/lib/tk-x11/libtk.dylib
 }
 
-if {![variant_isset quartz] && ![variant_isset x11]} {
-    default_variants +x11
-}
-
 pre-configure {
-    if {![variant_isset quartz] && ![variant_isset x11]} {
+    if {!([variant_exists quartz] && [variant_isset quartz]) && ![variant_isset x11]} {
         error "Either +x11 or +quartz is required"
     }
 }

--- a/x11/tktable/Portfile
+++ b/x11/tktable/Portfile
@@ -43,20 +43,27 @@ configure.args      --with-tcl=${prefix}/lib \
                     CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
                     LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
 
-variant quartz conflicts x11 {
-    depends_build-append    port:tk-quartz
-    configure.args-append   --with-tk=${prefix}/lib/tk-quartz \
-                            --with-tkinclude=${prefix}/include/tk-quartz
+if {${os.platform} eq "moof" && ${os.subplatform} eq "macosx"
+    && ${os.major} >= 10 && ![string match ppc* ${build_arch}]} {
+
+    variant quartz conflicts x11 {
+        depends_build-append    port:tk-quartz
+        configure.args-append   --with-tk=${prefix}/lib/tk-quartz \
+                                --with-tkinclude=${prefix}/include/tk-quartz
+    }
+    if {![variant_isset x11]} {
+        default_variants +quartz
+    }
+    set x11conflicts quartz
+} else {
+    default_variants +x11
+    set x11conflicts {}
 }
 
-variant x11 conflicts quartz {
+variant x11 conflicts {*}${x11conflicts} {
     depends_build-append    port:tk-x11
     configure.args-append   --with-tk=${prefix}/lib/tk-x11 \
                             --with-tkinclude=${prefix}/include/tk-x11
-}
-
-if {![variant_isset quartz]} {
-    default_variants +x11
 }
 
 test.run            yes


### PR DESCRIPTION
These ports offer quartz and x11 variants and use the corresponding tk subports. The tk port now defaults to +quartz when it will work, and otherwise doesn't offer a quartz variant and defaults to +x11, so this makes these ports do the same.