### PR TITLE
openjdk21-zulu: update 21.40.17

### DIFF
--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk#zulu
-version      ${feature}.38.21
+version      ${feature}.40.17
 revision     0
 
-set openjdk_version ${feature}.0.5
+set openjdk_version ${feature}.0.6
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -35,14 +35,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  ae5bd466f38eb649fcb2e6cd31805889f7b48f0d \
-                 sha256  cd74e5eb738c91459d4b8e5e10eac918ae2a05d21a9fc7ca5dc2da64e65bcebd \
-                 size    208365257
+    checksums    rmd160  833e3fe3f681af1d5ea2b529ec3e524bca35fc28 \
+                 sha256  0b0f05e53e2b85f3881f1b8f5e3ef7e2e992796a1872afbc851b73127b16933d \
+                 size    208622823
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  13eba9368fdc8a1fee007b93060738ecf9a59eaa \
-                 sha256  80ffc25df79b95565318dbfc8309c515726ff42e9bdb533061edc7ad26f13df2 \
-                 size    206147293
+    checksums    rmd160  29b72cecae741f2a94262cfe12eecb595984a779 \
+                 sha256  1d6385f17ae2dc3b57a6d1b6fd6aeadafe1c7138bc744f62a767851eececd092 \
+                 size    206431049
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 21.40.17 based on OpenJDK 21.0.6.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?