### PR TITLE
openjdk17: update to 17.0.14

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 set feature 17
 name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk17/ for the version and build number that matches the latest '-ga' version
-version             ${feature}.0.13
-set build 11
+version             ${feature}.0.14
+set build 7
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -21,9 +21,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  61878ca56c7b0b395b545c43b1350e80616c0418 \
-                    sha256  bb53c87cea4e1d145d2bef567f003f50e47f10495bbaac43c1d50874aa89c694 \
-                    size    66424164
+checksums           rmd160  d44423fb510e75d0516423573190959d7e9a284d \
+                    sha256  39a984e49a4216013e7a418fb91d46263165e5762e4ad9bd4ef95f9545e96fd6 \
+                    size    66483076
 
 depends_lib         port:freetype \
                     port:libiconv
@@ -37,8 +37,8 @@ pre-patch {
     reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
 }
 
-# Temporary workaround for clang 16: https://trac.macports.org/ticket/70819
-# Temporary workaround for undeclared enum in < 11.00: https://trac.macports.org/ticket/71049
+# Workaround for clang 16.0-16.1: https://trac.macports.org/ticket/70819
+# Workaround for undeclared enum in < 11.00: https://trac.macports.org/ticket/71049
 patchfiles          JDK-8340341-clang-16-workaround.patch \
                     JDK-8342071-undecl-ident-nsbun-arm64-workaround.patch
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.14.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?