### PR TITLE
libframe: fix bugs in cmake configuration

### DIFF
--- a/science/libframe/Portfile
+++ b/science/libframe/Portfile
@@ -1,13 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       cmake 1.0
+PortGroup       cmake 1.1
 PortGroup       gitlab 1.0
 
 gitlab.instance https://git.ligo.org
 gitlab.setup    virgo/virgoapp Fr 8.48.3
 
 name            libframe
+revision        1
 categories      science
 license         lgpl-2.1+
 maintainers     {aronnax @lpsinger} openmaintainer
@@ -23,7 +24,8 @@ checksums       rmd160  78ad55d1d7c8fa098c54a8998852ceb50c745bf1 \
                 sha256  214326250c6cb3f388174bb4c1936e23154be1a9a3bc0464953301c847706072 \
                 size    2710621
 
-configure.args  -DENABLE_C:BOOL=yes \
+configure.args-append \
+                -DENABLE_C:BOOL=yes \
                 -DENABLE_MATLAB:BOOL=no \
                 -DENABLE_PACKAGING:BOOL=no \
                 -DENABLE_PYTHON:BOOL=no


### PR DESCRIPTION
#### Description

This PR fixes problems with the cmake configuration for `libframe` introduced by #27384.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
