### PR TITLE
py-black: update to 24.10.0, add py313 subport

### DIFF
--- a/python/py-black/Portfile
+++ b/python/py-black/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-black
-version             24.4.2
+version             24.10.0
 revision            0
 
 supported_archs     noarch
@@ -28,11 +28,11 @@ long_description \
 
 homepage            https://${python.rootname}.readthedocs.io/
 
-checksums           rmd160  5bef62f87b169b3efdbf2edf8b44583d92465c36 \
-                    sha256  c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d \
-                    size    642299
+checksums           rmd160  4490b17e690214c6023a6b51c32f51acfd706d7f \
+                    sha256  846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875 \
+                    size    645813
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 python.pep517_backend   hatch
 
 if {${subport} ne ${name}} {

--- a/python/py-black/files/black313
+++ b/python/py-black/files/black313
@@ -1,0 +1,2 @@
+bin/black-3.13
+bin/blackd-3.13


### PR DESCRIPTION
#### Description

This version explicitly states support for Python 3.9 through 3.13 on PyPI.

Note: PR #27172 also updates Black, but is tagged as work in progress and has had draft status for several weeks. Black is only one of several ports that it updates. Being a widely use package without strong ties to the other packages in that PR, I think that Black can be updated separately to avoid delays. I propose the same changes here to Black’s Portfile as the other PR, except that I do not re-add the py38 subport (it is my understanding that we are removing those now and, besides, Black no longer officially supports 3.8 according to its pyproject.toml file)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? (***see note above***)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Testing: I have been running this locally for a couple of weeks now without problems.