### PR TITLE
legacy-support-devel: Update to latest master.

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -13,10 +13,12 @@ maintainers         {mascguy @mascguy} \
                     openmaintainer
 license             MIT BSD APSL-2
 
-description         Installs wrapper headers to add missing functionality to legacy OSX versions.
+description         Installs wrapper headers and a runtime library to add \
+                    missing functionality to legacy OSX versions.
 long_description    {*}${description}
 
-# To roll back to 1.0.13 release due to issues with 1.1.0. Must now stay.
+# Introduced to roll back to 1.0.13 release due to issues with 1.1.0.
+# Must now stay.
 epoch               1
 
 # Primary release version
@@ -46,17 +48,30 @@ subport ${name} {
 
 subport ${name}-devel {
     conflicts           ${name}
-    github.setup        macports macports-legacy-support 0f1292b4734aac30188ee03561ecd1430a255062
-    version             20241201
+    github.setup        macports macports-legacy-support \
+                        f109400eccefe2f735bcd9a068dad7a53407d548
+    version             20250111
     revision            0
     livecheck.type      none
-    checksums           rmd160  355cb69d0b2cf8d4fc4074bb1e4711f80be9d325 \
-                        sha256  6e9e4af031dad99a89bb57b28ae8318a92dd9152e5b101f8eacaa6ec45c7de4f \
-                        size    122396
+    checksums           rmd160  43b6d529471aeb3833af14c5f7348a904da1b19b \
+                        sha256  b1531131532530dc5e52d92b417d141c385ad2fc72d074844c8beff3ef416afb \
+                        size    156651
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
+
+    # Include Leopard-specific additions
+    platform darwin 9 {
+        build.target-append     leopard-bins
+        destroot.target-append  install-leopard
+    }
 }
 
+# The makefile PG brings in the unnecessary compiler_wrapper PG.
+# Disable it to reduce logfile clutter and obfuscation.
+compwrap.compilers_to_wrap
+
+# NOTE: Update this comment on the next release (C++ tests are gone).
+#
 # This port doesn't use C++ at all, except for a couple of tests which may
 # fail to build with a non-OS-default stdlib setting.  Since the cxx_stdlib
 # selection is unimportant for the tests (which are actually only testing
@@ -93,10 +108,12 @@ test.target         test
 
 if {![file exists ${prefix}/libexec/mpstats]} {
     notes "
-    To help make sure your system continues to be well represented by MacPorts, especially\
-    if your system is not one of the latest macOS releases, please consider installing mpstats.\
-    It will periodically send an anonymous synopsis of your OS settings and installed ports.\
-    The information provided by this is useful to help determine how resources are allocated.
+    To help make sure your system continues to be well-represented by\
+    MacPorts, especially if your system is not one of the latest macOS\
+    releases, please consider installing mpstats.  It will periodically\
+    send an anonymous synopsis of your OS settings and installed ports.\
+    The information provided by this is useful to help determine how\
+    resources are allocated.
 
     You can install mpstats like this:    sudo port install mpstats
     "


### PR DESCRIPTION
Notable changes since last -devel version:

- Adds support for code that can't tolerate the normal scandir() fix.
- Limits unavoidable GCC warnings to cases that really need the fix.
- Replaces broken copyfile wrapper with full 10.6 copyfile.
- Extends 10.4 INODE64 support to *statx_np() functions.
- Expands TARGET_* defaults. See: https://trac.macports.org/ticket/70824

Also (Portfile only):

- Disables unnecessary compiler_wrapper PG.
- Adds note to update cxx_stdlib comment on next release.
- Cleans up some long lines.

TESTED:
Tested both normal and -devel versions on 10.4-10.5 ppc, 10.5-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-15.x arm64. Builds and passes all tests on all tested platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.2 22H313, arm64, Xcode 15.2 15C500b
macOS 14.7.2 23H311, arm64, Xcode 16.2 16C5032a
macOS 15.2 24C101, arm64, Xcode 16.2 16C5032a
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
