### PR TITLE
openjdk21: update to 21.0.6

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 set feature 21
 name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk21/ for the version and build number that matches the latest '-ga' version
-version             ${feature}.0.5
-set build 11
+version             ${feature}.0.6
+set build 7
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -26,9 +26,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  3005b3b3dbd1c1fed06af9f9b60e03a53923fcaf \
-                    sha256  8a5d8be31d83edead93b02c7495960f969ddea38b59426a8d7b45aaadd82a960 \
-                    size    69823212
+checksums           rmd160  2987f9e3ae3542b1913c65c4e0385564c963270a \
+                    sha256  586bf34a4ce41d6a02f81315ef6cac7d2395a6d47d293af94a6a8fa7c7014ead \
+                    size    70317744
 
 set bootjdk_port    openjdk21-zulu
 
@@ -47,8 +47,8 @@ pre-patch {
     reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
 }
 
-# Temporary workaround for clang 16: https://trac.macports.org/ticket/70819
-# Temporary workaround for undeclared enum in < 11.00: https://trac.macports.org/ticket/71049
+# Workaround for clang 16.0-16.1: https://trac.macports.org/ticket/70819
+# Workaround for undeclared enum in < 11.00: https://trac.macports.org/ticket/71049
 patchfiles          JDK-8340341-clang-16-workaround.patch \
                     JDK-8342071-undecl-ident-nsbun-arm64-workaround.patch
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.6.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?