### PR TITLE
icu,icu-devel: Tweak usage of muniversal

### DIFF
--- a/devel/icu-devel/Portfile
+++ b/devel/icu-devel/Portfile
@@ -51,9 +51,9 @@ set docdir          ${prefix}/share/doc/${my_name}
 
 if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
 
-    # we will only use the muniversal PG on < 10.14. (see footnote 1).
+    # we will only use the muniversal PG on < 10.15. (see footnote 1).
     set using_muniversal_PG false
-    if {${os.platform} eq "darwin" && ${os.major} < 18} {
+    if {${os.platform} eq "darwin" && ${os.major} < 19} {
 
         set using_muniversal_PG true
         PortGroup muniversal 1.0

--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -51,9 +51,9 @@ set docdir          ${prefix}/share/doc/${my_name}
 
 if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
 
-    # we will only use the muniversal PG on < 10.14. (see footnote 1).
+    # we will only use the muniversal PG on < 10.15. (see footnote 1).
     set using_muniversal_PG false
-    if {${os.platform} eq "darwin" && ${os.major} < 18} {
+    if {${os.platform} eq "darwin" && ${os.major} < 19} {
 
         set using_muniversal_PG true
         PortGroup muniversal 1.0


### PR DESCRIPTION
macOS Mojave with a copy of `MacOSX10.13.sdk` and forced 10.13 deployment target can compile for i386 & x86_64

This change was required when trying to build `wine-devel` & `wine-staging`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6
Xcode 11.3.1

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
