### PR TITLE
jdk23-graalvm: update to 23.0.2

### DIFF
--- a/java/jdk23-graalvm/Portfile
+++ b/java/jdk23-graalvm/Portfile
@@ -16,8 +16,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava23-mac
 supported_archs  x86_64 arm64
 
-version     ${feature}.0.1
-set build 11
+version     ${feature}.0.2
+set build 7
 revision    0
 
 master_sites https://download.oracle.com/graalvm/${feature}/archive/
@@ -35,14 +35,14 @@ long_description Oracle GraalVM for JDK ${feature} compiles your Java applicatio
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  4b4a4c326110a51e7b0bc03361d44c6899a83de1 \
-                 sha256  539699d8ff4979623bc7bdf8282ac6f76cd2560f47d14ec5438bada24f136f96 \
-                 size    336189146
+    checksums    rmd160  033a52345e8cfb3270c3248335b75a7a4494bab3 \
+                 sha256  b4599fbfd394304a84e9435bf7c673069d4fe0c565d2d44d70f0f6f5804cea35 \
+                 size    337796764
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  1c24bce8638a9d43cf55ab0ff40f6e3045c8680b \
-                 sha256  c00a7a62ce453aa026bff65e5a18c63464f725c01e5a71771856226928ba5b0f \
-                 size    350643130
+    checksums    rmd160  cf8c4ad2fbab57f78132f5828bf2b7e5f5745ee4 \
+                 sha256  0e644b92d03d39bdf4842e378b8b22713faaa4edae8efff0da9929d1e04dd0cb \
+                 size    352088817
 }
 
 worksrcdir   graalvm-jdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM for JDK 23.0.2.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?