### PR TITLE
ngspice: update to version 44.2

### DIFF
--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -3,8 +3,8 @@
 PortSystem      1.0
 
 name            ngspice
-version         43
-revision        1
+version         44.2
+revision        0
 license         BSD
 categories      science cad
 maintainers     {gmail.com:degnan.68k @bpdegnan} \
@@ -19,13 +19,19 @@ long_description \
                 suite of Electronic Design Automation tools.
 
 homepage        http://ngspice.sourceforge.net/
-master_sites    sourceforge:project/ngspice/ng-spice-rework/${version}
 
-checksums       rmd160  577a26e18e70fdf1fceb87ae3c6a783c3cf00d8e \
-                sha256  14dd6a6f08531f2051c13ae63790a45708bd43f3e77886a6a84898c297b13699 \
-                size    10279606
+distname        ${name}-${version}
+master_sites    https://sourceforge.net/projects/ngspice/files/ng-spice-rework/${version}
+
+checksums       rmd160  4194feaa1163de2bad9459d79be0a47ea0b4b4ec \
+                sha256  e7dadfb7bd5474fd22409c1e5a67acdec19f77e597df68e17c5549bc1390d7fd \
+                size    11198335
 
 set docdir      ${prefix}/share/doc/${name}
+
+#this strips the .x from 4.x 
+set major_version [string range ${version} 0 [expr {[string first "." ${version}]-1}]]
+
 
 # checking whether C compiler accepts -std=gnu11... no
 # C compiler cannot compile C11 code, etc.
@@ -116,13 +122,13 @@ subport ngspice-docs {
     description         PDF manual for ngspice
     long_description    {*}${description}
 
-    distname            ${name}-${version}-manual.pdf
+    distname            ${name}-${major_version}-manual.pdf
     extract.suffix
     extract.only
 
-    checksums           rmd160  af261765d31bb74434eb66f1e13b67c116223b04 \
-                        sha256  ae1d8db376df224e0d82e46d34a9d7ada068a69d685144f43b5efe5a2d06f0e8 \
-                        size    2559027
+    checksums           rmd160  a6cf586696a6307df9be3d40091b355829b35e90 \
+                        sha256  ab302f45ce5f866279638c8e7a4fb8e6a3b8b67cfbfd76d7951ccc4f636ce83e \
+                        size    2575573
 
     use_configure       no
 


### PR DESCRIPTION
#### Description

- Updated ngspice to version 44.2
- Modified the Portfile to handle the "." of the version.

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 13.7.2 22H313 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

[skip notification]
