### PR TITLE
google-cloud-sdk: update to 509.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             508.0.0
+version             509.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  6fcb85dc724bfa9fec49b90b0bbac4f5e0aab071 \
-                    sha256  2bd2a5e16e134d7068098c98de1d4803f72aa2f756365812250842340d6e3da1 \
-                    size    53536882
+    checksums       rmd160  2d2b738f1ea9f4648170d71fa6096c8daa7369ba \
+                    sha256  a8b7fe597b4202a8c7687c83105fb22209996dd5279611f90a2732e0d5476b26 \
+                    size    53724765
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  632f9895f8c57709488c70c9294b7d737171e231 \
-                    sha256  a3f62ce9ab0e9988f81efafeae5cf00bce4c866f34e23b3a371e11dd624d92e0 \
-                    size    55009058
+    checksums       rmd160  3c8ad577d9ba11301af4557d4b84f9ddc6e91e41 \
+                    sha256  53ab02f03cfcd15f5c6be8001686711d109bb665eb3e921ec9cddf550e627ac3 \
+                    size    55191627
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  f1979341c93a1c1196fb643d2f73c5601fba8a66 \
-                    sha256  261442089aacb2b73a350f4ed2fd99fe1b7f83c9a8d49d781c821c72ef9124bb \
-                    size    54945303
+    checksums       rmd160  fc11f03d1940ba7689533c405e94e59e144dace5 \
+                    sha256  575e571ea07de9a0cd08dc1008ee4feca7c2d95a0510c903bff0bfe726746f4c \
+                    size    55133447
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 509.0.0.

###### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?