### PR TITLE
fastfetch: update to 2.35.0, use python 3.13

### DIFF
--- a/sysutils/fastfetch/Portfile
+++ b/sysutils/fastfetch/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        fastfetch-cli fastfetch 2.32.1
+github.setup        fastfetch-cli fastfetch 2.35.0
 github.tarball_from archive
 revision            0
 
@@ -24,17 +24,18 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  f4ce52721c713921055d6ed9fafce5b81a275bd2 \
-                    sha256  f08efaaffa9f1c58b085105acfc41c65ed8f5721bdc7b1746b80700c727a4f60 \
-                    size    1158012
+checksums           rmd160  d338d0a89752126683fd6d4e635377d29fef26d3 \
+                    sha256  e066d84f9ca176e24f162ce99dab7fac5238b5e8c94ab4aaff5850b6cc5c6ead \
+                    size    1171386
 
-set py_version      312
+set py_branch       3.13
+set py_version      [string map {. ""} ${py_branch}]
 
 depends_build-append \
-                    path:bin/pkg-config:pkgconfig
+                    path:bin/pkg-config:pkgconfig \
+                    port:python${py_version}
 
 depends_lib-append  port:chafa                  \
-                    port:python${py_version}    \
                     port:sqlite3                \
                     port:yyjson
 
@@ -53,6 +54,11 @@ if {${os.platform} eq "darwin" \
     && (${os.major} > 10 && ${os.major} < 15)} {
     patchfiles-append \
                     1001-CMakeLists-disable-bluetooth-modules.patch
+}
+
+post-patch {
+    reinplace "s|#!/usr/bin/env python3|#!${prefix}/bin/python${py_branch}|" {*}[glob ${worksrcpath}/scripts/*.py]
+    reinplace "s|find_package(Python)|find_package(Python ${py_branch})|g" ${worksrcpath}/CMakeLists.txt
 }
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {


### PR DESCRIPTION
switch python to build dep and make sure the build process uses the specified version

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
