### PR TITLE
toast: Add patches to fix build

### DIFF
--- a/devel/toast/Portfile
+++ b/devel/toast/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        stepchowfun toast 0.47.6 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         \
     Containerize your development and continuous integration environments.
@@ -30,6 +30,12 @@ checksums           ${distname}${extract.suffix} \
                     rmd160  b09f57d3b8efd6b382d530f3c193ee1e46722d27 \
                     sha256  6cda205ec551232106a05a94b6a71d9eb90e4d3bf1541e629062c65257aa3e6a \
                     size    124657
+
+patch.pre_args-replace  -p0 -p1
+patchfiles              01-use-set-x-for-shell-scripts.patch \
+                        02-update-a-comment-about-signal-handling.patch \
+                        03-update-rust-to-183.patch \
+                        04-eliminate-needless-lifetimes.patch
 
 destroot {
     xinstall -m 0755 \

--- a/devel/toast/files/01-use-set-x-for-shell-scripts.patch
+++ b/devel/toast/files/01-use-set-x-for-shell-scripts.patch
@@ -1,0 +1,64 @@
+From f0109e5107e58760ec357fd1a9945553b0e2d8a3 Mon Sep 17 00:00:00 2001
+From: Stephan Boyer <stepchowfun@users.github.com>
+Date: Tue, 12 Mar 2024 20:39:49 -0700
+Subject: [PATCH] Use `set -x` for shell scripts
+
+---
+ src/toastfile.rs                              | 12 +++----
+
+diff --git a/src/toastfile.rs b/src/toastfile.rs
+index 1b149ae1..a2a0fdb0 100644
+--- a/src/toastfile.rs
++++ b/src/toastfile.rs
+@@ -2009,13 +2009,13 @@ tasks:
+             default: None,
+             location: UnixPath::new(DEFAULT_LOCATION).to_owned(),
+             user: DEFAULT_USER.to_owned(),
+-            command_prefix: "set -euo pipefail".to_owned(),
++            command_prefix: "set -euxo pipefail".to_owned(),
+             tasks,
+         };
+
+         assert_eq!(
+             command(&toastfile, &toastfile.tasks["foo"]),
+-            "set -euo pipefail".to_owned(),
++            "set -euxo pipefail".to_owned(),
+         );
+     }
+
+@@ -2079,7 +2079,7 @@ tasks:
+                 location: None,
+                 user: None,
+                 command: String::new(),
+-                command_prefix: Some("set -euo pipefail".to_owned()),
++                command_prefix: Some("set -euxo pipefail".to_owned()),
+                 extra_docker_arguments: vec![],
+             },
+         );
+@@ -2095,7 +2095,7 @@ tasks:
+
+         assert_eq!(
+             command(&toastfile, &toastfile.tasks["foo"]),
+-            "set -euo pipefail".to_owned(),
++            "set -euxo pipefail".to_owned(),
+         );
+     }
+
+@@ -2119,7 +2119,7 @@ tasks:
+                 location: None,
+                 user: None,
+                 command: "echo hello".to_owned(),
+-                command_prefix: Some("set -euo pipefail".to_owned()),
++                command_prefix: Some("set -euxo pipefail".to_owned()),
+                 extra_docker_arguments: vec![],
+             },
+         );
+@@ -2135,7 +2135,7 @@ tasks:
+
+         assert_eq!(
+             command(&toastfile, &toastfile.tasks["foo"]),
+-            "set -euo pipefail\necho hello".to_owned(),
++            "set -euxo pipefail\necho hello".to_owned(),
+         );
+     }
+ }

--- a/devel/toast/files/02-update-a-comment-about-signal-handling.patch
+++ b/devel/toast/files/02-update-a-comment-about-signal-handling.patch
@@ -1,0 +1,24 @@
+From 82c684177c9ae34a2db16d79fa800efee93997f2 Mon Sep 17 00:00:00 2001
+From: Stephan Boyer <stepchowfun@users.github.com>
+Date: Fri, 5 Apr 2024 02:23:15 -0700
+Subject: [PATCH] Update a comment about signal handling
+
+---
+ src/main.rs | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/main.rs b/src/main.rs
+index 4e28d4d..b5ea9aa 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -117,8 +117,8 @@ fn set_up_signal_handlers(
+     // If Toast is in the foreground process group for some TTY, the process will receive a SIGINT
+     // when the user types CTRL+C at the terminal. The default behavior is to crash when this signal
+     // is received. However, we would rather clean up resources before terminating, so we trap the
+-    // signal here. This code also traps SIGTERM, because we compile the `ctrlc` crate with the
+-    // `termination` feature [ref:ctrlc_term].
++    // signal here. This code also traps SIGHUP and SIGTERM, since we compile the `ctrlc` crate with
++    // the `termination` feature [ref:ctrlc_term].
+     ctrlc::set_handler(move || {
+         // Let the rest of the program know the user wants to quit.
+         if interrupted.swap(true, Ordering::SeqCst) {

--- a/devel/toast/files/03-update-rust-to-183.patch
+++ b/devel/toast/files/03-update-rust-to-183.patch
@@ -1,0 +1,35 @@
+From a19b52ad583137b1acd6eef116a668512b68976f Mon Sep 17 00:00:00 2001
+From: Stephan Boyer <stepchowfun@users.github.com>
+Date: Thu, 28 Nov 2024 13:03:40 -0800
+Subject: [PATCH] Update Rust to v1.83.0
+
+---
+ src/failure.rs           |  2 +-
+ src/toastfile.rs         |  2 +-
+
+diff --git a/src/failure.rs b/src/failure.rs
+index bb01653..212eb9d 100644
+--- a/src/failure.rs
++++ b/src/failure.rs
+@@ -24,7 +24,7 @@ impl fmt::Display for Failure {
+ }
+
+ impl error::Error for Failure {
+-    fn source<'a>(&'a self) -> Option<&(dyn error::Error + 'static)> {
++    fn source<'a>(&'a self) -> Option<&'a (dyn error::Error + 'static)> {
+         match self {
+             Self::System(_, source) => source.as_ref().map(|e| &**e),
+             Self::User(_, source) => source.as_ref().map(|e| &**e),
+diff --git a/src/toastfile.rs b/src/toastfile.rs
+index a2a0fdb..79bf0d5 100644
+--- a/src/toastfile.rs
++++ b/src/toastfile.rs
+@@ -79,7 +79,7 @@ impl Display for MappingPath {
+
+ struct MappingPathVisitor;
+
+-impl<'de> serde::de::Visitor<'de> for MappingPathVisitor {
++impl serde::de::Visitor<'_> for MappingPathVisitor {
+     type Value = MappingPath;
+
+     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {

--- a/devel/toast/files/04-eliminate-needless-lifetimes.patch
+++ b/devel/toast/files/04-eliminate-needless-lifetimes.patch
@@ -1,0 +1,23 @@
+From c965854bf601289dd067c3fb863d959958951067 Mon Sep 17 00:00:00 2001
+From: Rui Chen <chenrui333@users.github.com>
+Date: Sat, 30 Nov 2024 15:32:20 -0500
+Subject: [PATCH] fix: eliminate needless lifetimes
+
+Signed-off-by: Rui Chen <chenrui333@users.github.com>
+---
+ src/failure.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/failure.rs b/src/failure.rs
+index 212eb9d..05ab70b 100644
+--- a/src/failure.rs
++++ b/src/failure.rs
+@@ -24,7 +24,7 @@ impl fmt::Display for Failure {
+ }
+ 
+ impl error::Error for Failure {
+-    fn source<'a>(&'a self) -> Option<&'a (dyn error::Error + 'static)> {
++    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+         match self {
+             Self::System(_, source) => source.as_ref().map(|e| &**e),
+             Self::User(_, source) => source.as_ref().map(|e| &**e),


### PR DESCRIPTION
#### Description

The patches are trimmed-down versions of stepchowfun/toast#504, stepchowfun/toast#506, stepchowfun/toast#522, and stepchowfun/toast#524.

I have opened stepchowfun/toast#528 for a new release, when the patches can be deleted.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
