### PR TITLE
py-flit: add py313 (nomaintainer)

### DIFF
--- a/python/py-flit/Portfile
+++ b/python/py-flit/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160 23eaf71e1d56308be6190094776bdce9f575dbdc \
                     sha256 d75edf5eb324da20d53570a6a6f87f51e606eee8384925cd66a90611140844c7 \
                     size   141104
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 python.pep517_backend
 


### PR DESCRIPTION
Adding py313 flavor. Port has no maintainer.