### PR TITLE
openjdk11-microsoft: update to 11.0.26

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.25
-set build    9
+version      ${feature}.0.26
+set build    4
 revision     0
 
 description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  9493aba024d41e37481f7d1ea9f8974d870618ab \
-                 sha256  8a8be7a59c7a9d44bffc8e96a6bbc5e3e7c2c743b277e991df1803326f10f051 \
-                 size    191541600
+    checksums    rmd160  38e0cf382c47d6ca5aee9c6794ea3fcf4c38f4c3 \
+                 sha256  9411b7efa62aa7c222489c18353d2031ebd6a04296cd5f77f6c4803cdedf5c8a \
+                 size    191532609
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  7d77b65a7ada748cab9a628513365803a99dd6d7 \
-                 sha256  652ed4f3d72337e88c569aeb6bef735d3809a4e60d7606d759a8a1883a72e750 \
-                 size    185634319
+    checksums    rmd160  3b9ed83d09fae20fe750486627eab19f6870143d \
+                 sha256  093d6c306dfc219b0a7937cb7544607536adc54ed34da7acbd169c37dd179a81 \
+                 size    185632300
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.26.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?