### PR TITLE
utfcpp: new port

### DIFF
--- a/textproc/utfcpp/Portfile
+++ b/textproc/utfcpp/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        nemtrif utfcpp 4.0.6 v
+revision            0
+categories          textproc
+installs_libs       no
+license             Boost-1
+maintainers         nomaintainer
+
+description         UTF-8 with C++ in a Portable Way
+
+long_description    ${description}
+
+homepage            https://github.com/nemtrif/utfcpp
+
+checksums           rmd160  66b3815ca93ecab4a3552988e9f7e6a4093f07ee \
+                    sha256  ea331a2124d94b066a2adbc2b78316665713823aa97ab8f00d06bbfaada7adbf \
+                    size    34173


### PR DESCRIPTION
#### Description

New port `utfcpp` (“UTF-8 with C++ in a Portable Way”): https://github.com/nemtrif/utfcpp

This library is now a dependency of `lttoolbox` and `apertium`, which I plan to update.

The library is header-only. It has a CMakeLists.txt file that provides an `install` target, so the easiest solution was to use the `cmake 1.1` port group. According to the developer, the CMakeLists.txt file was only intended for testing and might go away in a future release, but it has been there for over nine years, so I took the chance and used it. We can always update the Portfile if the file eventually gets deleted.

```
$ port cont utfcpp
Port utfcpp @4.0.6_0 contains:
  /opt/local/include/utf8cpp/utf8.h
  /opt/local/include/utf8cpp/utf8/checked.h
  /opt/local/include/utf8cpp/utf8/core.h
  /opt/local/include/utf8cpp/utf8/cpp11.h
  /opt/local/include/utf8cpp/utf8/cpp17.h
  /opt/local/include/utf8cpp/utf8/cpp20.h
  /opt/local/include/utf8cpp/utf8/unchecked.h
  /opt/local/share/utf8cpp/cmake/utf8cppConfig.cmake
  /opt/local/share/utf8cpp/cmake/utf8cppConfigVersion.cmake
  /opt/local/share/utf8cpp/cmake/utf8cppTargets.cmake
```

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
