### PR TITLE
man: Fixes C99 implicit int errors in configure script

### DIFF
--- a/sysutils/man/Portfile
+++ b/sysutils/man/Portfile
@@ -40,7 +40,8 @@ patchfiles          configure-DEF_NLSPATH.patch \
                     src__man-getopt.c.diff \
                     src__man.c.diff \
                     src__manpath.c.diff \
-                    src__util.c.diff
+                    src__util.c.diff \
+                    patch-int-main.diff
 
 configure.universal_args-delete --disable-dependency-tracking
 

--- a/sysutils/man/files/patch-int-main.diff
+++ b/sysutils/man/files/patch-int-main.diff
@@ -1,0 +1,65 @@
+--- configure.orig	2025-02-05 18:18:26.282384940 +1100
++++ configure	2025-02-05 18:19:18.847823147 +1100
+@@ -225,7 +225,7 @@
+ echo checking for ANSI C header files
+ echo "#include <stdlib.h>
+ #include <string.h>
+-main() { exit(0); strerror(0); }" > conftest.c
++int main() { exit(0); strerror(0); }" > conftest.c
+ eval $compile
+ if test -s conftest && ./conftest 2>/dev/null; then
+   DEFS="$DEFS -DSTDC_HEADERS"
+@@ -239,7 +239,7 @@
+ echo checking for sys/termios.h
+ echo "#include <sys/termios.h>
+ #include <stdlib.h>
+-main() { exit(0); }" > conftest.c
++int main() { exit(0); }" > conftest.c
+ eval $compile
+ if test -s conftest && ./conftest 2>/dev/null; then
+   DEFS="$DEFS -DTERMIOS_HEADER"
+@@ -249,7 +249,7 @@
+ echo checking for POSIX.1 header files
+ echo "#include <unistd.h>
+ #include <stdlib.h>
+-main() {
++int main() {
+ #ifdef _POSIX_VERSION
+ exit(0);
+ #else
+@@ -265,7 +265,7 @@
+ echo checking for BSD string and memory functions
+ echo "#include <strings.h>
+ #include <stdlib.h>
+-main() { exit(0); rindex(0, 0); bzero(0, 0); }" > conftest.c
++int main() { exit(0); rindex(0, 0); bzero(0, 0); }" > conftest.c
+ eval $compile
+ if test -s conftest && ./conftest 2>/dev/null; then :
+   else DEFS="$DEFS -DUSG"
+@@ -275,7 +275,7 @@
+ echo checking whether sys/types.h defines uid_t
+ echo '#include <sys/types.h>
+ #include <stdlib.h>
+-main() { uid_t x; exit(0); }' > conftest.c
++int main() { uid_t x; exit(0); }' > conftest.c
+ eval $compile
+ if test -s conftest && ./conftest 2>/dev/null; then :
+ else
+@@ -309,7 +309,7 @@
+ #endif
+ #endif
+ #endif
+-main() { char *p = (char *) alloca(1); exit(0); }' > conftest.c
++int main() { char *p = (char *) alloca(1); exit(0); }' > conftest.c
+ eval $compile
+ if test -s conftest && ./conftest 2>/dev/null; then :
+ elif test -d /usr/ucblib; then LIBS="$LIBS -L/usr/ucblib -lucb"
+@@ -341,7 +341,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ struct option long_opts[] = { { "", no_argument, NULL, 0 } };
+-main() { exit(0); }' > conftest.c
++int main() { exit(0); }' > conftest.c
+ eval $compile
+ if test -s conftest && ./conftest 2>/dev/null; then
+   manpathoption="--path"


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3 24D60 x86_64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
