### PR TITLE
yadm: fix install paths and install completions

### DIFF
--- a/sysutils/yadm/Portfile
+++ b/sysutils/yadm/Portfile
@@ -6,7 +6,7 @@ PortGroup           makefile 1.0
 
 github.setup        yadm-dev yadm 3.3.0
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          sysutils
 platforms           any
@@ -29,4 +29,19 @@ checksums           sha256  a977836ee874fece3d69b5a8f7436e6ce4e6bf8d2520f8517c12
 installs_libs       no
 supported_archs     noarch
 makefile.has_destdir \
-                    no
+                    yes
+
+post-destroot {
+    # Install shell completions
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    xinstall ${worksrcpath}/completion/bash/${name} \
+        ${destroot}${prefix}/share/bash-completion/completions/
+
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d/
+    xinstall ${worksrcpath}/completion/fish/${name}.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/
+
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall ${worksrcpath}/completion/zsh/_${name} \
+        ${destroot}${prefix}/share/zsh/site-functions/
+}


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
