### PR TITLE
ruby3[23]: Fix build on 10.4 with gcc14.

### DIFF
--- a/lang/ruby32/Portfile
+++ b/lang/ruby32/Portfile
@@ -14,7 +14,7 @@ set ruby_patch      6
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
-revision            0
+revision            1
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} \
@@ -64,7 +64,7 @@ select.file         ${filespath}/ruby${ruby_ver_nodot}
 # patch-sources.diff: fixes for various issues.
 # This includes the 'gem' versioning fix formerly handled via reinplace.
 #
-# This diff is from v3_2_6 vs. macports-3_2_6.
+# This diff is from v3_2_6 vs. macports-3_2_6r1.
 #
 patchfiles-append   patch-sources.diff
 

--- a/lang/ruby32/files/patch-sources.diff
+++ b/lang/ruby32/files/patch-sources.diff
@@ -1,5 +1,5 @@
 --- .gdbinit.orig	2024-10-30 02:47:11.000000000 -0700
-+++ .gdbinit	2024-11-27 15:13:42.000000000 -0800
++++ .gdbinit	2025-01-06 14:46:11.000000000 -0800
 @@ -1,4 +1,5 @@
 -set startup-with-shell off
 +# Move this to end, so failure on older gdbs doesn't blow the rest
@@ -15,7 +15,7 @@
 +# Moved from beginning, since it fails on older gdbs
 +set startup-with-shell off
 --- ext/digest/md5/md5cc.h.orig	2024-10-30 02:47:11.000000000 -0700
-+++ ext/digest/md5/md5cc.h	2024-11-27 15:13:42.000000000 -0800
++++ ext/digest/md5/md5cc.h	2025-01-06 14:46:11.000000000 -0800
 @@ -17,3 +17,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(MD5
  #undef MD5_Finish
  #define MD5_Update rb_digest_MD5_update
@@ -29,7 +29,7 @@
 +#undef MD5_Init
 +#define MD5_Init CC_MD5_Init
 --- ext/digest/sha1/sha1cc.h.orig	2024-10-30 02:47:11.000000000 -0700
-+++ ext/digest/sha1/sha1cc.h	2024-11-27 15:13:42.000000000 -0800
++++ ext/digest/sha1/sha1cc.h	2025-01-06 14:46:11.000000000 -0800
 @@ -12,3 +12,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(SHA
  #undef SHA1_Finish
  #define SHA1_Update rb_digest_SHA1_update
@@ -43,7 +43,7 @@
 +#undef SHA1_Init
 +#define SHA1_Init CC_SHA1_Init
 --- ext/digest/sha2/sha2cc.h.orig	2024-10-30 02:47:11.000000000 -0700
-+++ ext/digest/sha2/sha2cc.h	2024-11-27 15:13:42.000000000 -0800
++++ ext/digest/sha2/sha2cc.h	2025-01-06 14:46:11.000000000 -0800
 @@ -1,6 +1,33 @@
  #define COMMON_DIGEST_FOR_OPENSSL 1
  #include <CommonCrypto/CommonDigest.h>
@@ -94,8 +94,61 @@
 +#define SHA384_Init CC_SHA384_Init
 +#undef SHA512_Init
 +#define SHA512_Init CC_SHA512_Init
+--- file.c.orig	2024-10-30 02:47:11.000000000 -0700
++++ file.c	2025-01-06 14:46:11.000000000 -0800
+@@ -300,10 +300,30 @@ rb_CFString_class_initialize_before_fork
+     long len = sizeof(small_str) - 1;
+ 
+     const CFAllocatorRef alloc = kCFAllocatorDefault;
++
++/*
++ * The 'NoCopy' version of CFStringCreateWithBytes didn't appear until
++ * 10.5, though the original CFStringCreateWithBytes has been available
++ * since 10.0.  Hence, we need to use CFStringCreateWithBytes on OS versions
++ * earlier than 10.5.
++ *
++ * There's probably no significant benefit to using the 'NoCopy' version
++ * in this context, so making that substitution unconditionally would
++ * probably be fine (and simpler), but by the principle of least change,
++ * we limit the substitution to earlier OS versions (i.e., 10.4).
++ */
++# if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+     CFStringRef s = CFStringCreateWithBytesNoCopy(alloc,
+                                                   (const UInt8 *)small_str,
+                                                   len, kCFStringEncodingUTF8,
+                                                   FALSE, kCFAllocatorNull);
++# else /* 10.4 */
++    CFStringRef s = CFStringCreateWithBytes(alloc,
++                                            (const UInt8 *)small_str,
++                                            len, kCFStringEncodingUTF8,
++                                            FALSE);
++# endif /* 10.4 */
++
+     CFMutableStringRef m = CFStringCreateMutableCopy(alloc, len, s);
+     CFRelease(m);
+     CFRelease(s);
+@@ -315,10 +335,19 @@ rb_str_append_normalized_ospath(VALUE st
+ {
+     CFIndex buflen = 0;
+     CFRange all;
++
++/* See above comment regarding CFStringCreateWithBytes[NoCopy]. */
++# if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+     CFStringRef s = CFStringCreateWithBytesNoCopy(kCFAllocatorDefault,
+                                                   (const UInt8 *)ptr, len,
+                                                   kCFStringEncodingUTF8, FALSE,
+                                                   kCFAllocatorNull);
++# else /* 10.4 */
++    CFStringRef s = CFStringCreateWithBytes(kCFAllocatorDefault,
++                                            (const UInt8 *)ptr, len,
++                                            kCFStringEncodingUTF8, FALSE);
++# endif /* 10.4 */
++
+     CFMutableStringRef m = CFStringCreateMutableCopy(kCFAllocatorDefault, len, s);
+     long oldlen = RSTRING_LEN(str);
+ 
 --- lib/bundler/gem_helper.rb.orig	2024-10-30 02:47:11.000000000 -0700
-+++ lib/bundler/gem_helper.rb	2024-11-27 15:13:42.000000000 -0800
++++ lib/bundler/gem_helper.rb	2025-01-06 14:46:11.000000000 -0800
 @@ -231,7 +231,7 @@ module Bundler
      end
  
@@ -106,7 +159,7 @@
    end
  end
 --- signal.c.orig	2024-10-30 02:47:11.000000000 -0700
-+++ signal.c	2024-11-27 15:13:42.000000000 -0800
++++ signal.c	2025-01-06 14:46:11.000000000 -0800
 @@ -841,7 +841,8 @@ check_stack_overflow(int sig, const uint
      const greg_t bp = mctx->gregs[REG_EBP];
  #   endif
@@ -117,8 +170,33 @@
  #     define MCTX_SS_REG(reg) __ss.__##reg
  #   else
  #     define MCTX_SS_REG(reg) ss.reg
+--- thread_pthread.c.orig	2024-10-30 02:47:11.000000000 -0700
++++ thread_pthread.c	2025-01-06 14:46:11.000000000 -0800
+@@ -42,6 +42,22 @@
+ 
+ #if defined __APPLE__
+ # include <AvailabilityMacros.h>
++
++/*
++ * This code is built with _XOPEN_SOURCE=1 and _DARWIN_C_SOURCE=1, which
++ * blocks the declaration of pthread_mach_thread_np() in pthread.h on 10.4.
++ * Overriding this by also defining _DARWIN_C_SOURCE didn't become available
++ * until 10.5.  The missing prototype went unnoticed until gcc14 started
++ * calling it an error.
++ *
++ * Note that many uses of Apple-specific functions with these settings are
++ * illegal (on 10.4), but for now we just fix the immediate problem by
++ * duplicating the missing declaration.  There's no need to make this
++ * conditional, since redundant prototypes are legal.
++ */
++#include <mach/port.h>
++mach_port_t 	pthread_mach_thread_np(pthread_t);
++
+ #endif
+ 
+ #if defined(HAVE_SYS_EVENTFD_H) && defined(HAVE_EVENTFD)
 --- time.c.orig	2024-10-30 02:47:11.000000000 -0700
-+++ time.c	2024-11-27 15:13:42.000000000 -0800
++++ time.c	2025-01-06 14:46:11.000000000 -0800
 @@ -2322,7 +2322,7 @@ zone_timelocal(VALUE zone, VALUE time)
      struct time_object *tobj = DATA_PTR(time);
      wideval_t t, s;
@@ -129,7 +207,7 @@
      utc = rb_check_funcall(zone, id_local_to_utc, 1, &tm);
      if (UNDEF_P(utc)) return 0;
 --- tool/transform_mjit_header.rb.orig	2024-10-30 02:47:11.000000000 -0700
-+++ tool/transform_mjit_header.rb	2024-11-27 15:13:42.000000000 -0800
++++ tool/transform_mjit_header.rb	2025-01-06 14:46:11.000000000 -0800
 @@ -181,7 +181,9 @@ module MJITHeader
    def self.conflicting_types?(code, cc, cflags)
      with_code(code) do |path|
@@ -142,7 +220,7 @@
          (out.match?(/error: conflicting types for '[^']+'/) ||
           out.match?(/error: redefinition of parameter '[^']+'/))
 --- vm_dump.c.orig	2024-10-30 02:47:11.000000000 -0700
-+++ vm_dump.c	2024-11-27 15:13:42.000000000 -0800
++++ vm_dump.c	2025-01-06 14:46:11.000000000 -0800
 @@ -470,7 +470,8 @@ rb_vmdebug_thread_dump_state(VALUE self)
  }
  

--- a/lang/ruby33/Portfile
+++ b/lang/ruby33/Portfile
@@ -21,7 +21,7 @@ set ruby_patch      6
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
-revision            0
+revision            1
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} \
@@ -69,7 +69,7 @@ select.file         ${filespath}/ruby${ruby_ver_nodot}
 
 # patch-sources.diff: fixes for various issues.
 #
-# This diff is from v3_3_6 vs. macports-3_3_6.
+# This diff is from v3_3_6 vs. macports-3_3_6r1.
 #
 patchfiles-append   patch-sources.diff
 

--- a/lang/ruby33/files/patch-sources.diff
+++ b/lang/ruby33/files/patch-sources.diff
@@ -1,5 +1,5 @@
 --- .gdbinit.orig	2024-11-04 16:49:11.000000000 -0800
-+++ .gdbinit	2024-11-27 15:23:38.000000000 -0800
++++ .gdbinit	2025-01-06 14:44:26.000000000 -0800
 @@ -1,4 +1,5 @@
 -set startup-with-shell off
 +# Move this to end, so failure on older gdbs doesn't blow the rest
@@ -15,7 +15,7 @@
 +# Moved from beginning, since it fails on older gdbs
 +set startup-with-shell off
 --- ext/digest/md5/md5cc.h.orig	2024-11-04 16:49:11.000000000 -0800
-+++ ext/digest/md5/md5cc.h	2024-11-27 15:23:38.000000000 -0800
++++ ext/digest/md5/md5cc.h	2025-01-06 14:44:26.000000000 -0800
 @@ -17,3 +17,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(MD5
  #undef MD5_Finish
  #define MD5_Update rb_digest_MD5_update
@@ -29,7 +29,7 @@
 +#undef MD5_Init
 +#define MD5_Init CC_MD5_Init
 --- ext/digest/sha1/sha1cc.h.orig	2024-11-04 16:49:11.000000000 -0800
-+++ ext/digest/sha1/sha1cc.h	2024-11-27 15:23:38.000000000 -0800
++++ ext/digest/sha1/sha1cc.h	2025-01-06 14:44:26.000000000 -0800
 @@ -12,3 +12,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(SHA
  #undef SHA1_Finish
  #define SHA1_Update rb_digest_SHA1_update
@@ -43,7 +43,7 @@
 +#undef SHA1_Init
 +#define SHA1_Init CC_SHA1_Init
 --- ext/digest/sha2/sha2cc.h.orig	2024-11-04 16:49:11.000000000 -0800
-+++ ext/digest/sha2/sha2cc.h	2024-11-27 15:23:38.000000000 -0800
++++ ext/digest/sha2/sha2cc.h	2025-01-06 14:44:26.000000000 -0800
 @@ -1,6 +1,33 @@
  #define COMMON_DIGEST_FOR_OPENSSL 1
  #include <CommonCrypto/CommonDigest.h>
@@ -94,8 +94,61 @@
 +#define SHA384_Init CC_SHA384_Init
 +#undef SHA512_Init
 +#define SHA512_Init CC_SHA512_Init
+--- file.c.orig	2024-11-04 16:49:11.000000000 -0800
++++ file.c	2025-01-06 14:44:26.000000000 -0800
+@@ -299,10 +299,30 @@ rb_CFString_class_initialize_before_fork
+     long len = sizeof(small_str) - 1;
+ 
+     const CFAllocatorRef alloc = kCFAllocatorDefault;
++
++/*
++ * The 'NoCopy' version of CFStringCreateWithBytes didn't appear until
++ * 10.5, though the original CFStringCreateWithBytes has been available
++ * since 10.0.  Hence, we need to use CFStringCreateWithBytes on OS versions
++ * earlier than 10.5.
++ *
++ * There's probably no significant benefit to using the 'NoCopy' version
++ * in this context, so making that substitution unconditionally would
++ * probably be fine (and simpler), but by the principle of least change,
++ * we limit the substitution to earlier OS versions (i.e., 10.4).
++ */
++# if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+     CFStringRef s = CFStringCreateWithBytesNoCopy(alloc,
+                                                   (const UInt8 *)small_str,
+                                                   len, kCFStringEncodingUTF8,
+                                                   FALSE, kCFAllocatorNull);
++# else /* 10.4 */
++    CFStringRef s = CFStringCreateWithBytes(alloc,
++                                            (const UInt8 *)small_str,
++                                            len, kCFStringEncodingUTF8,
++                                            FALSE);
++# endif /* 10.4 */
++
+     CFMutableStringRef m = CFStringCreateMutableCopy(alloc, len, s);
+     CFRelease(m);
+     CFRelease(s);
+@@ -314,10 +334,19 @@ rb_str_append_normalized_ospath(VALUE st
+ {
+     CFIndex buflen = 0;
+     CFRange all;
++
++/* See above comment regarding CFStringCreateWithBytes[NoCopy]. */
++# if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+     CFStringRef s = CFStringCreateWithBytesNoCopy(kCFAllocatorDefault,
+                                                   (const UInt8 *)ptr, len,
+                                                   kCFStringEncodingUTF8, FALSE,
+                                                   kCFAllocatorNull);
++# else /* 10.4 */
++    CFStringRef s = CFStringCreateWithBytes(kCFAllocatorDefault,
++                                            (const UInt8 *)ptr, len,
++                                            kCFStringEncodingUTF8, FALSE);
++# endif /* 10.4 */
++
+     CFMutableStringRef m = CFStringCreateMutableCopy(kCFAllocatorDefault, len, s);
+     long oldlen = RSTRING_LEN(str);
+ 
 --- lib/bundler/gem_helper.rb.orig	2024-11-04 16:49:11.000000000 -0800
-+++ lib/bundler/gem_helper.rb	2024-11-27 15:23:38.000000000 -0800
++++ lib/bundler/gem_helper.rb	2025-01-06 14:44:26.000000000 -0800
 @@ -231,7 +231,7 @@ module Bundler
      end
  
@@ -106,7 +159,7 @@
    end
  end
 --- signal.c.orig	2024-11-04 16:49:11.000000000 -0800
-+++ signal.c	2024-11-27 15:23:38.000000000 -0800
++++ signal.c	2025-01-06 14:44:26.000000000 -0800
 @@ -803,7 +803,8 @@ check_stack_overflow(int sig, const uint
      const greg_t bp = mctx->gregs[REG_EBP];
  #   endif
@@ -117,8 +170,33 @@
  #     define MCTX_SS_REG(reg) __ss.__##reg
  #   else
  #     define MCTX_SS_REG(reg) ss.reg
+--- thread_pthread.c.orig	2024-11-04 16:49:11.000000000 -0800
++++ thread_pthread.c	2025-01-06 14:44:26.000000000 -0800
+@@ -42,6 +42,22 @@
+ 
+ #if defined __APPLE__
+ # include <AvailabilityMacros.h>
++
++/*
++ * This code is built with _XOPEN_SOURCE=1 and _DARWIN_C_SOURCE=1, which
++ * blocks the declaration of pthread_mach_thread_np() in pthread.h on 10.4.
++ * Overriding this by also defining _DARWIN_C_SOURCE didn't become available
++ * until 10.5.  The missing prototype went unnoticed until gcc14 started
++ * calling it an error.
++ *
++ * Note that many uses of Apple-specific functions with these settings are
++ * illegal (on 10.4), but for now we just fix the immediate problem by
++ * duplicating the missing declaration.  There's no need to make this
++ * conditional, since redundant prototypes are legal.
++ */
++#include <mach/port.h>
++mach_port_t 	pthread_mach_thread_np(pthread_t);
++
+ #endif
+ 
+ #if defined(HAVE_SYS_EVENTFD_H) && defined(HAVE_EVENTFD)
 --- vm_dump.c.orig	2024-11-04 16:49:11.000000000 -0800
-+++ vm_dump.c	2024-11-27 15:23:38.000000000 -0800
++++ vm_dump.c	2025-01-06 14:44:26.000000000 -0800
 @@ -490,7 +490,8 @@ rb_vmdebug_thread_dump_state(FILE *errou
  }
  


### PR DESCRIPTION
This fixes a couple of issues that were warnings until gcc14 made them errors.  At least one such issue probably would have caused a crash if the relevant code were executed.

This changes the installed content on 10.4, and hence gets a revbump.

TESTED:
Built successfully on OSX 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-14.x arm64.  Included all variants compatible with available dependencies on the respective platforms (except ppc builds, which were limited to default variants to save time).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.2 22H313, arm64, Xcode 15.2 15C500b
macOS 14.7.2 23H311, arm64, Xcode 16.2 16C5032a
macOS 15.2 24C101, arm64, Xcode 16.2 16C5032a
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - The test framework has issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
