### PR TITLE
py-protobuf3: update to 5.29.3, remove py27 and py38 subports

### DIFF
--- a/python/py-protobuf3/Portfile
+++ b/python/py-protobuf3/Portfile
@@ -1,134 +1,37 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       compiler_blacklist_versions 1.0
 PortGroup       python 1.0
-PortGroup       github 1.0
 
-# note the python package is a major version greater than the cpp package
+# Note that the Python package is a different major version than the C++
+# package. https://protobuf.dev/support/version-support/
 set release_version \
-                21.12
+                29.3
 name            py-protobuf3
-version         4.${release_version}
-revision        2
+python.rootname protobuf
+version         5.${release_version}
+revision        0
 
-checksums       sha256  e2b976e67d6fcf7078f799143a73f2a4d9cf3126ca68a1a6f1bda30fe5f3585c \
-                rmd160  5cb0e68bcf7674138208d5acac258330d5a6d4dd \
-                size    5211420
+checksums       sha256  5da0f41edaf117bde316404bad1a486cb4ededf8e4a54891296f648e8e076620 \
+                rmd160  f4b56ea8e0195d255d5e91ce95654d176e56ea99 \
+                size    424945
 
 categories-append  devel
 maintainers     nomaintainer
 license         BSD
-description     Encode data in an efficient yet extensible format.
+description     An extensible mechanism for serializing structured data.
 
 long_description \
-                Google Protocol Buffers are a flexible, efficient, \
-                automated mechanism for serializing structured data -- \
-                think XML, but smaller, faster, and simpler.  You \
-                define how you want your data to be structured once, \
-                then you can use special generated source code to \
-                easily write and read your structured data to and from \
-                a variety of data streams and using a variety of \
-                languages.  You can even update your data structure \
-                without breaking deployed programs that are compiled \
-                against the "old" format.  You specify how you want \
-                the information you're serializing to be structured by \
-                defining protocol buffer message types in .proto \
-                files.  Each protocol buffer message is a small \
-                logical record of information, containing a series of \
-                name-value pairs.
+                Protocol buffers are Google’s language-neutral, \
+                platform-neutral, extensible mechanism for serializing \
+                structured data – think XML, but smaller, faster, and simpler. \
+                You define how you want your data to be structured once, then \
+                you can use special generated source code to easily write and \
+                read your structured data to and from a variety of data \
+                streams and using a variety of languages.
 
-supported_archs noarch
 platforms       {darwin any}
 
-github.setup    google protobuf ${version} v
-github.tarball_from releases
-homepage        https://github.com/google/protobuf
-master_sites    https://github.com/google/protobuf/releases/download/v${release_version}
-distfiles       protobuf-python-${version}.tar.gz
+homepage        https://protobuf.dev/
 
-compiler.cxx_standard  \
-                2011
-# error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
-compiler.blacklist {clang < 900}
-
-python.versions 27 38 39 310 311 312 313
-
-if {${name} ne ${subport}} {
-    conflicts       py${python.version}-protobuf
-
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
-    depends_lib-append \
-                    port:protobuf3-cpp \
-                    port:py${python.version}-six
-
-    if {${python.version} == 27} {
-        # Use the last compatible version.
-        set release_version \
-                        17.3
-        version         3.${release_version}
-        revision        0
-        checksums       sha256  3253c6d17ec0bb6f6382e555cf5ca0a9ffab8d81b691f100f96ce9f5e753018e \
-                        rmd160  548d88f3d75b8c75fe43eb0d620e8f40757e1566 \
-                        size    5038061
-        github.setup    google protobuf ${version} v
-        master_sites    https://github.com/google/protobuf/releases/download/v${release_version}
-        distfiles       protobuf-python-${version}.tar.gz
-    }
-
-    if {${python.version} > 36} {
-           depends_lib-append \
-               port:py${python.version}-flatbuffers
-    }
-
-    worksrcdir      ${worksrcdir}/python
-
-    if {${python.version} > 27} {
-        # tricks to force the right -stdlib setting
-        # and to put a needed CXX flag on the 10.6 build
-        # see https://trac.macports.org/ticket/56482
-        patchfiles-append \
-                    patch-py-protobuf3-settings.diff
-    }
-
-    if {${python.version} >= 311} {
-        patchfiles-append \
-                    patch-protobuf-pyext-descriptor.cc.diff
-    }
-    if {${python.pep517}} {
-        build.cmd-append       -C--cpp_implementation
-    } else {
-        build.cmd-append       --cpp_implementation
-
-        destroot.cmd-append    --cpp_implementation
-    }
-
-
-    post-patch {
-        set extraargs ""
-        set clang_stdlib ""
-
-        if {[string match *clang* ${configure.compiler}] && ${configure.cxx_stdlib} ne ""} {
-            set clang_stdlib -stdlib=${configure.cxx_stdlib}
-
-            if {${os.platform} eq "darwin" && ${os.major} < 11} {
-                set extraargs -DGOOGLE_PROTOBUF_NO_THREADLOCAL
-            }
-        }
-
-        reinplace "s|@@MACPORTS_STDLIB@@|${clang_stdlib}|g" setup.py
-        reinplace "s|@@MACPORTS_EXTRAARG@@|${extraargs}|g" setup.py
-    }
-
-
-    if {${python.version} > 27} {
-        test.run        yes
-        python.test_framework
-        test.cmd        "${python.bin} setup.py"
-        test.target     test --cpp_implementation
-    }
-}
-
-github.livecheck.regex  {([0-9.]+)}
+python.versions 39 310 311 312 313


### PR DESCRIPTION
@mascguy This is a draft. I’m putting it here for discussion.

protobuf3-cpp and py-protobuf3 are currently at version 21.12 (2022-12-12). The current py-protobuf3 port uses the pure-Python implementation. There is a upb implementation that offers better performance with the same interface, and this pull request began as an attempt to migrate to upb.

I’m not sure what reasons may have previously existed to keep protobuf3-cpp and py-protobuf3 in version lock, but I believe that py-protobuf3 is fully independent of protobuf3-cpp at 29.3, the new version proposed here. That said, it would certainly be better to not have to hold protobuf3-cpp back, and I see that there’s a more recent protobuf3-cpp-upstream at 29.2. Can you help understand what the current situation with protobuf3 versions is?

This pull request removes the py27 and py38 subports from py-protobuf3. The py38 one appears unused as far as I can tell. The py27 one has a few references from things like caffe+python27, but that port also depends on py27-numpy and py27-scipy which are gone, so removing py27-protobuf3 shouldn’t be breaking. On the other hand, ola+python27 (in its default_variants) would appear to break if py27-protobuf3 disappeared. I could certainly restore the py27 variant at protobuf 17.3 if desired, but I thought I’d save myself the trouble until we could talk about whether this is even a feasible direction forward, or if there’s a reason to continue holding py-protobuf3 back to 21.12.

What are your thoughts?

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
