### PR TITLE
py-pymc: correct checksums

### DIFF
--- a/python/py-pymc/Portfile
+++ b/python/py-pymc/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        pymc-devs pymc 5.20.0 v
 github.tarball_from archive
-revision            0
+revision            1
 name                py-pymc
 
 supported_archs     noarch
@@ -22,9 +22,9 @@ long_description    PyMC (formerly PyMC3) is a Python package for Bayesian \
                     Its flexibility and extensibility make it applicable to a \
                     large suite of problems.
 
-checksums           rmd160  b55e25bfeeca7f06dd2cbc18d1f023f7ee6b2627 \
-                    sha256  d9ac1dec75b1e641d80699d97b3092b9ff7c91507264faa92c1f28fae5b2f7b0 \
-                    size    6874233
+checksums           rmd160  81369ff917bf2c24bf492c59ccbdbc7e2a1f45cb \
+                    sha256  521fe94a5cc1f56b21e1df0070c3c49d1284c1fae0682caf7e2eccb3531be4e8 \
+                    size    6874226
 
 python.versions     310 311 312
 


### PR DESCRIPTION
#### Description

Correcting the checksums in the Porfile for `py-pymc`.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
