### PR TITLE
openjdk21-corretto: update to 21.0.6.7.1

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      ${feature}.0.5.11.1
+version      ${feature}.0.6.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  7721ba23ac23ea6c0f86bc3b9802c69c798a9f30 \
-                 sha256  4274dd18d9d563d2493e8963c2796ab159200074b663c67d7adf55aaac18d541 \
-                 size    202361109
+    checksums    rmd160  8bc78b3ff91ab35a2062afd0c3a44a782e317093 \
+                 sha256  d444621a84ce91a314ac54525a2efa410b660e03c26b9895e83da2f76e0c5db5 \
+                 size    202366538
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  cd70edae0e6204ad5f19f6bec5f7c4e3cc8a0199 \
-                 sha256  4e66663ff4c4ae664a4ba87563a8a6e6f0f41bb44f62377c2a1c80efc1f62686 \
-                 size    200255822
+    checksums    rmd160  bc0e369a1ab4e7e689f0c747926974bb700fa407 \
+                 sha256  49a051e6e6940b29dd093b4bd317a06d2145d8340ef953821022e517f89d2bea \
+                 size    200248007
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 21.0.6.7.1.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?