### PR TITLE
[submission] wabt: initial port for the Web Assembly Binary Toolkit

### DIFF
--- a/lang/wabt/Portfile
+++ b/lang/wabt/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                wabt
+version             1.0.36
+categories          lang
+homepage            https://github.com/WebAssembly/wabt
+license             Apache-2
+
+description         The WebAssembly Binary Toolkit
+long_description    \
+    WABT (we pronounce it \"wabbit\") is a suite of tools for WebAssembly, including: \
+ \
+      wat2wasm: translate from WebAssembly text format to the WebAssembly binary format \
+      wasm2wat: the inverse of wat2wasm, translate from the binary format back to the text format (also known as a .wat) \
+      wasm-objdump: print information about a wasm binary. Similiar to objdump. \
+      wasm-interp: decode and run a WebAssembly binary file using a stack-based interpreter \
+      wasm-decompile: decompile a wasm binary into readable C-like syntax. \
+      wat-desugar: parse .wat text form as supported by the spec interpreter (s-expressions, flat syntax, or mixed) and print \"canonical\" flat format \
+      wasm2c: convert a WebAssembly binary file to a C source and header \
+      wasm-strip: remove sections of a WebAssembly binary file \
+      wasm-validate: validate a file in the WebAssembly binary format \
+      wast2json: convert a file in the wasm spec test format to a JSON file and associated wasm binary files \
+      wasm-stats: output stats for a module \
+      spectest-interp: read a Spectest JSON file, and run its tests in the interpreter \
+ \
+    These tools are intended for use in (or for development of) toolchains \
+    or other systems that want to manipulate WebAssembly files.
+
+maintainers         easieste openmaintainer
+
+PortGroup           github  1.0
+github.setup        WebAssembly wabt 1.0.36
+fetch.type          git
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+PortGroup           cmake   1.1


### PR DESCRIPTION
A collection of utilities for working with webassembly ("wasm") binaries.

From <https://github.com/WebAssembly/wabt>:

     WABT (we pronounce it "wabbit") is a suite of tools for WebAssembly, including:

         wat2wasm: translate from WebAssembly text format to the WebAssembly binary format
         wasm2wat: the inverse of wat2wasm, translate from the binary
           format back to the text format (also known as a .wat)
         wasm-objdump: print information about a wasm binary. Similiar to objdump.
         wasm-interp: decode and run a WebAssembly binary file using a stack-based interpreter
         wasm-decompile: decompile a wasm binary into readable C-like syntax.
         wat-desugar: parse .wat text form as supported by the spec
           interpreter (s-expressions, flat syntax, or mixed) and print
           "canonical" flat format
         wasm2c: convert a WebAssembly binary file to a C source and header
         wasm-strip: remove sections of a WebAssembly binary file
         wasm-validate: validate a file in the WebAssembly binary format
         wast2json: convert a file in the wasm spec test format to a JSON file
          and associated wasm binary files
         wasm-stats: output stats for a module
         spectest-interp: read a Spectest JSON file, and run its tests in the interpreter

     These tools are intended for use in (or for development of) toolchains
     or other systems that want to manipulate WebAssembly files. Unlike the
     WebAssembly spec interpreter (which is written to be as simple,
     declarative and "speccy" as possible), they are written in C/C++ and
     designed for easier integration into other systems. Unlike Binaryen
     these tools do not aim to provide an optimization platform or a
     higher-level compiler target; instead they aim for full fidelity and
     compliance with the spec (e.g. 1:1 round-trips with no changes to
     instructions).

