### PR TITLE
py312-meld3: fix checksum

### DIFF
--- a/python/py-meld3/Portfile
+++ b/python/py-meld3/Portfile
@@ -20,9 +20,9 @@ long_description    meld3 is an HTML/XML templating system for Python 2.3+ \
 
 homepage            https://github.com/supervisor/meld3
 
-checksums           rmd160  087c67816bc0cdcc8dabccec0b1bb9dd384e267a \
-                    sha256  1efda676264490db2e30bfb81b27a918cc6d9c2de6d609491aa43410b9537eb9 \
-                    size    36464
+checksums           rmd160  96ca23ce08569abb62f0779600b2dc5be7c68c5b \
+                    sha256  3ea266994f1aa83507679a67b493b852c232a7905e29440a6b868558cad5e775 \
+                    size    36097
 
 python.versions     312
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/71856

#### Description
py312-meld3 currently has a checksum failure; this is supposed to fix it. Unfortunately upon testing, the old checksums continue to get picked up instead of the new ones I added here; maybe there is a stale PortIndex file somewhere getting in the way or something?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
