### PR TITLE
mat2: update to 0.13.5, update default python

### DIFF
--- a/multimedia/mat2/Portfile
+++ b/multimedia/mat2/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                mat2
-version             0.13.4
-revision            1
+version             0.13.5
+revision            0
 categories-prepend  multimedia
 license             LGPL-3
 supported_archs     noarch
@@ -18,11 +18,11 @@ long_description    mat2 is a metadata removal tool, supporting a wide range \
                     of commonly used file formats, written in python3.
 homepage            https://0xacab.org/jvoisin/mat2
 
-checksums           rmd160  2b44330ae69d37ecb916fc35614365dfbc4fe67f \
-                    sha256  744aeee924c9898a397fe930593b803c540389bf39cd24553b99a89acc2f5901 \
-                    size    47947
+checksums           rmd160  f46d1fb8933eb07ee66cff173560cceabc692678 \
+                    sha256  d7e7c4f0f0cfcf8bd656f97919281d0c6207886d84bdfdbb192c152ebf91fe19 \
+                    size    52277
 
-python.default_version 312
+python.default_version 313
 
 depends_lib-append  port:py${python.version}-cairo \
                     port:py${python.version}-mutagen \

--- a/python/py-mutagen/Portfile
+++ b/python/py-mutagen/Portfile
@@ -31,7 +31,7 @@ checksums           rmd160  7c409dd63eb770a1cb14150b2611d16d43975b74 \
                     sha256  719fadef0a978c31b4cf3c956261b3c58b6948b32023078a2117b1de09f0fc99 \
                     size    1274186
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     post-destroot {


### PR DESCRIPTION
#### Description

mat2: update to 0.13.5, update default python

py-mutagen: add python 3.13 support (port is currently unmaintained). 


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
