### PR TITLE
ghidra: update to 11.3

### DIFF
--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -5,12 +5,11 @@ PortGroup           github 1.0
 PortGroup           java 1.0
 PortGroup           app 1.0
 
-github.setup        NationalSecurityAgency ghidra 11.2.1 Ghidra_ _build
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-checksums           rmd160  387011c078775375144aedfc8001d45d6e3c9f97 \
-                    sha256  dd4271dbe7c646bc8f3824f8dd44d66a700c22e389881ea4de4ada345525bd07 \
-                    size    70364666
+github.setup        NationalSecurityAgency ghidra 11.3 Ghidra_ _build
+github.tarball_from archive
+checksums           rmd160  b4a3d87104398bc3f62aa7f9266a3dfa1707d508 \
+                    sha256  418f7c5d111ba1b69c08163dc5b065954b5a6fabf0642fc517f25e1a535fc17d \
+                    size   69602474
 
 categories          devel
 license             Apache
@@ -24,7 +23,8 @@ java.version        21
 java.fallback       openjdk21
 
 universal_variant   no
-depends_build-append    port:gradle
+depends_build-append    port:gradle port:py313-pip port:python313
+depends_run-append      port:python313
 
 set javadest        ${prefix}/share/java/${name}-${version}
 configure.env-append    GRADLE_USER_HOME=${worksrcpath}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
update ghidra to 11.3, requires python3 now to build/run

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
