### PR TITLE
openjdk23-temurin: update to 23.0.2

### DIFF
--- a/java/openjdk23-temurin/Portfile
+++ b/java/openjdk23-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.1
-set build    11
+version      ${feature}.0.2
+set build    7
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Short Term Support until March 2025)
@@ -27,14 +27,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e8cffdb310089ca2afbb0f41b3e30fe185353ec8 \
-                 sha256  055a5b9c27991ad955c8207a20b549ac3254d479aa8a4fc199b6b02d56b1875e \
-                 size    201014412
+    checksums    rmd160  1cb673b89ddbb35e497552d777dad249854d714a \
+                 sha256  97fca2e90668351f248f149d4e96e16875094eba6716a8dd1dcf163be9e19085 \
+                 size    201048651
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  1051c6ef12de12758b193e4a6ff2b80f635cb88e \
-                 sha256  9e69810a50c8183e01429243d0bb112e381a122c6e7be936b7c13c3cfe7b29a0 \
-                 size    207156358
+    checksums    rmd160  f7e3cc436d630cbb7936d9a4d2fe8a3c1f51d8a9 \
+                 sha256  749993e751f085c7ae713140066a90800075e4aeedfac50a5ed0c5457131c5a0 \
+                 size    207224316
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 23.0.2.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?