### PR TITLE
minipro: Update to 0.7.2.

### DIFF
--- a/devel/minipro/Portfile
+++ b/devel/minipro/Portfile
@@ -3,15 +3,14 @@
 PortSystem          1.0
 PortGroup           gitlab 1.0
 
-gitlab.setup        DavidGriffith minipro 0.5
+gitlab.setup        DavidGriffith minipro 0.7.2
 revision            0
-checksums           rmd160  99b73fa0e04c71cce43b01a050fc6db656dbdfcb \
-                    sha256  34285cd786d645b2ed8fe6dfebaa04fbb904165d7060e15231aaa3d106c7f19a \
-                    size    246205
+checksums           rmd160  2c3d835658590cdf3784b79479ffd9e2f17a7c91 \
+                    sha256  41eefd44bb405ef89806983bea5d7bd02aba9f4619d23f2085aab056e048fcfc \
+                    size    287826
 
 categories          devel
 maintainers         openmaintainer {krischik @krischik}
-platforms           darwin
 license             GPL-3
 description         Utility for the MiniPRO TL866CS and TL866A universal programmers
 long_description    Opensource tool that aims to create a complete cross-platform \


### PR DESCRIPTION
#### Description

This updates minipro to 0.7.2. Also removes the platform line to satisfy `port lint`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
