### PR TITLE
openjdk23-zulu: update to 23.32.11

### DIFF
--- a/java/openjdk23-zulu/Portfile
+++ b/java/openjdk23-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-23-lts&os=macos&package=jdk#zulu
-version      23.30.13
+version      23.32.11
 revision     0
 
-set openjdk_version 23.0.1
+set openjdk_version 23.0.2
 
 description  Azul Zulu Community OpenJDK 23 (Short Term Support until March 2025)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  5625a607334b65adf6c7ed74e223c9d64c2e84a7 \
-                 sha256  698c9fd522901a03b9c0f6fe7c17c9835f6cfaa515987bde9a1eb10f05d0b697 \
-                 size    215289637
+    checksums    rmd160  6c161020c6210f5b17638737b8855ca1e143b3e3 \
+                 sha256  1dad9af7867e400737ebbbe81043171a8f0bc3ddaf72fbeef6295b3d1dbe728c \
+                 size    215334133
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  a0083293bdb9b4deb2d139cf07893b8eb22b945e \
-                 sha256  3885df560c7a8a9c77b802c22dc1946cd2ee129d9dfcd74558a8ff9e9459e6cf \
-                 size    212937165
+    checksums    rmd160  f46499a99003ef9025fe4bf0a022ee41e8fcca58 \
+                 sha256  e8bcdcd5dd0bad0b2a3a71c83d500a8be8d12cff691198b273f14d247b635113 \
+                 size    213014826
 }
 
 worksrcdir   ${distname}/zulu-23.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 23.32.11 based on OpenJDK 23.0.2.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?