### PR TITLE
openjdk24-zulu: update to 24.0.77

### DIFF
--- a/java/openjdk24-zulu/Portfile
+++ b/java/openjdk24-zulu/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-24-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.73
+version      ${feature}.0.77
 revision     0
 
 set openjdk_version ${feature}.0.0
@@ -29,18 +29,18 @@ long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant 
 master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.32-macosx_x64
-    checksums    rmd160  7edc56bcee1d553b868229db1c1453036f3c4891 \
-                 sha256  d834887fb625ad2cb0203b449021c60d209eb8dbcb32a34f0a546bcdafea380e \
-                 size    224930344
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.34-macosx_x64
+    checksums    rmd160  595bfbb012255f556bf45b5ef41489384868a68b \
+                 sha256  cff7284aad88dec1afe5931e300b803b1dc987261631f658baf37594e8d03571 \
+                 size    224969512
 } elseif {${configure.build_arch} eq "arm64"} {
     # No .tar.gz (yet?) for arm64
     use_zip yes
 
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.32-macosx_aarch64
-    checksums    rmd160  ed9b10414bf442168d7b24bd7b4d566a0a52452d \
-                 sha256  991714636fed7a33b2343d0b772b354b70deb5706343cf81626e529c39c26ac6 \
-                 size    225987756
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.34-macosx_aarch64
+    checksums    rmd160  fa6b17ae6b83b842a94420ebea7d177c0466b2bd \
+                 sha256  5bd8fee8257ce34566da3c79b9d962de9051f291b6fd5002b37c946ac924e06f \
+                 size    226015246
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 24.0.77.

###### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?