### PR TITLE
mise: Update to 2025.2.0

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.1.17 v
+github.setup        jdx mise 2025.2.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  4fd9f47270c6381cccd0eb7182dd36e5650a7544 \
-                    sha256  82539d96cfd88edd8f05f997ad410c075f03a9406f479c0290dca7fc09626bc1 \
-                    size    4294059
+                    rmd160  178ba36b90664c6183233443d8c677afbb093557 \
+                    sha256  f79fe7c35f06ccd64c65b657e1f73fd8e0679ab0e63971a6a1da5611d11a4678 \
+                    size    4273223
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -112,7 +112,7 @@ cargo.crates \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     async-compression               0.4.18  df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522 \
-    async-trait                     0.1.85  3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056 \
+    async-trait                     0.1.86  644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
@@ -139,7 +139,7 @@ cargo.crates \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                              1.2.10  13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229 \
+    cc                              1.2.11  e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
@@ -240,6 +240,7 @@ cargo.crates \
     fluent-langneg                  0.13.0  2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94 \
     fluent-syntax                   0.11.1  2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foldhash                         0.1.4  a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
@@ -361,7 +362,7 @@ cargo.crates \
     idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
-    imara-diff                       0.1.7  fc9da1a252bd44cd341657203722352efc9bc0c847d06ea6d2dc1cd1135e0a01 \
+    imara-diff                       0.1.8  17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2 \
     impl-tools                      0.10.3  0ae95c9095c2f1126d7db785955c73cdc5fc33e7c3fa911bd4a42931672029a7 \
     impl-tools-lib                  0.11.1  2a391adcea096a89a593317881fb61ef4e68d3e7d9de9e2338e6e1557be29e10 \
     indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
@@ -381,7 +382,7 @@ cargo.crates \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
-    jiff                            0.1.28  c607c728e28764fecde611a2764a3a5db19ae21dcec46f292244f5cc5c085a81 \
+    jiff                            0.1.29  c04ef77ae73f3cf50510712722f0c4e8b46f5aaa1bf5ffad2ae213e6495e78e5 \
     jiff-tzdb                        0.1.2  cf2cec2f5d266af45a071ece48b1fb89f3b00b2421ac3a5fe10285a6caaa60d3 \
     jiff-tzdb-platform               0.1.2  a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
@@ -414,8 +415,8 @@ cargo.crates \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     memmap2                          0.9.5  fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f \
-    miette                           7.4.0  317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64 \
-    miette-derive                    7.4.0  23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67 \
+    miette                           7.5.0  1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484 \
+    miette-derive                    7.5.0  bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     minisign-verify                  0.2.3  6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3 \
@@ -498,8 +499,11 @@ cargo.crates \
     quinn-udp                        0.5.9  1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904 \
     quote                           1.0.38  0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand                             0.9.0  3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+    rand_core                        0.9.0  b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                    0.5.8  03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834 \
@@ -589,7 +593,7 @@ cargo.crates \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.96  d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80 \
+    syn                             2.0.98  36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
@@ -661,7 +665,7 @@ cargo.crates \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                        2.0.3  cbbaeb12c0a624b90c36daee220349c9084d0c7f619ba9fdb30825c84d14327d \
+    usage-lib                        2.0.4  57baf0038580e05341b56bffc4511cf6fff4cd80e825bd5ab936ade1b44cebfc \
     utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -669,7 +673,7 @@ cargo.crates \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
-    vfox                             1.0.0  6d66bb0124101043f5195f7c0f1c62d7e7a159c06e0c1e9a583774b44cb28718 \
+    vfox                             1.0.1  7a932a911ab6acdcb7d20c481cdbf7eea562ef209c6d1e13204c78a9549e58a3 \
     vte                             0.10.1  6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983 \
     vte_generate_state_changes       0.1.2  2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
@@ -728,13 +732,15 @@ cargo.crates \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     x25519-dalek                     2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
     xattr                            1.4.0  e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909 \
-    xx                               2.0.3  43e8a6586de03e05832a7e364b3b94fb86ae16bbaa881f3e7998c4e66c6b900f \
+    xx                               2.0.4  660d7629bc5d128108fc09a32b5187442de98ba1ad9c4681c5381cf53733aa0d \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
+    zerocopy                        0.8.14  a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468 \
     zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
+    zerocopy-derive                 0.8.14  d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1 \
     zerofrom                         0.1.5  cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e \
     zerofrom-derive                  0.1.5  595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808 \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \


### PR DESCRIPTION
#### Description

mise: Update to 2025.2.0

##### Tested on

macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
