### PR TITLE
py-jedi: update to 0.19.2

### DIFF
--- a/python/py-jedi/Portfile
+++ b/python/py-jedi/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jedi
-version             0.19.1
+version             0.19.2
 revision            0
 categories-append   devel
 platforms           {darwin any}
@@ -20,9 +20,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/davidhalter/jedi
 
-checksums           rmd160  cf6ca56867b5c5593e090c8a39a0b346af900c4f \
-                    sha256  cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd \
-                    size    1227821
+checksums           rmd160  110960b552d972376e2bf1a0aa6da9bd3f07b9e7 \
+                    sha256  4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0 \
+                    size    1231287
 
 if {${name} ne ${subport}} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
