### PR TITLE
openjdk23: update to 23.0.2

### DIFF
--- a/java/openjdk23/Portfile
+++ b/java/openjdk23/Portfile
@@ -9,8 +9,8 @@ set boot_feature 22
 
 name                openjdk${feature}
 # See https://github.com/openjdk/jdk23u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             ${feature}.0.1
-set build 11
+version             ${feature}.0.2
+set build 7
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -24,9 +24,9 @@ master_sites        https://github.com/openjdk/jdk${feature}u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk${feature}u-${distname}
 
-checksums           rmd160  d415bdbf8fe2783dcf381c6009fb9dfb23a0d202 \
-                    sha256  0e058ae2956871aafc5be33960b6e0f8dd954d234d590d249bcb3b619b579a0a \
-                    size    116677478
+checksums           rmd160  633a621e6ffbdd06fb83afb2773197a2b6e2820f \
+                    sha256  0812e2e4d51ab1d752c1d532150297a56bd47557db67f8e2b298199e7f65db1c \
+                    size    117217990
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 
@@ -45,7 +45,7 @@ pre-patch {
     reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
 }
 
-# Temporary workaround for clang 16: https://trac.macports.org/ticket/70819
+# Temporary workaround for clang 16.0-16.1: https://trac.macports.org/ticket/70819
 patchfiles          JDK-8340341-clang-16-workaround.patch
 
 set tpath ${prefix}/Library/Java


### PR DESCRIPTION
#### Description

Update to OpenJDK 23.0.2.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?