### PR TITLE
girara: update to version 0.4.5

### DIFF
--- a/devel/girara/Portfile
+++ b/devel/girara/Portfile
@@ -1,15 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           gitlab 1.0
 PortGroup           meson 1.0
 
-gitlab.instance     https://git.pwmt.org
-gitlab.setup        pwmt girara 0.4.3
+name                girara
+version             0.4.5
 revision            0
-checksums           rmd160  e556260edbc76947816465260389d3791a87974d \
-                    sha256  b53c2d6a96f9482252fc26844762d08c975b9677f0a33b2d584081d318800530 \
-                    size    59765
+homepage            https://pwmt.org/projects/girara/
+master_sites        ${homepage}/download/
+use_xz              yes
+checksums           rmd160  666dee0e1011ca8ae819435a53dc33d81fcbdcf4 \
+                    sha256  6b7f7993f82796854d5036572b879ffaaf7e0b619d12abdb318ce14757bdda91 \
+                    size    60204
 
 categories          devel gnome
 license             zlib
@@ -54,3 +56,7 @@ platform darwin     {
         patchfiles-append   patch-getline.diff
     }
 }
+
+livecheck.type      regex
+livecheck.url       ${homepage}/download/
+livecheck.regex     ${name}-(\\d\.\\d\.\\d)${extract.suffix}


### PR DESCRIPTION
#### Description
* update to version 0.4.5
* don't use the gitlab PortGroup since this project is not hosted on GitLab anymore
* update homepage (project moved)
* update master_sites (project moved)
* update livecheck (project moved)
* distfiles are now compressed using xz

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2 24C101 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
