### PR TITLE
bettercap: patch default caplets path

### DIFF
--- a/net/bettercap/Portfile
+++ b/net/bettercap/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/bettercap/bettercap 2.41.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://www.bettercap.org
 
@@ -47,13 +47,16 @@ post-extract {
 }
 
 depends_build-append \
-                    port:pkgconfig \
-                    port:python310
+                    port:pkgconfig
 
 depends_lib-append  port:libpcap \
                     path:lib/pkgconfig/libusb-1.0.pc:libusb
 
 go.offline_build    no
+
+post-patch {
+    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/caplets/env.go
+}
 
 build.cmd           make
 build.target        build
@@ -61,7 +64,3 @@ build.target        build
 destroot {
     system -W ${worksrcpath} "make -w PREFIX=${destroot}${prefix} install"
 }
-
-notes \
-  "PLEASE NOTE: bettercap will install its caplets to /usr/local/share/bettercap"
-


### PR DESCRIPTION
remove python build dep

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
