### PR TITLE
jdk23: update to 23.0.2

### DIFF
--- a/java/jdk23/Portfile
+++ b/java/jdk23/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk23-mac
-version      ${feature}.0.1
+version      ${feature}.0.2
 revision     0
 
 description  Oracle Java SE Development Kit ${feature} (Short Term Support until March 2025)
@@ -27,14 +27,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  a74944abf0cb70a7fc67b950d7cdd4493286a1f5 \
-                 sha256  deee028d44aa76c506624bc21886543bd1948283234237f7a40d4b8a8fb73bd2 \
-                 size    239982938
+    checksums    rmd160  40dcbeb4f5f7f1c7593a6a3dd976add30cdc21d8 \
+                 sha256  01e53b35eb2d0c69d1d0e67a040586477e584a2777a206381ccef6aaf2398198 \
+                 size    240096333
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  33f973656845914b6c721ab5f7e8c4cc6d4db614 \
-                 sha256  e5595d2bceae027a604cd3a2a5c6709ff57a2d3695bd173074716b95a617cee2 \
-                 size    237296293
+    checksums    rmd160  920ea5902c4496c7a80b67dff130172ab3f74a2f \
+                 sha256  1be59c70b115ef946a307df4e4808271a6b4a9f594afcfc3e0c6b3b9738d8edd \
+                 size    237256596
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 23.0.2.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?