### PR TITLE
di: Avoid some interference from Makefile

### DIFF
--- a/sysutils/di/Portfile
+++ b/sysutils/di/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           makefile 1.0
 
 name                di
 version             5.0.3
@@ -25,17 +24,25 @@ depends_build       path:bin/cmake:cmake \
 
 depends_lib         port:gettext-runtime
 
-makefile.override-append \
-                    PREFIX
+configure.cmd       ${build.cmd}
+configure.pre_args  cmake-unix
+configure.args      PREFIX=${prefix}
+configure.env       "COMP=${configure.cc}"
 
 # Could use gmp (or tommath when https://trac.macports.org/ticket/71791 is fixed)
-build.args          DI_MATH=DI_INTERNAL
+configure.args-append \
+                    DI_MATH=DI_INTERNAL
 
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     # clang: error: unknown argument: '-fstack-protector-strong'
-    build.args-append \
+    configure.args-append \
                     DI_FORTIFY=N
 }
+
+build.target        cmake-build
+build.env           "pmode=--verbose --parallel ${build.jobs}"
+
+destroot.target     cmake-install
 
 livecheck.type      regex
 livecheck.url       https://sourceforge.net/projects/diskinfo-di/files/


### PR DESCRIPTION
#### Description

di uses a Makefile to drive cmake or mkc. Avoid some of the Makefile machinery by invoking lower-level Makefile targets directly. This ensures we always use cmake and don't risk accidentally using mkc instead, lets us run the configure step in the configure phase instead of as part of the build phase, and may work around a problem where failed builds were not exiting. It also lets us specify that we want a verbose build and how many parallel build jobs we want. The use of the makefile portgroup is no longer necessary.

See: https://trac.macports.org/ticket/72016

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
