### PR TITLE
kustomize: update to 5.6.0

### DIFF
--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes-sigs/kustomize 5.5.0 kustomize/v
+go.setup            github.com/kubernetes-sigs/kustomize 5.6.0 kustomize/v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    kustomize lets you customize raw, template-free YAML files f
 
 homepage            https://kustomize.io
 
-checksums           rmd160  503213e788e5bade1c62e2e90afde749eb72799f \
-                    sha256  a90ed294c874404934bb5aa132185604d31fbd5622fbcb5ce2c3f56d67eeb322 \
-                    size    3545141
+checksums           rmd160  b87382917b2e7d72ba20d1435cbff60348c2f2f8 \
+                    sha256  80822d3227c0dbbd38bff19c4630f4fa7eccbacd0ff269a1795a63aa3a45714f \
+                    size    3548345
 
 build.dir           ${worksrcpath}/${name}
 


### PR DESCRIPTION
#### Description

Update to Kustomize 5.6.0.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?