### PR TITLE
mise: Update to 2025.1.7

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.1.6 v
+github.setup        jdx mise 2025.1.7 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  7c50a95967897d0a846582083ed354cade659368 \
-                    sha256  6ab71f407b050325352b76b007274134e6fc4a1a677d1a7d46c72b3ced46951b \
-                    size    4275712
+                    rmd160  679240e9ebd9ef600417fd3a9d9d46f9642fe856 \
+                    sha256  802fc070fdaf1988abcf6677765ec1a62c464ed308a3741b01395763e2e9013f \
+                    size    4276875
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -103,7 +103,7 @@ cargo.crates \
     anstyle                         1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
     anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
-    anstyle-wincon                   3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
+    anstyle-wincon                   3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
     anyhow                          1.0.95  34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04 \
     arbitrary                        1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
@@ -316,7 +316,7 @@ cargo.crates \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
-    js-sys                          0.3.76  6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7 \
+    js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
     junction                         1.2.0  72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16 \
     kdl                              6.2.2  6d63de1aa3d632a8dd61da7cddfc499e9f88e6265d85bd84002419c3cdd3dc8f \
     lazy-regex                       3.4.1  60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126 \
@@ -334,7 +334,7 @@ cargo.crates \
     litrs                            0.4.1  b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
     lockfree-object-pool             0.1.6  9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e \
-    log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
+    log                             0.4.25  04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f \
     logos                           0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                    0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
     lua-src                        547.0.0  1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42 \
@@ -351,7 +351,7 @@ cargo.crates \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     minisign-verify                  0.2.3  6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3 \
     miniz_oxide                      0.7.4  b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08 \
-    miniz_oxide                      0.8.2  4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394 \
+    miniz_oxide                      0.8.3  b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924 \
     mio                              1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
     mlua                            0.10.2  9ea43c3ffac2d0798bd7128815212dd78c98316b299b7a902dabef13dc7b6b8d \
     mlua-sys                         0.6.6  63a11d485edf0f3f04a508615d36c7d50d299cf61a7ee6d3e2530651e0a31771 \
@@ -598,13 +598,13 @@ cargo.crates \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.99  a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396 \
-    wasm-bindgen-backend            0.2.99  5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79 \
-    wasm-bindgen-futures            0.4.49  38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2 \
-    wasm-bindgen-macro              0.2.99  2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe \
-    wasm-bindgen-macro-support      0.2.99  30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2 \
-    wasm-bindgen-shared             0.2.99  943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6 \
-    web-sys                         0.3.76  04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc \
+    wasm-bindgen                   0.2.100  1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
+    wasm-bindgen-backend           0.2.100  2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
+    wasm-bindgen-futures            0.4.50  555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61 \
+    wasm-bindgen-macro             0.2.100  7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407 \
+    wasm-bindgen-macro-support     0.2.100  8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de \
+    wasm-bindgen-shared            0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
+    web-sys                         0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                    0.26.7  5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e \
     which                            6.0.3  b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f \


### PR DESCRIPTION
#### Description

mise: Update to 2025.1.7

##### Tested on

macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
