### PR TITLE
google-cloud-sdk: update to 507.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             506.0.0
+version             507.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  45ffd0c83823de108e48b7ad517f1e8b509cbbad \
-                    sha256  28fa6360cc7ff4394a065f0bb2aa10591a4f7fb0ff1e6fab9a80c53593e0181d \
-                    size    53417128
+    checksums       rmd160  0bc599f0a9ed07638e74c54cc95f9aaffd8c2674 \
+                    sha256  c72fb5d31a466df08020a5b14fb2e1c916234dc1cabab33e39db072192635d4f \
+                    size    53508710
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  e6398cb85078a7658237ef984d12dbe017ae8ab0 \
-                    sha256  ba858537ca7c00d6d131935593321bcb4af457501398954a0f5b9673a8f570d7 \
-                    size    54883799
+    checksums       rmd160  32d05a1c84d5ea38034794dbb85ee84e1b0ab1f6 \
+                    sha256  75dd769823f56b2436c5fd89d74e2ad1464583a6409cc800cba97ec4412d77bc \
+                    size    54978420
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  db34582a6d3ea133d2905d5a17c41faa46ed768f \
-                    sha256  15a50df6b58c5b27b159e84cef87b9b477419feb5edd8d987a2b8707c907fb42 \
-                    size    54825568
+    checksums       rmd160  2884e539a3d60f25559fd2556cf545fc82e483f0 \
+                    sha256  d75acab82d23e5bb4e4fc376e66122486a12bc35b51b2af515ffacb2cda41298 \
+                    size    54917377
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 507.0.0.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?