### PR TITLE
openjdk24-zulu: update to 24.0.67

### DIFF
--- a/java/openjdk24-zulu/Portfile
+++ b/java/openjdk24-zulu/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-24-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.65
+version      ${feature}.0.67
 revision     0
 
 set openjdk_version ${feature}.0.0
@@ -29,18 +29,18 @@ long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant 
 master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.28-macosx_x64
-    checksums    rmd160  72dc494d9e9be7e816f150dc09ad8492c32396cf \
-                 sha256  c003299668b2c17e8fb4164e7e7842741b89e1983feacea190687f4aa2f593d3 \
-                 size    224891858
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.29-macosx_x64
+    checksums    rmd160  9ccefde9bfb6c1287897d7926af77bc7c7ddbc16 \
+                 sha256  29287d87b196b538e02de49b2ade68be1bbc596f80f53de1dc198c3cf5b17e28 \
+                 size    224895264
 } elseif {${configure.build_arch} eq "arm64"} {
     # No .tar.gz (yet?) for arm64
     use_zip yes
 
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.28-macosx_aarch64
-    checksums    rmd160  3b9a56546f2d393d7cccb9212348449cce304442 \
-                 sha256  44480e9b75eefb0f4bb85729aedd3fc172c409fda0350f6666a2c9ec609745a3 \
-                 size    225946144
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.29-macosx_aarch64
+    checksums    rmd160  caca2b7448206cd903feeab8f64a4ca573076af3 \
+                 sha256  67f1c307548fd58f9c250815c34332faa044690766c20da8f9de53f56bb193ca \
+                 size    225948005
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 24.0.67.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?