### PR TITLE
mise: Update to 2025.1.17

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.1.16 v
+github.setup        jdx mise 2025.1.17 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  54ed1d05ccec5cd8b93c506152807684bdfcf25c \
-                    sha256  2189375724bab09fa721ce0b4afc78e2cc2de811cd134e439b426166f212acf5 \
-                    size    4291961
+                    rmd160  4fd9f47270c6381cccd0eb7182dd36e5650a7544 \
+                    sha256  82539d96cfd88edd8f05f997ad410c075f03a9406f479c0290dca7fc09626bc1 \
+                    size    4294059
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -524,7 +524,7 @@ cargo.crates \
     rustc-hash                       2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
-    rustls                         0.23.21  8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8 \
+    rustls                         0.23.22  9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.11.0  917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c \
@@ -625,7 +625,7 @@ cargo.crates \
     toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
     toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
-    toml_edit                      0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
+    toml_edit                      0.22.23  02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee \
     tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
@@ -684,7 +684,7 @@ cargo.crates \
     wasm-bindgen-shared            0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
     web-sys                         0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-roots                    0.26.7  5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e \
+    webpki-roots                    0.26.8  2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9 \
     which                            7.0.1  fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028 \
     widestring                       1.1.0  7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
@@ -720,7 +720,8 @@ cargo.crates \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                          0.6.25  ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310 \
+    winnow                          0.6.26  1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28 \
+    winnow                           0.7.0  7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419 \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     wit-bindgen-rt                  0.33.0  3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.1.17

##### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
