### PR TITLE
crossbinutils: Add compiler blacklist

### DIFF
--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -192,7 +192,7 @@ proc crossbinutils.setup {target version} {
 
     # fatal error: error in backend: Cannot select: intrinsic %llvm.x86.sha1rnds4
     # https://github.com/macports/macports-ports/pull/27345#issuecomment-2601373548
-    if {[vercmp ${xcodeversion} > "2.41"]} {
+    if {[vercmp ${version} >= "2.41"]} {
         compiler.blacklist-append {clang < 1001}
     }
 

--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -113,6 +113,7 @@ proc crossbinutils.setup {target version} {
 
     crossbinutils.target ${target}
 
+    PortGroup           compiler_blacklist_versions 1.0
     default name        ${target}-binutils
     version             ${version}
     default categories  {cross devel}
@@ -187,6 +188,12 @@ proc crossbinutils.setup {target version} {
     # Opportunistic links zstd for compression
     if {[vercmp ${version} >= "2.40"]} {
         depends_lib-append  port:zstd
+    }
+
+    # fatal error: error in backend: Cannot select: intrinsic %llvm.x86.sha1rnds4
+    # https://github.com/macports/macports-ports/pull/27345#issuecomment-2601373548
+    if {[vercmp ${xcodeversion} > "2.41"]} {
+        compiler.blacklist-append {clang < 1001}
     }
 
     build.dir ${workpath}/build


### PR DESCRIPTION
Needed to build binutils versions greater than 2.41

From feedback from @kencu in https://github.com/macports/macports-ports/pull/27345#issuecomment-2601373548

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
