### PR TITLE
ruby-build: Update to 20250114

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,22 +3,23 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20241225.2 v
+github.setup        rbenv ruby-build 20250114 v
 github.tarball_from archive
 categories          ruby
 license             MIT
 platforms           any
 supported_archs     noarch
 
-maintainers         {macports.halostatue.ca:austin @halostatue} \
+maintainers         {mojca @mojca} \
+                    {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  b8b72b07f63537e0142620a5e055dde336fe3015 \
-                    sha256  ae43d89f54b8765d04673fa9da993143ac5269c1ae2671509c3d3fab73f06d20 \
-                    size    93369
+checksums           rmd160  9b0d1814dafef36675ccc6537e2047653433c961 \
+                    sha256  fdfc6b2234c0984822f120afb6bbb50ee92413c16875bc153db1c390bca156cc \
+                    size    93602
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250114

##### Tested on

macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
