### PR TITLE
openjdk24-zulu: update to 24.0.73

### DIFF
--- a/java/openjdk24-zulu/Portfile
+++ b/java/openjdk24-zulu/Portfile
@@ -30,8 +30,8 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.32-macosx_x64
-    checksums    rmd160  2aaebaf0645d9bc9b3d5a9e252cdc7675b395a82 \
-                 sha256  2877e06e973bfd0ec58ed2524dfbfddb5c8163a577e9cb5c1d75ab7a82c00e00 \
+    checksums    rmd160  7edc56bcee1d553b868229db1c1453036f3c4891 \
+                 sha256  d834887fb625ad2cb0203b449021c60d209eb8dbcb32a34f0a546bcdafea380e \
                  size    224930344
 } elseif {${configure.build_arch} eq "arm64"} {
     # No .tar.gz (yet?) for arm64

--- a/java/openjdk24-zulu/Portfile
+++ b/java/openjdk24-zulu/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-24-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.67
+version      ${feature}.0.73
 revision     0
 
 set openjdk_version ${feature}.0.0
@@ -29,18 +29,18 @@ long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant 
 master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.29-macosx_x64
-    checksums    rmd160  9ccefde9bfb6c1287897d7926af77bc7c7ddbc16 \
-                 sha256  29287d87b196b538e02de49b2ade68be1bbc596f80f53de1dc198c3cf5b17e28 \
-                 size    224895264
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.32-macosx_x64
+    checksums    rmd160  2aaebaf0645d9bc9b3d5a9e252cdc7675b395a82 \
+                 sha256  2877e06e973bfd0ec58ed2524dfbfddb5c8163a577e9cb5c1d75ab7a82c00e00 \
+                 size    224930344
 } elseif {${configure.build_arch} eq "arm64"} {
     # No .tar.gz (yet?) for arm64
     use_zip yes
 
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.29-macosx_aarch64
-    checksums    rmd160  caca2b7448206cd903feeab8f64a4ca573076af3 \
-                 sha256  67f1c307548fd58f9c250815c34332faa044690766c20da8f9de53f56bb193ca \
-                 size    225948005
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.32-macosx_aarch64
+    checksums    rmd160  ed9b10414bf442168d7b24bd7b4d566a0a52452d \
+                 sha256  991714636fed7a33b2343d0b772b354b70deb5706343cf81626e529c39c26ac6 \
+                 size    225987756
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 24.0.73.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?