### PR TITLE
openh264: use -read_only_relocs suppress in LDFLAGS on macOS <=10.6 i386

### DIFF
--- a/multimedia/openh264/Portfile
+++ b/multimedia/openh264/Portfile
@@ -46,4 +46,13 @@ if {[string match *clang* ${configure.compiler}]} {
                         -Wno-error=deprecated-declarations
 }
 
+# ld: illegal text-relocation to wels_p1p2p1p2w_128
+# in codec/common/libcommon.a(dct.o) from WelsDctFourT4_sse2
+# in codec/common/libcommon.a(dct.o) on macOS <=10.6 i386
+if {${configure.build_arch} eq "i386"} {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        configure.ldflags-append -read_only_relocs suppress
+    }
+}
+
 test.run                yes


### PR DESCRIPTION
#### Description

https://build.macports.org/builders/ports-10.6_i386-builder/builds/187131/steps/install-port/logs/stdio
I can't really test it, so any help would be appreciated.
OpenBSD ports use a [similar flag](https://github.com/openbsd/ports/blob/92b9942255c68e66a313ff8255b654038b05da47/multimedia/openh264/Makefile#L23) for i386.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
