### PR TITLE
py-awscli2: add python 3.13

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  1cbeb9fcbccecdc6fe77e9e084c45c3fb2f88412 \
                     sha256  44daed0a1337620fe1447674c3a8711928827c513a9723fba269831ddedc58c1 \
                     size    15955046
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 python.pep517       yes
 python.pep517_backend \
                     flit


### PR DESCRIPTION
#### Description

Add python 3.13 support to py-awscli2

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.3 24D60 x86_64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

`port lint` does complain that this conflicts with nonexistent port py313-awscli. I didn't think it made sense to add that version in this PR or to try to avoid the conflict now (which would become necessary if the py313-awscli version were added. It also looks like py312-awscli was added long before py313-awscli2 so I think this is "tradition".