### PR TITLE
openjdk17-microsoft: update to 17.0.14

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.13
-set build    11
+version      ${feature}.0.14
+set build    7
 revision     0
 
 description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  4f0ea55bf011d4a90338041083e3983c7c7c7559 \
-                 sha256  ce87d4110d61922ae3ee6d61d4c0ee48d7a98dcda38cffb8abc8299c47b5a730 \
-                 size    187631798
+    checksums    rmd160  f8f5c18e99c9bf5f81fc68bac979ba796d6260de \
+                 sha256  c0d677165073b08f765982d8bb20c08db03933c79ab269103150f88805c93e6e \
+                 size    187664597
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  0be73092714b48fe455da45c9dbc6184f70be8aa \
-                 sha256  095372e6d1a44890c52d0c8650c09ae26f740f5b740f1e6559398a492555a573 \
-                 size    185460735
+    checksums    rmd160  6fa553461daa9ecfbf27bb184d168e2f712f0b57 \
+                 sha256  1c00394d83edb32275d98463d64184c33a4ee3ddd89aa5b0762289a9ab3277ec \
+                 size    185525741
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.14.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?