### PR TITLE
kotlin: update to 2.1.10

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 2.1.0 v
+github.setup        JetBrains kotlin 2.1.10 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  19a0c53688493b7f5a9d60d64b36e71a74c7193e \
-                    sha256  b6698d5728ad8f9edcdd01617d638073191d8a03139cc538a391b4e3759ad297 \
-                    size    86409360
+checksums           rmd160  b2639755a4b0d512ebeaf3953a0397a06343ba9a \
+                    sha256  c6e9e2636889828e19c8811d5ab890862538c89dc2a3101956dfee3c2a8ba6b1 \
+                    size    86422666
 
 java.version        1.8+
 java.fallback       openjdk21


### PR DESCRIPTION
#### Description

Update to Kotlin 2.1.10.

###### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?