### PR TITLE
openjdk21-microsoft: update to 21.0.6

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.5
-set build    11
+version      ${feature}.0.6
+set build    7
 revision     0
 
 description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  e2c00a519b9d78f6e0f3efc90e542a6bffa39c2e \
-                 sha256  3e2317348141b28203fac39eaa60c14a1b3f1fdb9cfdbcb793eaa4dd5828da6e \
-                 size    202026107
+    checksums    rmd160  846b3e53f7a0856861f0dc2de0a9183058bea323 \
+                 sha256  72a4be9114ff8fb1830aeccd9dc2cde5eaad685aef9b3869f5d8a1dc9ce40eee \
+                 size    202004724
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  6c703010f5c0f950c25338b9710f650f934a38a4 \
-                 sha256  78aa915475b426c03059cc51e9c12596a5138457bd7ebb9b90daad119551662d \
-                 size    199572433
+    checksums    rmd160  4e6a72e4d74ffd315707cbb8c20e169e314a2433 \
+                 sha256  c277969b6b9021179e1e356d03e91f59333699e776ede58b66c99fb39fec6c43 \
+                 size    199599557
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 21.0.6.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?