### PR TITLE
ImageMagick7: Update to 7.1.1-43

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -21,14 +21,13 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-github.setup        ImageMagick ImageMagick 7.1.1-41
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-revision            1
+github.setup        ImageMagick ImageMagick 7.1.1-43
+github.tarball_from archive
+revision            0
 
-checksums           rmd160  33aaaa6f16fd50916abfaa646c56d2c5d25da52e \
-                    sha256  38b8de7ca1f2b3cabfba3f1dd2010a63e07818bce41b930c6565f9f1ad1cf2fb \
-                    size    15669516
+checksums           rmd160  02a98cf83620ab04c83dbab93dbd3107f04b80bc \
+                    sha256  ceb972266b23dc7c1cfce0da5a7f0c9acfb4dc81f40eb542a49476fedbc2618f \
+                    size    15663097
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \


### PR DESCRIPTION
#### Description

ImageMagick7: Update 7.1.1-41 --> 7.1.1-43

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
