### PR TITLE
openjdk21-sap: update to 21.0.6

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/21
-version      ${feature}.0.5
+version      ${feature}.0.6
 revision     0
 
 description  SAP Machine ${feature}
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  11187bd9102e719eaafa3eb5bc0188931949dcf2 \
-                 sha256  e344087aa42b1910c6191a7bc5d31d71a776e32e4c89292df0f9b6c4cb29140f \
-                 size    202511940
+    checksums    rmd160  4a6b76ffa4c593a0ec6057fae683c397ce69bdfa \
+                 sha256  7f550106bf0bcf926b9637c70c3ce3a40e7b311c01f2a81a0dc7d95064c5054d \
+                 size    202583192
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  d0a9ac3c98f2953c57667570834068e108f8a8da \
-                 sha256  dd0abf66425a0b299dbccae9b4b6006694c1393d011bb2e7c562363bfb96fe96 \
-                 size    200225682
+    checksums    rmd160  e2f729a097ed99d1f36a2d02ddb197543f00ea25 \
+                 sha256  5b5acc052a823f6861bf43aacbecf0b0c3c93204a3bced36d7426591c4792a8f \
+                 size    200322931
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 21.0.6.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?