### PR TITLE
openjdk11-corretto: update to 11.0.26.4.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      ${feature}.0.25.9.1
+version      ${feature}.0.26.4.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  52fc2f3f46165e5e99951e5266873676320bd547 \
-                 sha256  7eda66648dadf112e51c461c9bdd79f0bcaf79e5665b26d99b4ee92c13a8bf4b \
-                 size    187885510
+    checksums    rmd160  42ccede61365ef9cb6ec7a632638e996e4af8e09 \
+                 sha256  0855810233e5075917b316fb153a5119ebccca0983293f62f0fff077cee82064 \
+                 size    187876762
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  78ba4200ff695c2a5f80d2329db6ef8205790c97 \
-                 sha256  de89646c6232c288853c080013edfecc455982e9572a48d3c9dc442ba659e55a \
-                 size    185445776
+    checksums    rmd160  baf31812b80cce46990346646f4431184fbc8a79 \
+                 sha256  e722d9389ff488ec52b64e6d36913c47502f2b5e428c1feb4876566faa075dfb \
+                 size    185451618
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.26.4.1.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?