### PR TITLE
ocaml-uri and geneweb: bump revision as ocaml-angstrom was updated

### DIFF
--- a/genealogy/geneweb/Portfile
+++ b/genealogy/geneweb/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        geneweb geneweb 7.1-beta v
-revision            2
+revision            3
 categories          genealogy
 maintainers         {pguyot @pguyot} openmaintainer
 license             GPL-2

--- a/ocaml/ocaml-uri/Portfile
+++ b/ocaml/ocaml-uri/Portfile
@@ -5,7 +5,7 @@ PortGroup           ocaml 1.1
 PortGroup           github 1.0
 
 github.setup        mirage ocaml-uri 4.4.0 v
-revision            1
+revision            2
 categories          ocaml devel
 maintainers         {pguyot @pguyot} openmaintainer
 license             ISC


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

geneweb build was broken as ocaml-uri had to be rebuilt.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3 24D60 x86_64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
