### PR TITLE
mise: Update to 2025.1.14

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.1.13 v
+github.setup        jdx mise 2025.1.14 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fcb70fa3172a28312f097d63be26dab3e3047551 \
-                    sha256  8841f51718753e4a1627104960b3c7e676a77712342097048f793110af1b6542 \
-                    size    4280996
+                    rmd160  03ace3fd5c3c0eeed866fea0699a1ee7feb5bc9c \
+                    sha256  6745ef5b1be5478848e1e45d826dc1e37b177efeefc5fedf6fb184ddb7204aac \
+                    size    4281768
 
 patchfiles          patch-src_cli_self_update.diff
 


### PR DESCRIPTION
#### Description

mise: Update to 2025.1.14

##### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
