### PR TITLE
openjdk11-zulu: update to 11.78.15

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -15,10 +15,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.76.21
+version      ${feature}.78.15
 revision     0
 
-set openjdk_version ${feature}.0.25
+set openjdk_version ${feature}.0.26
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -30,14 +30,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  de9d2b92bbd086b9250efde0214e7bf3cd14d2df \
-                 sha256  134fd0738cb3b204f89f137a989a55b3ed1795751eb38f4e4b01d900b6b6d9bd \
-                 size    194831156
+    checksums    rmd160  1a2dbe33bd5f5f43d541e6ec5aab7e86873d1c6f \
+                 sha256  bb3884619c6f09ec5ca3ce43810c61ade647bb896f4120a6cf076ec993b5a1a0 \
+                 size    195096639
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  1f130ba6333f53347bc78f6cb0f59e67e7ec4ba2 \
-                 sha256  e62bdbbaa97d631933554e59a842f0e94b2355fcf6bf8341dd6f2d040653a1f6 \
-                 size    192808746
+    checksums    rmd160  d5317f917c80169cec233e4cc31567ccc25d0bc8 \
+                 sha256  3708badcc0c79fc1791e74b62478188a1f43c4f9a1e7d3e1bd4173da995479a3 \
+                 size    193064136
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.78.15 based on OpenJDK 11.0.26.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?