### PR TITLE
yq: Fix checksum mismatch of manpage distfile

### DIFF
--- a/textproc/yq/Portfile
+++ b/textproc/yq/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/mikefarah/yq 4.45.1 v
 go.package          github.com/mikefarah/yq/v4
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://mikefarah.gitbook.io/yq
 
@@ -24,8 +24,8 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 # use generated man page to avoid build depedency on pandoc
-master_sites-append https://github.com/mikefarah/yq/releases/download/v${version}/:yqman
-distfiles-append    yq_man_page_only.tar.gz:yqman
+master_sites-append https://github.com/mikefarah/yq/releases/download/v${version}/yq_man_page_only${extract.suffix}?dummy=:yqman
+distfiles-append    yq_man_page_only-${version}${extract.suffix}:yqman
 
 build.pre_args-append \
                     -ldflags \"-X ${go.package}/cmd.Version=${version}\"
@@ -60,10 +60,10 @@ checksums           ${distname}${extract.suffix} \
                         rmd160  36d897af3821a8744194239780256014004bfa56 \
                         sha256  074a21a002c32a1db3850064ad1fc420083d037951c8102adecfea6c5fd96427 \
                         size    299351 \
-                    yq_man_page_only.tar.gz \
-                        rmd160  a38c7c842b404ecc70093f0bd5c076b310549784 \
-                        sha256  3c3a40707480ebb939922690ff38bb236f473aee1d013c3bf5d6d8b7b1ad0edc \
-                        size    42042
+                    yq_man_page_only-${version}${extract.suffix} \
+                        rmd160  80766c5c1d4b41db3bcb8ae1834e60c539fff680 \
+                        sha256  e7b8a378baa9d8ae62ce3f84f9d914616adee771902835acb3da4c87d4331bcd \
+                        size    42037
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/71959

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
