### PR TITLE
jdk21: update to 21.0.6

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      ${feature}.0.5
+version      ${feature}.0.6
 revision     0
 
 description  Oracle Java SE Development Kit ${feature}
@@ -27,14 +27,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  a43c8166eb36fae0491b1a7f3715ad0c9610bba1 \
-                 sha256  6e5afb736b47fd49d81545fee8b6453f67e92a6b35f9b5b77426dc66cf5488b8 \
-                 size    193475240
+    checksums    rmd160  9fcd44e14b065b4bf5ccdb30f5bb64c3de158d61 \
+                 sha256  2b06509c933817a6194b3f36f39148f576d76721b0767eb63b825ce2f673d719 \
+                 size    193200583
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  225235978e0e7013283c7294a1b1f8e5edd4aff5 \
-                 sha256  13cb8d754069fc76a2ff6eee96273cc1a96cb47ecf3afa7820407635c386dd37 \
-                 size    191126741
+    checksums    rmd160  2d71574b8c0d07f67dc131891424ab1c3e9f1196 \
+                 sha256  816196c571a537f0d07b4f6a15eb16c2f9521bbd21f3b731ac36b15885f8a413 \
+                 size    190854257
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 21.0.6.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?