### PR TITLE
openjdk11: update to 11.0.26

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 set feature 11
 name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk11/ for the version and build number that matches the latest '-ga' version
-version             ${feature}.0.25
-set build 9
+version             ${feature}.0.26
+set build 4
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -21,9 +21,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  b0edf71371b1e0114ca6fe8de4b111e09b80ea48 \
-                    sha256  6eaf2248b50c1d46b6405d26018ba6fa975c60f7682a85909a9f466282e39ca2 \
-                    size    72344244
+checksums           rmd160  a3fecc599f2889260a4ecc352adb2f1d4cab7631 \
+                    sha256  c8c08c47bf5f610c93f1b8428b9cd770c577349fbb73f2e1d818e1234de62006 \
+                    size    72352076
 
 depends_lib         port:freetype \
                     port:libiconv
@@ -38,7 +38,7 @@ pre-patch {
     reinplace "s|assert|vmassert|g" ${worksrcpath}/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
 }
 
-# Temporary workaround for clang 16: https://trac.macports.org/ticket/70819
+# Workaround for clang 16.0-16.1: https://trac.macports.org/ticket/70819
 patchfiles          JDK-8340341-clang-16-workaround.patch
 
 set tpath ${prefix}/Library/Java


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.26.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?