### PR TITLE
py-clang: Update clang19 to 19.1.7

### DIFF
--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -5,11 +5,11 @@ PortGroup               python 1.0
 
 # meta-version; bump whenever underlying variants are updated. Needed to
 # support portindex (variants can't have different versions.)
-version                 12
+version                 13
 # Needed for change to meta-versioning
 epoch                   1
 name                    py-clang
-python.versions         39 310 311 312
+python.versions         39 310 311 312 313
 license                 NCSA
 maintainers             {eborisch @eborisch} \
                         openmaintainer
@@ -23,7 +23,7 @@ platforms               {darwin any}
 
 livecheck.url           https://api.github.com/repos/llvm/llvm-project/git/refs/tags
 # Update this to the most recent clang supported
-livecheck.version       19.1.2
+livecheck.version       19.1.7
 livecheck.regex         {llvmorg-([\d.]+)\"}
 
 if {${name} ne ${subport}} {
@@ -35,9 +35,9 @@ if {${name} ne ${subport}} {
      cfe-3.7.1.src.tar.xz \
       rmd160  185b0f75970bc50682766a21794440578db87b5d \
       sha256  56e2164c7c2a1772d5ed2a3e57485ff73ff06c97dff12edbeea1acc4412b0674 \
-     clang-19.1.2.src.tar.xz \
-      rmd160  cbc65ca6a76b59d4a8827416a0177cca7fabd95d \
-      sha256  54aa3514c96a28b26482e84c44916fb3eac7c3bca2d1721d67154b52e84433c1 \
+     clang-19.1.7.src.tar.xz \
+      rmd160  320657b6b78ae206d3a95cebeb4050062f6dc519 \
+      sha256  11e5e4ecab5338b9914de3b83a4622cb200de466b7c56ba675afb72fa7d64675 \
      clang-18.1.8.src.tar.xz \
       rmd160  703b8825a5451db6011e8614dd7bc403877849b8 \
       sha256  5724fe0a13087d5579104cedd2f8b3bc10a212fb79a0fcdac98f4880e19f4519
@@ -46,7 +46,7 @@ if {${name} ne ${subport}} {
 
     # Keeping 37 around for old systems; otherwise two latest releases.
     set clanglist       {37    19     18}
-    set clangvlist      {3.7.1 19.1.2 18.1.8}
+    set clangvlist      {3.7.1 19.1.7 18.1.8}
 
     foreach cvnum $clanglist {
         # Explictly use (and depend on) the libclang we select during install


### PR DESCRIPTION
Maintainer update.