### PR TITLE
astyle: update to 3.6.6

### DIFF
--- a/devel/astyle/Portfile
+++ b/devel/astyle/Portfile
@@ -3,14 +3,14 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           java 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                astyle
-version             3.6.4
+version             3.6.6
 set branch          [join [lrange [split ${version} .] 0 1] .]
 revision            0
 categories          devel
 license             MIT
-platforms           darwin
 maintainers         nomaintainer
 
 description         source code beautifier for the C, C++, C# and Java programming languages
@@ -21,18 +21,22 @@ long_description    Artistic Style is a source code indenter, source code format
 homepage            https://astyle.sourceforge.net
 master_sites        sourceforge:project/astyle/astyle/astyle%20${branch}
 use_bzip2           yes
-checksums           rmd160  f03ecbc72d7df3ad0a768ec353f4c2cf43717f74 \
-                    sha256  1e94b64f4f06461f9039d094aefe9d4b28c66d34916b27a456055e7d62d73702 \
-                    size    218851
+checksums           rmd160  158da5b416add31c8338d403b9722faf666de06c \
+                    sha256  e731a262aeecdf4e3d5ccdd8c73b832749b1277078464ea7697adba26e6e6bb6 \
+                    size    218759
 
 patchfiles          dont-force-stdlib.diff
 
 compiler.cxx_standard   2017
 
+# The <filesystem> header is only provided by Xcode 11 and later.
+compiler.blacklist-append {clang < 1100}
+
 # This build system can only build one thing at a time. Since we want several
-# things, we have to do each one separately.
+# things, we have to do each one separately. Docs will be installed with the
+# exectuable.
 set builds {
-                    executable  {}
+                    executable  {-DINSTALL_DOC=ON}
                     shared      {-DBUILD_SHARED_LIBS=ON}
                     static      {-DBUILD_STATIC_LIBS=ON}
 }

--- a/devel/astyle/files/dont-force-stdlib.diff
+++ b/devel/astyle/files/dont-force-stdlib.diff
@@ -1,11 +1,11 @@
---- CMakeLists.txt.old	2024-11-02 13:23:29
-+++ CMakeLists.txt	2024-11-02 13:23:39
-@@ -52,7 +52,7 @@
+--- CMakeLists.txt.old	2025-01-07 14:49:30
++++ CMakeLists.txt	2025-01-07 14:49:39
+@@ -54,7 +54,7 @@
  # compiler options:
  
  if(APPLE)
--    target_compile_options( astyle PRIVATE -W -Wall -fno-rtti -fno-exceptions -std=c++17 -stdlib=libc++)
-+    target_compile_options( astyle PRIVATE -W -Wall -fno-rtti -fno-exceptions -std=c++17)
+-    target_compile_options( astyle PRIVATE -W -Wall -fno-rtti -fno-exceptions -stdlib=libc++)
++    target_compile_options( astyle PRIVATE -W -Wall -fno-rtti -fno-exceptions)
  elseif(NOT WIN32)   # Linux
-     target_compile_options(astyle PRIVATE -Wall -Wextra -fno-rtti -fno-exceptions -std=c++17)
+     target_compile_options(astyle PRIVATE -Wall -Wextra -fno-rtti -fno-exceptions)
      if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "gnu")


### PR DESCRIPTION
#### Description

 - update to 3.6.6
 - fix build on Mojave, where Xcode 10 does not have the <filesystem> header
 - make sure docs are installed on all platforms

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
