### PR TITLE
chezmoi: Update to 2.59.0

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 2.58.0 v
+go.setup            github.com/twpayne/chezmoi 2.59.0 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
@@ -21,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  05dad1a7b040d3746aea801db4d085aba156f419 \
-                    sha256  50ac56d7e0624c5b1df2f451fbdec5c46e0e381476e8f2212669840de0d42984 \
-                    size    2522159
+checksums           rmd160  9b46d6660a3bb2cac66833e03bdbd91b67d834d1 \
+                    sha256  af1244c07ff5f3b04d6a2af186a9f2bdd33044399c94a051b64162f238a6b8bb \
+                    size    2522607
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

chezmoi: Update to 2.59.0

##### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
