### PR TITLE
rebels-in-the-sky: Update to 1.0.28

### DIFF
--- a/games/rebels-in-the-sky/Portfile
+++ b/games/rebels-in-the-sky/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        ricott1 rebels-in-the-sky 1.0.27 v
+github.setup        ricott1 rebels-in-the-sky 1.0.28 v
 revision            0
 
 categories          games
@@ -29,9 +29,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix}  \
-                    rmd160  9b57f1a6a1ac3935d6dcfe46074935db9fe4152f \
-                    sha256  60123dea3aada5ce87b6801bab0aee8cc2f40c20737a96abd947f12810040128 \
-                    size    9768745
+                    rmd160  339d83d601a6534a87174c1de8e9996fbc7c4a4e \
+                    sha256  e340e6db161ec1697b4a30668145b9e3ae86fc3a11ff17455bee3fe331594b5f \
+                    size    9771458
 
 cargo.crates \
     ab_glyph                           0.2.29  ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0 \
@@ -53,7 +53,7 @@ cargo.crates \
     anstyle                            1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
     anstyle-parse                       0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                       1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
-    anstyle-wincon                      3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
+    anstyle-wincon                      3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
     anyhow                             1.0.95  34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04 \
     approx                              0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
     arbitrary                           1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
@@ -73,10 +73,11 @@ cargo.crates \
     async-lock                          3.4.0  ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18 \
     async-net                           2.0.0  b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7 \
     async-process                       2.3.0  63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb \
+    async-recursion                     1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
     async-signal                       0.2.10  637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3 \
     async-std                          1.13.0  c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615 \
     async-task                          4.7.1  8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de \
-    async-trait                        0.1.83  721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd \
+    async-trait                        0.1.85  3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056 \
     asynchronous-codec                  0.7.0  a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233 \
     atomic-waker                        1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     attohttpc                          0.24.1  8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2 \
@@ -92,7 +93,7 @@ cargo.crates \
     bindgen                            0.70.1  f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f \
     bit_field                          0.10.2  dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61 \
     bitflags                            1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                            2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
+    bitflags                            2.8.0  8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36 \
     bitstream-io                        2.6.0  6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2 \
     blake2                             0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
     block-buffer                       0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
@@ -109,7 +110,7 @@ cargo.crates \
     cassowary                           0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     castaway                            0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
     cbc                                 0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.6  8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333 \
+    cc                                 1.2.10  13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229 \
     cesu8                               1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cexpr                               0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-expr                           0.15.8  d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02 \
@@ -120,16 +121,16 @@ cargo.crates \
     chrono                             0.4.39  7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825 \
     cipher                              0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     clang-sys                           1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    clap                               4.5.23  3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84 \
-    clap_builder                       4.5.23  30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838 \
-    clap_derive                        4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
+    clap                               4.5.26  a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783 \
+    clap_builder                       4.5.26  96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121 \
+    clap_derive                        4.5.24  54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     claxon                              0.4.3  4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688 \
     cmake                              0.1.52  c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e \
     color_quant                         1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
     colorchoice                         1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     combine                             4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
-    compact_str                         0.8.0  6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644 \
+    compact_str                         0.8.1  3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32 \
     concurrent-queue                    2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     const-oid                           0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     const-random                       0.1.18  87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359 \
@@ -142,6 +143,7 @@ cargo.crates \
     cpal                               0.15.3  873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779 \
     cpufeatures                        0.2.16  16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3 \
     crc32fast                           1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
+    crossbeam-channel                  0.5.14  06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471 \
     crossbeam-deque                     0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                    0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
     crossbeam-utils                    0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
@@ -157,20 +159,19 @@ cargo.crates \
     darling_core                      0.20.10  95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5 \
     darling_macro                     0.20.10  d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806 \
     dasp_sample                        0.11.0  0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f \
-    data-encoding                       2.6.0  e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2 \
-    data-encoding-macro                0.1.15  f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639 \
-    data-encoding-macro-internal       0.1.13  332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f \
-    delegate                           0.13.1  bc2323e10c92e1cf4d86e11538512e6dc03ceb586842970b6332af3d4046a046 \
+    data-encoding                       2.7.0  0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f \
+    data-encoding-macro                0.1.16  5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b \
+    data-encoding-macro-internal       0.1.14  1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b \
+    delegate                           0.13.2  297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945 \
     der                                 0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     der-parser                          9.0.0  5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553 \
     deranged                           0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     derivative                          2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
     des                                 0.8.1  ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e \
     destructure_traitobject             0.2.0  3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7 \
-    diff                               0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     digest                             0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
-    directories                         5.0.1  9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35 \
-    dirs-sys                            0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
+    directories                         6.0.0  16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
+    dirs-sys                            0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     displaydoc                          0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     dtoa                                1.0.9  dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653 \
     ecdsa                              0.16.9  ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca \
@@ -186,7 +187,7 @@ cargo.crates \
     equivalent                          1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                              0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
     event-listener                      2.5.3  0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0 \
-    event-listener                      5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
+    event-listener                      5.4.0  3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae \
     event-listener-strategy             0.5.3  3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2 \
     exr                                1.73.0  f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0 \
     fastrand                            2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
@@ -204,34 +205,36 @@ cargo.crates \
     futures-core                       0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
     futures-executor                   0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
     futures-io                         0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
-    futures-lite                        2.5.0  cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1 \
+    futures-lite                        2.6.0  f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532 \
     futures-macro                      0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
     futures-rustls                     0.26.0  a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb \
     futures-sink                       0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
     futures-task                       0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
-    futures-ticker                      0.0.3  9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e \
     futures-timer                       3.0.3  f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24 \
     futures-util                       0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
+    generator                           0.8.4  cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd \
     generic-array                      0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                          0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
     ghash                               0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gif                                0.13.1  3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2 \
     gimli                              0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     glam                               0.29.2  dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677 \
-    glob                                0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
+    glob                                0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
     gloo-timers                         0.3.0  bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994 \
     group                              0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
-    h2                                 0.3.26  81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8 \
+    h2                                  0.4.7  ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e \
     half                                2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
+    hashbrown                          0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                          0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
+    hashlink                            0.9.1  6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af \
     heck                                0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                          0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hermit-abi                          0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
     hex                                 0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hex-literal                         0.4.1  6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46 \
     hex_fmt                             0.3.0  b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f \
-    hickory-proto                      0.24.2  447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5 \
-    hickory-resolver                   0.24.2  0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4 \
+    hickory-proto              0.25.0-alpha.4  d063c0692ee669aa6d261988aa19ca5510f1cc40e4f211024f50c888499a35d7 \
+    hickory-resolver           0.25.0-alpha.4  42bc352e4412fb657e795f79b4efcf2bd60b59ee5ca0187f3554194cd1107a27 \
     hkdf                               0.12.4  7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7 \
     hmac                               0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
     home                               0.5.11  589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf \
@@ -239,13 +242,10 @@ cargo.crates \
     hound                               3.5.1  62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f \
     http                               0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
     http                                1.2.0  f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea \
-    http-body                           0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-body                           1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                      0.1.2  793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f \
     httparse                            1.9.5  7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946 \
-    httpdate                            1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     humantime                           2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
-    hyper                             0.14.32  41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7 \
     hyper                               1.5.2  256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0 \
     hyper-rustls                       0.27.5  2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2 \
     hyper-util                         0.1.10  df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4 \
@@ -266,9 +266,9 @@ cargo.crates \
     idna_adapter                        1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     if-addrs                           0.10.2  cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a \
     if-watch                            3.2.1  cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38 \
-    igd-next                           0.14.3  064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4 \
+    igd-next                           0.15.1  76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93 \
     image                              0.25.5  cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b \
-    image-webp                          0.2.0  e031e8e3d94711a9ccb5d6ea357439ef3dcbed361798bd4071dc4d9793fbe22f \
+    image-webp                          0.2.1  b77d01e822461baa8409e156015a1d91735549f0f2c17691bd2d996bef238f7f \
     imageproc                          0.25.0  2393fb7808960751a52e8a154f67e7dd3f8a2ef9bd80d1553078a7b4e8ed3f0d \
     imgref                             1.11.0  d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408 \
     include_dir                         0.7.4  923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd \
@@ -276,20 +276,20 @@ cargo.crates \
     indexmap                            2.7.0  62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f \
     indoc                               2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inout                               0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
-    instability                         0.3.5  898e106451f7335950c9cc64f8ec67b5f65698679ac67ed00619aeef14e1cf75 \
-    instant                            0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
+    instability                         0.3.7  0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d \
     interpolate_name                    0.2.4  c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60 \
     ipconfig                            0.3.2  b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f \
     ipnet                              2.10.1  ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708 \
     is_terminal_polyfill               1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                          0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
     itertools                          0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
+    itertools                          0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                               1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
     jni                                0.21.1  1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97 \
     jni-sys                             0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
     jobserver                          0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jpeg-decoder                        0.3.1  f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0 \
-    js-sys                             0.3.76  6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7 \
+    js-sys                             0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
     kv-log-macro                        1.0.7  0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f \
     lazy_static                         1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     lebe                                0.5.2  03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8 \
@@ -298,41 +298,41 @@ cargo.crates \
     libfuzzer-sys                       0.4.8  9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa \
     libloading                          0.8.6  fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34 \
     libm                               0.2.11  8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa \
-    libp2p                             0.54.1  bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4 \
-    libp2p-allow-block-list             0.4.0  d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041 \
-    libp2p-connection-limits            0.4.0  8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8 \
-    libp2p-core                        0.42.0  a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298 \
-    libp2p-dns                         0.42.0  97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd \
-    libp2p-gossipsub                   0.47.0  b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543 \
+    libp2p                             0.55.0  b72dc443ddd0254cb49a794ed6b6728400ee446a0f7ab4a07d0209ee98de20e9 \
+    libp2p-allow-block-list             0.5.0  38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b \
+    libp2p-connection-limits            0.5.0  efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c \
+    libp2p-core                        0.43.0  193c75710ba43f7504ad8f58a62ca0615b1d7e572cb0f1780bc607252c39e9ef \
+    libp2p-dns                         0.43.0  1b780a1150214155b0ed1cdf09fbd2e1b0442604f9146a431d1b21d23eef7bd7 \
+    libp2p-gossipsub                   0.48.0  d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a \
     libp2p-identity                    0.2.10  257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d \
-    libp2p-kad                         0.46.2  ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3 \
-    libp2p-mdns                        0.46.0  14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417 \
-    libp2p-metrics                     0.15.0  77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566 \
-    libp2p-noise                       0.45.0  36b137cb1ae86ee39f8e5d6245a296518912014eaa87427d24e6ff58cfc1b28c \
-    libp2p-ping                        0.45.0  005a34420359223b974ee344457095f027e51346e992d1e0dcd35173f4cdd422 \
-    libp2p-plaintext                   0.42.0  5b63d926c6be56a2489e0e7316b17fe95a70bc5c4f3e85740bb3e67c0f3c6a44 \
-    libp2p-quic                        0.11.1  46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e \
-    libp2p-swarm                       0.45.1  d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a \
+    libp2p-kad                         0.47.0  2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23 \
+    libp2p-mdns                        0.47.0  11d0ba095e1175d797540e16b62e7576846b883cb5046d4159086837b36846cc \
+    libp2p-metrics                     0.16.0  2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a \
+    libp2p-noise                       0.46.0  afcc133e0f3cea07acde6eb8a9665cb11b600bd61110b010593a0210b8153b16 \
+    libp2p-ping                        0.46.0  7b2529993ff22deb2504c0130a58b60fb77f036be555053922db1a0490b5798b \
+    libp2p-plaintext                   0.43.0  7e659439578fc6d305da8303834beb9d62f155f40e7f5b9d81c9f2b2c69d1926 \
+    libp2p-quic                        0.12.0  41432a159b00424a0abaa2c80d786cddff81055ac24aa127e0cf375f7858d880 \
+    libp2p-swarm                       0.46.0  803399b4b6f68adb85e63ab573ac568154b193e9a640f03e0f2890eabbcb37f8 \
     libp2p-swarm-derive                0.35.0  206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8 \
-    libp2p-swarm-test                   0.4.0  ea4e1d1d92421dc4c90cad42e3cd24f50fd210191c9f126d41bd483a09567f67 \
-    libp2p-tcp                         0.42.0  ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314 \
-    libp2p-tls                          0.5.0  47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847 \
-    libp2p-upnp                         0.3.0  01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f \
-    libp2p-yamux                       0.46.0  788b61c80789dba9760d8c669a5bedb642c8267555c803fabd8396e4ca5c5882 \
+    libp2p-swarm-test                   0.5.0  2bb6354e3a50496d750805f6cf33679bd698850d535602f42c61e465e0734d0b \
+    libp2p-tcp                         0.43.0  65346fb4d36035b23fec4e7be4c320436ba53537ce9b6be1d1db1f70c905cad0 \
+    libp2p-tls                          0.6.0  dcaebc1069dea12c5b86a597eaaddae0317c2c2cb9ec99dc94f82fd340f5c78b \
+    libp2p-upnp                         0.4.0  d457b9ecceb66e7199f049926fad447f1f17f040e8d29d690c086b4cab8ed14a \
+    libp2p-yamux                       0.47.0  f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8 \
     libredox                            0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    libz-ng-sys                        1.1.20  8f0f7295a34685977acb2e8cc8b08ee4a8dffd6cf278eeccddbe1ed55ba815d5 \
-    linked-hash-map                     0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
-    linux-raw-sys                      0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
+    libz-ng-sys                        1.1.21  7cee1488e961a80d172564fd6fcda11d8a4ac6672c06fe008e9213fa60520c2b \
+    linux-raw-sys                      0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     litemap                             0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
     lock_api                           0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
-    log                                0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
+    log                                0.4.25  04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f \
     log-mdc                             0.1.0  a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7 \
     log4rs                              1.3.0  0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6 \
+    loom                                0.7.2  419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca \
     loop9                               0.1.5  0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062 \
     lru                                0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
-    lru-cache                           0.1.2  31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c \
     mach2                               0.4.2  19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709 \
     match_cfg                           0.1.0  ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4 \
+    matchers                            0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
     matrixmultiply                      0.3.9  9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a \
     maybe-rayon                         0.1.1  8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519 \
     md5                                 0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
@@ -340,8 +340,9 @@ cargo.crates \
     memchr                              2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     mime                               0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                     0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
-    miniz_oxide                         0.8.2  4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394 \
+    miniz_oxide                         0.8.3  b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924 \
     mio                                 1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
+    moka                              0.12.10  a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926 \
     multiaddr                          0.18.2  fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961 \
     multibase                           0.9.1  9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404 \
     multihash                          0.19.3  6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d \
@@ -360,6 +361,7 @@ cargo.crates \
     nohash-hasher                       0.2.0  2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451 \
     nom                                 7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     noop_proc_macro                     0.3.0  0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8 \
+    nu-ansi-term                       0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
     num                                 0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
     num-bigint                          0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
     num-bigint-dig                      0.8.4  dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151 \
@@ -382,6 +384,7 @@ cargo.crates \
     opaque-debug                        0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
     option-ext                          0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                      2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
+    overload                            0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     owned_ttf_parser                   0.25.0  22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4 \
     p256                               0.13.2  c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b \
     p384                               0.13.0  70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209 \
@@ -395,9 +398,9 @@ cargo.crates \
     pem                                 3.0.4  8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae \
     pem-rfc7468                         0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
     percent-encoding                    2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    pin-project                         1.1.7  be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95 \
-    pin-project-internal                1.1.7  3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c \
-    pin-project-lite                   0.2.15  915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff \
+    pin-project                         1.1.8  1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916 \
+    pin-project-internal                1.1.8  d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb \
+    pin-project-lite                   0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                           0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     piper                               0.2.4  96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066 \
     pkcs1                               0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
@@ -408,12 +411,12 @@ cargo.crates \
     polling                             3.7.4  a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f \
     poly1305                            0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
     polyval                             0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
+    portable-atomic                    1.10.0  280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6 \
     powerfmt                            0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                         0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
-    pretty_assertions                   1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     primeorder                         0.13.6  353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6 \
     proc-macro-crate                    3.2.0  8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b \
-    proc-macro2                        1.0.92  37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0 \
+    proc-macro2                        1.0.93  60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99 \
     profiling                          1.0.16  afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d \
     profiling-procmacros               1.0.16  a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30 \
     prometheus-client                  0.22.3  504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca \
@@ -440,11 +443,13 @@ cargo.crates \
     rayon-core                         1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     rcgen                              0.11.3  52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6 \
     redox_syscall                       0.5.8  03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834 \
-    redox_users                         0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
+    redox_users                         0.5.0  dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b \
     regex                              1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
+    regex-automata                     0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                      0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
+    regex-syntax                       0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    reqwest                           0.12.11  7fe060fe50f524be480214aba758c71f99f90ee8c83c5a36b5e9e1d568eb4eb3 \
+    reqwest                           0.12.12  43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da \
     resolv-conf                         0.7.0  52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00 \
     rfc6979                             0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
     rgb                                0.8.50  57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a \
@@ -463,8 +468,8 @@ cargo.crates \
     rustc-hash                          2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
     rustc_version                       0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rusticata-macros                    4.1.0  faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632 \
-    rustix                            0.38.42  f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85 \
-    rustls                            0.23.20  5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b \
+    rustix                            0.38.43  a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6 \
+    rustls                            0.23.21  8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8 \
     rustls-pemfile                      2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                   1.10.1  d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37 \
     rustls-webpki                     0.101.7  8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765 \
@@ -475,21 +480,23 @@ cargo.crates \
     safe_arch                           0.7.4  96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323 \
     salsa20                            0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                           1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    scoped-tls                          1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                          1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scrypt                             0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
     sec1                                0.7.3  d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc \
     seize                               0.3.3  689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3 \
     semver                             1.0.24  3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba \
-    serde                             1.0.216  0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e \
+    serde                             1.0.217  02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70 \
     serde-value                         0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
-    serde_derive                      1.0.216  46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e \
-    serde_json                        1.0.134  d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d \
+    serde_derive                      1.0.217  5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0 \
+    serde_json                        1.0.135  2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9 \
     serde_repr                         0.1.19  6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9 \
     serde_spanned                       0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                    0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     serde_yaml              0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     sha1                               0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha2                               0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
+    sharded-slab                        0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shlex                               1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                        0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
     signal-hook-mio                     0.2.4  34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd \
@@ -521,20 +528,22 @@ cargo.crates \
     symphonia-core                      0.5.4  798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3 \
     symphonia-metadata                  0.5.4  bc622b9841a10089c5b18e99eb904f4341615d5aa55bbf4eedde1be721a4023c \
     syn                               1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                                2.0.92  70ae51629bf965c5c098cc9e87908a3df5301051a9e087d6f9bef5c9771ed126 \
+    syn                                2.0.96  d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80 \
     sync_wrapper                        1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                       0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     system-configuration                0.6.1  3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b \
     system-configuration-sys            0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
     system-deps                         6.2.2  a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349 \
+    tagptr                              0.2.0  7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417 \
     tap                                 1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
     target-lexicon                    0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
-    tempfile                           3.14.0  28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c \
+    tempfile                           3.15.0  9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704 \
     thiserror                          1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                           2.0.9  f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc \
+    thiserror                          2.0.11  d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc \
     thiserror-impl                     1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                      2.0.9  7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4 \
+    thiserror-impl                     2.0.11  26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2 \
     thread-id                           4.2.2  cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea \
+    thread_local                        1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tiff                                0.9.1  ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e \
     time                               0.3.37  35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21 \
     time-core                           0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
@@ -543,8 +552,8 @@ cargo.crates \
     tinystr                             0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                             1.8.1  022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8 \
     tinyvec_macros                      0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                              1.42.0  5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551 \
-    tokio-macros                        2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
+    tokio                              1.43.0  3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e \
+    tokio-macros                        2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-rustls                       0.26.1  5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37 \
     tokio-stream                       0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
     tokio-util                         0.7.13  d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078 \
@@ -557,12 +566,14 @@ cargo.crates \
     tracing                            0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-attributes                 0.1.28  395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d \
     tracing-core                       0.1.33  e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c \
+    tracing-log                         0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
+    tracing-subscriber                 0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
     try-lock                            0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     ttf-parser                         0.25.1  d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31 \
     tui-textarea                        0.7.0  0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae \
     typemap-ors                         1.0.0  a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867 \
     typenum                            1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
-    uint                                0.9.5  76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52 \
+    uint                               0.10.0  909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e \
     unicode-ident                      1.0.14  adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83 \
     unicode-segmentation               1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-truncate                    1.1.0  b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf \
@@ -579,8 +590,9 @@ cargo.crates \
     utf16_iter                          1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8_iter                           1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                           0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                               1.11.0  f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a \
+    uuid                               1.12.0  744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4 \
     v_frame                             0.3.8  d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b \
+    valuable                            0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     value-bag                          1.10.0  3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2 \
     version-compare                     0.2.0  852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b \
     version_check                       0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
@@ -588,18 +600,18 @@ cargo.crates \
     walkdir                             2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                                0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi        0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                       0.2.99  a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396 \
-    wasm-bindgen-backend               0.2.99  5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79 \
-    wasm-bindgen-futures               0.4.49  38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2 \
-    wasm-bindgen-macro                 0.2.99  2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe \
-    wasm-bindgen-macro-support         0.2.99  30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2 \
-    wasm-bindgen-shared                0.2.99  943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6 \
+    wasm-bindgen                      0.2.100  1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
+    wasm-bindgen-backend              0.2.100  2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
+    wasm-bindgen-futures               0.4.50  555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61 \
+    wasm-bindgen-macro                0.2.100  7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407 \
+    wasm-bindgen-macro-support        0.2.100  8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de \
+    wasm-bindgen-shared               0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
     wasm-streams                        0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
-    web-sys                            0.3.76  04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc \
+    web-sys                            0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                            1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                       0.26.7  5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e \
     weezl                               0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
-    wide                               0.7.30  58e6db2670d2be78525979e9a5f9c69d296fd7d670549fe9ebf70f8708cb5019 \
+    wide                               0.7.32  41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22 \
     widestring                          1.1.0  7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311 \
     winapi                              0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu          0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -647,17 +659,16 @@ cargo.crates \
     windows_x86_64_msvc                0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
     windows_x86_64_msvc                0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc                0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                             0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
+    winnow                             0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
     winreg                             0.50.0  524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1 \
     write16                             1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                           0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     x25519-dalek                        2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
     x509-parser                        0.16.0  fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69 \
-    xml-rs                             0.8.24  ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432 \
+    xml-rs                             0.8.25  c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4 \
     xmltree                            0.10.3  d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb \
     yamux                              0.12.1  9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776 \
     yamux                              0.13.4  17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4 \
-    yansi                               1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yasna                               0.5.2  e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd \
     yoke                                0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                         0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \


### PR DESCRIPTION
#### Description

rebels-in-the-sky: Update to 1.0.28

##### Tested on

macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
