### PR TITLE
py-urwid: add subport py313

### DIFF
--- a/python/py-urwid/Portfile
+++ b/python/py-urwid/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  2f64dbd917c28345607c6d77fcf1597978492de4 \
                     sha256  4956910067e501ae6d6779bd865d0300d5fa71eb35ca2891636eeb1918cd1fb0 \
                     size    810668
 
-python.versions     27 37 38 39 310 311 312
+python.versions     27 37 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     test.run        yes


### PR DESCRIPTION
#### Description


###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

No binary files to test. Python 3.13 support is explicitly stated in the project README.md.