### PR TITLE
paho.mqtt.c: update to 1.3.14, paho.mqtt.cpp: update to 1.5.0

### DIFF
--- a/net/paho.mqtt.c/Portfile
+++ b/net/paho.mqtt.c/Portfile
@@ -6,8 +6,8 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
-github.setup        eclipse paho.mqtt.c 1.3.13 v
-revision            1
+github.setup        eclipse paho.mqtt.c 1.3.14 v
+revision            0
 categories          net
 maintainers         nomaintainer
 license             EPL-2
@@ -35,9 +35,9 @@ configure.args-append \
                     -DPAHO_ENABLE_TESTING=ON \
                     -DPAHO_WITH_SSL=ON
 
-checksums           rmd160  69206580bada08a339b932d3082bf8b91a6e9827 \
-                    sha256  307361735039878bb82654a9decaf86b3d45f6aa62b96648dfae5fd4a1f65925 \
-                    size    3489430
+checksums           rmd160  efef65d164aba2da6e879ce84bbaf776224e89ea \
+                    sha256  d1b4731354fd437b5cde8efab4ff85e86afd6f094349c231524e041e723810ad \
+                    size    1198284
 
 configure.pre_args-replace \
                     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \

--- a/net/paho.mqtt.cpp/Portfile
+++ b/net/paho.mqtt.cpp/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           openssl 1.0
 
-github.setup        eclipse paho.mqtt.cpp 1.4.1 v
+github.setup        eclipse paho.mqtt.cpp 1.5.0 v
 revision            0
 categories          net
 maintainers         nomaintainer
@@ -24,15 +24,14 @@ depends_lib-append \
                     port:paho.mqtt.c
 
 # We enable SSL so that the paho.mqtt.cpp library builds without issues
-# TODO: enable static libs as well once this is fixed:
-# https://github.com/eclipse/paho.mqtt.cpp/issues/515
 configure.args-append \
                     -DPAHO_BUILD_SHARED=ON \
+                    -DPAHO_BUILD_STATIC=ON \
                     -DPAHO_WITH_SSL=ON
 
-checksums           rmd160  543046a3d39cb2bb35266354394130520273b0e6 \
-                    sha256  9c7c8f95960e669465390de2d6d65e30248ad8d30895f52c71ba086b6a41a61a \
-                    size    235708
+checksums           rmd160  079f4514d00a17cf653a9ad59e3efb999842782d \
+                    sha256  afc703dc0373a69959a6a34562e1f7e32d794e426981b4856a58fe61e968bf4e \
+                    size    264677
 
-# Target "paho-mqttpp3" requires the language dialect "CXX11"
-compiler.cxx_standard   2011
+# Since 1.5.0 a C++17 compiler is required
+compiler.cxx_standard   2017


### PR DESCRIPTION
#### Description
* https://github.com/eclipse-paho/paho.mqtt.c/releases/tag/v1.3.14
* https://github.com/eclipse-paho/paho.mqtt.cpp/releases/tag/v1.5.0

cc @barracuda156 

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
