### PR TITLE
haproxy: enable the Prometheus Exporter service

### DIFF
--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -7,7 +7,7 @@ PortGroup           makefile 1.0
 
 name                haproxy
 version             3.0.3
-revision            0
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
@@ -62,6 +62,7 @@ build.args-append   SSL_INC=[openssl::include_dir] \
                     USE_OPENSSL=1 \
                     USE_PCRE=1 \
                     USE_PCRE_JIT=1 \
+                    USE_PROMEX=1 \
                     USE_THREAD=1 \
                     USE_ZLIB=1
 


### PR DESCRIPTION
#### Description

haproxy: enable the Prometheus Exporter service

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
