### PR TITLE
1password: Update to provide completions on install

### DIFF
--- a/security/1password-cli/Portfile
+++ b/security/1password-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                1password-cli
 version             2.30.3
-revision            0
+revision            1
 
 homepage            https://support.1password.com/command-line
 
@@ -48,17 +48,45 @@ post-extract {
     system -W ${pkg_workpath} "cat ./Payload.cpio | cpio -i"
 }
 
+post-build {
+    set op ${pkg_workpath}/${bin_name}
+    set completions ${worksrcpath}/completions
+
+    xinstall -m 0755 -d ${completions}
+
+    foreach shell {bash fish zsh} {
+        system -nodup -W ${worksrcpath} \
+          "${op} completion ${shell} > ${completions}/${bin_name}.${shell}"
+    }
+}
+
 destroot {
     xinstall -m 0755 ${pkg_workpath}/${bin_name} ${destroot}${prefix}/bin
+
+    set completions ${worksrcpath}/completions
+
+    set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0755 -d ${bash_comp_path}
+    xinstall -m 0644 ${completions}/${bin_name}.bash ${bash_comp_path}/${bin_name}
+
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0755 -d ${fish_comp_path}
+    xinstall -m 0644 ${completions}/${bin_name}.fish ${fish_comp_path}
+
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0755 -d ${zsh_comp_path}
+    xinstall -m 0644 ${completions}/${bin_name}.zsh ${zsh_comp_path}/_${bin_name}
 }
 
 livecheck.type      regex
 livecheck.url       https://app-updates.agilebits.com/product_history/CLI2
 livecheck.regex     ${archive}_v(\\d+(\\.\\d+)+)${extract.suffix}
 
-notes "
-1Password CLI has been installed as ${bin_name}
+notes {
+  1Password CLI has been installed as ${bin_name}
 
-For instructions on getting started, see:
-https://support.1password.com/command-line-getting-started/#get-started-with-the-command-line-tool
-"
+  For instructions on getting started, see:
+  https://support.1password.com/command-line-getting-started/#get-started-with-the-command-line-tool
+
+  Completion scripts have been installed for Bash, Fish, and Zsh.
+}


### PR DESCRIPTION
#### Description

1password: Update to provide completions on install

###### Type(s)

- [x] enhancement

###### Tested on

macOS 14.7.2 23H311
arm64 Xcode 16.2 16C5032a

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?