### PR TITLE
ruby33: update to 3.3.7

### DIFF
--- a/lang/ruby33/Portfile
+++ b/lang/ruby33/Portfile
@@ -17,11 +17,11 @@ legacysupport.newest_darwin_requires_legacy 14
 # This property should be preserved.
 
 set ruby_ver        3.3
-set ruby_patch      6
+set ruby_patch      7
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
-revision            1
+revision            0
 
 categories          lang ruby
 maintainers         {kimuraw @kimuraw} \
@@ -42,9 +42,9 @@ master_sites        ruby:${ruby_ver}
 distname            ruby-${version}
 dist_subdir         ruby${ruby_ver_nodot}
 
-checksums           rmd160  b77ffe3a13d630664a1ba91e5298575a430666f8 \
-                    sha256  8dc48fffaf270f86f1019053f28e51e4da4cce32a36760a0603a9aee67d7fd8d \
-                    size    22153657
+checksums           rmd160  b1cd4784744213af706c973f705dd859e6688928 \
+                    sha256  9c37c3b12288c7aec20ca121ce76845be5bb5d77662a24919651aaf1d12c8628 \
+                    size    22163173
 
 # Universal builds don't currently work, including via the approach used
 # in ruby30.
@@ -69,7 +69,7 @@ select.file         ${filespath}/ruby${ruby_ver_nodot}
 
 # patch-sources.diff: fixes for various issues.
 #
-# This diff is from v3_3_6 vs. macports-3_3_6r1.
+# This diff is from v3_3_7 vs. macports-3_3_7.
 #
 patchfiles-append   patch-sources.diff
 
@@ -83,6 +83,10 @@ patchfiles-append   patch-sources.diff
 compiler.blacklist-append \
                     { clang >= 900 < 901 }
 
+# Ruby3.3 no longer builds with Xcode clang 425 on 10.7
+compiler.blacklist-append { clang < 500 }
+
+# Ensure that the correct dsymutil is used.
 if { [string match macports-clang-* ${configure.compiler}] } {
     # clang-mp-14 => dsymutil-mp-14; fix POSTLINK
     configure.env-append dsymutil=[string map {clang dsymutil} ${configure.cc}]
@@ -157,18 +161,17 @@ variant gmp description "use gmp" {
 }
 
 variant jemalloc description "use jemalloc" {
-        configure.args-delete   --without-jemalloc
-        configure.args-append   --with-jemalloc
+        configure.args-replace  --without-jemalloc --with-jemalloc
         depends_lib-append      port:jemalloc
 }
 
 variant yjit description "enable YJIT (requires rust)" {
-        configure.args-delete   --disable-yjit
-        configure.args-append   --enable-yjit
+        configure.args-replace  --disable-yjit --enable-yjit
         depends_build-append    port:rust
 }
 # yjit supports x86_64 or arm64
-if {${os.major} >= 19 && [info exists build_arch]} {
+if {${os.platform} eq "darwin" && ${os.major} >= 19 \
+   && [info exists build_arch]} {
     if {$build_arch in [list x86_64 arm64]} {
         default_variants-append +yjit
     }

--- a/lang/ruby33/files/patch-sources.diff
+++ b/lang/ruby33/files/patch-sources.diff
@@ -1,5 +1,5 @@
---- .gdbinit.orig	2024-11-04 16:49:11.000000000 -0800
-+++ .gdbinit	2025-01-06 14:44:26.000000000 -0800
+--- .gdbinit.orig	2025-01-14 23:22:35.000000000 -0800
++++ .gdbinit	2025-01-20 13:54:57.000000000 -0800
 @@ -1,4 +1,5 @@
 -set startup-with-shell off
 +# Move this to end, so failure on older gdbs doesn't blow the rest
@@ -14,8 +14,8 @@
 +
 +# Moved from beginning, since it fails on older gdbs
 +set startup-with-shell off
---- ext/digest/md5/md5cc.h.orig	2024-11-04 16:49:11.000000000 -0800
-+++ ext/digest/md5/md5cc.h	2025-01-06 14:44:26.000000000 -0800
+--- ext/digest/md5/md5cc.h.orig	2025-01-14 23:22:35.000000000 -0800
++++ ext/digest/md5/md5cc.h	2025-01-20 13:54:57.000000000 -0800
 @@ -17,3 +17,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(MD5
  #undef MD5_Finish
  #define MD5_Update rb_digest_MD5_update
@@ -28,8 +28,8 @@
 + */
 +#undef MD5_Init
 +#define MD5_Init CC_MD5_Init
---- ext/digest/sha1/sha1cc.h.orig	2024-11-04 16:49:11.000000000 -0800
-+++ ext/digest/sha1/sha1cc.h	2025-01-06 14:44:26.000000000 -0800
+--- ext/digest/sha1/sha1cc.h.orig	2025-01-14 23:22:35.000000000 -0800
++++ ext/digest/sha1/sha1cc.h	2025-01-20 13:54:57.000000000 -0800
 @@ -12,3 +12,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(SHA
  #undef SHA1_Finish
  #define SHA1_Update rb_digest_SHA1_update
@@ -42,8 +42,8 @@
 + */
 +#undef SHA1_Init
 +#define SHA1_Init CC_SHA1_Init
---- ext/digest/sha2/sha2cc.h.orig	2024-11-04 16:49:11.000000000 -0800
-+++ ext/digest/sha2/sha2cc.h	2025-01-06 14:44:26.000000000 -0800
+--- ext/digest/sha2/sha2cc.h.orig	2025-01-14 23:22:35.000000000 -0800
++++ ext/digest/sha2/sha2cc.h	2025-01-20 13:54:57.000000000 -0800
 @@ -1,6 +1,33 @@
  #define COMMON_DIGEST_FOR_OPENSSL 1
  #include <CommonCrypto/CommonDigest.h>
@@ -94,8 +94,8 @@
 +#define SHA384_Init CC_SHA384_Init
 +#undef SHA512_Init
 +#define SHA512_Init CC_SHA512_Init
---- file.c.orig	2024-11-04 16:49:11.000000000 -0800
-+++ file.c	2025-01-06 14:44:26.000000000 -0800
+--- file.c.orig	2025-01-14 23:22:35.000000000 -0800
++++ file.c	2025-01-20 13:54:57.000000000 -0800
 @@ -299,10 +299,30 @@ rb_CFString_class_initialize_before_fork
      long len = sizeof(small_str) - 1;
  
@@ -147,8 +147,8 @@
      CFMutableStringRef m = CFStringCreateMutableCopy(kCFAllocatorDefault, len, s);
      long oldlen = RSTRING_LEN(str);
  
---- lib/bundler/gem_helper.rb.orig	2024-11-04 16:49:11.000000000 -0800
-+++ lib/bundler/gem_helper.rb	2025-01-06 14:44:26.000000000 -0800
+--- lib/bundler/gem_helper.rb.orig	2025-01-14 23:22:35.000000000 -0800
++++ lib/bundler/gem_helper.rb	2025-01-20 13:54:57.000000000 -0800
 @@ -231,7 +231,7 @@ module Bundler
      end
  
@@ -158,8 +158,8 @@
      end
    end
  end
---- signal.c.orig	2024-11-04 16:49:11.000000000 -0800
-+++ signal.c	2025-01-06 14:44:26.000000000 -0800
+--- signal.c.orig	2025-01-14 23:22:35.000000000 -0800
++++ signal.c	2025-01-20 13:54:57.000000000 -0800
 @@ -803,7 +803,8 @@ check_stack_overflow(int sig, const uint
      const greg_t bp = mctx->gregs[REG_EBP];
  #   endif
@@ -170,8 +170,8 @@
  #     define MCTX_SS_REG(reg) __ss.__##reg
  #   else
  #     define MCTX_SS_REG(reg) ss.reg
---- thread_pthread.c.orig	2024-11-04 16:49:11.000000000 -0800
-+++ thread_pthread.c	2025-01-06 14:44:26.000000000 -0800
+--- thread_pthread.c.orig	2025-01-14 23:22:35.000000000 -0800
++++ thread_pthread.c	2025-01-20 13:54:57.000000000 -0800
 @@ -42,6 +42,22 @@
  
  #if defined __APPLE__
@@ -195,8 +195,8 @@
  #endif
  
  #if defined(HAVE_SYS_EVENTFD_H) && defined(HAVE_EVENTFD)
---- vm_dump.c.orig	2024-11-04 16:49:11.000000000 -0800
-+++ vm_dump.c	2025-01-06 14:44:26.000000000 -0800
+--- vm_dump.c.orig	2025-01-14 23:22:35.000000000 -0800
++++ vm_dump.c	2025-01-20 13:54:57.000000000 -0800
 @@ -490,7 +490,8 @@ rb_vmdebug_thread_dump_state(FILE *errou
  }
  


### PR DESCRIPTION
See:
https://www.ruby-lang.org/en/news/2025/01/15/ruby-3-3-7-released/

Ruby 3.3 no longer builds with Xcode 10.1 clang 425 on 10.7, so this blacklists clangs < 500 (in addition to the preexisting blacklisting of clang 900).

Also cleans up a couple of long-standing Portfile issues.

TESTED:
Built successfully on OSX 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-15.x arm64.  Included all variants compatible with available dependencies on the respective platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.2 22H313, arm64, Xcode 15.2 15C500b
macOS 14.7.2 23H311, arm64, Xcode 16.2 16C5032a
macOS 15.2 24C101, arm64, Xcode 16.2 16C5032a
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` The test framework has issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
