### PR TITLE
sqlite3: Avoid rpath; tweak install name

### DIFF
--- a/databases/sqlite3/Portfile
+++ b/databases/sqlite3/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           clang_dependency 1.0
 
 name                sqlite3
-# update libsqlite3.dylib to libsqlite3.0.dylib in post-destroot on next version update
 # don't forget to update the checksums for sqlite3-tools when updating sqlite3
 version             3.49.0
-revision            1
+revision            2
 categories          databases
 license             public-domain
 
@@ -65,6 +64,9 @@ platform darwin 8 {
 }
 
 if {${subport} eq ${name}} {
+    patchfiles-append \
+                    no-rpath.patch
+
     post-patch {
         # See https://sqlite.org/forum/forumpost/566126d8c7 this should not
         # be needed for future versions
@@ -87,13 +89,18 @@ if {${subport} eq ${name}} {
                                 -DSQLITE_SOUNDEX \
                                 -I${worksrcpath}
 
+    post-build {
+        system -W ${worksrcpath} "install_name_tool -id [shellescape ${prefix}/lib/libsqlite3.0.dylib] libsqlite3.dylib"
+    }
+
     post-destroot {
         xinstall -m 644 ${worksrcpath}/${name}.1 ${destroot}${prefix}/share/man/man1
-        system "install_name_tool -id [shellescape ${prefix}/lib/libsqlite3.dylib] [shellescape ${destroot}${prefix}/lib/libsqlite3.${version}.dylib]"
     }
 }
 
 subport ${name}-tcl {
+    revision        1
+
     depends_lib     port:tcl
 
     configure.dir   ${worksrcpath}/tea

--- a/databases/sqlite3/files/no-rpath.patch
+++ b/databases/sqlite3/files/no-rpath.patch
@@ -1,0 +1,13 @@
+Don't use -rpath. It's not needed in MacPorts and causes an error with
+older compilers.
+--- autosetup/proj.tcl.orig	2025-02-06 07:59:25.000000000 -0600
++++ autosetup/proj.tcl	2025-02-08 18:16:09.000000000 -0600
+@@ -918,6 +918,8 @@
+ # checked here will work but then fails at build-time, and the current
+ # order of checks reflects that.
+ proc proj-check-rpath {} {
++  define LDFLAGS_RPATH ""
++  return 0
+   set rc 1
+   if {[proj-opt-was-provided libdir]
+       || [proj-opt-was-provided exec-prefix]} {


### PR DESCRIPTION
#### Description

Don't use -rpath since it's never needed and causes an error with older compilers.

Closes: https://trac.macports.org/ticket/72018

Change the install name from /opt/local/lib/libsqlite3.dylib back to /opt/local/lib/libsqlite3.0.dylib as it was in 3.48.0 and earlier.

Change the install name in post-build not post-destroot and use shellescape when doing so.

See: https://trac.macports.org/ticket/72021

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
