### PR TITLE
openjdk11-temurin: update to 11.0.26

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -20,25 +20,26 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?os=mac&version=11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.25
-set build    9
+version      ${feature}.0.26
+set build    4
 revision     0
 
-description  Eclipse Temurin, based on OpenJDK ${feature}
+# See https://adoptium.net/support/ for end of support date
+description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least October 2027)
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
 
 master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk-${version}%2B${build}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  abd97d0101aa81f517fe555a5982e25ff1638303 \
-                 sha256  fa6f88ebd8c3d2b4f5146cd45e4ef875cb2d073b6e95b60de86a1ce0bfdb463a \
-                 size    187793518
+    checksums    rmd160  dff7ba0f169ecd42cfe7bd70e744052f00146766 \
+                 sha256  b0142c2c85da43bb3565321164e8129b1166de5d6a43c88e567a92c39128c003 \
+                 size    187768613
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  162514abbfb3a876b4f8d1a603ba2f1242ddd2a0 \
-                 sha256  658f73050ab168109862d4e25eefeedb587063cc01128a78ea4081e8ec62edcf \
-                 size    185072722
+    checksums    rmd160  215de772cb718ddb36b876b5faff2ab97224fd18 \
+                 sha256  c970e5917964da1b50c0029ba88a6fbe962783def4de6a8a2835af6a6859002c \
+                 size    185055401
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.26.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?