### PR TITLE
xcode-build-server: update to v1.2.0

### DIFF
--- a/devel/xcode-build-server/Portfile
+++ b/devel/xcode-build-server/Portfile
@@ -4,10 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        SolaWing xcode-build-server 1.1.0 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-version             1.1.0
+github.setup        SolaWing xcode-build-server 1.2.0 v
+github.tarball_from archive
 revision            0
 platforms           {macosx any}
 license             MIT
@@ -25,9 +23,9 @@ long_description    ${name} integrates Xcode with Apple's sourcekit-lsp. \
                     server to provide sourcekit-lsp with the build \
                     information it needs for an Xcode project.
 
-checksums           rmd160  95128d3653a1e1fc0a078e6811249169c2308e51 \
-                    sha256  99c928c2d12494bd7d0ef61feda79cf6065592b4e48e495b4704b615928d67d1 \
-                    size    20640
+checksums           rmd160  c691dd2fc9c4a8010851038b47ea2e28f7321d3b \
+                    sha256  dc2a7019e00ff0d2b0d8c2761900395b39fb69543b9278285d2e85bd57382531 \
+                    size    21947
 
 build {}
 
@@ -41,6 +39,8 @@ destroot {
     xinstall -m 0755 {*}[glob ${worksrcpath}/*.py] ${destroot}/${python.pkgd}/${name}
     xinstall -d ${destroot}/${python.pkgd}/${name}/config
     xinstall -m 0755 {*}[glob ${worksrcpath}/config/*.py] ${destroot}/${python.pkgd}/${name}/config
+    xinstall -d ${destroot}/${python.pkgd}/${name}/xcode
+    xinstall -m 0755 {*}[glob ${worksrcpath}/xcode/*.js] ${destroot}/${python.pkgd}/${name}/xcode
     xinstall -m 0755 -W ${worksrcpath} ${name} ${destroot}/${python.pkgd}/${name}
     ln -s ${python.pkgd}/${name}/${name} ${destroot}${prefix}/bin/${name}
 }


### PR DESCRIPTION
#### Description

Update with the latest release, v1.2.0. The project has a new helper OSAScript file, "xcode/build.js", so that is added to the install steps.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.5 23F79 arm64
Xcode 16.0 16A242d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
