### PR TITLE
google-cloud-sdk: update to 505.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             504.0.1
+version             505.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  8136d720042f1feac9009d39ecb665aa6d3c638a \
-                    sha256  0c4515a3fc3983f7214e55fcd5b0d6fb0a2933a25f57c773ee94e145d1df8884 \
-                    size    53240119
+    checksums       rmd160  6dde5c2d3ee61a4dac1808f6078b531edae1ba9d \
+                    sha256  27255fe4432a7b22d52e38aa2c775bce071f6fb9cafbbc428510c71eb8dec3ed \
+                    size    53340897
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  8f322d5389247fe0a3d4fe0ef2968ff6a4c7ee33 \
-                    sha256  87fd436a6fbe556b472d1467130825cf6f0f64448070f5644228219b92771001 \
-                    size    54590053
+    checksums       rmd160  b30b911a3e784b033e5bade1adcb4bcba0b28ec2 \
+                    sha256  84850290f2f666312268a5dfd287623195300434f65d9c48f5b86bfa34afaebf \
+                    size    54695098
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  70267be0838ea3793d36d9ad910067c78a8ccf3b \
-                    sha256  d73664d78308386aa1a480ccbebaf0d805241ed27cbce8fb2c24677bcb5edac9 \
-                    size    54536494
+    checksums       rmd160  8b4b9052068ca43537c13056e3d69744411e33f4 \
+                    sha256  c8bd4fc7227c54ccfab12ebb74148bb2da4bde724a2e0a5c5ec5fe90941f45f4 \
+                    size    54641739
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 505.0.0.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?