### PR TITLE
ruby-build: Update to 20250127

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250121 v
+github.setup        rbenv ruby-build 20250127 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  5cf3bb23479854cd82a52533efc2950845877a62 \
-                    sha256  8e69b30941913f7aa3cbf9c464a21e4be43120f631f1ad3cc3992cc273b574cc \
-                    size    94174
+checksums           rmd160  e4deceb861c535a1af5defac8b369457289b94d7 \
+                    sha256  09f5e96be3ea26edb9b2f119195f05cc488085f19302276879c2de079024ec2e \
+                    size    94746
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250127

##### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
