### PR TITLE
ollama: new port

### DIFF
--- a/llm/ollama/Portfile
+++ b/llm/ollama/Portfile
@@ -1,0 +1,395 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/ollama/ollama v0.5.7
+revision            0
+
+categories          llm
+license             MIT
+maintainers         {mascguy @mascguy} openmaintainer
+
+description         Get up and running with large language models
+long_description    ${description}
+homepage            https://ollama.com
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  0ec96bdce153249d295ac862c9dd0c4aaf31d6fc \
+                        sha256  d74ecd0181f9eb415a2f6bc4f4f963b5693e5fbee46839c25e33836a5abdada4 \
+                        size    2345156
+
+go.vendors          gorgonia.org/vecf64 \
+                        repo    github.com/gorgonia/vecf64 \
+                        lock    v0.9.0 \
+                        rmd160  f030f4d8bfe25a4ac8203e9eafa6b1a3169cc979 \
+                        sha256  7c0d58505ad3a7a54315ea14fd3b875286b7a642c203cd445139d57a6788f60e \
+                        size    16180 \
+                    gorgonia.org/vecf32 \
+                        repo    github.com/gorgonia/vecf32 \
+                        lock    v0.9.0 \
+                        rmd160  d70b296f4a1341b89b2b3f3cc5ec0e17ba0f889f \
+                        sha256  27f94694c15021ace4d7e6eed35fb6d42b79edbee77d720f318a7c913d8509fd \
+                        size    14550 \
+                    gopkg.in/yaml.v3 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
+                    gopkg.in/check.v1 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
+                    google.golang.org/protobuf \
+                        repo    github.com/protocolbuffers/protobuf-go \
+                        lock    v1.34.1 \
+                        rmd160  6939f6e0dddf72b2cc221dedf346352713bf4e78 \
+                        sha256  a2b35ea4a7e6e9ad71819d821adbfd099a62bad78979c9d8f1711604e9d11ac5 \
+                        size    1508300 \
+                    gonum.org/v1/gonum \
+                        repo    github.com/gonum/gonum \
+                        lock    v0.15.0 \
+                        rmd160  1422e5129750c2b6c8036bcd3c8baa72c50d6e2a \
+                        sha256  71a2ab81246597897b0720fb48f0da7b421bc1f4589cb12fcee7115f8869c466 \
+                        size    3476849 \
+                    golang.org/x/xerrors \
+                        lock    5ec99f83aff1 \
+                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
+                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
+                        size    13667 \
+                    golang.org/x/text \
+                        lock    v0.21.0 \
+                        rmd160  0a0d95c777a2df3108c79f5a23de3c226ad84d06 \
+                        sha256  de16b0463799b320acfa2707e154091015d4b25dbaae866a8fc9bf2f72d67b5c \
+                        size    8976785 \
+                    golang.org/x/term \
+                        lock    v0.27.0 \
+                        rmd160  f060955e0b7cc9dc5e1018982660cc2743a2141d \
+                        sha256  acb423ae00c889d7aa6b91be449ddf53e5e5026c9542fe3a1f0b1bb351b64e94 \
+                        size    14696 \
+                    golang.org/x/sys \
+                        lock    v0.28.0 \
+                        rmd160  6afc12ada3ca9173b9f8ba2c66caf3dbf0ac7929 \
+                        sha256  aa8ba4cd13aa5d7f839d604e002d2c994e6dfc09c3746f532bf69fc64617869c \
+                        size    1520294 \
+                    golang.org/x/sync \
+                        lock    v0.10.0 \
+                        rmd160  3cdb4e0e41894bd4f102154d7e193423451c64c6 \
+                        sha256  0318693e1204134ef8d4110f1fd961fd0273ff4d59874c542d8b4739236bebfe \
+                        size    18107 \
+                    golang.org/x/net \
+                        lock    v0.25.0 \
+                        rmd160  f9afa0b277fff8cc6458e54cf907bc3a8f623cb8 \
+                        sha256  4cc00833236ee934170624089cb8a7964dc120d897fdecdda2a28bb273030c94 \
+                        size    1510776 \
+                    golang.org/x/image \
+                        lock    v0.22.0 \
+                        rmd160  809e95f8f276a61dab2d46ade4700ed482eac804 \
+                        sha256  324fb9c12d61f047daa6d93d358fd22d169604a0136aa025e5672aec1624dc56 \
+                        size    5104190 \
+                    golang.org/x/exp \
+                        lock    9a3e6036ecaa \
+                        rmd160  d550becf8d5e2fee3164793c7c9cc30a54d6444c \
+                        sha256  869d27c4289deefb75d9483ca2fca84dd4dca1aa9ba36c0e9c0c6a3b6bb7fd20 \
+                        size    1635127 \
+                    golang.org/x/crypto \
+                        lock    v0.31.0 \
+                        rmd160  ccd79163c4c288444622b7e39560353ba8caef9a \
+                        sha256  8c60e95193c8a72264fef36dc5f6a23e69c9a5948680829fcfbe9d28030f9dca \
+                        size    1837747 \
+                    golang.org/x/arch \
+                        lock    v0.8.0 \
+                        rmd160  4930074a78d25f7a1bb2f72af69f9b34fa791165 \
+                        sha256  93709c0085365270425a1f2b8ac15dffa7d78a37cf34ed13b32c3dd71a0439fe \
+                        size    845830 \
+                    go4.org/unsafe/assume-no-moving-gc \
+                        repo    github.com/go4org/unsafe-assume-no-moving-gc \
+                        lock    b99613f794b6 \
+                        rmd160  a6f9d5d1380c4b53cb718f089559251fecea0565 \
+                        sha256  1330702a46588d740e2925c8a9a738b6e5694ce8a015d5117136fde9e6a4161b \
+                        size    2622 \
+                    github.com/xtgo/set \
+                        lock    v1.0.0 \
+                        rmd160  8844d180700acf1c2bb18c5f339f2960711cee87 \
+                        sha256  ac51dc4cb9226e280aad6083e3bee762229fe090e61e593586d4784dede1942b \
+                        size    10194 \
+                    github.com/x448/float16 \
+                        lock    v0.8.4 \
+                        rmd160  21b735f1bde517216d8a47db4bd7ee450136c230 \
+                        sha256  16f51a49934264475113239764c6cfe83c7ecac550f2bd968b6e0e8c10d4c3e2 \
+                        size    13102 \
+                    github.com/ugorji/go/codec \
+                        lock    v1.2.12 \
+                        rmd160  f5e864c68da81f85d10746782430c0d4388470ff \
+                        sha256  fa6a504126f9ade7493bbd8313913cdd1dee6632b1d48f1492b37ba6a322b5e7 \
+                        size    366444 \
+                    github.com/twitchyliquid64/golang-asm \
+                        lock    v0.15.1 \
+                        rmd160  a6863c548a5ebf8ac605e2ee418e00393d5d7b03 \
+                        sha256  60196146f7d46cd3fd0059aa236ebbf498fb3557856204773899fcf5b7cd3a52 \
+                        size    423238 \
+                    github.com/stretchr/testify \
+                        lock    v1.9.0 \
+                        rmd160  59147e117812fdf8270ec79e46a229c472caf08d \
+                        sha256  e6fa4f530cad5bac94bf08af05ddd1f569aeac8db4017ab4330ab7fe2802a6a3 \
+                        size    108716 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/cobra \
+                        lock    v1.7.0 \
+                        rmd160  2d0592a4c5aca1ba5daa45cd1d4e662adadd0703 \
+                        sha256  913afd358ab699baf7773e7a5661c9f6436c6f825da2a1d61623e69d2c0b4b2d \
+                        size    187188 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.8.0 \
+                        rmd160  22e8b4dadfbeefb32fd38f3ebab26c94d4b165c5 \
+                        sha256  c7ab367e516959a51525f8152a62df0acc9a32ca153a502da967f072ae69d899 \
+                        size    129032 \
+                    github.com/rivo/uniseg \
+                        lock    v0.2.0 \
+                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
+                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
+                        size    44037 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/pierrec/lz4 \
+                        lock    v4.1.8 \
+                        rmd160  2f315428beae0b94be01d59e7b81bd24dff1c5d5 \
+                        sha256  b029fadc297a94890f7b88bfd73c8fdb0acc73b7b64404c6decedb10cea78b8b \
+                        size    40904253 \
+                    github.com/pelletier/go-toml \
+                        lock    v2.2.2 \
+                        rmd160  e5dae680f17a37b0675f8a71e873cac68f0f0262 \
+                        sha256  ad3959ec620bf7d2aac6a3f407bf4e54bc921798ecd114b720678bf98d3ff4b5 \
+                        size    909095 \
+                    github.com/pdevine/tensor \
+                        lock    f88f4562727c \
+                        rmd160  c3f727129c4ff63ebb3bfbac17610c0aecedfbe7 \
+                        sha256  02ffab0db4fa4cb7a850a3ca1b280d6d22367264acdca56f6015e687d2bd6479 \
+                        size    381014 \
+                    github.com/olekukonko/tablewriter \
+                        lock    v0.0.5 \
+                        rmd160  aa952a560c3aa5102bfb3e55f12facf048379adf \
+                        sha256  830bdee7f05aa76353c113075a864359762a502c6d6a1f72bfb7055247c0539b \
+                        size    19579 \
+                    github.com/nlpodyssey/gopickle \
+                        lock    v0.3.0 \
+                        rmd160  8b629fb6ba4e89a611bc557f27eac8576ac3d1bc \
+                        sha256  0c3361169d8e0b9fa61e275a031954dc58e3b5cde170c3ff9e3d9245d087722d \
+                        size    35716 \
+                    github.com/modern-go/reflect2 \
+                        lock    v1.0.2 \
+                        rmd160  02f0f5d652cd9d03a27876e11610edb31ed7c8b5 \
+                        sha256  6394630fb95f41f31a329473d221cecda03753fec7ebfca41e4eb70e32a58b89 \
+                        size    14049 \
+                    github.com/modern-go/concurrent \
+                        lock    bacd9c7ef1dd \
+                        rmd160  b039328d6fd40b97513dea8bf5b00adfdd53f14b \
+                        sha256  2f3333805bef60544e64ac9a734522205b513f5c461ba19f3d557510bb205afb \
+                        size    7533 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.14 \
+                        rmd160  7186117475d80aff012960b61daefd53c7efeca6 \
+                        sha256  71e68e76e460aff1af8b58453a5a7b2278c42f6659c8c7b4321907bdf14ee6eb \
+                        size    18269 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.20 \
+                        rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
+                        sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
+                        size    4717 \
+                    github.com/leodido/go-urn \
+                        lock    v1.4.0 \
+                        rmd160  ceb452492eb72d1cc179f3ea4e068e74ca22be3c \
+                        sha256  8002ffa13ae89de5bc4c53b87e23fef9c75d1f09af1ae330022464bcbfef1c8a \
+                        size    1998706 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kr/pretty \
+                        lock    v0.3.0 \
+                        rmd160  0895c899b9d88b87beccda0a9b4c5c7057e858f0 \
+                        sha256  88d8d187ffa4faf0362b48c3d327ad440c7e5fb179ea3247e69269cab128a6b9 \
+                        size    10043 \
+                    github.com/klauspost/cpuid \
+                        lock    v2.2.7 \
+                        rmd160  cb4530770791c560999696eb8f2b2f0b1391949a \
+                        sha256  fab942e51410399b098fba70d4a8b2eeccdbbafadb4b7b8ef94d667a4054d420 \
+                        size    457415 \
+                    github.com/klauspost/compress \
+                        lock    v1.13.1 \
+                        rmd160  cad64f9160d15063f4181bcdd3a9a36d4bf506b6 \
+                        sha256  14e84d2b6143576da9da6076c85d0195216a946f7875679169553511c677f174 \
+                        size    15412744 \
+                    github.com/json-iterator/go \
+                        lock    v1.1.12 \
+                        rmd160  7b530ae077fa1fa5db7b7e228e92dd39c79c4a4d \
+                        sha256  e0ec0450ef7ecedf0dfc1b5c430324fd0e8aedc18bddd0bd730e5a6cb35c41a8 \
+                        size    84301 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.1.0 \
+                        rmd160  88f9577df93ac0f8801d8960adc7f28e38867f3e \
+                        sha256  f69af10ff08c0e87f92dac3ee5172d8ed02463725b74edfc8943ef018a1a632d \
+                        size    5343 \
+                    github.com/google/uuid \
+                        lock    v1.6.0 \
+                        rmd160  3d4f6f95018c6313f7258805845eb2a7e717850c \
+                        sha256  72700459e75cad2b36586e8a13aa12c2d6248c45db24d1eebf41e18b1ec1c811 \
+                        size    20895 \
+                    github.com/google/go-cmp \
+                        lock    v0.6.0 \
+                        rmd160  2c9f5dab93f8a0895591466fe4a07c5dd9166ae2 \
+                        sha256  0d550825fae514f8a947ab7e42fcb874f509d9cbfa3ad2711d7570a25f31571a \
+                        size    104795 \
+                    github.com/google/flatbuffers \
+                        lock    v24.3.25 \
+                        rmd160  f6da954c921ba69bc36d8d86f2bacf5833aecf05 \
+                        sha256  4079a437c14029a86149e18301feb19cd1b40f20768f86d7e85d5e9ec9ccaa4c \
+                        size    2297977 \
+                    github.com/golang/snappy \
+                        lock    v0.0.3 \
+                        rmd160  171e3de70a1e477829c27cf67e87d29ee461e043 \
+                        sha256  5d2b36b275164254106f20d2843ff65a4e3fccca5aaf0f9a50aa875b59add4f3 \
+                        size    65996 \
+                    github.com/golang/protobuf \
+                        lock    v1.5.4 \
+                        rmd160  d69db706fd894bafba23bda9df27167c6ff37e83 \
+                        sha256  25e849ffcfef59114f3a6247d4d4c386449a3d5a347b25d4b5ada1f1a2bf5e5d \
+                        size    173020 \
+                    github.com/gogo/protobuf \
+                        lock    v1.3.2 \
+                        rmd160  c16e6e6fb8f26d3d1ceef9e99fa4dfb5899878fd \
+                        sha256  d24f8e0b99dbc6ffaa0731490bf80d3ab4cb0b332bcf4b57e3fd830c60e0960b \
+                        size    2040306 \
+                    github.com/goccy/go-json \
+                        lock    v0.10.2 \
+                        rmd160  4d0deafc49dd3f41ef30214af9654756977d2f3f \
+                        sha256  ded690d40fdfb129a3f8f1e029ecccb4c9622ac9befaf3a336d82dedd456218a \
+                        size    397454 \
+                    github.com/go-playground/validator \
+                        lock    v10.20.0 \
+                        rmd160  6bebcad0e1a43739b57cfe7c49776eb2d3829f37 \
+                        sha256  cf6527df911921d6cec0131fdf847426a4676230ebdb5a0fa2d2e7d4abbf3f97 \
+                        size    254065 \
+                    github.com/go-playground/universal-translator \
+                        lock    v0.18.1 \
+                        rmd160  db17dd09961812609699c2c30016db647c4e18b6 \
+                        sha256  4613483514bc2df0f103c7ddbb32341fcf4335874063e967001ed150d1b05325 \
+                        size    37150 \
+                    github.com/go-playground/locales \
+                        lock    v0.14.1 \
+                        rmd160  762675a94ea6b0bb97d607041d41f9907e961a9e \
+                        sha256  ea9d52236f0db72988de8dccc7cdba8162e7e27ba52d455a2c819d11ddef5a0b \
+                        size    4365413 \
+                    github.com/go-playground/assert \
+                        lock    v2.2.0 \
+                        rmd160  70d1eaf8695e149d6939fe76d9339f759bfef1b9 \
+                        sha256  b71f6cdc47a13b84a9480491077fcddb6309c1cd64a446fb856cff623d31f392 \
+                        size    4206 \
+                    github.com/gin-gonic/gin \
+                        lock    v1.10.0 \
+                        rmd160  4c68a9c4bbc1ff380817946d01683e8a9ae75438 \
+                        sha256  5486e4c8e70dcbf140784aee9458d61504abc5cdb8f3f0fc3dcc4ff6f452d115 \
+                        size    169238 \
+                    github.com/gin-contrib/sse \
+                        lock    v0.1.0 \
+                        rmd160  13fcc4b8d3f6bb01e0c281a8e1abea601e9af809 \
+                        sha256  f021daeb55664e0eb4013e89f95bbcd235c34d39521a32a60d74b906527a5f41 \
+                        size    6121 \
+                    github.com/gin-contrib/cors \
+                        lock    v1.7.2 \
+                        rmd160  c763319fed791dc81946f1d01553fee4af9541b5 \
+                        sha256  5acd5b9e5180dc87a2dd11ca0ea4fcb3e7911baa9ebdcb5312215502dce6f3a7 \
+                        size    15574 \
+                    github.com/gabriel-vasile/mimetype \
+                        lock    v1.4.3 \
+                        rmd160  7cc45a302c1d936bcaf3cc0343e72206dd59c0b4 \
+                        sha256  a64578fd8d2a03e1ef76f8aabcf390baefbf1283815d8a5165e3f71b3889ad73 \
+                        size    24986313 \
+                    github.com/emirpasic/gods \
+                        lock    v2.0.0-alpha \
+                        rmd160  c7f85e54356e7fb99cd44cfdc641b508fc57fd53 \
+                        sha256  e331e7121d70d969c3def99808ab9c74f0b23378e1dbf625fd2bdd0da94e88a8 \
+                        size    101251 \
+                    github.com/dgryski/trifles \
+                        lock    dd97f9abfb48 \
+                        rmd160  a789b9c27b3aad1962a5ef67b93fdcada0a21433 \
+                        sha256  f8f4a13927c260acb33d2bd0ec8757959c10ef851797143e2217a1a3bfa6d1bd \
+                        size    169343 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/d4l3k/go-bfloat16 \
+                        lock    690c3bdd05f1 \
+                        rmd160  0f18eb2f5753d05eb3fbd43a102b1414b35ba816 \
+                        sha256  d07aaeb36167255e74946ea2e5a1231efeae06d4d088500ad961dac8f89c3209 \
+                        size    1962 \
+                    github.com/containerd/console \
+                        lock    v1.0.3 \
+                        rmd160  0ddcc08a0582fd25a653a0a6a599c0f9eed7538e \
+                        sha256  a032c6f2eecefbeb998ef96bb92f65423552f8e0ac7c410ec0f8c5829af704ea \
+                        size    13726 \
+                    github.com/cloudwego/iasm \
+                        lock    v0.2.0 \
+                        rmd160  4bdf7f764755573f95fff7b359409c1f3d79a713 \
+                        sha256  7bc57cef66b0978000d554ac768731e5f11e50d3837583d9e3bbc8398c1ffd17 \
+                        size    270662 \
+                    github.com/cloudwego/base64x \
+                        lock    v0.1.4 \
+                        rmd160  0a702019b267f03ef70a95401773ca55ec6e4479 \
+                        sha256  5112ae6c21e58f3f6ec86a46bbd8aa21ed24dc80e3d724a12ceb6a6b2cd41f79 \
+                        size    72330 \
+                    github.com/chewxy/math32 \
+                        lock    v1.11.0 \
+                        rmd160  f329226d21c28282acb4f1055e09576b2e2d470a \
+                        sha256  cfd4fd3eca07fd520ce7f515437250ced700770df1de962e9ca0d87b862b0f77 \
+                        size    43908 \
+                    github.com/chewxy/hm \
+                        lock    v1.0.0 \
+                        rmd160  83286096b21eaddd96fd5b82a9b27f89e61bd35d \
+                        sha256  7eb91d1b47c02c9889d69292df9af2dc97cd442492ec1c9d72f0c1ff7d01e7bd \
+                        size    19586 \
+                    github.com/bytedance/sonic/loader \
+                        lock    v0.1.1 \
+                        rmd160  0 \
+                        sha256  0 \
+                        size    0 \
+                    github.com/bytedance/sonic \
+                        lock    v1.11.6 \
+                        rmd160  79df107e0ed7e1271d147aa9fcec960d1ec47b16 \
+                        sha256  40f3c77579f5412ae6ee26bad24598efa574f84aed372943b47300d5d48f5367 \
+                        size    3094969 \
+                    github.com/arbovm/levenshtein \
+                        lock    48b4e1c0c4d0 \
+                        rmd160  e120f24c9eb4a1ceb6cced3794f9d1fa24599657 \
+                        sha256  62efbacf1d742da8e0becfadf239d93855c51a913b4f3e846a941be4036d6087 \
+                        size    2251 \
+                    github.com/apache/arrow/go/arrow \
+                        lock    bc219186db40 \
+                        rmd160  c15048327d09bb781da1549c4c915e85c950a726 \
+                        sha256  0f034cd6d9dc5d7a78062ccbe5de036aec5db615cf724a6faabaa0f014295c2e \
+                        size    9017987 \
+                    github.com/agnivade/levenshtein \
+                        lock    v1.1.1 \
+                        rmd160  77d8e394bff0702503542fbd168fe66d43879306 \
+                        sha256  b25af8fd56c9831755f479670f1c020f98a6b5c1847b1f6c6b13132e7fcb3405 \
+                        size    1807023
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
### Description

Draft port, for discussion with our Go experts: This was generated by `go2port`, with only modifications to categories, license, maintainer, etc. However, several of the requested packages are invalid:

```
$ port lint --nitpick ollama
--->  Verifying Portfile for ollama
Error: bytedance-sonic-loader-v0.1.1.tar.gz - checksum type rmd160, but checksum is invalid: 0
Error: bytedance-sonic-loader-v0.1.1.tar.gz - checksum type sha256, but checksum is invalid: 0
Warning: bytedance-sonic-loader-v0.1.1.tar.gz - missing recommended checksum type: rmd160
Warning: bytedance-sonic-loader-v0.1.1.tar.gz - missing recommended checksum type: sha256
Warning: bytedance-sonic-loader-v0.1.1.tar.gz - checksum type is insecure on its own: size
--->  2 errors and 3 warnings found.
```

Then there are other issues, such as incorrect/invalid artifacts:

<details>
<summary>Artifact Fetch Errors - Click to Expand</summary>

```
--->  Attempting to fetch apache-arrow-go-bc219186db40.tar.gz from http://bos.us.distfiles.macports.org/go
--->  Attempting to fetch apache-arrow-go-bc219186db40.tar.gz from https://mirrors.mit.edu/macports/distfiles/go

[...17 attempts later...]

--->  Attempting to fetch apache-arrow-go-bc219186db40.tar.gz from https://mirror.sjtu.edu.cn/macports/distfiles/go
--->  Attempting to fetch apache-arrow-go-bc219186db40.tar.gz from http://atl.us.distfiles.macports.org/go

Error: Failed to fetch ollama: The requested URL returned error: 404 Not Found
Error: See /opt/local/var/macports/logs/_opt_macports_sources_ports_latest_llm_ollama/ollama/main.log for details.
```

</details>

`go2port` was run with debug enabled, and the pre-port output follows below. As expected, there is a warning related to `bytedance-sonic-loader`. But the troublesome `apache-arrow-go`, above, appears fine.

Can you Go gurus help?

<details>
<summary>`cargo2port` Debug Output - Click to Expand</summary>

```
$ go2port --debug get github.com/ollama/ollama v0.5.7

Generating portfile for github.com/ollama/ollama (v0.5.7)
Looking for go.sum at https://raw.githubusercontent.com/ollama/ollama/v0.5.7///go.sum
Found dependency: github.com/agnivade/levenshtein (v1.1.1)
Found dependency: github.com/apache/arrow/go/arrow (bc219186db40)
Found dependency: github.com/arbovm/levenshtein (48b4e1c0c4d0)
Found dependency: github.com/bytedance/sonic (v1.11.6)
Found dependency: github.com/bytedance/sonic/loader (v0.1.1)
Found dependency: github.com/chewxy/hm (v1.0.0)
Found dependency: github.com/chewxy/math32 (v1.11.0)
Found dependency: github.com/cloudwego/base64x (v0.1.4)
Found dependency: github.com/cloudwego/iasm (v0.2.0)
Found dependency: github.com/containerd/console (v1.0.3)
Found dependency: github.com/d4l3k/go-bfloat16 (690c3bdd05f1)
Found dependency: github.com/davecgh/go-spew (v1.1.1)
Found dependency: github.com/dgryski/trifles (dd97f9abfb48)
Found dependency: github.com/emirpasic/gods (v2.0.0-alpha)
Found dependency: github.com/gabriel-vasile/mimetype (v1.4.3)
Found dependency: github.com/gin-contrib/cors (v1.7.2)
Found dependency: github.com/gin-contrib/sse (v0.1.0)
Found dependency: github.com/gin-gonic/gin (v1.10.0)
Found dependency: github.com/go-playground/assert (v2.2.0)
Found dependency: github.com/go-playground/locales (v0.14.1)
Found dependency: github.com/go-playground/universal-translator (v0.18.1)
Found dependency: github.com/go-playground/validator (v10.20.0)
Found dependency: github.com/goccy/go-json (v0.10.2)
Found dependency: github.com/gogo/protobuf (v1.3.2)
Found dependency: github.com/golang/protobuf (v1.5.4)
Found dependency: github.com/golang/snappy (v0.0.3)
Found dependency: github.com/google/flatbuffers (v24.3.25)
Found dependency: github.com/google/go-cmp (v0.6.0)
Found dependency: github.com/google/uuid (v1.6.0)
Found dependency: github.com/inconshreveable/mousetrap (v1.1.0)
Found dependency: github.com/json-iterator/go (v1.1.12)
Found dependency: github.com/klauspost/compress (v1.13.1)
Found dependency: github.com/klauspost/cpuid (v2.2.7)
Found dependency: github.com/kr/pretty (v0.3.0)
Found dependency: github.com/kr/text (v0.2.0)
Found dependency: github.com/leodido/go-urn (v1.4.0)
Found dependency: github.com/mattn/go-isatty (v0.0.20)
Found dependency: github.com/mattn/go-runewidth (v0.0.14)
Found dependency: github.com/modern-go/concurrent (bacd9c7ef1dd)
Found dependency: github.com/modern-go/reflect2 (v1.0.2)
Found dependency: github.com/nlpodyssey/gopickle (v0.3.0)
Found dependency: github.com/olekukonko/tablewriter (v0.0.5)
Found dependency: github.com/pdevine/tensor (f88f4562727c)
Found dependency: github.com/pelletier/go-toml (v2.2.2)
Found dependency: github.com/pierrec/lz4 (v4.1.8)
Found dependency: github.com/pkg/errors (v0.9.1)
Found dependency: github.com/pmezard/go-difflib (v1.0.0)
Found dependency: github.com/rivo/uniseg (v0.2.0)
Found dependency: github.com/rogpeppe/go-internal (v1.8.0)
Found dependency: github.com/spf13/cobra (v1.7.0)
Found dependency: github.com/spf13/pflag (v1.0.5)
Found dependency: github.com/stretchr/testify (v1.9.0)
Found dependency: github.com/twitchyliquid64/golang-asm (v0.15.1)
Found dependency: github.com/ugorji/go/codec (v1.2.12)
Found dependency: github.com/x448/float16 (v0.8.4)
Found dependency: github.com/xtgo/set (v1.0.0)
Found dependency: go4.org/unsafe/assume-no-moving-gc (b99613f794b6)
Found dependency: golang.org/x/arch (v0.8.0)
Found dependency: golang.org/x/crypto (v0.31.0)
Found dependency: golang.org/x/exp (9a3e6036ecaa)
Found dependency: golang.org/x/image (v0.22.0)
Found dependency: golang.org/x/net (v0.25.0)
Found dependency: golang.org/x/sync (v0.10.0)
Found dependency: golang.org/x/sys (v0.28.0)
Found dependency: golang.org/x/term (v0.27.0)
Found dependency: golang.org/x/text (v0.21.0)
Found dependency: golang.org/x/xerrors (5ec99f83aff1)
Found dependency: gonum.org/v1/gonum (v0.15.0)
Found dependency: google.golang.org/protobuf (v1.34.1)
Found dependency: gopkg.in/check.v1 (10cb98267c6c)
Found dependency: gopkg.in/yaml.v3 (v3.0.1)
Found dependency: gorgonia.org/vecf32 (v0.9.0)
Found dependency: gorgonia.org/vecf64 (v0.9.0)
Using dependency: gorgonia.org/vecf64 (v0.9.0)
Using dependency: gorgonia.org/vecf32 (v0.9.0)
Using dependency: gopkg.in/yaml.v3 (v3.0.1)
Using dependency: gopkg.in/check.v1 (10cb98267c6c)
Using dependency: google.golang.org/protobuf (v1.34.1)
Using dependency: gonum.org/v1/gonum (v0.15.0)
Using dependency: golang.org/x/xerrors (5ec99f83aff1)
Using dependency: golang.org/x/text (v0.21.0)
Using dependency: golang.org/x/term (v0.27.0)
Using dependency: golang.org/x/sys (v0.28.0)
Using dependency: golang.org/x/sync (v0.10.0)
Using dependency: golang.org/x/net (v0.25.0)
Using dependency: golang.org/x/image (v0.22.0)
Using dependency: golang.org/x/exp (9a3e6036ecaa)
Using dependency: golang.org/x/crypto (v0.31.0)
Using dependency: golang.org/x/arch (v0.8.0)
Using dependency: go4.org/unsafe/assume-no-moving-gc (b99613f794b6)
Using dependency: github.com/xtgo/set (v1.0.0)
Using dependency: github.com/x448/float16 (v0.8.4)
Using dependency: github.com/ugorji/go/codec (v1.2.12)
Using dependency: github.com/twitchyliquid64/golang-asm (v0.15.1)
Using dependency: github.com/stretchr/testify (v1.9.0)
Using dependency: github.com/spf13/pflag (v1.0.5)
Using dependency: github.com/spf13/cobra (v1.7.0)
Using dependency: github.com/rogpeppe/go-internal (v1.8.0)
Using dependency: github.com/rivo/uniseg (v0.2.0)
Using dependency: github.com/pmezard/go-difflib (v1.0.0)
Using dependency: github.com/pkg/errors (v0.9.1)
Using dependency: github.com/pierrec/lz4 (v4.1.8)
Using dependency: github.com/pelletier/go-toml (v2.2.2)
Using dependency: github.com/pdevine/tensor (f88f4562727c)
Using dependency: github.com/olekukonko/tablewriter (v0.0.5)
Using dependency: github.com/nlpodyssey/gopickle (v0.3.0)
Using dependency: github.com/modern-go/reflect2 (v1.0.2)
Using dependency: github.com/modern-go/concurrent (bacd9c7ef1dd)
Using dependency: github.com/mattn/go-runewidth (v0.0.14)
Using dependency: github.com/mattn/go-isatty (v0.0.20)
Using dependency: github.com/leodido/go-urn (v1.4.0)
Using dependency: github.com/kr/text (v0.2.0)
Using dependency: github.com/kr/pretty (v0.3.0)
Using dependency: github.com/klauspost/cpuid (v2.2.7)
Using dependency: github.com/klauspost/compress (v1.13.1)
Using dependency: github.com/json-iterator/go (v1.1.12)
Using dependency: github.com/inconshreveable/mousetrap (v1.1.0)
Using dependency: github.com/google/uuid (v1.6.0)
Using dependency: github.com/google/go-cmp (v0.6.0)
Using dependency: github.com/google/flatbuffers (v24.3.25)
Using dependency: github.com/golang/snappy (v0.0.3)
Using dependency: github.com/golang/protobuf (v1.5.4)
Using dependency: github.com/gogo/protobuf (v1.3.2)
Using dependency: github.com/goccy/go-json (v0.10.2)
Using dependency: github.com/go-playground/validator (v10.20.0)
Using dependency: github.com/go-playground/universal-translator (v0.18.1)
Using dependency: github.com/go-playground/locales (v0.14.1)
Using dependency: github.com/go-playground/assert (v2.2.0)
Using dependency: github.com/gin-gonic/gin (v1.10.0)
Using dependency: github.com/gin-contrib/sse (v0.1.0)
Using dependency: github.com/gin-contrib/cors (v1.7.2)
Using dependency: github.com/gabriel-vasile/mimetype (v1.4.3)
Using dependency: github.com/emirpasic/gods (v2.0.0-alpha)
Using dependency: github.com/dgryski/trifles (dd97f9abfb48)
Using dependency: github.com/davecgh/go-spew (v1.1.1)
Using dependency: github.com/d4l3k/go-bfloat16 (690c3bdd05f1)
Using dependency: github.com/containerd/console (v1.0.3)
Using dependency: github.com/cloudwego/iasm (v0.2.0)
Using dependency: github.com/cloudwego/base64x (v0.1.4)
Using dependency: github.com/chewxy/math32 (v1.11.0)
Using dependency: github.com/chewxy/hm (v1.0.0)
Using dependency: github.com/bytedance/sonic/loader (v0.1.1)
Using dependency: github.com/bytedance/sonic (v1.11.6)
Using dependency: github.com/arbovm/levenshtein (48b4e1c0c4d0)
Using dependency: github.com/apache/arrow/go/arrow (bc219186db40)
Using dependency: github.com/agnivade/levenshtein (v1.1.1)
Resolved github.com/ollama/ollama to https://github.com/ollama/ollama/tarball/v0.5.7
Resolved dependency gorgonia.org/vecf64 to github.com/gorgonia/vecf64
Calculating checksums for gorgonia.org/vecf64
Resolved gorgonia.org/vecf64 to https://github.com/gorgonia/vecf64/tarball/v0.9.0
Resolved dependency gorgonia.org/vecf32 to github.com/gorgonia/vecf32
Calculating checksums for gorgonia.org/vecf32
Resolved gorgonia.org/vecf32 to https://github.com/gorgonia/vecf32/tarball/v0.9.0
Calculating checksums for gopkg.in/yaml.v3
Resolved gopkg.in/yaml.v3 to https://github.com/go-yaml/yaml/tarball/v3.0.1
Calculating checksums for gopkg.in/check.v1
Resolved gopkg.in/check.v1 to https://github.com/go-check/check/tarball/10cb98267c6c
Calculating checksums for google.golang.org/protobuf
Resolved google.golang.org/protobuf to https://github.com/protocolbuffers/protobuf-go/tarball/v1.34.1
Resolved dependency gonum.org/v1/gonum to github.com/gonum/gonum
Calculating checksums for gonum.org/v1/gonum
Resolved gonum.org/v1/gonum to https://github.com/gonum/gonum/tarball/v0.15.0
Calculating checksums for golang.org/x/xerrors
Resolved golang.org/x/xerrors to https://github.com/golang/xerrors/tarball/5ec99f83aff1
Calculating checksums for golang.org/x/text
Resolved golang.org/x/text to https://github.com/golang/text/tarball/v0.21.0
Calculating checksums for golang.org/x/term
Resolved golang.org/x/term to https://github.com/golang/term/tarball/v0.27.0
Calculating checksums for golang.org/x/sys
Resolved golang.org/x/sys to https://github.com/golang/sys/tarball/v0.28.0
Calculating checksums for golang.org/x/sync
Resolved golang.org/x/sync to https://github.com/golang/sync/tarball/v0.10.0
Calculating checksums for golang.org/x/net
Resolved golang.org/x/net to https://github.com/golang/net/tarball/v0.25.0
Calculating checksums for golang.org/x/image
Resolved golang.org/x/image to https://github.com/golang/image/tarball/v0.22.0
Calculating checksums for golang.org/x/exp
Resolved golang.org/x/exp to https://github.com/golang/exp/tarball/9a3e6036ecaa
Calculating checksums for golang.org/x/crypto
Resolved golang.org/x/crypto to https://github.com/golang/crypto/tarball/v0.31.0
Calculating checksums for golang.org/x/arch
Resolved golang.org/x/arch to https://github.com/golang/arch/tarball/v0.8.0
Resolved dependency go4.org/unsafe/assume-no-moving-gc to github.com/go4org/unsafe-assume-no-moving-gc
Calculating checksums for go4.org/unsafe/assume-no-moving-gc
Resolved go4.org/unsafe/assume-no-moving-gc to https://github.com/go4org/unsafe-assume-no-moving-gc/tarball/b99613f794b6
Calculating checksums for github.com/xtgo/set
Resolved github.com/xtgo/set to https://github.com/xtgo/set/tarball/v1.0.0
Calculating checksums for github.com/x448/float16
Resolved github.com/x448/float16 to https://github.com/x448/float16/tarball/v0.8.4
Calculating checksums for github.com/ugorji/go/codec
Resolved github.com/ugorji/go/codec to https://github.com/ugorji/go/tarball/v1.2.12
Calculating checksums for github.com/twitchyliquid64/golang-asm
Resolved github.com/twitchyliquid64/golang-asm to https://github.com/twitchyliquid64/golang-asm/tarball/v0.15.1
Calculating checksums for github.com/stretchr/testify
Resolved github.com/stretchr/testify to https://github.com/stretchr/testify/tarball/v1.9.0
Calculating checksums for github.com/spf13/pflag
Resolved github.com/spf13/pflag to https://github.com/spf13/pflag/tarball/v1.0.5
Calculating checksums for github.com/spf13/cobra
Resolved github.com/spf13/cobra to https://github.com/spf13/cobra/tarball/v1.7.0
Calculating checksums for github.com/rogpeppe/go-internal
Resolved github.com/rogpeppe/go-internal to https://github.com/rogpeppe/go-internal/tarball/v1.8.0
Calculating checksums for github.com/rivo/uniseg
Resolved github.com/rivo/uniseg to https://github.com/rivo/uniseg/tarball/v0.2.0
Calculating checksums for github.com/pmezard/go-difflib
Resolved github.com/pmezard/go-difflib to https://github.com/pmezard/go-difflib/tarball/v1.0.0
Calculating checksums for github.com/pkg/errors
Resolved github.com/pkg/errors to https://github.com/pkg/errors/tarball/v0.9.1
Calculating checksums for github.com/pierrec/lz4
Resolved github.com/pierrec/lz4 to https://github.com/pierrec/lz4/tarball/v4.1.8
Calculating checksums for github.com/pelletier/go-toml
Resolved github.com/pelletier/go-toml to https://github.com/pelletier/go-toml/tarball/v2.2.2
Calculating checksums for github.com/pdevine/tensor
Resolved github.com/pdevine/tensor to https://github.com/pdevine/tensor/tarball/f88f4562727c
Calculating checksums for github.com/olekukonko/tablewriter
Resolved github.com/olekukonko/tablewriter to https://github.com/olekukonko/tablewriter/tarball/v0.0.5
Calculating checksums for github.com/nlpodyssey/gopickle
Resolved github.com/nlpodyssey/gopickle to https://github.com/nlpodyssey/gopickle/tarball/v0.3.0
Calculating checksums for github.com/modern-go/reflect2
Resolved github.com/modern-go/reflect2 to https://github.com/modern-go/reflect2/tarball/v1.0.2
Calculating checksums for github.com/modern-go/concurrent
Resolved github.com/modern-go/concurrent to https://github.com/modern-go/concurrent/tarball/bacd9c7ef1dd
Calculating checksums for github.com/mattn/go-runewidth
Resolved github.com/mattn/go-runewidth to https://github.com/mattn/go-runewidth/tarball/v0.0.14
Calculating checksums for github.com/mattn/go-isatty
Resolved github.com/mattn/go-isatty to https://github.com/mattn/go-isatty/tarball/v0.0.20
Calculating checksums for github.com/leodido/go-urn
Resolved github.com/leodido/go-urn to https://github.com/leodido/go-urn/tarball/v1.4.0
Calculating checksums for github.com/kr/text
Resolved github.com/kr/text to https://github.com/kr/text/tarball/v0.2.0
Calculating checksums for github.com/kr/pretty
Resolved github.com/kr/pretty to https://github.com/kr/pretty/tarball/v0.3.0
Calculating checksums for github.com/klauspost/cpuid
Resolved github.com/klauspost/cpuid to https://github.com/klauspost/cpuid/tarball/v2.2.7
Calculating checksums for github.com/klauspost/compress
Resolved github.com/klauspost/compress to https://github.com/klauspost/compress/tarball/v1.13.1
Calculating checksums for github.com/json-iterator/go
Resolved github.com/json-iterator/go to https://github.com/json-iterator/go/tarball/v1.1.12
Calculating checksums for github.com/inconshreveable/mousetrap
Resolved github.com/inconshreveable/mousetrap to https://github.com/inconshreveable/mousetrap/tarball/v1.1.0
Calculating checksums for github.com/google/uuid
Resolved github.com/google/uuid to https://github.com/google/uuid/tarball/v1.6.0
Calculating checksums for github.com/google/go-cmp
Resolved github.com/google/go-cmp to https://github.com/google/go-cmp/tarball/v0.6.0
Calculating checksums for github.com/google/flatbuffers
Resolved github.com/google/flatbuffers to https://github.com/google/flatbuffers/tarball/v24.3.25
Calculating checksums for github.com/golang/snappy
Resolved github.com/golang/snappy to https://github.com/golang/snappy/tarball/v0.0.3
Calculating checksums for github.com/golang/protobuf
Resolved github.com/golang/protobuf to https://github.com/golang/protobuf/tarball/v1.5.4
Calculating checksums for github.com/gogo/protobuf
Resolved github.com/gogo/protobuf to https://github.com/gogo/protobuf/tarball/v1.3.2
Calculating checksums for github.com/goccy/go-json
Resolved github.com/goccy/go-json to https://github.com/goccy/go-json/tarball/v0.10.2
Calculating checksums for github.com/go-playground/validator
Resolved github.com/go-playground/validator to https://github.com/go-playground/validator/tarball/v10.20.0
Calculating checksums for github.com/go-playground/universal-translator
Resolved github.com/go-playground/universal-translator to https://github.com/go-playground/universal-translator/tarball/v0.18.1
Calculating checksums for github.com/go-playground/locales
Resolved github.com/go-playground/locales to https://github.com/go-playground/locales/tarball/v0.14.1
Calculating checksums for github.com/go-playground/assert
Resolved github.com/go-playground/assert to https://github.com/go-playground/assert/tarball/v2.2.0
Calculating checksums for github.com/gin-gonic/gin
Resolved github.com/gin-gonic/gin to https://github.com/gin-gonic/gin/tarball/v1.10.0
Calculating checksums for github.com/gin-contrib/sse
Resolved github.com/gin-contrib/sse to https://github.com/gin-contrib/sse/tarball/v0.1.0
Calculating checksums for github.com/gin-contrib/cors
Resolved github.com/gin-contrib/cors to https://github.com/gin-contrib/cors/tarball/v1.7.2
Calculating checksums for github.com/gabriel-vasile/mimetype
Resolved github.com/gabriel-vasile/mimetype to https://github.com/gabriel-vasile/mimetype/tarball/v1.4.3
Calculating checksums for github.com/emirpasic/gods
Resolved github.com/emirpasic/gods to https://github.com/emirpasic/gods/tarball/v2.0.0-alpha
Calculating checksums for github.com/dgryski/trifles
Resolved github.com/dgryski/trifles to https://github.com/dgryski/trifles/tarball/dd97f9abfb48
Calculating checksums for github.com/davecgh/go-spew
Resolved github.com/davecgh/go-spew to https://github.com/davecgh/go-spew/tarball/v1.1.1
Calculating checksums for github.com/d4l3k/go-bfloat16
Resolved github.com/d4l3k/go-bfloat16 to https://github.com/d4l3k/go-bfloat16/tarball/690c3bdd05f1
Calculating checksums for github.com/containerd/console
Resolved github.com/containerd/console to https://github.com/containerd/console/tarball/v1.0.3
Calculating checksums for github.com/cloudwego/iasm
Resolved github.com/cloudwego/iasm to https://github.com/cloudwego/iasm/tarball/v0.2.0
Calculating checksums for github.com/cloudwego/base64x
Resolved github.com/cloudwego/base64x to https://github.com/cloudwego/base64x/tarball/v0.1.4
Calculating checksums for github.com/chewxy/math32
Resolved github.com/chewxy/math32 to https://github.com/chewxy/math32/tarball/v1.11.0
Calculating checksums for github.com/chewxy/hm
Resolved github.com/chewxy/hm to https://github.com/chewxy/hm/tarball/v1.0.0
Calculating checksums for github.com/bytedance/sonic/loader
Resolved github.com/bytedance/sonic/loader to https://github.com/bytedance/sonic/tarball/v0.1.1
WARNING: Could not calculate checksums for package: github.com/bytedance/sonic/loader
Could not retrieve tarball for github.com/bytedance/sonic/loader; HTTP status=404
Expected at: https://github.com/bytedance/sonic/tarball/v0.1.1
Calculating checksums for github.com/bytedance/sonic
Resolved github.com/bytedance/sonic to https://github.com/bytedance/sonic/tarball/v1.11.6
Calculating checksums for github.com/arbovm/levenshtein
Resolved github.com/arbovm/levenshtein to https://github.com/arbovm/levenshtein/tarball/48b4e1c0c4d0
Calculating checksums for github.com/apache/arrow/go/arrow
Resolved github.com/apache/arrow/go/arrow to https://github.com/apache/arrow/tarball/bc219186db40
Calculating checksums for github.com/agnivade/levenshtein
Resolved github.com/agnivade/levenshtein to https://github.com/agnivade/levenshtein/tarball/v1.1.1
```

</details>

Can anyone 