### PR TITLE
starship: update to 1.22.1

### DIFF
--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo   1.0
 PortGroup           github  1.0
 PortGroup           openssl 1.0
 
-github.setup        starship starship 1.21.1 v
+github.setup        starship starship 1.22.1 v
 github.tarball_from archive
 revision            0
 
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  a9df04b2eb6d1ce45440083ca0eea8a9d29d3c80 \
-                    sha256  f543dfa3229441ca2a55b8a625ce4bad5756a896378b019f4d0f0e00cf34dcc8 \
-                    size    9435990
+                    rmd160  c1002b4244dff021e84276fab9239b63674e0e24 \
+                    sha256  5434a3d1ca16987a1dd30146c36aaa4371dbe1c7f1a7995c0cf12ab3eb9326d7 \
+                    size    9444990
 
 # crate:openssl-sys requires pkgconfig & libssl.dylib
 depends_build-append \
@@ -48,29 +48,29 @@ cargo.crates \
     adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
     ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
-    allocator-api2                  0.2.18  5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f \
+    allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anstream                        0.6.15  64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526 \
-    anstyle                          1.0.8  1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1 \
-    anstyle-parse                    0.2.5  eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb \
-    anstyle-query                    1.1.1  6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a \
-    anstyle-wincon                   3.0.4  5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8 \
-    anyhow                          1.0.89  86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6 \
+    anstream                        0.6.18  8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b \
+    anstyle                         1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
+    anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
+    anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
+    anstyle-wincon                   3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
+    anyhow                          1.0.95  34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arraydeque                       0.5.1  7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236 \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
-    async-broadcast                  0.7.1  20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e \
+    async-broadcast                  0.7.2  435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532 \
     async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
     async-executor                  1.13.1  30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec \
     async-fs                         2.1.2  ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a \
-    async-io                         2.3.4  444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8 \
+    async-io                         2.4.0  43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059 \
     async-lock                       3.4.0  ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18 \
     async-process                    2.3.0  63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb \
     async-recursion                  1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
     async-signal                    0.2.10  637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3 \
     async-task                       4.7.1  8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de \
-    async-trait                     0.1.83  721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd \
+    async-trait                     0.1.84  1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
@@ -81,35 +81,35 @@ cargo.crates \
     block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     blocking                         1.6.1  703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea \
-    bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
+    bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytesize                         1.3.0  a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc \
-    cc                              1.1.30  b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945 \
+    cc                               1.2.7  a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
-    clap                            4.5.20  b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8 \
-    clap_builder                    4.5.20  19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54 \
-    clap_complete                   4.5.33  9646e2e245bf62f45d39a0f3f36f1171ad1ea0d6967fd114bca72cb02a8fcdfb \
-    clap_derive                     4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
-    clap_lex                         0.7.2  1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97 \
+    chrono                          0.4.39  7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825 \
+    clap                            4.5.26  a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783 \
+    clap_builder                    4.5.26  96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121 \
+    clap_complete                   4.5.42  33a7e468e750fa4b6be660e8b5651ad47372e8fb114030b594c2d75d48c5ffd0 \
+    clap_derive                     4.5.24  54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c \
+    clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     clru                             0.6.2  cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59 \
-    cmake                           0.1.51  fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a \
-    colorchoice                      1.0.2  d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0 \
+    cmake                           0.1.52  c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e \
+    colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     const-random                    0.1.18  87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359 \
     const-random-macro              0.1.16  f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e \
-    const_format                    0.2.33  50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b \
-    const_format_proc_macros        0.2.33  eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1 \
+    const_format                    0.2.34  126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd \
+    const_format_proc_macros        0.2.34  1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744 \
     core-foundation                 0.10.0  b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
-    cpufeatures                     0.2.14  608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0 \
+    cpufeatures                     0.2.16  16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
-    crossbeam-channel               0.5.13  33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2 \
-    crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
+    crossbeam-channel               0.5.14  06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471 \
+    crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
+    crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     deelevate                        0.2.0  1c7397f8c48906dd9b5afc75001368c979418e5dff5575998a831eb2319b424e \
@@ -122,114 +122,135 @@ cargo.crates \
     dirs-sys                         0.3.7  1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6 \
     dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
     dirs-sys-next                    0.1.2  4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d \
+    displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     dlv-list                         0.5.2  442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f \
     downcast                        0.11.0  1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1 \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.17  0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125 \
     either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
-    encoding_rs                     0.8.34  b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59 \
+    encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     endi                             1.1.0  a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf \
     enumflags2                      0.7.10  d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d \
     enumflags2_derive               0.7.10  de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8 \
+    env_home                         0.1.0  c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+    erased-serde                     0.4.5  24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d \
     errno                            0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
-    errno                            0.3.9  534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba \
+    errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
     errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
     event-listener                   5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
-    event-listener-strategy          0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
+    event-listener-strategy          0.5.3  3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2 \
     faster-hex                       0.9.0  a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183 \
-    fastrand                         2.1.1  e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6 \
+    fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     filedescriptor                   0.8.2  7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
-    flate2                          1.0.34  a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0 \
+    flate2                          1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fragile                          2.0.0  6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa \
     futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
     futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
-    futures-lite                     2.3.0  52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5 \
+    futures-lite                     2.5.0  cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1 \
     futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
     futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
     futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
-    gix                             0.66.0  9048b8d1ae2104f045cb37e5c450fc49d5d8af22609386bfc739c11ba88995eb \
-    gix-actor                       0.32.0  fc19e312cd45c4a66cd003f909163dc2f8e1623e30a0c0c6df3776e89b308665 \
-    gix-bitmap                      0.2.11  a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae \
-    gix-chunk                        0.4.8  45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52 \
-    gix-commitgraph                 0.24.3  133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78 \
-    gix-config                      0.40.0  78e797487e6ca3552491de1131b4f72202f282fb33f198b1c34406d765b42bb0 \
-    gix-config-value                0.14.8  03f76169faa0dec598eac60f83d7fcdd739ec16596eca8fb144c88973dbe6f8c \
-    gix-date                         0.9.0  35c84b7af01e68daf7a6bb8bb909c1ff5edb3ce4326f1f43063a5a96d3c3c8a5 \
-    gix-diff                        0.46.0  92c9afd80fff00f8b38b1c1928442feb4cd6d2232a6ed806b6b193151a3d336c \
-    gix-discover                    0.35.0  0577366b9567376bc26e815fd74451ebd0e6218814e242f8e5b7072c58d956d2 \
-    gix-features                    0.38.2  ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69 \
-    gix-fs                          0.11.3  f2bfe6249cfea6d0c0e0990d5226a4cb36f030444ba9e35e0639275db8f98575 \
-    gix-glob                        0.16.5  74908b4bbc0a0a40852737e5d7889f676f081e340d5451a16e5b4c50d592f111 \
-    gix-hash                        0.14.2  f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e \
-    gix-hashtable                    0.5.2  7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242 \
-    gix-index                       0.35.0  0cd4203244444017682176e65fd0180be9298e58ed90bd4a8489a357795ed22d \
-    gix-lock                        14.0.0  e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d \
-    gix-object                      0.44.0  2f5b801834f1de7640731820c2df6ba88d95480dc4ab166a5882f8ff12b88efa \
-    gix-odb                         0.63.0  a3158068701c17df54f0ab2adda527f5a6aca38fd5fd80ceb7e3c0a2717ec747 \
-    gix-pack                        0.53.0  3223aa342eee21e1e0e403cad8ae9caf9edca55ef84c347738d10681676fd954 \
-    gix-path                       0.10.11  ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af \
-    gix-quote                       0.4.12  cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff \
-    gix-ref                         0.47.0  ae0d8406ebf9aaa91f55a57f053c5a1ad1a39f60fdf0303142b7be7ea44311e5 \
-    gix-refspec                     0.25.0  ebb005f82341ba67615ffdd9f7742c87787544441c88090878393d0682869ca6 \
-    gix-revision                    0.29.0  ba4621b219ac0cdb9256883030c3d56a6c64a6deaa829a92da73b9a576825e1e \
-    gix-revwalk                     0.15.0  b41e72544b93084ee682ef3d5b31b1ba4d8fa27a017482900e5e044d5b1b3984 \
-    gix-sec                         0.10.8  0fe4d52f30a737bbece5276fab5d3a8b276dc2650df963e293d0673be34e7a5f \
-    gix-tempfile                    14.0.2  046b4927969fa816a150a0cda2e62c80016fe11fb3c3184e4dddf4e542f108aa \
-    gix-trace                       0.1.10  6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b \
-    gix-traverse                    0.41.0  030da39af94e4df35472e9318228f36530989327906f38e27807df305fccb780 \
-    gix-url                         0.27.5  fd280c5e84fb22e128ed2a053a0daeacb6379469be6a85e3d518a0636e160c89 \
-    gix-utils                       0.1.12  35192df7fd0fa112263bad8021e2df7167df4cc2a6e6d15892e1e55621d3d4dc \
-    gix-validate                     0.9.0  81f2badbb64e57b404593ee26b752c26991910fd0d81fe6f9a71c1a8309b6c86 \
+    gix                             0.69.1  8d0eebdaecdcf405d5433a36f85e4f058cf4de48ee2604388be0dbccbaad353e \
+    gix-actor                       0.33.1  32b24171f514cef7bb4dfb72a0b06dacf609b33ba8ad2489d4c4559a03b7afb3 \
+    gix-bitmap                      0.2.13  d48b897b4bbc881aea994b4a5bbb340a04979d7be9089791304e04a9fbc66b53 \
+    gix-chunk                       0.4.10  c6ffbeb3a5c0b8b84c3fe4133a6f8c82fa962f4caefe8d0762eced025d3eb4f7 \
+    gix-command                      0.4.0  9405c0a56e17f8365a46870cd2c7db71323ecc8bda04b50cb746ea37bd091e90 \
+    gix-commitgraph                 0.25.1  a8da6591a7868fb2b6dabddea6b09988b0b05e0213f938dbaa11a03dd7a48d85 \
+    gix-config                      0.42.0  6649b406ca1f99cb148959cf00468b231f07950f8ec438cc0903cda563606f19 \
+    gix-config-value               0.14.10  49aaeef5d98390a3bcf9dbc6440b520b793d1bf3ed99317dc407b02be995b28e \
+    gix-date                         0.9.3  c57c477b645ee248b173bb1176b52dd528872f12c50375801a58aaf5ae91113f \
+    gix-diff                        0.49.0  a8e92566eccbca205a0a0f96ffb0327c061e85bc5c95abbcddfe177498aa04f6 \
+    gix-discover                    0.37.0  83bf6dfa4e266a4a9becb4d18fc801f92c3f7cc6c433dd86fdadbcf315ffb6ef \
+    gix-features                    0.39.1  7d85d673f2e022a340dba4713bed77ef2cf4cd737d2f3e0f159d45e0935fd81f \
+    gix-fs                          0.12.1  3b3d4fac505a621f97e5ce2c69fdc425742af00c0920363ca4074f0eb48b1db9 \
+    gix-glob                        0.17.1  aaf69a6bec0a3581567484bf99a4003afcaf6c469fd4214352517ea355cf3435 \
+    gix-hash                        0.15.1  0b5eccc17194ed0e67d49285e4853307e4147e95407f91c1c3e4a13ba9f4e4ce \
+    gix-hashtable                    0.6.0  0ef65b256631078ef733bc5530c4e6b1c2e7d5c2830b75d4e9034ab3997d18fe \
+    gix-index                       0.37.0  270645fd20556b64c8ffa1540d921b281e6994413a0ca068596f97e9367a257a \
+    gix-lock                        15.0.1  1cd3ab68a452db63d9f3ebdacb10f30dba1fa0d31ac64f4203d395ed1102d940 \
+    gix-object                      0.46.1  e42d58010183ef033f31088479b4eb92b44fe341b35b62d39eb8b185573d77ea \
+    gix-odb                         0.66.0  cb780eceb3372ee204469478de02eaa34f6ba98247df0186337e0333de97d0ae \
+    gix-pack                        0.56.0  4158928929be29cae7ab97afc8e820a932071a7f39d8ba388eed2380c12c566c \
+    gix-packetline                  0.18.2  911aeea8b2dabeed2f775af9906152a1f0109787074daf9e64224e3892dde453 \
+    gix-path                       0.10.13  afc292ef1a51e340aeb0e720800338c805975724c1dfbd243185452efd8645b7 \
+    gix-protocol                    0.47.0  c84642e8b6fed7035ce9cc449593019c55b0ec1af7a5dce1ab8a0636eaaeb067 \
+    gix-quote                       0.4.14  64a1e282216ec2ab2816cd57e6ed88f8009e634aec47562883c05ac8a7009a63 \
+    gix-ref                         0.49.1  a91b61776c839d0f1b7114901179afb0947aa7f4d30793ca1c56d335dfef485f \
+    gix-refspec                     0.27.0  00c056bb747868c7eb0aeb352c9f9181ab8ca3d0a2550f16470803500c6c413d \
+    gix-revision                    0.31.1  61e1ddc474405a68d2ce8485705dd72fe6ce959f2f5fe718601ead5da2c8f9e7 \
+    gix-revwalk                     0.17.0  510026fc32f456f8f067d8f37c34088b97a36b2229d88a6a5023ef179fcb109d \
+    gix-sec                        0.10.10  a8b876ef997a955397809a2ec398d6a45b7a55b4918f2446344330f778d14fd6 \
+    gix-shallow                      0.1.0  88d2673242e87492cb6ff671f0c01f689061ca306c4020f137197f3abc84ce01 \
+    gix-tempfile                    15.0.0  2feb86ef094cc77a4a9a5afbfe5de626897351bbbd0de3cb9314baf3049adb82 \
+    gix-trace                       0.1.11  04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952 \
+    gix-transport                   0.44.0  dd04d91e507a8713cfa2318d5a85d75b36e53a40379cc7eb7634ce400ecacbaf \
+    gix-traverse                    0.43.1  6ed47d648619e23e93f971d2bba0d10c1100e54ef95d2981d609907a8cabac89 \
+    gix-url                         0.28.2  d096fb733ba6bd3f5403dba8bd72bdd8809fe2b347b57844040b8f49c93492d9 \
+    gix-utils                       0.1.13  ba427e3e9599508ed98a6ddf8ed05493db114564e338e41f6a996d2e4790335f \
+    gix-validate                     0.9.2  cd520d09f9f585b34b32aba1d0b36ada89ab7fefb54a8ca3fe37fc482a750937 \
     guess_host_triple                0.1.4  5dd62763349a2c83ed2ce9ce5429158085fa43e0cdd8c60011a7843765d04e18 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashbrown                       0.15.0  1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb \
+    hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     hashlink                         0.9.1  6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
+    home                            0.5.11  589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf \
     iana-time-zone                  0.1.61  235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
-    idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
+    icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
+    icu_locid                        1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
+    icu_locid_transform              1.5.0  01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e \
+    icu_locid_transform_data         1.5.0  fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e \
+    icu_normalizer                   1.5.0  19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f \
+    icu_normalizer_data              1.5.0  f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516 \
+    icu_properties                   1.5.1  93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5 \
+    icu_properties_data              1.5.0  67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569 \
+    icu_provider                     1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
+    icu_provider_macros              1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
+    idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
+    idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                         2.6.0  707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da \
+    indexmap                         2.7.0  62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-wsl                           0.4.0  173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5 \
-    is_debug                         1.0.1  06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89 \
+    is_debug                         1.0.2  e8ea828c9d6638a5bd3d8b14e37502b4d56cae910ccf8a5b7f51c7a0eb1d0508 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
-    itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
-    jiff                            0.1.13  8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb \
+    itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
+    jiff                            0.1.21  ed0ce60560149333a8e41ca7dc78799c47c5fd435e2bc18faf6a054382eec037 \
     jiff-tzdb                        0.1.1  91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653 \
     jiff-tzdb-platform               0.1.1  9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329 \
-    js-sys                          0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
+    js-sys                          0.3.76  6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                           0.2.159  561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5 \
+    libc                           0.2.169  b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     libz-ng-sys                     1.1.16  4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438 \
     libz-sys                        1.1.20  d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472 \
     linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
+    litemap                          0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
-    log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
+    log                             0.4.24  3d6ea2a48c204030ee31a7d7fc72c93294c92fe87ecb1789881c9543516e1a0d \
     mac-notification-sys             0.6.2  dce8f34f3717aa37177e723df6c1fc5fb02b2a1087374ea3fe0ea42316dc8f91 \
     mach2                            0.4.2  19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709 \
     malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
+    maybe-async                     0.2.10  5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11 \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     memmap2                          0.9.5  fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f \
     memmem                           0.1.1  a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15 \
     memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
-    miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
-    mockall                         0.13.0  d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a \
-    mockall_derive                  0.13.0  341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020 \
+    miniz_oxide                      0.8.2  4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394 \
+    mockall                         0.13.1  39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2 \
+    mockall_derive                  0.13.1  25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898 \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              5.1.3  08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
@@ -244,70 +265,73 @@ cargo.crates \
     objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
     once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
     opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
-    open                             5.3.0  61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3 \
+    open                             5.3.2  e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     ordered-multimap                 0.7.3  49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79 \
     ordered-stream                   0.2.0  9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50 \
-    os_info                          3.8.2  ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092 \
+    os_info                          3.9.2  6e6520c8cc998c5741ee68ec1dc369fc47e5f0ea5320018ecf2a1ccd6328f48b \
     parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     path-slash                       0.2.1  1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42 \
-    pathdiff                         0.2.2  d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361 \
+    pathdiff                         0.2.3  df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3 \
     pathsearch                       0.2.0  da983bc5e582ab17179c190b4b66c7d76c5943a69c6d34df2a2b6bf8a2977b05 \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    pest                            2.7.14  879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442 \
-    pest_derive                     2.7.14  d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd \
-    pest_generator                  2.7.14  eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e \
-    pest_meta                       2.7.14  b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d \
+    pest                            2.7.15  8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc \
+    pest_derive                     2.7.15  816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e \
+    pest_generator                  2.7.15  7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b \
+    pest_meta                       2.7.15  e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea \
     phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
     phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
     phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
     phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
-    pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
+    pin-project-lite                0.2.15  915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     piper                            0.2.4  96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066 \
     pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
     plist                            1.7.0  42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016 \
-    polling                          3.7.3  cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511 \
+    polling                          3.7.4  a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f \
+    portable-atomic                 1.10.0  280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6 \
+    portable-atomic-util             0.2.4  d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
-    predicates                       3.1.2  7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97 \
-    predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
-    predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
+    predicates                       3.1.3  a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573 \
+    predicates-core                  1.0.9  727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa \
+    predicates-tree                 1.0.12  72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c \
     proc-macro-crate                 3.2.0  8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b \
-    proc-macro2                     1.0.87  b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a \
+    proc-macro2                     1.0.92  37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0 \
     process_control                  5.0.0  f32c4eb5a227708adf07971a8b0da3d7c8f7fb3e54de64aaaedc9bef72f70b62 \
-    prodash                         28.0.0  744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79 \
+    prodash                         29.0.0  a266d8d6020c61a437be704c5e618037588e1985c7dbb7bf8d265db84cffe325 \
     quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
     quick-xml                       0.32.0  1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2 \
-    quick-xml                       0.36.2  f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe \
-    quote                           1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
+    quick-xml                       0.37.2  165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003 \
+    quote                           1.0.38  0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
-    redox_syscall                    0.5.7  9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f \
+    redox_syscall                    0.5.8  03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834 \
     redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
-    regex                           1.11.0  38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8 \
-    regex-automata                   0.4.8  368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3 \
+    regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
+    regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     rust-ini                        0.21.1  4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f \
-    rustix                         0.38.37  8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811 \
+    rustix                         0.38.42  f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85 \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schemars                        0.8.21  09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92 \
     schemars_derive                 0.8.21  b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     semver                          0.11.0  f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6 \
-    semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
-    semver-parser                   0.10.2  00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7 \
-    serde                          1.0.210  c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a \
-    serde_derive                   1.0.210  243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f \
+    semver                          1.0.24  3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba \
+    semver-parser                   0.10.3  9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2 \
+    serde                          1.0.217  02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70 \
+    serde_derive                   1.0.217  5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0 \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                     1.0.129  6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2 \
+    serde_fmt                        1.0.3  e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4 \
+    serde_json                     1.0.135  2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9 \
     serde_repr                      0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
@@ -315,7 +339,7 @@ cargo.crates \
     sha1_smol                        1.0.1  bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d \
     sha2                             0.9.9  4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800 \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
-    shadow-rs                       0.35.1  2311e39772c00391875f40e34d43efef247b23930143a70ca5fbec9505937420 \
+    shadow-rs                       0.37.0  974eb8222c62a8588bc0f02794dd1ba5b60b3ec88b58e050729d0907ed6af610 \
     shared_library                   0.1.9  5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11 \
     shell-words                      1.1.0  24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
@@ -325,51 +349,69 @@ cargo.crates \
     siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
+    stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     starship-battery                0.10.0  9017a937879cf3db80807fa7c28f09eafd4981c998265233028ee7b75f898ed2 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
+    sval                            2.13.2  f6dc0f9830c49db20e73273ffae9b5240f63c42e515af1da1fceefb69fceafd8 \
+    sval_buffer                     2.13.2  429922f7ad43c0ef8fd7309e14d750e38899e32eb7e8da656ea169dd28ee212f \
+    sval_dynamic                    2.13.2  68f16ff5d839396c11a30019b659b0976348f3803db0626f736764c473b50ff4 \
+    sval_fmt                        2.13.2  c01c27a80b6151b0557f9ccbe89c11db571dc5f68113690c1e028d7e974bae94 \
+    sval_json                       2.13.2  0deef63c70da622b2a8069d8600cf4b05396459e665862e7bdb290fd6cf3f155 \
+    sval_nested                     2.13.2  a39ce5976ae1feb814c35d290cf7cf8cd4f045782fe1548d6bc32e21f6156e9f \
+    sval_ref                        2.13.2  bb7c6ee3751795a728bc9316a092023529ffea1783499afbc5c66f5fabebb1fa \
+    sval_serde                      2.13.2  2a5572d0321b68109a343634e3a5d576bf131b82180c6c442dee06349dfc652a \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.79  89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590 \
-    systemstat                       0.2.3  a24aec24a9312c83999a28e3ef9db7e2afd5c64bf47725b758cdc1cafd5b0bd2 \
+    syn                             2.0.95  46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a \
+    synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
+    systemstat                       0.2.4  668a4db78b439df482c238f559e4ea869017f9e62ef0a059c8bfcd841a4df544 \
     tauri-winrt-notification         0.2.1  f89f5fb70d6f62381f5d9b2ba9008196150b40b75f3068eb24faeddf1c686871 \
-    tempfile                        3.13.0  f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b \
-    terminal_size                    0.4.0  4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef \
+    tempfile                        3.15.0  9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704 \
+    terminal_size                    0.4.1  5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9 \
     terminfo                         0.7.5  da31aef70da0f6352dbcb462683eb4dd2bfad01cf3fc96cf204547b9a839a585 \
     termios                          0.3.3  411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b \
-    termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
+    termtree                         0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     termwiz                         0.15.0  31ef6892cc0348a9b3b8c377addba91e0f6365863d92354bf27559dca81ee8c5 \
-    thiserror                       1.0.64  d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84 \
-    thiserror-impl                  1.0.64  08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3 \
-    time                            0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
+    thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
+    thiserror                        2.0.9  f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc \
+    thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
+    thiserror-impl                   2.0.9  7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4 \
+    time                            0.3.37  35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
-    time-macros                     0.2.18  3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf \
+    time-macros                     0.2.19  2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de \
     tiny-keccak                      2.0.2  2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237 \
-    tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
+    tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
+    tinyvec                          1.8.1  022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
     toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                      0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
-    tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
-    tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
-    tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
+    tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
+    tracing-attributes              0.1.28  395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d \
+    tracing-core                    0.1.33  e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c \
     trim-in-place                    0.1.7  343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc \
+    typeid                           1.0.2  0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     uds_windows                      1.1.0  89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9 \
     uluru                            3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
-    unicase                          2.7.0  f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89 \
-    unicode-bidi                    0.3.17  5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893 \
+    unicase                          2.8.1  75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539 \
     unicode-bom                      2.0.3  7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217 \
-    unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
+    unicode-ident                   1.0.14  adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83 \
     unicode-normalization           0.1.24  5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956 \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     uom                             0.36.0  ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c \
-    url                              2.5.2  22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c \
+    url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
+    utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
+    utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
+    value-bag                       1.10.0  3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2 \
+    value-bag-serde1                1.10.0  4bb773bd36fd59c7ca6e336c94454d9c66386416734817927ac93d81cb3c5b0b \
+    value-bag-sval2                 1.10.0  53a916a702cac43a88694c97657d449775667bcd14b70419441d05b7fea4a83a \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
@@ -377,60 +419,77 @@ cargo.crates \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
     wasite                           0.1.0  b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b \
-    wasm-bindgen                    0.2.95  128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e \
-    wasm-bindgen-backend            0.2.95  cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358 \
-    wasm-bindgen-macro              0.2.95  e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56 \
-    wasm-bindgen-macro-support      0.2.95  26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68 \
-    wasm-bindgen-shared             0.2.95  65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d \
-    which                            6.0.3  b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f \
+    wasm-bindgen                    0.2.99  a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396 \
+    wasm-bindgen-backend            0.2.99  5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79 \
+    wasm-bindgen-macro              0.2.99  2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe \
+    wasm-bindgen-macro-support      0.2.99  30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2 \
+    wasm-bindgen-shared             0.2.99  943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6 \
+    which                            7.0.1  fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028 \
     whoami                           1.5.2  372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     windows                         0.56.0  1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132 \
-    windows                         0.58.0  dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6 \
+    windows                         0.59.0  7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1 \
     windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
     windows-core                    0.56.0  4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6 \
-    windows-core                    0.58.0  6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99 \
+    windows-core                    0.59.0  810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce \
     windows-implement               0.56.0  f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b \
-    windows-implement               0.58.0  2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b \
+    windows-implement               0.59.0  83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1 \
     windows-interface               0.56.0  08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc \
-    windows-interface               0.58.0  053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515 \
+    windows-interface               0.59.0  cb26fd936d991781ea39e87c3a27285081e3c0da5ca0fcbc02d368cc6f52ff01 \
     windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
-    windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
-    windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
+    windows-result                   0.3.0  d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34 \
+    windows-strings                  0.3.0  b888f919960b42ea4e11c2f408fadb55f78a9f236d5eef084103c8ce52893491 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-targets                 0.53.0  b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b \
     windows-version                  0.1.1  6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515 \
     windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
     windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_gnullvm         0.53.0  86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
     windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
     windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_aarch64_msvc            0.53.0  c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c \
     windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
     windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnu                0.53.0  c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3 \
     windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_gnullvm            0.53.0  9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11 \
     windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
     windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_i686_msvc               0.53.0  581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d \
     windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
     windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnu              0.53.0  2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba \
     windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_gnullvm          0.53.0  0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                          0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
+    windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
+    winnow                          0.6.22  39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980 \
     winres                          0.1.12  b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
+    write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
+    writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     xdg-home                         1.3.0  ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6 \
     yaml-rust2                       0.9.0  2a1a1c0bc9823338a3bdf8c61f994f23ac004c6fa32c08cd152984499b445e8d \
+    yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
+    yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
     zbus                             4.4.0  bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725 \
     zbus_macros                      4.4.0  267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e \
     zbus_names                       3.0.0  4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
     zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
+    zerofrom                         0.1.5  cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e \
+    zerofrom-derive                  0.1.5  595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808 \
+    zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
+    zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
     zvariant                         4.2.0  2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe \
     zvariant_derive                  4.2.0  73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449 \
     zvariant_utils                   2.1.0  c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340


### PR DESCRIPTION
#### Description

Update to Starship 1.22.1.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?