### PR TITLE
glib2: Fix code generator with Python 3.13

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -15,7 +15,7 @@ name                        glib2
 conflicts                   glib2-devel
 set my_name                 glib
 version                     2.78.4
-revision                    1
+revision                    2
 epoch                       1
 
 checksums                   rmd160  7941be85af18c428d86f4a00e52f41542b061aa9 \

--- a/devel/glib2/files/no-distutils.patch
+++ b/devel/glib2/files/no-distutils.patch
@@ -1,17 +1,88 @@
-From 6ef967a0f930ce37a8c9b5aff969693b34714291 Mon Sep 17 00:00:00 2001
+From a828672e2dcff0bb621aa30e9f370b09fd15b8b0 Mon Sep 17 00:00:00 2001
 From: Jordan Williams <jordan@jwillikers.com>
 Date: Fri, 1 Dec 2023 09:53:50 -0600
-Subject: [PATCH] Switch from the deprecated distutils module to the packaging
- module
+Subject: [PATCH 1/3] Switch from the deprecated distutils module to the
+ packaging module
 
 The distutils module was removed in Python 3.12.
----
- gio/gdbus-2.0/codegen/utils.py      | 4 ++--
 
+(cherry picked from commit 6ef967a0f930ce37a8c9b5aff969693b34714291)
+
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/6ef967a0f930ce37a8c9b5aff969693b34714291]
+---
+ .gitlab-ci.yml                      | 7 ++++---
+ .gitlab-ci/debian-stable.Dockerfile | 1 +
+ .gitlab-ci/fedora.Dockerfile        | 1 +
+ .gitlab-ci/mingw.Dockerfile         | 4 +++-
+ gio/gdbus-2.0/codegen/utils.py      | 4 ++--
+ 5 files changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+index bd10823a2..b812e6b7d 100644
+--- ./.gitlab-ci.yml
++++ ./.gitlab-ci.yml
+@@ -11,10 +11,10 @@ cache:
+     - _ccache/
+ 
+ variables:
+-  FEDORA_IMAGE: "registry.gitlab.gnome.org/gnome/glib/fedora:v20"
++  FEDORA_IMAGE: "registry.gitlab.gnome.org/gnome/glib/fedora:v24"
+   COVERITY_IMAGE: "registry.gitlab.gnome.org/gnome/glib/coverity:v7"
+-  DEBIAN_IMAGE: "registry.gitlab.gnome.org/gnome/glib/debian-stable:v14"
+-  MINGW_IMAGE: "registry.gitlab.gnome.org/gnome/glib/mingw:v10"
++  DEBIAN_IMAGE: "registry.gitlab.gnome.org/gnome/glib/debian-stable:v18"
++  MINGW_IMAGE: "registry.gitlab.gnome.org/gnome/glib/mingw:v14"
+   MESON_TEST_TIMEOUT_MULTIPLIER: 4
+   G_MESSAGES_DEBUG: all
+   MESON_COMMON_OPTIONS: "--buildtype debug --wrap-mode=nodownload --fatal-meson-warnings"
+@@ -551,6 +551,7 @@ macos-x86_64:
+     - source .venv/bin/activate
+     - pip3 install meson==1.2.0
+     - pip3 install ninja==1.11.1
++    - pip3 install packaging==23.2
+   script:
+     # FIXME: Use --wrap-mode=default so we download dependencies each time,
+     # until the macOS runner is a VM where we can use a pre-made image which
+diff --git a/.gitlab-ci/debian-stable.Dockerfile b/.gitlab-ci/debian-stable.Dockerfile
+index b2559cad6..6f07e2ec1 100644
+--- ./.gitlab-ci/debian-stable.Dockerfile
++++ ./.gitlab-ci/debian-stable.Dockerfile
+@@ -34,6 +34,7 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -qq -y \
+     locales \
+     ninja-build \
+     python3 \
++    python3-packaging \
+     python3-pip \
+     python3-setuptools \
+     python3-wheel \
+diff --git a/.gitlab-ci/fedora.Dockerfile b/.gitlab-ci/fedora.Dockerfile
+index 85f910cb9..1b477d56e 100644
+--- ./.gitlab-ci/fedora.Dockerfile
++++ ./.gitlab-ci/fedora.Dockerfile
+@@ -45,6 +45,7 @@ RUN dnf -y update \
+     ninja-build \
+     pcre2-devel \
+     "python3-dbusmock >= 0.18.3-2" \
++    python3-packaging \
+     python3-pip \
+     python3-pygments \
+     python3-wheel \
+diff --git a/.gitlab-ci/mingw.Dockerfile b/.gitlab-ci/mingw.Dockerfile
+index b109122fc..ac6e3ed77 100644
+--- ./.gitlab-ci/mingw.Dockerfile
++++ ./.gitlab-ci/mingw.Dockerfile
+@@ -1,4 +1,6 @@
+-FROM fedora:34
++FROM registry.gitlab.gnome.org/gnome/glib/fedora:v24
++
++USER root
+ 
+ RUN dnf -y install \
+     bindfs \
 diff --git a/gio/gdbus-2.0/codegen/utils.py b/gio/gdbus-2.0/codegen/utils.py
-index 02046108da..08f1ba9731 100644
---- gio/gdbus-2.0/codegen/utils.py
-+++ gio/gdbus-2.0/codegen/utils.py
+index 02046108d..08f1ba973 100644
+--- ./gio/gdbus-2.0/codegen/utils.py
++++ ./gio/gdbus-2.0/codegen/utils.py
 @@ -19,7 +19,7 @@
  #
  # Author: David Zeuthen <davidz@redhat.com>
@@ -28,5 +99,164 @@ index 02046108da..08f1ba9731 100644
 -    return (distutils.version.LooseVersion(v), key[1])
 +    return (packaging.version.Version(v), key[1])
 -- 
-GitLab
+2.47.1
+
+From b855c4ebd117fbc1ff64f501ea0e5ed76690ca69 Mon Sep 17 00:00:00 2001
+From: Ernesto de Gracia Herranz <ernestodgh@jfrog.com>
+Date: Thu, 4 Jul 2024 11:04:38 +0000
+Subject: [PATCH 2/3] replace package.version.Version by internal code
+
+This drops the dependency on the Python `packaging` module.
+
+Signed-off-by: Ernesto de Gracia Herranz <ernestodgh@jfrog.com>
+(cherry picked from commit 38faeca62ebd5be89b1ec3e6c530e499ce2d7240)
+
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/38faeca62ebd5be89b1ec3e6c530e499ce2d7240]
+---
+ .gitlab-ci.yml                      |  1 -
+ .gitlab-ci/debian-stable.Dockerfile |  1 -
+ .gitlab-ci/fedora.Dockerfile        |  2 +-
+ .gitlab-ci/test-msvc.bat            |  2 +-
+ gio/gdbus-2.0/codegen/utils.py      | 29 +++++++++++++++++++++++++++--
+ 5 files changed, 29 insertions(+), 8 deletions(-)
+
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+index b812e6b7d..68f66db4e 100644
+--- ./.gitlab-ci.yml
++++ ./.gitlab-ci.yml
+@@ -551,7 +551,6 @@ macos-x86_64:
+     - source .venv/bin/activate
+     - pip3 install meson==1.2.0
+     - pip3 install ninja==1.11.1
+-    - pip3 install packaging==23.2
+   script:
+     # FIXME: Use --wrap-mode=default so we download dependencies each time,
+     # until the macOS runner is a VM where we can use a pre-made image which
+diff --git a/.gitlab-ci/debian-stable.Dockerfile b/.gitlab-ci/debian-stable.Dockerfile
+index 6f07e2ec1..b2559cad6 100644
+--- ./.gitlab-ci/debian-stable.Dockerfile
++++ ./.gitlab-ci/debian-stable.Dockerfile
+@@ -34,7 +34,6 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -qq -y \
+     locales \
+     ninja-build \
+     python3 \
+-    python3-packaging \
+     python3-pip \
+     python3-setuptools \
+     python3-wheel \
+diff --git a/.gitlab-ci/fedora.Dockerfile b/.gitlab-ci/fedora.Dockerfile
+index 1b477d56e..d827516b9 100644
+--- ./.gitlab-ci/fedora.Dockerfile
++++ ./.gitlab-ci/fedora.Dockerfile
+@@ -45,7 +45,7 @@ RUN dnf -y update \
+     ninja-build \
+     pcre2-devel \
+     "python3-dbusmock >= 0.18.3-2" \
+-    python3-packaging \
++    python3-docutils \
+     python3-pip \
+     python3-pygments \
+     python3-wheel \
+diff --git a/.gitlab-ci/test-msvc.bat b/.gitlab-ci/test-msvc.bat
+index aee77d33d..23906920b 100644
+--- ./.gitlab-ci/test-msvc.bat
++++ ./.gitlab-ci/test-msvc.bat
+@@ -12,7 +12,7 @@ for %%x in (%*) do (
+ set args=%args:~1%
+ 
+ :: FIXME: make warnings fatal
+-pip3 install --upgrade --user meson==1.0.0  || goto :error
++pip3 install --upgrade --user meson==1.2.3 || goto :error
+ meson setup %args% _build || goto :error
+ python .gitlab-ci/check-missing-install-tag.py _build || goto :error
+ meson compile -C _build || goto :error
+diff --git a/gio/gdbus-2.0/codegen/utils.py b/gio/gdbus-2.0/codegen/utils.py
+index 08f1ba973..753756923 100644
+--- ./gio/gdbus-2.0/codegen/utils.py
++++ ./gio/gdbus-2.0/codegen/utils.py
+@@ -22,6 +22,7 @@
+ import packaging.version
+ import os
+ import sys
++import re
+ 
+ 
+ # pylint: disable=too-few-public-methods
+@@ -159,11 +160,35 @@ def lookup_brief_docs(annotations):
+ def version_cmp_key(key):
+     # If the 'since' version is 'UNRELEASED', compare higher than anything else
+     # If it is empty put a 0 in its place as this will
+-    # allow LooseVersion to work and will always compare lower.
++    # allow _parse_version() to work and will always compare lower.
+     if key[0] == "UNRELEASED":
+         v = "9999"
+     elif key[0]:
+         v = str(key[0])
+     else:
+         v = "0"
+-    return (packaging.version.Version(v), key[1])
++    return (_parse_version(v), key[1])
++
++
++def _parse_version(version):
++    """
++    Parse a version string into a list of integers and strings.
++
++    This function takes a version string and breaks it down into its component parts.
++    It separates numeric and non-numeric segments, converting numeric segments to integers.
++
++    Args:
++        version (str): The version string to parse.
++
++    Returns:
++        list: A list where each element is either an integer (for numeric parts)
++              or a string (for non-numeric parts).
++
++    Example:
++        >>> parseversion("1.2.3a")
++        [1, 2, 3, 'a']
++        >>> parseversion("2.0.0-rc1")
++        [2, 0, 0, 'rc1']
++    """
++    blocks = re.findall(r"(\d+|\w+)", version)
++    return [int(b) if b.isdigit() else b for b in blocks]
+-- 
+2.47.1
+
+From e024bc6a187f2b282ebe8e8e9e0983d12f9978c5 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Sun, 7 Jul 2024 13:48:46 +0100
+Subject: [PATCH 3/3] codegen: Drop unused import
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This should have been dropped in commit
+38faeca62ebd5be89b1ec3e6c530e499ce2d7240 but somehow that didn’t happen
+and somehow it wasn’t caught by the CI until afterwards.
+
+Fixes: https://gitlab.gnome.org/GNOME/glib/-/jobs/4049254
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+(cherry picked from commit 3993d8db52f1426920285543fbcd8d7ee9327825)
+
+Upstream-Stauts: Backport [https://gitlab.gnome.org/GNOME/glib/-/commit/3993d8db52f1426920285543fbcd8d7ee9327825]
+---
+ gio/gdbus-2.0/codegen/utils.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/gio/gdbus-2.0/codegen/utils.py b/gio/gdbus-2.0/codegen/utils.py
+index 753756923..649ed5b67 100644
+--- ./gio/gdbus-2.0/codegen/utils.py
++++ ./gio/gdbus-2.0/codegen/utils.py
+@@ -19,7 +19,6 @@
+ #
+ # Author: David Zeuthen <davidz@redhat.com>
+ 
+-import packaging.version
+ import os
+ import sys
+ import re
+-- 
+2.47.1
 


### PR DESCRIPTION
#### Description

This was broken by aa0ed802cb96987a14af16d7974f68dbc218cdf5 and breaks the build of gtk3.

Backport the upstream patches to remove the dependency completely.

The same patch or an update to an upstream version with the fix is probably required for glib2-devel, but I don't have time to do that right now.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 arm64
Xcode 16.1 16B40
gtk3 @3.24.43_1+quartz

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
