### PR TITLE
openjdk8-temurin: update to 8u442

### DIFF
--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -20,20 +20,20 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64
 
-version      ${feature}u432
+version      ${feature}u442
 set build    06
 revision     0
 
-description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support)
+description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least November 2026)
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
 
 master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk${version}-b${build}/
 distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}b${build}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  5f8860f55c3cc25de4e5a348aa8c946c7d646255 \
-             sha256  e5cc78b704cf96f7a6c4ad677048f79331f38cd37fbef6c86dce75e1bfe28895 \
-             size    109538778
+checksums    rmd160  bac02eaf33fe65fdc4a0c98decc55fbb9cf9e5a8 \
+             sha256  2f70725e032fe55629a2659d53646b14c538b12cdcedc2d3c9fa342e1b401cf1 \
+             size    109560420
 
 homepage     https://adoptium.net
 


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u442.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?