### PR TITLE
openjdk17-corretto: update to 17.0.14.7.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.13.11.1
+version      ${feature}.0.14.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  81b438712730ef5f1ae3c411e718e9cb8ea9f718 \
-                 sha256  17fb370f6b6e4f79e6fb6ee720631d2c3fd39d90f37d079352327aef4d834689 \
-                 size    188055151
+    checksums    rmd160  1c13170637b07811863d9c88b826d16ca4c6eeac \
+                 sha256  7b67fe48ada326153257acce0c96a62b0c5a551012ba511a1675c7ca3c2c66d8 \
+                 size    188076599
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  6c6e79216889d9c43feb59ede8ac78629d4a19d8 \
-                 sha256  33b40aee3ae3db7d298bea0bd34574e755beb2f017ce4eb323f8e28960f0324d \
-                 size    186193229
+    checksums    rmd160  07e382c40b4b813cb1729b1c65a05aabcfc03773 \
+                 sha256  34986a2c682a12404ae2fb1ea409400ef74f4d1c8da8cc7e6a285180cfd8d351 \
+                 size    186222574
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.14.7.1.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?