### PR TITLE
micronaut: update to 4.7.4

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.7.3 v
+github.setup    micronaut-projects micronaut-starter 4.7.4 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  04832766055e6821056c012ccd82ebb33c0c10cc \
-                 sha256  870c7839460cc153a0c8b4f1fe5c32fecf510aebb602c537cca47fad34dde848 \
-                 size    27808338
+    checksums    rmd160  7253fb74b347473af3e5e25264586709ef847cd6 \
+                 sha256  4378e5a08c2c9b6537418c69eaeabdc70bd4307d7169bc87bd6f7202c8b23aa6 \
+                 size    27810802
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  87b3b9a5f18386f2741732d56bf5232098f9ce4a \
-                 sha256  d927685d269e8736769e1cb6d959382ca80ae086ce000fa01f2b3ac6ca0563c1 \
-                 size    27590069
+    checksums    rmd160  1a17baf29782263692b1353da5cef16914a27c21 \
+                 sha256  aede660b49fdcafb393218d7279618bbb9dde40bdb8a0bad135b61235dd79167 \
+                 size    27595008
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.7.4.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?