### PR TITLE
openssl3: Fix no_cache issue w/3rd party providers

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -14,7 +14,7 @@ set major_v         3
 epoch               1
 github.setup        openssl openssl ${major_v}.4.0 openssl-
 name                openssl3
-revision            0
+revision            1
 
 github.tarball_from releases
 checksums           rmd160  d300c74dce877d7099bd59fa82d8f0691f13cc97 \
@@ -93,6 +93,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 18 && ${os.major} > 8} {
 # OS versions with slightly less code.
 #
 patchfiles-append   patch-use-timegm.diff
+
+# Backport fix for negative caching issue with 3rd party providers, see
+# https://trac.macports.org/ticket/71760
+patchfiles-append   5549fcd4783cb6c2a7f07e74505a2eea4939e5b1.patch
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a

--- a/devel/openssl3/files/5549fcd4783cb6c2a7f07e74505a2eea4939e5b1.patch
+++ b/devel/openssl3/files/5549fcd4783cb6c2a7f07e74505a2eea4939e5b1.patch
@@ -1,0 +1,32 @@
+From 5549fcd4783cb6c2a7f07e74505a2eea4939e5b1 Mon Sep 17 00:00:00 2001
+From: Dmitry Belyavskiy <beldmit@gmail.com>
+Date: Wed, 18 Dec 2024 21:28:14 +0100
+Subject: [PATCH] Take into account no_store when pushing algorithm
+
+When we put algorithm to the store, we have a fallback to the
+OSSL_LIB_CTX level store when store is NULL.
+
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/26197)
+
+(cherry picked from commit b3bb214720f20f3b126ae4b9c330e9a48b835415)
+
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/5549fcd4783cb6c2a7f07e74505a2eea4939e5b1]
+---
+ crypto/core_fetch.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crypto/core_fetch.c b/crypto/core_fetch.c
+index d311158d77589..70715e7d6a99c 100644
+--- ./crypto/core_fetch.c
++++ ./crypto/core_fetch.c
+@@ -120,7 +120,7 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
+      * It is *expected* that the put function increments the refcnt
+      * of the passed method.
+      */
+-    data->mcm->put(data->store, method, provider, algo->algorithm_names,
++    data->mcm->put(no_store ? data->store : NULL, method, provider, algo->algorithm_names,
+                    algo->property_definition, data->mcm_data);
+ 
+     /* refcnt-- because we're dropping the reference */


### PR DESCRIPTION
#### Description

This fixes using an algorithm from the legacy provider while the pkcs11-provider is active.

Closes: https://trac.macports.org/ticket/71760

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
