### PR TITLE
gdal-grass: update to 1.0.3, build with CMake

### DIFF
--- a/gis/gdal-grass/Portfile
+++ b/gis/gdal-grass/Portfile
@@ -1,84 +1,35 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=2:ts=2:sts=2
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           cmake  1.1
 
 name                gdal-grass
-categories          gis
 
 # Due to upstream reset of version numbering after split from GDAL source repo,
 # do not (re-)publish 1.4.3_0, 2.1.0_0, 2.1.0_1, 2.2.0_0, 2.2.0_1, or 2.2.0_2
-github.setup        OSGeo gdal-grass 1.0.2
-github.tarball_from archive
-revision            11
+version             1.0.3
+revision            0
 epoch               1
 
+categories          gis
+license             MIT
 maintainers         {yahoo.com:n_larsson @nilason} {vince @Veence} openmaintainer
-description         GRASS Drivers for GDAL and OGR.
+
+description         GRASS Drivers for GDAL and OGR
 long_description    This plugin allows GDAL to read GRASS raster and vector files.
 
-license             MIT
+homepage            https://github.com/OSGeo/gdal-grass
+master_sites        https://download.osgeo.org/gdal-grass/
 
 depends_lib         port:gdal \
                     port:grass
 
-checksums           rmd160  316d2faf2c66aecbec9d340ef37e799600f7a89c \
-                    sha256  91c45b3c316ed923f4fccb7e7e88fba131c883a6c92f950ec0c1a8b04a7bd851 \
-                    size    58045
+checksums           rmd160  3b5251029254b72215614df2e0690f0e9fa87ffc \
+                    sha256  eb000f9b953f3f2dc399e833969a2bc7f8f4637791add43240b69f77f382a71f \
+                    size    344478
 
-compiler.cxx_standard     2011
-configure.cxxflags-append -std=c++11
+compiler.cxx_standard  2011
 
-pre-configure {
-    set grass_gisbase [exec ${prefix}/bin/grass --config path]
-
-    configure.args-append --with-grass=${grass_gisbase}
-
-    # retrieve include path to <proj.h> from GRASS
-    set fp [open ${grass_gisbase}/include/Make/Platform.make r]
-    foreach line [split [read $fp] "\n"] {
-         if {[string match PROJINC* ${line}]} {
-             configure.cppflags-append [string trim [lindex [split ${line} "="] 1]]
-         }
-    }
-    close $fp
-
-    reinplace "s|CXXFLAGS = @CXX_WFLAGS@|CXXFLAGS = @CXXFLAGS@ @CXX_WFLAGS@|" \
-        ${worksrcpath}/Makefile.in
-}
-
-configure.args-append   --with-gdal=${prefix}/bin/gdal-config
-
-# PostGreSQL variants (from the GDAL port)
-set postgresql_suffixes {12 13 14 15 16}
-
-set postgresql_variants {}
-foreach suffix ${postgresql_suffixes} {
-    lappend postgresql_variants postgresql${suffix}
-}
-
-foreach suffix ${postgresql_suffixes} {
-    set vrt postgresql${suffix}
-    set pgversion [string index ${suffix} 0].[string index ${suffix} 1]
-    set index [lsearch -exact ${postgresql_variants} ${vrt}]
-    set conf [lreplace ${postgresql_variants} ${index} ${index}]
-
-    variant ${vrt} description "Use PostgreSQL ${pgversion}" conflicts {*}${conf} "
-        depends_lib-append      port:${vrt}
-        configure.args-append   --with-postgres-includes=${prefix}/include/${vrt}
-    "
-}
-
-# PostGreSQL default
-set pgdefault "if {"
-
-foreach suffix ${postgresql_suffixes} {
-    set pgdefault "${pgdefault}!\[variant_isset postgresql${suffix}\] && "
-}
-
-set pgdefault [string range ${pgdefault} 0 end-4]
-set pgdefault "${pgdefault}} { default_variants +postgresql${suffix} }"
-
-eval ${pgdefault}
-
-build.target            default
+livecheck.type      regex
+livecheck.url       [lindex ${master_sites} 0]
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)[quotemeta ${extract.suffix}]


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update `gdal-grass` to version 1.0.3, now build with CMake.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
