### PR TITLE
rsync: update to 3.4.0

### DIFF
--- a/net/rsync/Portfile
+++ b/net/rsync/Portfile
@@ -5,11 +5,11 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                rsync
 conflicts           rsync-hfscomp
-version             3.3.0
+version             3.4.0
 revision            0
-checksums           rmd160  e743ad58c56b0bcaaa40625b2294faa63f37dc22 \
-                    sha256  7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90 \
-                    size    1153969
+checksums           rmd160  d4bf30f22ee482d4ba94c71d655ea2ef05f0a38b \
+                    sha256  8e942f95a44226a012fe822faffa6c7fc38c34047add3a0c941e9bc8b8b93aa4 \
+                    size    1167983
 
 categories          net
 license             {GPL-3+ OpenSSLException}
@@ -39,7 +39,7 @@ depends_lib         port:popt \
 patch.pre_args-replace  -p0 -p1
 
 # This patch comes from
-# https://download.samba.org/pub/rsync/src/rsync-patches-3.3.0.tar.gz
+# https://download.samba.org/pub/rsync/src/rsync-patches-3.4.0.tar.gz
 # and needs to be updated with each release.
 # We used to use hfs-compression.diff but it has been deliberately
 # disabled by its developers as of 3.1.3 because it needs to be reworked

--- a/net/rsync/files/fileflags.diff
+++ b/net/rsync/files/fileflags.diff
@@ -7,7 +7,7 @@ To use this patch, run these commands for a successful build:
     ./configure                         (optional if already run)
     make
 
-based-on: 6c8ca91c731b7bf2b081694bda85b7dadc2b7aff
+based-on: e3ee0e7319eb4250ddb76b716510fd20441da329
 diff --git a/compat.c b/compat.c
 --- a/compat.c
 +++ b/compat.c
@@ -574,7 +574,7 @@ diff --git a/rsync.c b/rsync.c
  extern int preserve_executability;
  extern int preserve_mtimes;
  extern int omit_dir_times;
-@@ -468,6 +469,39 @@ mode_t dest_mode(mode_t flist_mode, mode_t stat_mode, int dflt_perms,
+@@ -471,6 +472,39 @@ mode_t dest_mode(mode_t flist_mode, mode_t stat_mode, int dflt_perms,
  	return new_mode;
  }
  
@@ -614,7 +614,7 @@ diff --git a/rsync.c b/rsync.c
  static int same_mtime(struct file_struct *file, STRUCT_STAT *st, int extra_accuracy)
  {
  #ifdef ST_MTIME_NSEC
-@@ -544,7 +578,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
+@@ -547,7 +581,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  		if (am_root >= 0) {
  			uid_t uid = change_uid ? (uid_t)F_OWNER(file) : sxp->st.st_uid;
  			gid_t gid = change_gid ? (gid_t)F_GROUP(file) : sxp->st.st_gid;
@@ -623,7 +623,7 @@ diff --git a/rsync.c b/rsync.c
  				/* We shouldn't have attempted to change uid
  				 * or gid unless have the privilege. */
  				rsyserr(FERROR_XFER, errno, "%s %s failed",
-@@ -654,7 +688,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
+@@ -657,7 +691,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  
  #ifdef HAVE_CHMOD
  	if (!BITS_EQUAL(sxp->st.st_mode, new_mode, CHMOD_BITS)) {
@@ -632,7 +632,7 @@ diff --git a/rsync.c b/rsync.c
  		if (ret < 0) {
  			rsyserr(FERROR_XFER, errno,
  				"failed to set permissions on %s",
-@@ -666,6 +700,19 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
+@@ -669,6 +703,19 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  	}
  #endif
  
@@ -652,7 +652,7 @@ diff --git a/rsync.c b/rsync.c
  	if (INFO_GTE(NAME, 2) && flags & ATTRS_REPORT) {
  		if (updated)
  			rprintf(FCLIENT, "%s\n", fname);
-@@ -743,7 +790,8 @@ int finish_transfer(const char *fname, const char *fnametmp,
+@@ -746,7 +793,8 @@ int finish_transfer(const char *fname, const char *fnametmp,
  
  	/* Change permissions before putting the file into place. */
  	set_file_attrs(fnametmp, file, NULL, fnamecmp,
@@ -662,7 +662,7 @@ diff --git a/rsync.c b/rsync.c
  
  	/* move tmp file over real file */
  	if (DEBUG_GTE(RECV, 1))
-@@ -760,6 +808,10 @@ int finish_transfer(const char *fname, const char *fnametmp,
+@@ -763,6 +811,10 @@ int finish_transfer(const char *fname, const char *fnametmp,
  	}
  	if (ret == 0) {
  		/* The file was moved into place (not copied), so it's done. */
@@ -685,7 +685,7 @@ diff --git a/rsync.h b/rsync.h
  #define XMIT_CRTIME_EQ_MTIME (1<<17)	/* any protocol - restricted by command-line option */
  
  /* These flags are used in the live flist data. */
-@@ -192,6 +192,7 @@
+@@ -193,6 +193,7 @@
  #define ATTRS_SKIP_MTIME	(1<<1)
  #define ATTRS_ACCURATE_TIME	(1<<2)
  #define ATTRS_SKIP_ATIME	(1<<3)
@@ -693,7 +693,7 @@ diff --git a/rsync.h b/rsync.h
  #define ATTRS_SKIP_CRTIME	(1<<5)
  
  #define MSG_FLUSH	2
-@@ -220,6 +221,7 @@
+@@ -221,6 +222,7 @@
  #define ITEM_REPORT_GROUP (1<<6)
  #define ITEM_REPORT_ACL (1<<7)
  #define ITEM_REPORT_XATTR (1<<8)
@@ -701,7 +701,7 @@ diff --git a/rsync.h b/rsync.h
  #define ITEM_REPORT_CRTIME (1<<10)
  #define ITEM_BASIS_TYPE_FOLLOWS (1<<11)
  #define ITEM_XNAME_FOLLOWS (1<<12)
-@@ -587,6 +589,31 @@ typedef unsigned int size_t;
+@@ -588,6 +590,31 @@ typedef unsigned int size_t;
  #define SUPPORT_CRTIMES 1
  #endif
  
@@ -733,7 +733,7 @@ diff --git a/rsync.h b/rsync.h
  /* Find a variable that is either exactly 32-bits or longer.
   * If some code depends on 32-bit truncation, it will need to
   * take special action in a "#if SIZEOF_INT32 > 4" section. */
-@@ -818,6 +845,7 @@ extern int pathname_ndx;
+@@ -819,6 +846,7 @@ extern int pathname_ndx;
  extern int depth_ndx;
  extern int uid_ndx;
  extern int gid_ndx;
@@ -741,7 +741,7 @@ diff --git a/rsync.h b/rsync.h
  extern int acls_ndx;
  extern int xattrs_ndx;
  extern int file_sum_extra_cnt;
-@@ -873,6 +901,11 @@ extern int file_sum_extra_cnt;
+@@ -874,6 +902,11 @@ extern int file_sum_extra_cnt;
  /* When the associated option is on, all entries will have these present: */
  #define F_OWNER(f) REQ_EXTRA(f, uid_ndx)->unum
  #define F_GROUP(f) REQ_EXTRA(f, gid_ndx)->unum
@@ -756,7 +756,7 @@ diff --git a/rsync.h b/rsync.h
 diff --git a/syscall.c b/syscall.c
 --- a/syscall.c
 +++ b/syscall.c
-@@ -38,6 +38,7 @@ extern int am_root;
+@@ -40,6 +40,7 @@ extern int am_root;
  extern int am_sender;
  extern int read_only;
  extern int list_only;
@@ -764,7 +764,7 @@ diff --git a/syscall.c b/syscall.c
  extern int inplace;
  extern int preallocate_files;
  extern int preserve_perms;
-@@ -81,7 +82,23 @@ int do_unlink(const char *path)
+@@ -85,7 +86,23 @@ int do_unlink(const char *path)
  {
  	if (dry_run) return 0;
  	RETURN_ERROR_IF_RO_OR_LO;
@@ -789,7 +789,7 @@ diff --git a/syscall.c b/syscall.c
  }
  
  #ifdef SUPPORT_LINKS
-@@ -146,14 +163,35 @@ int do_link(const char *old_path, const char *new_path)
+@@ -150,14 +167,35 @@ int do_link(const char *old_path, const char *new_path)
  }
  #endif
  
@@ -827,7 +827,7 @@ diff --git a/syscall.c b/syscall.c
  }
  
  int do_mknod(const char *pathname, mode_t mode, dev_t dev)
-@@ -193,7 +231,7 @@ int do_mknod(const char *pathname, mode_t mode, dev_t dev)
+@@ -197,7 +235,7 @@ int do_mknod(const char *pathname, mode_t mode, dev_t dev)
  			return -1;
  		close(sock);
  #ifdef HAVE_CHMOD
@@ -836,7 +836,7 @@ diff --git a/syscall.c b/syscall.c
  #else
  		return 0;
  #endif
-@@ -210,7 +248,22 @@ int do_rmdir(const char *pathname)
+@@ -214,7 +252,22 @@ int do_rmdir(const char *pathname)
  {
  	if (dry_run) return 0;
  	RETURN_ERROR_IF_RO_OR_LO;
@@ -860,7 +860,7 @@ diff --git a/syscall.c b/syscall.c
  }
  
  int do_open(const char *pathname, int flags, mode_t mode)
-@@ -229,7 +282,7 @@ int do_open(const char *pathname, int flags, mode_t mode)
+@@ -233,7 +286,7 @@ int do_open(const char *pathname, int flags, mode_t mode)
  }
  
  #ifdef HAVE_CHMOD
@@ -869,7 +869,7 @@ diff --git a/syscall.c b/syscall.c
  {
  	static int switch_step = 0;
  	int code;
-@@ -268,17 +321,72 @@ int do_chmod(const char *path, mode_t mode)
+@@ -272,17 +325,72 @@ int do_chmod(const char *path, mode_t mode)
  			code = chmod(path, mode & CHMOD_BITS); /* DISCOURAGED FUNCTION */
  		break;
  	}
@@ -946,16 +946,17 @@ diff --git a/syscall.c b/syscall.c
 diff --git a/t_stub.c b/t_stub.c
 --- a/t_stub.c
 +++ b/t_stub.c
-@@ -29,6 +29,8 @@ int protect_args = 0;
+@@ -28,6 +28,9 @@ int preallocate_files = 0;
+ int protect_args = 0;
  int module_id = -1;
  int relative_paths = 0;
- int module_dirlen = 0;
++int module_dirlen = 0;
 +int force_change = 0;
 +int preserve_acls = 0;
+ unsigned int module_dirlen = 0;
  int preserve_xattrs = 0;
  int preserve_perms = 0;
- int preserve_executability = 0;
-@@ -111,3 +113,23 @@ filter_rule_list daemon_filter_list;
+@@ -111,3 +114,23 @@ filter_rule_list daemon_filter_list;
  {
  	return cst ? 0 : 0;
  }
@@ -1121,6 +1122,13 @@ diff --git a/xattrs.c b/xattrs.c
 diff -Nurp a/rsync.1 b/rsync.1
 --- a/rsync.1
 +++ b/rsync.1
+@@ -1,5 +1,5 @@
+ .TH "rsync" "1" "14 Jan 2025" "rsync 3.4.0" "User Commands"
+-.\" prefix=/usr
++.\" prefix=/usr/local
+ .P
+ .SH "NAME"
+ .P
 @@ -545,6 +545,7 @@ has its own detailed description later i
  --keep-dirlinks, -K      treat symlinked dir on receiver as dir
  --hard-links, -H         preserve hard links
@@ -1341,3 +1349,53 @@ diff -Nurp a/rsync.1.html b/rsync.1.html
  of update being done, <strong>X</strong> is replaced by the file-type, and the other
  letters represent attributes that may be output if they are being modified.</p>
  <p>The update types that replace the <strong>Y</strong> are as follows:</p>
+diff -Nurp a/rsyncd.conf.5 b/rsyncd.conf.5
+--- a/rsyncd.conf.5
++++ b/rsyncd.conf.5
+@@ -1,5 +1,5 @@
+ .TH "rsyncd.conf" "5" "14 Jan 2025" "rsyncd.conf from rsync 3.4.0" "User Commands"
+-.\" prefix=/usr
++.\" prefix=/usr/local
+ .P
+ .SH "NAME"
+ .P
+@@ -73,11 +73,11 @@ and a single line something like this to
+ .RS 4
+ .P
+ .nf
+-rsync   stream  tcp     nowait  root   /usr/bin/rsync rsyncd --daemon
++rsync   stream  tcp     nowait  root   /usr/local/bin/rsync rsyncd --daemon
+ .fi
+ .RE
+ .P
+-Replace "/usr/bin/rsync" with the path to where you have rsync installed on
++Replace "/usr/local/bin/rsync" with the path to where you have rsync installed on
+ your system.  You will then need to send inetd a HUP signal to tell it to
+ reread its config file.
+ .P
+diff -Nurp a/rsyncd.conf.5.html b/rsyncd.conf.5.html
+--- a/rsyncd.conf.5.html
++++ b/rsyncd.conf.5.html
+@@ -77,10 +77,10 @@ command &quot;<code>rsync --daemon</code
+ </blockquote>
+ <p>and a single line something like this to /etc/inetd.conf:</p>
+ <blockquote>
+-<pre><code>rsync   stream  tcp     nowait  root   /usr/bin/rsync rsyncd --daemon
++<pre><code>rsync   stream  tcp     nowait  root   /usr/local/bin/rsync rsyncd --daemon
+ </code></pre>
+ </blockquote>
+-<p>Replace &quot;/usr/bin/rsync&quot; with the path to where you have rsync installed on
++<p>Replace &quot;/usr/local/bin/rsync&quot; with the path to where you have rsync installed on
+ your system.  You will then need to send inetd a HUP signal to tell it to
+ reread its config file.</p>
+ <p>Note that you should <strong>not</strong> send the rsync daemon a HUP signal to force it to
+diff -Nurp a/rsync-ssl.1 b/rsync-ssl.1
+--- a/rsync-ssl.1
++++ b/rsync-ssl.1
+@@ -1,5 +1,5 @@
+ .TH "rsync-ssl" "1" "14 Jan 2025" "rsync-ssl from rsync 3.4.0" "User Commands"
+-.\" prefix=/usr
++.\" prefix=/usr/local
+ .P
+ .SH "NAME"
+ .P


### PR DESCRIPTION
#### Description

Update to rsync 3.4.0, which fixes [a couple of CVEs](https://kb.cert.org/vuls/id/952657).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?