### PR TITLE
google-cloud-sdk: update to 508.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             507.0.0
+version             508.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  0bc599f0a9ed07638e74c54cc95f9aaffd8c2674 \
-                    sha256  c72fb5d31a466df08020a5b14fb2e1c916234dc1cabab33e39db072192635d4f \
-                    size    53508710
+    checksums       rmd160  6fcb85dc724bfa9fec49b90b0bbac4f5e0aab071 \
+                    sha256  2bd2a5e16e134d7068098c98de1d4803f72aa2f756365812250842340d6e3da1 \
+                    size    53536882
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  32d05a1c84d5ea38034794dbb85ee84e1b0ab1f6 \
-                    sha256  75dd769823f56b2436c5fd89d74e2ad1464583a6409cc800cba97ec4412d77bc \
-                    size    54978420
+    checksums       rmd160  632f9895f8c57709488c70c9294b7d737171e231 \
+                    sha256  a3f62ce9ab0e9988f81efafeae5cf00bce4c866f34e23b3a371e11dd624d92e0 \
+                    size    55009058
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  2884e539a3d60f25559fd2556cf545fc82e483f0 \
-                    sha256  d75acab82d23e5bb4e4fc376e66122486a12bc35b51b2af515ffacb2cda41298 \
-                    size    54917377
+    checksums       rmd160  f1979341c93a1c1196fb643d2f73c5601fba8a66 \
+                    sha256  261442089aacb2b73a350f4ed2fd99fe1b7f83c9a8d49d781c821c72ef9124bb \
+                    size    54945303
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 508.0.0.

###### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?