### PR TITLE
lttoolbox: upgrade to 3.7.6, apertium: upgrade to 3.9.4

### DIFF
--- a/textproc/apertium/Portfile
+++ b/textproc/apertium/Portfile
@@ -1,13 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               legacysupport 1.1
 
-name                    apertium
-version                 3.4.0
-set branch              [join [lrange [split ${version} .] 0 1] .]
+github.setup            apertium apertium 3.9.4 v
+revision                0
 categories              textproc
 license                 GPL-2+
-platforms               darwin
 maintainers             mm.st:unhammer+dill openmaintainer
 
 description             machine translation platform
@@ -25,12 +25,26 @@ long_description        Apertium is a free and open source machine \
                         new language pairs.
 
 homepage                http://apertium.org/
-master_sites            sourceforge:project/${name}/${name}/${branch}
 
-checksums               rmd160  a5bf6c017cfad361b51fa1fb22a1d59f38cba274 \
-                        sha256  2bd7f44b794615ebca1c5d3949b2139b665e2a5af24c40931ea0856e268fc3da
+checksums               rmd160  40325e2567d5d8af92c434f2d11558fdd44e87e6 \
+                        sha256  b78bf0c36e479c58e31ec10ebe30a031bf876d70ada1e61f52e320a1aa87c4dd \
+                        size    754947
 
-depends_build           port:pkgconfig
+compiler.cxx_standard   2017
+configure.cxxflags-append \
+                        -std=c++17 \
+                        -I${prefix}/include/utf8cpp \
+                        -Wno-register
 
-depends_lib             port:gawk port:libxslt \
+# For std::filesystem
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
+
+use_autoreconf          yes
+
+depends_build-append    path:bin/pkg-config:pkgconfig \
+                        port:utfcpp
+
+depends_lib-append      port:gawk port:libxslt \
                         port:lttoolbox port:pcre
+

--- a/textproc/lttoolbox/Portfile
+++ b/textproc/lttoolbox/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 
 PortSystem              1.0
+PortGroup               github 1.0
 
-name                    lttoolbox
-version                 3.5.0
-set branch              [join [lrange [split ${version} .] 0 1] .]
+github.setup            apertium lttoolbox 3.7.6 v
+revision                0
 categories              textproc
 license                 GPL-2+
 maintainers             nomaintainer
@@ -23,17 +23,25 @@ long_description        lttoolbox is a toolbox from the Apertium platform \
                         surface forms and lexical forms).
 
 homepage                http://wiki.apertium.org/wiki/Lttoolbox
-master_sites            sourceforge:project/apertium/lttoolbox/${branch}
 
-checksums               rmd160  4cb9d266657a04cd29a685d236a0b0576c7f9728 \
-                        sha256  cbfc6e38ba995d80114a250f9756bd28708e9b3510bde09fe7f91e0a83bbc623 \
-                        size    483444
+checksums               rmd160  6950ffe612a4667e8f67f28e290aed569fe5e8a1 \
+                        sha256  ab1291608ab56e541698d57a22bc1a64cd6f0b453bc2aee7792540f878bb1d1d \
+                        size    211782
 
-depends_build           path:bin/pkg-config:pkgconfig
+compiler.cxx_standard   2017
+configure.cxxflags-append \
+                        -std=c++17 \
+                        -I${prefix}/include/utf8cpp
 
-depends_lib             port:libxml2
+use_autoreconf          yes
 
-# configure: error: Could not enable at least C++1y (C++14) - upgrade your compiler
-compiler.cxx_standard   2014
+depends_build           port:autoconf \
+                        port:automake \
+                        port:libtool \
+                        path:bin/pkg-config:pkgconfig \
+                        port:utfcpp
+
+depends_lib             port:libxml2 \
+                        port:icu
 
 livecheck.regex         /${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

These ports have not been updated in several years. I am not sure if old and new versions work well together, so I thought it would be best to update them both in the same PR. They are separate ports even though both are part of the Apertium project, so there are two commits. Please let me know if I should squash them.

Both have migrated from SourceForge to GitHub. They now require C++17 (apertium needs LegacySupport for `std::filesystem` on Darwin < 19) and build with autoreconf. I have also updated the dependencies.

For `lttoolbox` I had to add dependencies `autoconf`, `automake` and `libtool` even though I put `use_autoreconf` in the Portfile. That was not necessary for `apertium`, and doing it would even have `port lint` complain about duplicate dependencies. I have no idea why.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Tested _some_ binaries, to check for linker errors. Both ports install quite a few binaries and I do not know how to use all of them.