### PR TITLE
tippecanoe: update to 2.74.0

### DIFF
--- a/gis/tippecanoe/Portfile
+++ b/gis/tippecanoe/Portfile
@@ -6,7 +6,7 @@ PortGroup               makefile 1.0
 PortGroup               legacysupport 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            felt tippecanoe 2.73.0
+github.setup            felt tippecanoe 2.74.0
 github.tarball_from     archive
 revision                0
 categories              gis
@@ -15,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             Build vector tilesets from large collections of GeoJSON features
 long_description        {*}${description}
 
-checksums               rmd160  3a7b3d41b43e8fa90aa43795d730f9c74adef749 \
-                        sha256  cf28515e304bbbe65cfc06d3395493b78f16fdbd4aa35bda45cda4cffe54b830 \
-                        size    25666072
+checksums               rmd160  dfc2b712b3d6b9e3d3f4d61e52236bbb57fb5953 \
+                        sha256  c8d0fb75ba50b11d7dae51947683a04a5a946bf1b043cf1aa979b8638ec23079 \
+                        size    25710434
 
 # https://github.com/felt/tippecanoe/issues/304
 if {${configure.build_arch} in [list i386 ppc]} {


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/felt/tippecanoe/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
