### PR TITLE
chezmoi: Update to 2.59.1

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 2.59.0 v
+go.setup            github.com/twpayne/chezmoi 2.59.1 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
@@ -21,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  9b46d6660a3bb2cac66833e03bdbd91b67d834d1 \
-                    sha256  af1244c07ff5f3b04d6a2af186a9f2bdd33044399c94a051b64162f238a6b8bb \
-                    size    2522607
+checksums           rmd160  090729cdbc8d76ad504f5d0b96d96715c49bbd1f \
+                    sha256  577bce7c9038ca17cda2c61c1ff3df90c4b366b68629e3056e274cf4b319be30 \
+                    size    2522729
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

chezmoi: Update to 2.59.1

##### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
