### PR TITLE
openjdk23-sap: update to 23.0.2

### DIFF
--- a/java/openjdk23-sap/Portfile
+++ b/java/openjdk23-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/23
-version      ${feature}.0.1
+version      ${feature}.0.2
 revision     0
 
 description  SAP Machine ${feature} (Short Term Support until March 2025)
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  609b1bdcd9642ca169f6b8049a77f0df1491ca27 \
-                 sha256  c3c9602fbf9c022792bf31459aceddf0b6510a7ee0126b82344eafb9797aa0f2 \
-                 size    210232199
+    checksums    rmd160  445a92d57e7935ac35b8d9d05e8b94aa2213b0cf \
+                 sha256  9e25bc013fe82552155d28b2c5b1d5573cebb4c8fd0d24cf93643e4e125f8592 \
+                 size    210336978
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  1083cb9638488387b8aeda6fd2d54c5caebee34d \
-                 sha256  0af67f212e33ed965cdba44cd0a0cabce41fc7df1224436dfa36b56ce358b088 \
-                 size    207776811
+    checksums    rmd160  0eefbbc46cd382f13e5227f05b99da44757a3953 \
+                 sha256  a1fcb8a65f9291d6b1c61ba6404e15572bcd8568a37f6ea49a74ca07f335d9ed \
+                 size    207912345
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 23.0.2.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?