### PR TITLE
glaze: new port

### DIFF
--- a/devel/glaze/Portfile
+++ b/devel/glaze/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               cmake 1.1
+
+github.setup            stephenberry glaze 4.3.0 v
+github.tarball_from     archive
+revision                0
+categories              devel
+platforms               any
+supported_archs         noarch
+license                 MIT
+maintainers             {@sikmir disroot.org:sikmir} openmaintainer
+description             Extremely fast, in memory, JSON and interface library for modern C++
+long_description        {*}${description}
+
+checksums               rmd160  61c6920a3bc4879695d6955e913729c5799118c2 \
+                        sha256  72cd174ad8839bc526a679a5a8ebf4bb18f3cb850a34fcfd3e89970f83c4d384 \
+                        size    546532
+
+compiler.cxx_standard   2023
+
+test.run                yes


### PR DESCRIPTION
#### Description
[glaze](https://github.com/stephenberry/glaze) - extremely fast, in memory, JSON and interface library for modern C++.

[![Packaging status](https://repology.org/badge/tiny-repos/glaze.svg)](https://repology.org/project/glaze/versions)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
