### PR TITLE
py-urwid-readline: new port

### DIFF
--- a/python/py-urwid-readline/Portfile
+++ b/python/py-urwid-readline/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-urwid-readline
+version             0.15.1
+revision            0
+
+supported_archs     noarch
+platforms           {darwin any}
+license             MIT
+maintainers         nomaintainer
+
+description         readline text edit for urwid
+long_description    Text input widget for urwid that supports readline shortcuts
+
+homepage            https://github.com/rr-/urwid_readline
+
+distname            urwid_readline-${version}
+checksums           rmd160  98799bc6479869fde3b571d7562f1edeb9dfb887 \
+                    sha256  9301444b86d58f7d26388506b704f142cefd193888488b4070d3a0fdfcfc0f84 \
+                    size    9007
+
+python.versions     39 310 311 312 313
+
+if {${name} ne ${subport}} {
+    depends_run-append \
+                    port:py${python.version}-urwid
+}


### PR DESCRIPTION
#### Description

Package needed by more recent versions of py-pudb.

`pyproject.toml` does not specify any dependencies, but `setup.py` does. Development dependencies (pytest, black) not added.

There is no information about supported Python versions, so I have specified the same subports as `py-urwid` has (py39, ..., py313).

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

No binaries to test, but I imported the package (in Python 3.13) and ran the example code.