### PR TITLE
mise: Update to 2025.1.2

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.1.1 v
+github.setup        jdx mise 2025.1.2 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  77d97592cbce709a68dc670dd9262904a3757cbf \
-                    sha256  cf9277fa07ce77fec5df24f2c7bf892bb70387cf7a3333812123a849dda3462b \
-                    size    4252429
+                    rmd160  7254938ac2e2aae1270c7d51f19255a9c8d215a5 \
+                    sha256  81ab3596bc6b334fc76cb6ecfafb8178a4fa8a2385b173ba8df6b06a92d2d16c \
+                    size    4253748
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -109,7 +109,7 @@ cargo.crates \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
     async-compression               0.4.18  df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522 \
-    async-trait                     0.1.84  1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0 \
+    async-trait                     0.1.85  3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
@@ -145,11 +145,11 @@ cargo.crates \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
-    clap                            4.5.23  3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84 \
-    clap_builder                    4.5.23  30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838 \
-    clap_derive                     4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
+    clap                            4.5.24  9560b07a799281c7e0958b9296854d6fafd4c5f31444a7e5bb1ad6dde5ccf1bd \
+    clap_builder                    4.5.24  874e0dd3eb68bf99058751ac9712f622e61e6f393a94f7128fa26e3f02f5c7cd \
+    clap_derive                     4.5.24  54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
-    clap_mangen                     0.2.24  fbae9cbfdc5d4fa8711c09bd7b83f644cb48281ac35bf97af3e47b0675864bdf \
+    clap_mangen                     0.2.25  acbfe6ac42a2438d0968beba18e3c35cacf16b0c25310bc22b1f5f3cffff09f4 \
     color-eyre                       0.6.3  55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5 \
     color-print                      0.3.7  3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4 \
     color-print-proc-macro           0.3.7  692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22 \
@@ -188,7 +188,7 @@ cargo.crates \
     darling_macro                  0.20.10  d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806 \
     dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
-    demand                           1.6.0  6baac05ea4b0164abd840ea135c0156ad7025d0920cd720ee4e654b822d94454 \
+    demand                           1.6.1  58c47e28442b8cafbd1e05139fa18993058da13baf6c7110d47aac2e570169ce \
     der                              0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
@@ -258,6 +258,7 @@ cargo.crates \
     h2                               0.4.7  ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
+    hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
@@ -300,7 +301,7 @@ cargo.crates \
     impl-tools-lib                  0.11.1  2a391adcea096a89a593317881fb61ef4e68d3e7d9de9e2338e6e1557be29e10 \
     indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                         2.5.0  68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5 \
+    indexmap                         2.7.0  62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f \
     indicatif                       0.17.9  cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inout                            0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
@@ -326,9 +327,9 @@ cargo.crates \
     libm                            0.2.11  8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
-    libz-sys                        1.1.20  d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472 \
+    libz-sys                        1.1.21  df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
-    linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
+    linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     litemap                          0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
     litrs                            0.4.1  b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
@@ -390,14 +391,14 @@ cargo.crates \
     pest_derive                     2.7.15  816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e \
     pest_generator                  2.7.15  7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b \
     pest_meta                       2.7.15  e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea \
-    petgraph                         0.7.0  e2b1374ec32450264534c67d1ccb5ca09818c4db8fd87cf97478d0df2fa44c65 \
-    phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
-    phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
-    phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
-    phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
-    pin-project                      1.1.7  be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95 \
-    pin-project-internal             1.1.7  3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c \
-    pin-project-lite                0.2.15  915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff \
+    petgraph                         0.7.1  3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772 \
+    phf                             0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
+    phf_codegen                     0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
+    phf_generator                   0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
+    phf_shared                      0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
+    pin-project                      1.1.8  1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916 \
+    pin-project-internal             1.1.8  d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb \
+    pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
@@ -444,7 +445,7 @@ cargo.crates \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                       2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
-    rustix                         0.38.42  f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85 \
+    rustix                         0.38.43  a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6 \
     rustls                         0.23.20  5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
@@ -461,8 +462,8 @@ cargo.crates \
     sdd                              3.0.5  478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9 \
     secrecy                          0.8.0  9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
-    security-framework               3.1.0  81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc \
-    security-framework-sys          2.13.0  1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5 \
+    security-framework               3.2.0  271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316 \
+    security-framework-sys          2.14.0  49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     self_cell                       0.10.3  e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d \
     self_cell                        1.1.0  c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe \
@@ -472,7 +473,7 @@ cargo.crates \
     serde-value                      0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
     serde_derive                   1.0.217  5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0 \
     serde_ignored                   0.1.10  a8e319a36d1b52126a0d608f24e93b2d81297091818cd70625fcf50a15d84ddf \
-    serde_json                     1.0.134  d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d \
+    serde_json                     1.0.135  2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9 \
     serde_regex                      1.1.0  a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
@@ -494,7 +495,6 @@ cargo.crates \
     signature                        2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
     simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \
     similar                          2.6.0  1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e \
-    siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
     siphasher                        1.0.1  56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     slug                             0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
@@ -537,8 +537,8 @@ cargo.crates \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                          1.8.1  022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.42.0  5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551 \
-    tokio-macros                     2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
+    tokio                           1.43.0  3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e \
+    tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                    0.26.1  5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37 \
     tokio-util                      0.7.13  d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078 \
@@ -586,7 +586,7 @@ cargo.crates \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
-    vfox                             0.3.4  d4c44e4ec114bba1eeed55bc3a47ced72545cd2ffa04ce0ec0bdba1fb535807d \
+    vfox                             0.3.5  32dfa4e97177d71ec00f5d01ec2c317a4f37a2a0c607550a8a70b552b8f4ace6 \
     vte                             0.10.1  6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983 \
     vte_generate_state_changes       0.1.2  2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \


### PR DESCRIPTION
#### Description

mise: Update to 2025.1.2

##### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
