### PR TITLE
mise: Update to 2025.1.15

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.1.14 v
+github.setup        jdx mise 2025.1.15 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  03ace3fd5c3c0eeed866fea0699a1ee7feb5bc9c \
-                    sha256  6745ef5b1be5478848e1e45d826dc1e37b177efeefc5fedf6fb184ddb7204aac \
-                    size    4281768
+                    rmd160  1be8a1e9a3b5075a4bbde62093e23185b570fb24 \
+                    sha256  d3f2db473b9639e77f63e1dca462b7ca8b5a3fee8083ce7f196c1463745fc69d \
+                    size    4290886
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -95,6 +95,7 @@ cargo.crates \
     age-core                        0.10.0  a5f11899bc2bbddd135edbc30c36b1924fa59d0746bb45beb5933fafe3fe509b \
     ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
+    allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     ansi-str                         0.8.0  1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d \
@@ -108,6 +109,7 @@ cargo.crates \
     arbitrary                        1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
+    arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     async-compression               0.4.18  df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522 \
     async-trait                     0.1.85  3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056 \
@@ -131,6 +133,7 @@ cargo.crates \
     bytecount                        0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                            1.9.0  325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b \
+    bytesize                         1.3.0  a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc \
     bzip2                            0.4.4  bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8 \
     bzip2                            0.5.0  bafdbf26611df8c14810e268ddceda071c297570a5fb360ceddf617fe417ef58 \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
@@ -151,6 +154,7 @@ cargo.crates \
     clap_derive                     4.5.24  54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     clap_mangen                     0.2.26  724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a \
+    clru                             0.6.2  cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59 \
     color-eyre                       0.6.3  55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5 \
     color-print                      0.3.7  3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4 \
     color-print-proc-macro           0.3.7  692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22 \
@@ -170,7 +174,7 @@ cargo.crates \
     core-foundation                 0.10.0  b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     countme                          3.0.1  7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636 \
-    cpufeatures                     0.2.16  16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3 \
+    cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
     crc                              3.2.1  69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636 \
     crc-catalog                      2.4.0  19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
@@ -189,8 +193,9 @@ cargo.crates \
     darling_core                   0.20.10  95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5 \
     darling_macro                  0.20.10  d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806 \
     dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
+    dashmap                          6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
-    demand                           1.6.1  58c47e28442b8cafbd1e05139fa18993058da13baf6c7110d47aac2e570169ce \
+    demand                           1.6.2  7d6c59d4d22c0837e599e2d8875fe2a1b16669a098a3530e7a23985c2d1387ab \
     der                              0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
@@ -222,6 +227,7 @@ cargo.crates \
     exec                             0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
     expr-lang                        0.2.2  bbf7d3d8b433d4dc8fe3e5383ad01f1cb2ffba8e999191af8bf7af1e9fa3e2ca \
     eyre                            0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
+    faster-hex                       0.9.0  a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183 \
     fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
@@ -253,7 +259,60 @@ cargo.crates \
     getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
     ghash                            0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
-    git2                            0.19.0  b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724 \
+    gix                             0.70.0  736f14636705f3a56ea52b553e67282519418d9a35bb1e90b3a9637a00296b68 \
+    gix-actor                       0.33.2  20018a1a6332e065f1fcc8305c1c932c6b8c9985edea2284b3c79dc6fa3ee4b2 \
+    gix-archive                     0.19.0  3d22c6ecdb350461a975159ebe514294064b9542a4cbc4a12d00c3f46a1107ce \
+    gix-attributes                  0.24.0  f151000bf662ef5f641eca6102d942ee31ace80f271a3ef642e99776ce6ddb38 \
+    gix-bitmap                      0.2.14  b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540 \
+    gix-chunk                       0.4.11  0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f \
+    gix-command                      0.4.1  cb410b84d6575db45e62025a9118bdbf4d4b099ce7575a76161e898d9ca98df1 \
+    gix-commitgraph                 0.26.0  e23a8ec2d8a16026a10dafdb6ed51bcfd08f5d97f20fa52e200bc50cb72e4877 \
+    gix-config                      0.43.0  377c1efd2014d5d469e0b3cd2952c8097bce9828f634e04d5665383249f1d9e9 \
+    gix-config-value               0.14.11  11365144ef93082f3403471dbaa94cfe4b5e72743bdb9560719a251d439f4cee \
+    gix-credentials                 0.27.0  cf950f9ee1690bb9c4388b5152baa8a9f41ad61e5cf1ba0ec8c207b08dab9e45 \
+    gix-date                         0.9.3  c57c477b645ee248b173bb1176b52dd528872f12c50375801a58aaf5ae91113f \
+    gix-diff                        0.50.0  62afb7f4ca0acdf4e9dad92065b2eb1bf2993bcc5014b57bc796e3a365b17c4d \
+    gix-dir                         0.12.0  c1d78db3927a12f7d1b788047b84efacaab03ef25738bd1c77856ad8966bd57b \
+    gix-discover                    0.38.0  d0c2414bdf04064e0f5a5aa029dfda1e663cf9a6c4bfc8759f2d369299bb65d8 \
+    gix-features                    0.40.0  8bfdd4838a8d42bd482c9f0cb526411d003ee94cc7c7b08afe5007329c71d554 \
+    gix-filter                      0.17.0  bdcc36cd7dbc63ed0ec3558645886553d1afd3cd09daa5efb9cba9cceb942bbb \
+    gix-fs                          0.13.0  182e7fa7bfdf44ffb7cfe7451b373cdf1e00870ac9a488a49587a110c562063d \
+    gix-glob                        0.18.0  4e9c7249fa0a78f9b363aa58323db71e0a6161fd69860ed6f48dedf0ef3a314e \
+    gix-hash                        0.16.0  e81c5ec48649b1821b3ed066a44efb95f1a268b35c1d91295e61252539fbe9f8 \
+    gix-hashtable                    0.7.0  189130bc372accd02e0520dc5ab1cef318dcc2bc829b76ab8d84bbe90ac212d1 \
+    gix-ignore                      0.13.0  4f529dcb80bf9855c0a7c49f0ac588df6d6952d63a63fefc254b9c869d2cdf6f \
+    gix-index                       0.38.0  acd12e3626879369310fffe2ac61acc828613ef656b50c4ea984dd59d7dc85d8 \
+    gix-lock                        16.0.0  9739815270ff6940968441824d162df9433db19211ca9ba8c3fc1b50b849c642 \
+    gix-mailmap                     0.25.2  017996966133afb1e631796d8cf32e43300f8f76233f2a15ce9af5be5069b0a6 \
+    gix-negotiate                   0.18.0  a6a8af1ef7bbe303d30b55312b7f4d33e955de43a3642ae9b7347c623d80ef80 \
+    gix-object                      0.47.0  ddc4b3a0044244f0fe22347fb7a79cca165e37829d668b41b85ff46a43e5fd68 \
+    gix-odb                         0.67.0  3e93457df69cd09573608ce9fa4f443fbd84bc8d15d8d83adecd471058459c1b \
+    gix-pack                        0.57.0  fc13a475b3db735617017fb35f816079bf503765312d4b1913b18cf96f3fa515 \
+    gix-packetline                  0.18.3  c7e5ae6bc3ac160a6bf44a55f5537813ca3ddb08549c0fd3e7ef699c73c439cd \
+    gix-packetline-blocking         0.18.2  c1cbf8767c6abd5a6779f586702b5bcd8702380f4208219449cf1c9d0cd1e17c \
+    gix-path                       0.10.14  c40f12bb65a8299be0cfb90fe718e3be236b7a94b434877012980863a883a99f \
+    gix-pathspec                     0.9.0  6430d3a686c08e9d59019806faa78c17315fe22ae73151a452195857ca02f86c \
+    gix-prompt                       0.9.1  79f2185958e1512b989a007509df8d61dca014aa759a22bee80cfa6c594c3b6d \
+    gix-protocol                    0.48.0  6c61bd61afc6b67d213241e2100394c164be421e3f7228d3521b04f48ca5ba90 \
+    gix-quote                       0.4.15  e49357fccdb0c85c0d3a3292a9f6db32d9b3535959b5471bb9624908f4a066c6 \
+    gix-ref                         0.50.0  47adf4c5f933429f8554e95d0d92eee583cfe4b95d2bf665cd6fd4a1531ee20c \
+    gix-refspec                     0.28.0  59650228d8f612f68e7f7a25f517fcf386c5d0d39826085492e94766858b0a90 \
+    gix-revision                    0.32.0  3fe28bbccca55da6d66e6c6efc6bb4003c29d407afd8178380293729733e6b53 \
+    gix-revwalk                     0.18.0  d4ecb80c235b1e9ef2b99b23a81ea50dd569a88a9eb767179793269e0e616247 \
+    gix-sec                        0.10.11  d84dae13271f4313f8d60a166bf27e54c968c7c33e2ffd31c48cafe5da649875 \
+    gix-shallow                      0.2.0  ab72543011e303e52733c85bef784603ef39632ddf47f69723def52825e35066 \
+    gix-status                      0.17.0  414cc1d85079d7ca32c3ab4a6479bf7e174cd251c74a82339c6cc393da3f4883 \
+    gix-submodule                   0.17.0  74972fe8d46ac8a09490ae1e843b4caf221c5b157c5ac17057e8e1c38417a3ac \
+    gix-tempfile                    16.0.0  2558f423945ef24a8328c55d1fd6db06b8376b0e7013b1bb476cc4ffdf678501 \
+    gix-trace                       0.1.12  7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7 \
+    gix-transport                   0.45.0  11187418489477b1b5b862ae1aedbbac77e582f2c4b0ef54280f20cfe5b964d9 \
+    gix-traverse                    0.44.0  2bec70e53896586ef32a3efa7e4427b67308531ed186bb6120fb3eca0f0d61b4 \
+    gix-url                         0.29.0  29218c768b53dd8f116045d87fec05b294c731a4b2bdd257eeca2084cc150b13 \
+    gix-utils                       0.1.14  ff08f24e03ac8916c478c8419d7d3c33393da9bb41fa4c24455d5406aeefd35f \
+    gix-validate                     0.9.3  9eaa01c3337d885617c0a42e92823922a2aea71f4caeace6fe87002bdcadbd90 \
+    gix-worktree                    0.39.0  6673512f7eaa57a6876adceca6978a501d6c6569a4f177767dc405f8b9778958 \
+    gix-worktree-state              0.17.0  86f5e199ad5af972086683bd31d640c82cb85885515bf86d86236c73ce575bf0 \
+    gix-worktree-stream             0.19.0  f61b0463c3cf4d07f2c72a10bdb03a2e4d70a9c26416c639346ad67456834485 \
     glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
     globset                         0.4.15  15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
@@ -267,12 +326,14 @@ cargo.crates \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hkdf                            0.12.4  7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7 \
     hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
+    home                            0.5.11  589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf \
     homedir                          0.3.4  5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2 \
     http                             1.2.0  f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                   0.1.2  793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f \
     httparse                         1.9.5  7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
+    human_format                     1.1.0  5c3b1f728c459d27b12448862017b96ad4767b1ec2ec5e6434e99f1577f085b8 \
     humansize                        2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
     humantime                        2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
     hyper                            1.5.2  256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0 \
@@ -299,6 +360,7 @@ cargo.crates \
     idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
+    imara-diff                       0.1.7  fc9da1a252bd44cd341657203722352efc9bc0c847d06ea6d2dc1cd1135e0a01 \
     impl-tools                      0.10.3  0ae95c9095c2f1126d7db785955c73cdc5fc33e7c3fa911bd4a42931672029a7 \
     impl-tools-lib                  0.11.1  2a391adcea096a89a593317881fb61ef4e68d3e7d9de9e2338e6e1557be29e10 \
     indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
@@ -307,9 +369,10 @@ cargo.crates \
     indicatif                       0.17.9  cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281 \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inout                            0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
-    insta                           1.42.0  6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5 \
+    insta                           1.42.1  71c1b125e30d93896b365e156c33dadfffab45ee8400afcbba4752f59de08a86 \
     intl-memoizer                    0.5.2  fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda \
     intl_pluralrules                 7.0.2  078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972 \
+    io-close                         0.3.7  9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc \
     io_tee                           0.1.1  4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304 \
     ipnet                           2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
@@ -317,19 +380,20 @@ cargo.crates \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
+    jiff                            0.1.27  a85348106ab244d90fe2d70faad939b71c5dad1258e5da9116e176064fc6c078 \
+    jiff-tzdb                        0.1.2  cf2cec2f5d266af45a071ece48b1fb89f3b00b2421ac3a5fe10285a6caaa60d3 \
+    jiff-tzdb-platform               0.1.2  a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
     junction                         1.2.0  72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16 \
-    kdl                              6.3.2  0a029b7a3f0cb86b0fcfd09718eeba23399d285f1827527ab88e88e6f44f6456 \
+    kdl                              6.3.3  412e2cf22cb560469db5b211c594ff9dcd490c6964e284ea64eddffe41c2249c \
+    kstring                          2.0.2  558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1 \
     lazy-regex                       3.4.1  60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126 \
     lazy-regex-proc_macros           3.4.1  4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     libc                           0.2.169  b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a \
-    libgit2-sys               0.17.0+1.8.1  10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224 \
     libm                            0.2.11  8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
-    libz-sys                        1.1.21  df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     litemap                          0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
@@ -345,8 +409,10 @@ cargo.crates \
     lzma-rust                        0.1.7  5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661 \
     lzma-sys                        0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
+    maybe-async                     0.2.10  5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11 \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
+    memmap2                          0.9.5  fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f \
     miette                           7.4.0  317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64 \
     miette-derive                    7.4.0  23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
@@ -359,7 +425,7 @@ cargo.crates \
     mlua-sys                         0.6.6  63a11d485edf0f3f04a508615d36c7d50d299cf61a7ee6d3e2530651e0a31771 \
     mlua_derive                     0.10.1  870d71c172fcf491c6b5fb4c04160619a2ee3e5a42a1402269c66bcbf1dd4deb \
     mockito                          1.6.1  652cd6d169a36eaf9d1e6bce1a221130439a966d7f27858af66a33a66e9c4ee2 \
-    native-tls                      0.2.12  a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466 \
+    native-tls                      0.2.13  0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     nt-time                          0.8.1  2de419e64947cd8830e66beb584acc3fb42ed411d103e3c794dda355d1b374b5 \
@@ -377,7 +443,7 @@ cargo.crates \
     object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
     once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
     opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
-    openssl                        0.10.68  6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5 \
+    openssl                        0.10.69  f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
     openssl-sys                    0.9.104  45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741 \
@@ -415,6 +481,7 @@ cargo.crates \
     poly1305                         0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
     polyval                          0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
     portable-atomic                 1.10.0  280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6 \
+    portable-atomic-util             0.2.4  d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
@@ -423,6 +490,7 @@ cargo.crates \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro2                     1.0.93  60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99 \
+    prodash                         29.0.0  a266d8d6020c61a437be704c5e618037588e1985c7dbb7bf8d265db84cffe325 \
     quick-xml                       0.37.2  165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003 \
     quinn                           0.11.6  62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef \
     quinn-proto                     0.11.9  a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d \
@@ -493,6 +561,7 @@ cargo.crates \
     serial_test_derive               3.2.0  5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef \
     sevenz-rust                      0.6.1  26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    sha1_smol                        1.0.1  bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shared_child                     1.0.1  09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c \
@@ -512,6 +581,7 @@ cargo.crates \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
+    static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
@@ -570,6 +640,7 @@ cargo.crates \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
     ubi                              0.4.1  771fe3d46f7fbcaf2a572ad253fea3a707e8e513d13de0cb4e40a5b7d6e198af \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
+    uluru                            3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
     unic-char-property               0.9.0  a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221 \
     unic-char-range                  0.9.0  0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc \
     unic-common                      0.9.0  80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc \
@@ -578,7 +649,9 @@ cargo.crates \
     unic-segment                     0.9.0  e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23 \
     unic-ucd-segment                 0.9.0  2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700 \
     unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
+    unicode-bom                      2.0.3  7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217 \
     unicode-ident                   1.0.15  11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243 \
+    unicode-normalization           0.1.24  5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956 \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \


### PR DESCRIPTION
#### Description

mise: Update to 2025.1.15

##### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
