### PR TITLE
mesa: Add missing build dep

### DIFF
--- a/x11/mesa/Portfile
+++ b/x11/mesa/Portfile
@@ -41,6 +41,7 @@ depends_build-append    path:bin/pkg-config:pkgconfig \
                         port:bison \
                         port:python${py_ver_nodot} \
                         port:py${py_ver_nodot}-mako \
+                        port:py${py_ver_nodot}-packaging \
                         port:py${py_ver_nodot}-yaml \
                         port:xorg-xorgproto
 


### PR DESCRIPTION
#### Description

Mesa uses python-packaging to check whether mako is installed, and fails to find mako if packaging isn't available (e.g., in trace mode).

No revbump, since it either builds correctly, or not at all.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
