### PR TITLE
mani: Install manpage and completions

### DIFF
--- a/devel/mani/Portfile
+++ b/devel/mani/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/alajmo/mani 0.30.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://manicli.com
 
@@ -36,6 +36,29 @@ build.cmd           make
 build.pre_args      DATE=""
 build.args          build
 
+post-build {
+    # Generate shell completions for supported shells
+    foreach shell {bash fish zsh} {
+        system -W ${worksrcpath}/dist \
+            "./${name} completion ${shell} > ${name}.${shell}"
+    }
+}
+
 destroot {
     xinstall -m 0755 ${worksrcpath}/dist/${name} ${destroot}${prefix}/bin/
+
+    set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0755 -d ${bash_comp_path}
+    xinstall -m 0644 ${worksrcpath}/dist/${name}.bash ${bash_comp_path}/${name}
+
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0755 -d ${fish_comp_path}
+    xinstall -m 0644 ${worksrcpath}/dist/${name}.fish ${fish_comp_path}
+
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0755 -d ${zsh_comp_path}
+    xinstall -m 0644 ${worksrcpath}/dist/${name}.zsh ${zsh_comp_path}/_${name}
+
+    xinstall -m 0755 -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0444 ${worksrcpath}/core/mani.1 ${destroot}${prefix}/share/man/man1
 }


### PR DESCRIPTION
###### Description

The manpage and completions are present after update.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 14.7.2 23H311 arm64 Xcode 16.2 16C5032a

###### Verification

Have you

- [x] followed our
      [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and
      [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open
      [pull requests](https://github.com/macports/macports-ports/pulls) for the
      same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
