### PR TITLE
reflex: update to 2.5.4-20241231

### DIFF
--- a/devel/reflex/Portfile
+++ b/devel/reflex/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                reflex
-version             2.5.4-20240906
+version             2.5.4-20241231
 revision            0
-checksums           rmd160  a53f3181d1b4a874e960e0b9688999d056e5aa4a \
-                    sha256  4e69f0e358da742e72de3996bbfc0f3ed2d438a5c16ee52e24667b07b566222e \
-                    size    483570
+checksums           rmd160  f42549480efa16b8f8009293c6991984a6505718 \
+                    sha256  06a8c57fb666d74c8450e6aa2e471835a0ca2995b3621fb64f9cc4ce9daad6b6 \
+                    size    483545
 
 set version_date    [lindex [split ${version} -] 1]
 categories          devel


### PR DESCRIPTION
#### Description

Update "reflex" to current version, for compiler-warning fixes.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.7.2 23H311 x86_64
Xcode 16.2 16C5032a

also macOS 15.2 24C101 x86_64
(same Xcode)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
