### PR TITLE
openjdk17-temurin: update to 17.0.14

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -20,25 +20,25 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.13
-set build    11
+version      ${feature}.0.14
+set build    7
 revision     0
 
-description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support)
+description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least October 2027)
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
 
 master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk-${version}%2B${build}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  61bf3a3347b7a8ae59937201df8dc1a5e1136d5c \
-                 sha256  840535070200a944a6b582d258ee84608bd25c9f2b5d1cdddb58dfadb019675a \
-                 size    179980449
+    checksums    rmd160  e81ef2563735e9f3f25047c3e9330786773058b5 \
+                 sha256  bc2e9225d156d27149fc7a91817e6b64f76132b2b81d1f44cb8c90d7497b6ea7 \
+                 size    180020160
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  c73a11e0e2151f8ff5588d275d300d28fe4d2c8e \
-                 sha256  d8b2f77f755d06e81a540834c5be22ed86f3c8a51a20396606c074303f8f9e2d \
-                 size    185240495
+    checksums    rmd160  2929341696d7b815065ebc7b7af80bdfba3e5d0d \
+                 sha256  95bcc8052340394b87644d71a60fb26f31857f4090a7dfee57113e9e0f2dfacb \
+                 size    185303401
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.14.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?