### PR TITLE
ack: Fix extract phase failure on old macOSes

### DIFF
--- a/devel/ack/Portfile
+++ b/devel/ack/Portfile
@@ -26,6 +26,10 @@ checksums           rmd160  36d09672cfdeb3197bcc5ab7f0110a68b519e337 \
                     sha256  1c03ab46f4922a0bd2462f4cf7eeb3cb4b4e6d43cebd3cfcf3a2e132319eb88e \
                     size    281551
 
+depends_extract     bin:gnutar:gnutar
+
+extract.post_args   "| gnutar -x"
+
 depends_lib-append  port:p${perl5.major}-file-next \
                     port:p${perl5.major}-getopt-long \
                     port:p${perl5.major}-text-parsewords \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/71725

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002 / Command Line Tools  8.2.0.0.1.1480973914

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
