### PR TITLE
mise: Update to 2025.1.4

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.1.3 v
+github.setup        jdx mise 2025.1.4 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fdbbe98658186c8815ef588c41033bd72fe7c9bc \
-                    sha256  1ff5d6c644d724689f154b220a4c89805d5aa27a01208c043c0671d12c92af58 \
-                    size    4254951
+                    rmd160  e81501b98128d009a1cb927869a81fa7275fb345 \
+                    sha256  7b26d0fc8ca0f60d72a4a90491602e2c9dc0e93900ab47c87f327e5cdc29b277 \
+                    size    4274704
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -122,7 +122,7 @@ cargo.crates \
     binstall-tar                    0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
     bit-set                          0.6.0  f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f \
     bit-vec                          0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
-    bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
+    bitflags                         2.7.0  1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
     built                            0.7.5  c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b \
@@ -145,11 +145,11 @@ cargo.crates \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
-    clap                            4.5.25  b95dca1b68188a08ca6af9d96a6576150f598824bdb528c1190460c2940a0b48 \
-    clap_builder                    4.5.25  9ab52925392148efd3f7562f2136a81ffb778076bcc85727c6e020d6dd57cf15 \
+    clap                            4.5.26  a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783 \
+    clap_builder                    4.5.26  96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121 \
     clap_derive                     4.5.24  54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
-    clap_mangen                     0.2.25  acbfe6ac42a2438d0968beba18e3c35cacf16b0c25310bc22b1f5f3cffff09f4 \
+    clap_mangen                     0.2.26  724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a \
     color-eyre                       0.6.3  55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5 \
     color-print                      0.3.7  3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4 \
     color-print-proc-macro           0.3.7  692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22 \
@@ -318,7 +318,7 @@ cargo.crates \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     js-sys                          0.3.76  6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7 \
     junction                         1.2.0  72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16 \
-    kdl                              4.7.0  3a18038fbecda667e7ea2101bdd02af754da5e17ca2887a7649b8f3fa809d8b8 \
+    kdl                              6.2.2  6d63de1aa3d632a8dd61da7cddfc499e9f88e6265d85bd84002419c3cdd3dc8f \
     lazy-regex                       3.4.1  60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126 \
     lazy-regex-proc_macros           3.4.1  4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
@@ -334,7 +334,7 @@ cargo.crates \
     litrs                            0.4.1  b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
     lockfree-object-pool             0.1.6  9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e \
-    log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
+    log                             0.4.24  3d6ea2a48c204030ee31a7d7fc72c93294c92fe87ecb1789881c9543516e1a0d \
     logos                           0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                    0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
     lua-src                        547.0.0  1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42 \
@@ -361,7 +361,13 @@ cargo.crates \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     nt-time                          0.8.1  2de419e64947cd8830e66beb584acc3fb42ed411d103e3c794dda355d1b374b5 \
     nu-ansi-term                    0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
+    num                              0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
+    num-bigint                       0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
+    num-complex                      0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
     num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
+    num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
+    num-iter                        0.1.45  1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
+    num-rational                     0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
@@ -446,7 +452,7 @@ cargo.crates \
     rustc-hash                       2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.43  a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6 \
-    rustls                         0.23.20  5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b \
+    rustls                         0.23.21  8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.10.1  d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37 \
@@ -472,6 +478,7 @@ cargo.crates \
     serde                          1.0.217  02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70 \
     serde-value                      0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
     serde_derive                   1.0.217  5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0 \
+    serde_fmt                        1.0.3  e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4 \
     serde_ignored                   0.1.10  a8e319a36d1b52126a0d608f24e93b2d81297091818cd70625fcf50a15d84ddf \
     serde_json                     1.0.135  2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9 \
     serde_regex                      1.1.0  a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf \
@@ -508,8 +515,16 @@ cargo.crates \
     strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
+    sval                            2.13.2  f6dc0f9830c49db20e73273ffae9b5240f63c42e515af1da1fceefb69fceafd8 \
+    sval_buffer                     2.13.2  429922f7ad43c0ef8fd7309e14d750e38899e32eb7e8da656ea169dd28ee212f \
+    sval_dynamic                    2.13.2  68f16ff5d839396c11a30019b659b0976348f3803db0626f736764c473b50ff4 \
+    sval_fmt                        2.13.2  c01c27a80b6151b0557f9ccbe89c11db571dc5f68113690c1e028d7e974bae94 \
+    sval_json                       2.13.2  0deef63c70da622b2a8069d8600cf4b05396459e665862e7bdb290fd6cf3f155 \
+    sval_nested                     2.13.2  a39ce5976ae1feb814c35d290cf7cf8cd4f045782fe1548d6bc32e21f6156e9f \
+    sval_ref                        2.13.2  bb7c6ee3751795a728bc9316a092023529ffea1783499afbc5c66f5fabebb1fa \
+    sval_serde                      2.13.2  2a5572d0321b68109a343634e3a5d576bf131b82180c6c442dee06349dfc652a \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.95  46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a \
+    syn                             2.0.96  d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
@@ -527,9 +542,9 @@ cargo.crates \
     test-log-macros                 0.2.16  5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5 \
     text-size                        1.1.1  f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.10  a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3 \
+    thiserror                       2.0.11  d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.10  9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb \
+    thiserror-impl                  2.0.11  26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     time                            0.3.37  35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
@@ -578,11 +593,14 @@ cargo.crates \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                        1.7.4  ab923f719b3048bd1cd2fb738fca978ed2a60756ce15cdad639fc40645adad9c \
+    usage-lib                        2.0.3  cbbaeb12c0a624b90c36daee220349c9084d0c7f619ba9fdb30825c84d14327d \
     utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
+    value-bag                       1.10.0  3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2 \
+    value-bag-serde1                1.10.0  4bb773bd36fd59c7ca6e336c94454d9c66386416734817927ac93d81cb3c5b0b \
+    value-bag-sval2                 1.10.0  53a916a702cac43a88694c97657d449775667bcd14b70419441d05b7fea4a83a \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
@@ -637,7 +655,7 @@ cargo.crates \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                          0.6.22  39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980 \
+    winnow                          0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.1.4

##### Tested on

macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
