### PR TITLE
openjdk8-zulu: update to 8.84.0.15

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      ${feature}.82.0.21
+version      ${feature}.84.0.15
 revision     0
 
-set openjdk_version ${feature}.0.432
+set openjdk_version ${feature}.0.442
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -35,14 +35,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  ab09bbdf3558c75ab4d3ed767b27b4041e1eb37f \
-                 sha256  a5a4bb4e95415d2a0ba719f76662ef87adeb1c8cf739c7ab14c0a2f1b3e62885 \
-                 size    106755351
+    checksums    rmd160  4ea10c09257a46b6f69d769e4261903fda68c466 \
+                 sha256  52131294512042dd6356426202e6a4116536477281fe76cfc0a3a15fe0d6ff44 \
+                 size    106931505
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  de8804b1115f3818b8edded23dd2495b7eab6568 \
-                 sha256  1036ce501972464c8e30ea2e0e2dc1c6c82e364edf99d13b9418286f61995f16 \
-                 size    104561942
+    checksums    rmd160  10a414d91ccdf10cd6ab7396040db909e5ce75ab \
+                 sha256  effa6d1bd4b6bce68328df66e063a97c2c4afeb0aa36fda4f85c434dd8246572 \
+                 size    104734182
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.84.0.15 based on OpenJDK 8u442.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?