### PR TITLE
py-pymc: correct checksums

### DIFF
--- a/python/py-pymc/Portfile
+++ b/python/py-pymc/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        pymc-devs pymc 5.17.0 v
+github.setup        pymc-devs pymc 5.20.0 v
 github.tarball_from archive
-revision            0
+revision            1
 name                py-pymc
 
 supported_archs     noarch
@@ -22,14 +22,17 @@ long_description    PyMC (formerly PyMC3) is a Python package for Bayesian \
                     Its flexibility and extensibility make it applicable to a \
                     large suite of problems.
 
-checksums           rmd160  8c93e58c44ce57f079f20e9bf1db36f989bb39cd \
-                    sha256  bb46b1f472c906181f5467cc418aae0901cdbce0877b0f4458ed3b265bfd891b \
-                    size    6856876
+checksums           rmd160  81369ff917bf2c24bf492c59ccbdbc7e2a1f45cb \
+                    sha256  521fe94a5cc1f56b21e1df0070c3c49d1284c1fae0682caf7e2eccb3531be4e8 \
+                    size    6874226
 
-python.versions     39 310 311 312
+python.versions     310 311 312
 
 if {${name} ne ${subport}} {
     conflicts   py${python.version}-pymc3
+
+    depends_build-append \
+                    port:py${python.version}-versioneer
 
     depends_lib-append \
                     port:py${python.version}-arviz \
@@ -41,6 +44,11 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-pytensor \
                     port:py${python.version}-scipy \
                     port:py${python.version}-typing_extensions
+
+    if {${python.version} < 311} {
+        depends_lib-append \
+                    port:py${python.version}-tomli
+    }
 }
 
 github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

Correcting the checksums in Portfile for `py-pymc`.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
