### PR TITLE
ruby-build: Update to 20250115

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250114 v
+github.setup        rbenv ruby-build 20250115 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  9b0d1814dafef36675ccc6537e2047653433c961 \
-                    sha256  fdfc6b2234c0984822f120afb6bbb50ee92413c16875bc153db1c390bca156cc \
-                    size    93602
+checksums           rmd160  82f24d6baf40b4c83c5ea6bfcd0d48ffe203d3e6 \
+                    sha256  a3de300a2d02fb4045f2d402465647802a64b626e73907210f13c4260a5a64ec \
+                    size    93700
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250115

##### Tested on

macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
