### PR TITLE
openjdk17-zulu: update to 17.56.15

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -15,10 +15,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.54.21
+version      ${feature}.56.15
 revision     0
 
-set openjdk_version ${feature}.0.13
+set openjdk_version ${feature}.0.14
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -30,14 +30,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  c558e9071619ff7feef483d707a4d7b5d15824e2 \
-                 sha256  0bfbf156542f6164e1d180bd1571982a644191dbf35389dda08d71aeb7f16f62 \
-                 size    193928655
+    checksums    rmd160  8b21cf7dda9d6d056f2527c5d7346d5fbab1843e \
+                 sha256  ee1a55b6b63d62d1a24d420b1550ef1736fda36db0e612893d9d26eb1d7f1611 \
+                 size    194233163
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  e1f3d85bbae662c7b53ae4ea559b026493380685 \
-                 sha256  8ad9d79c16a97f274df11362a072bb166e6dd00cf667e626f78c3ed2d70f72cb \
-                 size    191841301
+    checksums    rmd160  89d8186b9af1df410a6eb55034403991df97aa22 \
+                 sha256  c3b9bfb0a6dbe4c5d9efce6c46d3a89c92d7b07ba1bd0afc944612298ac284ec \
+                 size    192183605
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.56.15 based on OpenJDK 17.0.14.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?