### PR TITLE
ffmpeg7: add pixeldensity feature for retina displays

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -144,7 +144,7 @@ compiler.c_standard 2011
 # clang-139 hits https://trac.macports.org/ticket/38141
 # warning: unknown warning option '-Werror=partial-availability'; did you mean '-Werror=availability'? [-Wunknown-warning-option]
 # warning: unknown warning option '-Wno-bool-operation'; did you mean '-Wno-bool-conversion'? [-Wunknown-warning-option]
-compiler.blacklist-append {clang < 800}
+compiler.blacklist-append {clang < 900}
 
 # The old ffmpeg port was GPL-2+ as base and had a no_gpl variant, so this keeps us consistent
 # Also, -gpl2 causes other ports to fail to build due to the missing libpostproc (#35473)

--- a/multimedia/ffmpeg7/Portfile
+++ b/multimedia/ffmpeg7/Portfile
@@ -140,7 +140,7 @@ compiler.c_standard 2011
 # clang-139 hits https://trac.macports.org/ticket/38141
 # warning: unknown warning option '-Werror=partial-availability'; did you mean '-Werror=availability'? [-Wunknown-warning-option]
 # warning: unknown warning option '-Wno-bool-operation'; did you mean '-Wno-bool-conversion'? [-Wunknown-warning-option]
-compiler.blacklist-append {clang < 800}
+compiler.blacklist-append {clang < 900}
 
 # The old ffmpeg port was GPL-2+ as base and had a no_gpl variant, so this keeps us consistent
 # Also, -gpl2 causes other ports to fail to build due to the missing libpostproc (#35473)

--- a/multimedia/ffmpeg7/Portfile
+++ b/multimedia/ffmpeg7/Portfile
@@ -12,7 +12,7 @@ name                ffmpeg7
 set my_name         ffmpeg
 
 version             7.1
-revision            2
+revision            3
 
 license             LGPL-2.1+
 categories          multimedia
@@ -105,6 +105,14 @@ patchfiles-append   patch-libavcodec-profvidworkflow.diff
 # https://trac.macports.org/ticket/68973
 # TODO: Raise the issue to upstream
 patchfiles-append   patch-libavcodec-librsvgdec.diff
+
+# add retina resolution capabilities via -movflags write_pixeldensity flag
+# this patch is by daniel kaiser who posted on the ffmpeg bugtracker:
+# https://fftrac-bg.ffmpeg.org/ticket/7045
+# but he never formally submitted it to the FFMpeg mailing list, which i did
+# https://ffmpeg.org/pipermail/ffmpeg-devel/2024-July/331470.html
+# so the FFMpeg team does not seem to care to include this functionality
+patchfiles-append   patch-add-pixeldensity.diff
 
 platform darwin {
     # Typedef AVMediaType to NSString* on older systems

--- a/multimedia/ffmpeg7/files/patch-add-pixeldensity.diff
+++ b/multimedia/ffmpeg7/files/patch-add-pixeldensity.diff
@@ -1,0 +1,91 @@
+diff --git libavformat/movenc.c libavformat/movenc.c
+index a961390..c5eb12d 100644
+--- libavformat/movenc.c
++++ libavformat/movenc.c	2024-11-08 18:08:40.000000000 -0700
+@@ -109,6 +109,7 @@
+       { "skip_sidx", "Skip writing of sidx atom", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_SKIP_SIDX}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, .unit = "movflags" },
+       { "skip_trailer", "Skip writing the mfra/tfra/mfro trailer for fragmented files", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_SKIP_TRAILER}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, .unit = "movflags" },
+       { "use_metadata_tags", "Use mdta atom for metadata.", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_USE_MDTA}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, .unit = "movflags" },
++      { "write_pixeldensity", "Write pixeldensity metdata for HiDPI videos in QT", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_PIXELDENSITY}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, "movflags" },
+       { "write_colr", "Write colr atom even if the color info is unspecified (Experimental, may be renamed or changed, do not use from scripts)", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_WRITE_COLR}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, .unit = "movflags" },
+       { "write_gama", "Write deprecated gama atom", 0, AV_OPT_TYPE_CONST, {.i64 = FF_MOV_FLAG_WRITE_GAMA}, INT_MIN, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM, .unit = "movflags" },
+     { "min_frag_duration", "Minimum fragment duration", offsetof(MOVMuxContext, min_fragment_duration), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM},
+@@ -4008,6 +4009,56 @@
+     return size;
+ }
+ 
++static int mov_write_pixeldensity_meta_tag(AVIOContext *pb, MOVMuxContext *mov, MOVTrack *track, AVFormatContext *s)
++{
++    int size = 0;
++    int64_t pos = avio_tell(pb);
++    avio_wb32(pb, 0); /* meta atom size */
++    ffio_wfourcc(pb, "meta");
++
++    /* Metadata atom information as described in
++     * https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/Metadata/Metadata.html#//apple_ref/doc/uid/TP40000939-CH1-SW9
++     */
++    avio_wb32(pb, 33); /* hdlr atom size: size (4) + 'hdlr' (4) + version/flags (4) + predefined (4) + 'mdta' (4) +
++                          reserved (3*4) + name (1) = 33 */
++    ffio_wfourcc(pb, "hdlr");
++    avio_wb32(pb, 0); /* version (1 Byte) and flags (3 Bytes), must be zero */
++    avio_wb32(pb, 0); /* "predefined", must be zero */
++    ffio_wfourcc(pb, "mdta");
++    avio_wb32(pb, 0); /* Reseverved, uint32_t[3] */
++    avio_wb32(pb, 0);
++    avio_wb32(pb, 0);
++    avio_w8(pb, 0); /* Empty name (NULL-terminated) */
++
++    avio_wb32(pb, 56); /* keys atom size: size (4) + 'keys' (4) + version/flasgs (4) + entry_count (4) +
++                          keys (32+8) = 56 */
++    ffio_wfourcc(pb, "keys");
++    avio_wb32(pb, 0);      /* version (1 Byte) and flags (3 Bytes), must be zero */
++    avio_wb32(pb, 1);      /* entry count */
++    avio_wb32(pb, 32 + 8); /* key size: size (4) + 'mdta' (4) + strlen(key) */
++    ffio_wfourcc(pb, "mdta");
++    avio_write(pb, "com.apple.quicktime.pixeldensity", 32);
++
++    avio_wb32(pb, 48); /* ilst atom size: size (4) + 'ilst' (4) + value atom size (40) = 48 */
++    ffio_wfourcc(pb, "ilst");
++    avio_wb32(pb, 40); /* value atom size: size (4) + key (4) + data atom (32) = 40 */
++    avio_wb32(pb, 1);  /* metadata key index */
++
++    avio_wb32(pb, 32); /* data atom size: size (4) + 'data' (4) + data_type (4) + locale (4) + value (4 * 4) = 32 */
++    ffio_wfourcc(pb, "data");
++    avio_wb32(pb, 0x1e); /* data type */
++    avio_wb32(pb, 0);    /* locale */
++
++    /* actual data (value): consisting of 4 uint32_t: pixel width, pixel height, display width, display height */
++    avio_wb32(pb, track->par->width);
++    avio_wb32(pb, track->par->height);
++    avio_wb32(pb, track->par->width / 2);
++    avio_wb32(pb, track->par->height / 2);
++
++    size = update_size(pb, pos);
++    return size;
++}
++
+ static int mov_write_trak_tag(AVFormatContext *s, AVIOContext *pb, MOVMuxContext *mov,
+                               MOVTrack *track, AVStream *st)
+ {
+@@ -4067,6 +4118,9 @@
+     if (mov->flags & FF_MOV_FLAG_PIXELDENSITY) {
+          mov_write_pixeldensity_meta_tag(pb, mov, track, st);
+     }
++    if (mov->flags & FF_MOV_FLAG_PIXELDENSITY) {
++         mov_write_pixeldensity_meta_tag(pb, mov, track, st);
++    }
+     mov_write_track_udta_tag(pb, mov, st);
+     track->entry = entry_backup;
+     track->chunkCount = chunk_backup;
+diff --git libavformat/movenc.h libavformat/movenc.h
+index 68d6f23..ed7ea41 100644
+--- libavformat/movenc.h
++++ libavformat/movenc.h
+@@ -284,6 +284,7 @@
+ #define FF_MOV_FLAG_CMAF                  (1 << 22)
+ #define FF_MOV_FLAG_PREFER_ICC            (1 << 23)
+ #define FF_MOV_FLAG_HYBRID_FRAGMENTED     (1 << 24)
++#define FF_MOV_FLAG_PIXELDENSITY          (1 << 25)
+ 
+ int ff_mov_write_packet(AVFormatContext *s, AVPacket *pkt);
+ 


### PR DESCRIPTION
#### Description

Backport the patch to ffmpeg7, since the ffmpeg-devel port uses v7 branch.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
