### PR TITLE
google-cloud-sdk: update to 506.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             505.0.0
+version             506.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  6dde5c2d3ee61a4dac1808f6078b531edae1ba9d \
-                    sha256  27255fe4432a7b22d52e38aa2c775bce071f6fb9cafbbc428510c71eb8dec3ed \
-                    size    53340897
+    checksums       rmd160  45ffd0c83823de108e48b7ad517f1e8b509cbbad \
+                    sha256  28fa6360cc7ff4394a065f0bb2aa10591a4f7fb0ff1e6fab9a80c53593e0181d \
+                    size    53417128
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b30b911a3e784b033e5bade1adcb4bcba0b28ec2 \
-                    sha256  84850290f2f666312268a5dfd287623195300434f65d9c48f5b86bfa34afaebf \
-                    size    54695098
+    checksums       rmd160  e6398cb85078a7658237ef984d12dbe017ae8ab0 \
+                    sha256  ba858537ca7c00d6d131935593321bcb4af457501398954a0f5b9673a8f570d7 \
+                    size    54883799
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  8b4b9052068ca43537c13056e3d69744411e33f4 \
-                    sha256  c8bd4fc7227c54ccfab12ebb74148bb2da4bde724a2e0a5c5ec5fe90941f45f4 \
-                    size    54641739
+    checksums       rmd160  db34582a6d3ea133d2905d5a17c41faa46ed768f \
+                    sha256  15a50df6b58c5b27b159e84cef87b9b477419feb5edd8d987a2b8707c907fb42 \
+                    size    54825568
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 506.0.0.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?