### PR TITLE
libpng: update to 1.6.45

### DIFF
--- a/graphics/libpng/Portfile
+++ b/graphics/libpng/Portfile
@@ -4,11 +4,11 @@ PortSystem              1.0
 PortGroup               muniversal 1.0
 
 name                    libpng
-version                 1.6.44
+version                 1.6.45
 revision                0
-checksums               rmd160  2a33796f56352171daaa0a44d52552abca1348a1 \
-                        sha256  60c4da1d5b7f0aa8d158da48e8f8afa9773c1c8baa5d21974df61f1886b8ce8e \
-                        size    1045640
+checksums               rmd160  baae0f93d6d132cfabb754bc4a0dde839e6755cb \
+                        sha256  926485350139ffb51ef69760db35f78846c805fef3d59bfdcb2fba704663f370 \
+                        size    1051268
 
 set branch              [join [lrange [split ${version} .] 0 1] ""]
 categories              graphics


### PR DESCRIPTION
#### Description

Simple update to upstream version 1.6.45
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 x86_64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
