### PR TITLE
jdk21-graalvm: update to 21.0.6

### DIFF
--- a/java/jdk21-graalvm/Portfile
+++ b/java/jdk21-graalvm/Portfile
@@ -21,8 +21,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava21-mac
 supported_archs  x86_64 arm64
 
-version     ${feature}.0.5
-set build 9
+version     ${feature}.0.6
+set build 8
 revision    0
 
 master_sites https://download.oracle.com/graalvm/${feature}/archive/
@@ -40,14 +40,14 @@ long_description Oracle GraalVM for JDK ${feature} compiles your Java applicatio
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  0ea2d934cbb915c46fcf5ed1d1859265df553ace \
-                 sha256  2d9b09e28bc1bb6ff219bf62eacc4626c7740b4f1829ede9ea4450f33e9c0826 \
-                 size    314358647
+    checksums    rmd160  5ec242d980f733265c6041598a64c167a3553793 \
+                 sha256  a4e5ce59a63e8325c3eba2d2a7091fd99927b08e04eb8a90f35e0b358bc9dee7 \
+                 size    315781872
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  fa29e4657a1dedd98beeaa43902bbe2f52e5b05c \
-                 sha256  cb68cb2c796f42f37a56fcd1385d8b86cca12e0b46c5618a5ed3ec7dd2260f6f \
-                 size    327124226
+    checksums    rmd160  a66d9ed4019e3d3e65d9309cec3b3a33a5f0ef0c \
+                 sha256  3ee94ee274cef7d0fb79fb79a35c4bc11df0854434f88b18507da722f5962464 \
+                 size    328365882
 }
 
 worksrcdir   graalvm-jdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM for JDK 21.0.6.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?