### PR TITLE
llama.cpp: update to b4508; fix builds for 10.15 and earlier

### DIFF
--- a/llm/llama.cpp/Portfile
+++ b/llm/llama.cpp/Portfile
@@ -5,9 +5,9 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.1
 
-github.setup            ggerganov llama.cpp 4493 b
+github.setup            ggerganov llama.cpp 4508 b
 github.tarball_from     archive
-set git-commit          9c8dcef
+set git-commit          a1649cc
 # This line is for displaying commit in CLI only
 revision                0
 categories              llm
@@ -19,9 +19,9 @@ long_description        The main goal of ${name} is to enable LLM inference with
                         setup and state-of-the-art performance on a wide variety of hardware\
                          - locally and in the cloud.
 
-checksums               rmd160  166a6c335b56b1695d9e1b8a8909061bc03bb56b \
-                        sha256  2c5c75a80976a84e73fa7571df57e46878b5f459cf30b1748af0628dbcec3ff1 \
-                        size    20442823
+checksums               rmd160  b6700c8d3311bfa382ef9db1881846e10329c990 \
+                        sha256  3fcc3ae6b2605dfcfaf871cfa4281ac7cf215eb738e876e193890e7837d256f2 \
+                        size    20472113
 
 # error: 'filesystem' file not found on 10.14
 legacysupport.newest_darwin_requires_legacy \
@@ -29,7 +29,14 @@ legacysupport.newest_darwin_requires_legacy \
 legacysupport.use_mp_libcxx \
                         yes
 
+depends_build-append    path:bin/pkg-config:pkgconfig
+
 depends_lib-append      port:curl
+
+# Upstream patch for errno-related build failure; will be included in future release
+# See: https://trac.macports.org/ticket/71880
+# See: https://github.com/ggerganov/llama.cpp/issues/11295
+patchfiles-append       patch-llama-mmap-errno.diff
 
 # cmake relies on git for version info. We need to set them manually.
 post-patch {
@@ -41,6 +48,7 @@ compiler.cxx_standard   2017
 
 configure.args-append   -DGGML_LTO=ON \
                         -DGGML_CCACHE=OFF \
+                        -DGGML_OPENMP=OFF \
                         -DLLAMA_CURL=ON
 
 # error: use of undeclared identifier 'MTLGPUFamilyApple7' on 10.14

--- a/llm/llama.cpp/files/patch-llama-mmap-errno.diff
+++ b/llm/llama.cpp/files/patch-llama-mmap-errno.diff
@@ -1,0 +1,16 @@
+#==================================================================================================
+# Upstream patch to fix errno-related build failure on some systems
+#
+# Source: https://github.com/ggerganov/llama.cpp/pull/11296
+# Issue:  https://github.com/ggerganov/llama.cpp/issues/11295
+#==================================================================================================
+--- src/llama-mmap.cpp.orig	2025-01-18 15:49:52.000000000 -0500
++++ src/llama-mmap.cpp	2025-01-18 15:50:19.000000000 -0500
+@@ -7,6 +7,7 @@
+ #include <cstring>
+ #include <climits>
+ #include <stdexcept>
++#include <cerrno>
+ 
+ #ifdef __has_include
+     #if __has_include(<unistd.h>)


### PR DESCRIPTION
### Description

- Explicitly disable OpenMP
Fixes: https://trac.macports.org/ticket/71870

- Upstream patch for errno-related build failure on 10.15:
Fixes: https://trac.macports.org/ticket/71880