### PR TITLE
git-absorb: Add bash, zsh, and fish completions

### DIFF
--- a/devel/git-absorb/Portfile
+++ b/devel/git-absorb/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        tummychow git-absorb 0.6.16
 github.tarball_from archive
-revision            0
+revision            1
 
 description         git commit --fixup, but automatic
 
@@ -37,10 +37,41 @@ depends_run-append  bin:git:git
 
 depends_lib-append  path:lib/pkgconfig/libgit2.pc:libgit2
 
+post-build {
+    set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
+    set gitabsorb   ${release_dir}/${name}
+
+    set bash_completions_dir ${release_dir}/share/bash-completion/completions
+    set fish_completions_dir ${release_dir}/share/fish/vendor_completions.d
+    set zsh_completions_dir ${release_dir}/share/zsh/site-functions
+
+    xinstall -d ${bash_completions_dir} ${fish_completions_dir} ${zsh_completions_dir}
+
+    system "${gitabsorb} --gen-completions bash > ${bash_completions_dir}/${name}"
+    system "${gitabsorb} --gen-completions fish > ${fish_completions_dir}/${name}.fish"
+    system "${gitabsorb} --gen-completions zsh > ${zsh_completions_dir}/_${name}"
+}
+
 destroot {
-    xinstall -m 0755 \
-        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
-        ${destroot}${prefix}/bin/
+    set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
+
+    xinstall -m 0755 ${release_dir}/${name} ${destroot}${prefix}/bin/
+
+    set bash_completions_dir share/bash-completion/completions
+    set fish_completions_dir share/fish/vendor_completions.d
+    set zsh_completions_dir share/zsh/site-functions
+
+    xinstall -d ${destroot}${prefix}/${bash_completions_dir}
+    xinstall ${release_dir}/${bash_completions_dir}/${name} \
+        ${destroot}${prefix}/${bash_completions_dir}
+
+    xinstall -d ${destroot}${prefix}/${fish_completions_dir}
+    xinstall ${release_dir}/${fish_completions_dir}/${name}.fish \
+        ${destroot}${prefix}/${fish_completions_dir}
+
+    xinstall -d ${destroot}${prefix}/${zsh_completions_dir}
+    xinstall ${release_dir}/${zsh_completions_dir}/_${name} \
+        ${destroot}${prefix}/${zsh_completions_dir}
 
     xinstall -d ${destroot}${prefix}/share/man/man1
     xinstall -m 0644 ${worksrcpath}/Documentation/${name}.1 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [x] enhancement

###### Tested on

macOS 15.2 24C101 arm64 Xcode 16.2 16C5032a

###### Verification

Have you

- [x] followed our
      [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and
      [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open
      [pull requests](https://github.com/macports/macports-ports/pulls) for the
      same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -st install`?
- [x] tested basic functionality of all binary files?
