### PR TITLE
py-nbconvert: add missing dependency to py-jupyterlab_pygments

### DIFF
--- a/python/py-nbconvert/Portfile
+++ b/python/py-nbconvert/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-nbconvert
 version             7.16.2
-revision            1
+revision            2
 categories-append   textproc
 license             BSD
 supported_archs     noarch
@@ -81,6 +81,7 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-defusedxml \
                     port:py${python.version}-jinja2 \
                     port:py${python.version}-jupyter_core \
+                    port:py${python.version}-jupyterlab_pygments \
                     port:py${python.version}-markupsafe \
                     port:py${python.version}-mistune \
                     port:py${python.version}-nbclient \


### PR DESCRIPTION
#### Description

Add missing dependency of `py-nbconvert` to `py-jupyterlab_pygments` (file `/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nbconvert/preprocessors/csshtmlheader.py` from `py-nbconvert` contains `from jupyterlab_pygments import JupyterStyle`).

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.2 24C101 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
