### PR TITLE
Update to 1.24.1

### DIFF
--- a/net/ncdc/Portfile
+++ b/net/ncdc/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                ncdc
-version             1.23.1
+version             1.24.1
 categories          net chat
 platforms           darwin
 maintainers         nomaintainer
@@ -17,9 +17,9 @@ long_description    Modern and lightweight direct connect client with a \
 homepage            https://dev.yorhel.nl/ncdc
 master_sites        https://dev.yorhel.nl/download/
 
-checksums           rmd160  898fd9ccc7fb0ac7d88bcf3a04dcb413c10b74e4 \
-                    sha256  95881214077a5b3c24fbbaf020ada0d084ee3b596a7c3cc1e0e68aaac4c9b5e6 \
-                    size  378481
+checksums           rmd160  1ef94ffb761cec7eef49ef36a648c9f6f24ddaa9 \
+                    sha256  2a8ab9ad7d43f018fc73ba8babd689dfa44aba8cec53b88e4770185cb97778f7 \
+                    size  377704
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description

Add "u" key to file browser to sort non-local files first  
Fix possible crash on aarch64 when connected to an ADC hub  
Slightly improve ADC protocol compliance
Slightly improve C compiler compatibility

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
