### PR TITLE
wine-*: Don't use libpcap

### DIFF
--- a/emulators/wine-devel/Portfile
+++ b/emulators/wine-devel/Portfile
@@ -53,7 +53,6 @@ depends_lib \
     port:freetype \
     port:gettext-runtime \
     path:lib/pkgconfig/gnutls.pc:gnutls \
-    port:libpcap \
     port:libsdl2
 
 depends_run \
@@ -107,7 +106,7 @@ configure.args \
     --with-opencl \
     --with-opengl \
     --without-oss \
-    --with-pcap \
+    --without-pcap \
     --with-pcsclite \
     --with-pthread \
     --without-pulse \

--- a/emulators/wine-stable/Portfile
+++ b/emulators/wine-stable/Portfile
@@ -53,7 +53,6 @@ depends_lib \
     port:freetype \
     port:gettext-runtime \
     path:lib/pkgconfig/gnutls.pc:gnutls \
-    port:libpcap \
     port:libsdl2
 
 depends_run \
@@ -107,7 +106,7 @@ configure.args \
     --with-opencl \
     --with-opengl \
     --without-oss \
-    --with-pcap \
+    --without-pcap \
     --with-pcsclite \
     --with-pthread \
     --without-pulse \


### PR DESCRIPTION
With this enabled most of the MacPorts buildbots are failing so disable pcap, this didn't happen when building locally on macOS Mojave +universal nor has it happened on macOS Sonoma

@kencu weirdly the buildbots are failing due to libpcap, no clue why when this works just fine locally, I have no idea why it's the case with the buildbots when we both managed to build wine locally without issue on multiple macOS versions.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 x86_64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
