### PR TITLE
openjdk23-corretto: update to 23.0.2

### DIFF
--- a/java/openjdk23-corretto/Portfile
+++ b/java/openjdk23-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-23/releases
-version      ${feature}.0.1.8.1
+version      ${feature}.0.2.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Short Term Support until March 2025)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  0a4d6f96bf4b53599afebeb41eb899d5be12d68d \
-                 sha256  2d5ee2fb3cdcb080e009d2cfb3531961acf9d77cb4a2f45cb6976451bcf47dd3 \
-                 size    210053162
+    checksums    rmd160  827f5fba3b0da727c5f76fb52df341edd5155bab \
+                 sha256  c24ee30ef6eb84a176861cf241284c3ba903e7f7daba189eb6e84e3aacb24ce4 \
+                 size    210098667
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  65a5f9569f38112fdc039686f387b75a79d70b65 \
-                 sha256  4d56e723ac321f0d9de7297abc2c680f82957cbdf95aebfff512672a1b1103cd \
-                 size    207788843
+    checksums    rmd160  9e8eca26d661e531925244ea971ab00b678bb8fb \
+                 sha256  a642d09b59c7d5782481693be39129e03a87ea30879dc56442fa7d20f4911b6a \
+                 size    207854186
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 23.0.2.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?