### PR TITLE
age-plugin-se: An Age plugin for Apple's Secure Enclave

### DIFF
--- a/security/age-plugin-se/Portfile
+++ b/security/age-plugin-se/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        remko age-plugin-se 0.1.4 v
+github.tarball_from archive
+revision            0
+
+checksums           rmd160  74feaf0fb9a57bc2ef93bdd34ad0da4f75e3a8db \
+                    sha256  52d9b9583783988fbe5e94bbe72089a870d128a2eba197fc09a95c13926fb27a \
+                    size    325482
+
+license             MIT
+categories          security
+maintainers         {cal @neverpanic} openmaintainer
+installs_libs       no
+
+description         Age plugin for Apple's Secure Enclave
+long_description    \
+    age-plugin-se is a plugin for age, enabling encryption using Apple's Secure \
+    Enclave.
+
+use_configure       no
+use_xcode           yes
+
+depends_build       port:scdoc
+
+build.args          PREFIX=${prefix} RELEASE=1
+destroot.args       PREFIX=${prefix} RELEASE=1


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

