### PR TITLE
openjdk11-sap: end of support

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -23,8 +23,8 @@ supported_archs  x86_64 arm64
 version      ${feature}.0.25
 revision     0
 
-description  OpenJDK ${feature} builds (Long Term Support) maintained and supported by SAP
-long_description Sap builds of OpenJDK for everyone who wish to use OpenJDK to run their applications.
+description  SapMachine OpenJDK ${feature} (Long Term Support ended in December 2024)
+long_description OpenJDK ${feature} distribution by SAP. Free, production-ready and Java SE certified.
 
 master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
 


### PR DESCRIPTION
#### Description

End of support reached in December 2024.

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?