### PR TITLE
legcord: update to 1.0.7

### DIFF
--- a/net/Legcord/Portfile
+++ b/net/Legcord/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Legcord Legcord 1.0.6 v
+github.setup        Legcord Legcord 1.0.7 v
 github.tarball_from archive
 
 categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  9e8ea1cd293f26ab446d858b046f7f961d2bb412 \
-                    sha256  765238e63153268e1d5e14681fbb875abaf83c81aaf174beae8193411b09a540 \
-                    size    1601820
+checksums           rmd160  c57e2a9573c5ffd4dd6cee324e0b351dc308bc27 \
+                    sha256  024f2fb23d77902ac77befa771c6ecfe414c1d2841fe85e8edceb626536e22ab \
+                    size    1601902
 
 description         lightweight alternative to the regular Discord application
 long_description    ${name} is a {*}${description}. It wraps the Discord web \


### PR DESCRIPTION
#### Description

legcord: update to 1.0.7

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
