### PR TITLE
newsraft: update to 0.28

### DIFF
--- a/net/newsraft/Portfile
+++ b/net/newsraft/Portfile
@@ -5,7 +5,7 @@ PortGroup           codeberg 1.0
 PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
-codeberg.setup      newsraft newsraft 0.27 newsraft-
+codeberg.setup      newsraft newsraft 0.28 newsraft-
 revision            0
 
 categories          net
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Feed reader for terminal
 long_description    {*}${description}
 
-checksums           rmd160  fc114e7a912912512102c112bbf1d7a43d6a1cc4 \
-                    sha256  627b274901e5c3298d430f5adfedbd69b09de365ffeb18e768f091738fe39089 \
-                    size    155854
+checksums           rmd160  f20d883bb908dd66775d693433d07860c36d953d \
+                    sha256  4314c6f5b278e52583bc3a48808ac7b4e7bbea9e992fafb19c4e30c8399bf025 \
+                    size    159573
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
#### Description
https://codeberg.org/newsraft/newsraft/releases/tag/newsraft-0.28

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
