### PR TITLE
Lazarus: update to 3.8 and fixes for qt4 and gtk2 variants.

### DIFF
--- a/devel/lazarus/Portfile
+++ b/devel/lazarus/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                lazarus
-version             3.6-0
+version             3.8-0
 revision            0
 categories          devel
 license             GPL-2 LGPL-2
@@ -21,12 +21,12 @@ long_description    Lazarus is an open-source development system that builds \
                     to create applications with a graphical user interface \
                     (GUI).
 
-homepage            https://wiki.freepascal.org/Main_Page
+homepage            https://www.lazarus-ide.org
 master_sites        sourceforge:lazarus
 
-checksums           rmd160  1e02047c3cb8488c8f8e5c857fbac7dbb5c6334b \
-                    sha256  e65b90367f63bf17cb7bf35f5be69c9ef704ca494e91d8c67d072e3373fab085 \
-                    size    87683159
+checksums           rmd160  e334f4f19ff062a22392b929f48b9d87423c61bd \
+                    sha256  1da826fefa4175347f8e43324583b12d76f3ef56ebe48bd5fa6e847ec85295fc \
+                    size    87567292
 
 depends_lib         port:fpc port:fpc-sources
 supported_archs     x86_64 arm64 ppc
@@ -91,6 +91,10 @@ post-patch {
     copy ${worksrcpath}/components/virtualtreeview/units/cocoa         ${worksrcpath}/components/virtualtreeview/units/nogui
     copy ${worksrcpath}/components/virtualtreeview/include/intf/cocoa/ ${worksrcpath}/components/virtualtreeview/include/intf/nogui
 
+    if {[variant_isset gtk2]} {
+        reinplace "s|/sw/lib;/sw/lib/pango-ft219|${prefix}|g" ${worksrcpath}/lcl/interfaces/lcl.lpk
+        reinplace "s|/sw/lib|${prefix}/lib|g"                 ${worksrcpath}/lcl/interfaces/lcl.lpk
+    }
 }
 
 build.target       bigide
@@ -103,13 +107,13 @@ variant cocoa conflicts gtk2 qt4 description "Build with Cocoa backend" {
 
 variant gtk2 conflicts cocoa qt4 description "Build with GTK backend" {
     depends_lib-append path:lib/pkgconfig/gtk+-2.0.pc:gtk2
-
-    build.post_args    OPT=-gl LCL_PLATFORM=gtk2
+    build.post_args    OPT="-gl -Fl${prefix}/lib" LCL_PLATFORM=gtk2
 }
 
 variant qt4 conflicts cocoa gtk2 description "Build with Qt4 backend" {
     PortGroup          qt4 1.0
 
+    depends_lib-append port:qt4pas
     build.post_args    OPT=-gl LCL_PLATFORM=qt
 }
 


### PR DESCRIPTION
* update to version 3.8
* update homepage
* add dependence of qt4 variant on qt4pas
* fix missing library paths for gtk2 Note: issue 70817 refers to a much older version (2.10.1)

Closes: https://trac.macports.org/ticket/71939
Closes: https://trac.macports.org/ticket/71679
Possibly closes: https://trac.macports.org/ticket/70817

#### Description

Lazarus: update to 3.8 and fixes for qt4 and gtk2 variants.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [] security fix

###### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
