### PR TITLE
openjdk17-sap: update to 17.0.14

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.13
+version      ${feature}.0.14
 revision     0
 
 description  OpenJDK ${feature} builds (Long Term Support) maintained and supported by SAP
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  81c0f2434a1cec2853ad72c61b008eed731d2d9c \
-                 sha256  db43604a994ec4835c01d03fb7e4e7461d1c9a41b3fc5e3dcc7c0b2a763b044a \
-                 size    188211641
+    checksums    rmd160  f7801bece34a516bbe4cf9181d311874880ec49d \
+                 sha256  eca737bbc29de298da04856fdc9c856c2638df4151885050f710675a989cd31f \
+                 size    188308868
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  8256fd9b8533290ef00a3d45e564c3b711cf4370 \
-                 sha256  e3a9a204362a90d31d56c9c120b2f842c2dca837111ad8090ea50c49824f9678 \
-                 size    186144050
+    checksums    rmd160  e7de341bae6d1ae8150ed797e7512567d61edcce \
+                 sha256  8dfd53f5cc6a00d85500fc637b68e256c0b8ed6770e9b9c9779297761a24f276 \
+                 size    186270285
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.14.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?