### PR TITLE
openjdk8-corretto: update to 8.442.06.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.432.06.1
+version      ${feature}.442.06.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  949cfd5fcbef029217c235d17f4d84a8d4396a50 \
-                 sha256  b698659d8ac0dc816e1e971f43894f0d829a6c552887a89a78fa20e0b4e95090 \
-                 size    118482930
+    checksums    rmd160  b859fa6b678bab27a620955b16e063b9ae7bc873 \
+                 sha256  9c083edd6470af55d96591e39ce55b1e48e7353fde5f10fb40680e0064215a46 \
+                 size    118509798
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  442353162169b9055fc68ec72360d3bb136b6aeb \
-                 sha256  fe937f047efc3cb5e0f7102a81c7c03b9c82403f8a9baec79c6a3ac38751c3be \
-                 size    102915982
+    checksums    rmd160  bf7ab5e098ac1ce88647e17fcb5209aa913d9b24 \
+                 sha256  d0738d1f3dc01a9ad9518e2707fc1ef4e72fbb2ccb8b5202cd3ec89012ac8dfc \
+                 size    102934373
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.442.06.1.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?