### PR TITLE
sshuttle: update to 1.2.0

### DIFF
--- a/net/sshuttle/Portfile
+++ b/net/sshuttle/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                sshuttle
-version             1.1.2
+version             1.2.0
 revision            0
 
 homepage            https://sshuttle.readthedocs.io/en/stable
@@ -21,9 +21,9 @@ supported_archs     noarch
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  a375f4b1d551c5ca90adcfe0f8eb24c4501580e9 \
-                    sha256  f1f82bc59c45745df7543f38b0fa0f1a6a34d8a9e17dd8d9e5e259f069c763d6\
-                    size    59481
+checksums           rmd160  c75e567c4abc145e718c46fa38a552bdf359b5f7 \
+                    sha256  d887f9873f4e4358f9d51bd85496dd766ae0461f04130d6bed4276f77a1810fa \
+                    size    68095
 
 python.default_version \
                     312


### PR DESCRIPTION
#### Description
https://github.com/sshuttle/sshuttle/releases/tag/v1.2.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
