### PR TITLE
openjdk21-temurin: update to 21.0.6

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -20,25 +20,25 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.5
-set build    11
+version      ${feature}.0.6
+set build    7
 revision     0
 
-description  Eclipse Temurin, based on OpenJDK ${feature}
+description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least December 2029)
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
 
 master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk-${version}%2B${build}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e9ac00f5c86c885fecc2b9be6f7820baf9892b3b \
-                 sha256  b9b46f396ab5f3658fa5569af963896167c7f735cfec816359c04101fae38bdf \
-                 size    193852232
+    checksums    rmd160  b7a11f6421fff6e31852141c134595e423e45053 \
+                 sha256  7aacfc400078ad65b7c7de3ec75ff74bf5c2077d6740b350f85ae10be4f71e76 \
+                 size    193844017
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  d90bc6a7d0d5ecc341b59b6f22b574d1b25c0c05 \
-                 sha256  dc6db7347907d23743d13af935d3c10e8b3490acdf542115f578838227da0dab \
-                 size    199597948
+    checksums    rmd160  43b7b102d42446de0b783c1ed643961f5337e004 \
+                 sha256  4ef4083919126a3d93e603284b405c7493905497485a92b375f5d6c3e8f7e8f2 \
+                 size    199608953
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 21.0.6.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?