### PR TITLE
aerc: update to 0.19.0

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile    1.0
 PortGroup           sourcehut   1.0
 
-sourcehut.setup     rjarry aerc 0.18.2
+sourcehut.setup     rjarry aerc 0.19.0
 revision            0
 
 homepage            https://aerc-mail.org
@@ -22,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9d5516dd78f8880ce53bbe5b87859eccdf2995f0 \
-                    sha256  78408b3fe7a4991a6097c961c348fb7583af52dff80cbfcd99808415cf3d7586 \
-                    size    447348
+checksums           rmd160  ad2583128c6d2f5cc8efbbdee83a0403a5f7b386 \
+                    sha256  caf830959cf689db257ffb64893fd78f1a362a22fe774dd561340fc552d599eb \
+                    size    473597
 
 depends_build-append \
                     port:go \


### PR DESCRIPTION
#### Description
[Changelog](https://git.sr.ht/~rjarry/aerc/refs/0.19.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
