### PR TITLE
legacy-support-devel: Update to latest master.

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -31,6 +31,7 @@ subport ${name} {
     conflicts           ${name}-devel
     github.setup        macports macports-legacy-support ${release_ver} v
     # Change github.tarball_from to 'releases' or 'archive' next update
+    # N.B.: That's a nice theory, but neither choice works correctly
     github.tarball_from tarball
     revision            0
     checksums           rmd160  7d17aa039df1dd3e6d769a570bae703cea111e74 \
@@ -51,15 +52,16 @@ subport ${name} {
 subport ${name}-devel {
     conflicts           ${name}
     github.setup        macports macports-legacy-support \
-                        f109400eccefe2f735bcd9a068dad7a53407d548
+                        1965ad6ab6c31842158d53ee38f4828e517278a5
     # Change github.tarball_from to 'releases' or 'archive' next update
+    # N.B.: That's a nice theory, but neither choice works correctly
     github.tarball_from tarball
-    version             20250111
+    version             20250120
     revision            0
     livecheck.type      none
-    checksums           rmd160  43b6d529471aeb3833af14c5f7348a904da1b19b \
-                        sha256  b1531131532530dc5e52d92b417d141c385ad2fc72d074844c8beff3ef416afb \
-                        size    156651
+    checksums           rmd160  7869ee1f847476a90364b00550006608d008d653 \
+                        sha256  336e98b306fd3d928b43342664daa550953f8f25233467670486c62544c80f67 \
+                        size    163812
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
 


### PR DESCRIPTION
Notable changes since last -devel version:

- Fixes 10.4 Rosetta bug in fstatx_np()
- Makes renameat() available via stdio.h See: https://trac.macports.org/ticket/71842
- Implements interim clock_gettime_nsec_np() See: https://trac.macports.org/ticket/61691
- Implements clock_settime() See: https://trac.macports.org/ticket/71399
- Adds net/if_tun.h for <10.6 See: https://trac.macports.org/ticket/70231
- Provides pthread_[f]chdir_np() for 10.5+ See: https://trac.macports.org/ticket/71265
- Adds CPU_TYPE_ARM definition for 10.4 See: https://trac.macports.org/ticket/71621

Also adds Portfile comments regarding suggested github.tarball_from change.

Also, the prior addition of vdprintf() in v20241026 neglected to close the related tickets:
  Closes: https://trac.macports.org/ticket/67598
  Closes: https://trac.macports.org/ticket/70118

TESTED:
Tested both normal and -devel versions -/+universal on 10.4-10.5 ppc, 10.5-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-15.x arm64.
Builds and passes all tests on all tested platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.2 22H313, arm64, Xcode 15.2 15C500b
macOS 14.7.2 23H311, arm64, Xcode 16.2 16C5032a
macOS 15.2 24C101, arm64, Xcode 16.2 16C5032a
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
