### PR TITLE
meson: add llvm-config to cross files

### DIFF
--- a/python/py-meson/Portfile
+++ b/python/py-meson/Portfile
@@ -8,7 +8,7 @@ name                py-meson
 # update version and revision also in the meson port
 github.setup        mesonbuild meson 1.6.1
 github.tarball_from releases
-revision            0
+revision            1
 
 checksums           rmd160  b7c38c2626e32a40c1989a54f7bffca1a4a01a28 \
                     sha256  1eca49eb6c26d58bbee67fd3337d8ef557c0804e30a6d16bfdf269db997464de \

--- a/python/py-meson/files/cross/arm64-darwin
+++ b/python/py-meson/files/cross/arm64-darwin
@@ -7,3 +7,4 @@ endian = 'little'
 [binaries]
 pkgconfig = '@@PREFIX@@/bin/pkg-config'
 cmake = '@@PREFIX@@/bin/cmake'
+llvm-config = 'llvm-config'

--- a/python/py-meson/files/cross/i386-darwin
+++ b/python/py-meson/files/cross/i386-darwin
@@ -7,3 +7,4 @@ endian = 'little'
 [binaries]
 pkgconfig = '@@PREFIX@@/bin/pkg-config'
 cmake = '@@PREFIX@@/bin/cmake'
+llvm-config = 'llvm-config'

--- a/python/py-meson/files/cross/ppc-darwin
+++ b/python/py-meson/files/cross/ppc-darwin
@@ -7,3 +7,4 @@ endian = 'big'
 [binaries]
 pkgconfig = '@@PREFIX@@/bin/pkg-config'
 cmake = '@@PREFIX@@/bin/cmake'
+llvm-config = 'llvm-config'

--- a/python/py-meson/files/cross/ppc64-darwin
+++ b/python/py-meson/files/cross/ppc64-darwin
@@ -7,3 +7,4 @@ endian = 'big'
 [binaries]
 pkgconfig = '@@PREFIX@@/bin/pkg-config'
 cmake = '@@PREFIX@@/bin/cmake'
+llvm-config = 'llvm-config'

--- a/python/py-meson/files/cross/x86_64-darwin
+++ b/python/py-meson/files/cross/x86_64-darwin
@@ -7,3 +7,4 @@ endian = 'little'
 [binaries]
 pkgconfig = '@@PREFIX@@/bin/pkg-config'
 cmake = '@@PREFIX@@/bin/cmake'
+llvm-config = 'llvm-config'


### PR DESCRIPTION
when building a non-native cross arch,
meson requires most binaries used during
the build to be specified in the cross
files.

these don't have to be full path-specified,
however, and simply setting this:

llvm-config = 'llvm-config'

will satisfy meson that it's OK to use the
llvm-config binary found in the PATH.

closes: https://trac.macports.org/ticket/71852

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
