### PR TITLE
qdmr: Update to 1.12.1

### DIFF
--- a/science/qdmr/Portfile
+++ b/science/qdmr/Portfile
@@ -8,7 +8,7 @@ PortGroup           qt5 1.0
 
 name                qdmr
 maintainers         @hmatuschek {ra1nb0w @ra1nb0w} openmaintainer
-version             0.11.3
+version             0.12.1
 revision            1
 
 categories          science
@@ -26,9 +26,9 @@ homepage            https://dm3mat.darc.de/qdmr/
 
 github.setup        hmatuschek qdmr ${version} v
 
-checksums           rmd160  a7c7cd08e9e098798f684aa9ff0826fce2a1e3d9 \
-                    sha256  c1e6549c8074984f5437670cbb42e4734444b8308960155a7e726776108cccc3 \
-                    size    6579311
+checksums           rmd160  b7c20e8a017907d09708fc76e0f185158f0e4f2c \
+                    sha256  3f90d618a98d1a641b663804ddea1a7fa5f8fd45383b10c9321020eb16528309 \
+                    size    6958534
 
 qt5.depends_build_component \
     qttools


### PR DESCRIPTION
#### Description

* Update qDMR to version 1.12.1
* Reworked CTCSS/DCS settings.
* Reworked repeater database sources.
* Updated OpenGD77 support to R20240908.
* Bugfixes and updates

This release add support for the latest stable OpenGD77 firmware allowing macOS users the 
ability to program their OpenGD77 radios without requiring a windows box.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? -vs works, -t fails on arm64 so not tested.
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
