### PR TITLE
mise: Update to 2025.2.2

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.2.0 v
+github.setup        jdx mise 2025.2.2 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  178ba36b90664c6183233443d8c677afbb093557 \
-                    sha256  f79fe7c35f06ccd64c65b657e1f73fd8e0679ab0e63971a6a1da5611d11a4678 \
-                    size    4273223
+                    rmd160  226b8826e5d14cbe82cecc750f5f6733b03db785 \
+                    sha256  9042137c960bd0548dc88f60018c6842a4f5367279ec6b22967a469c3ef7a300 \
+                    size    4261247
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -132,14 +132,14 @@ cargo.crates \
     bumpalo                         3.17.0  1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf \
     bytecount                        0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                            1.9.0  325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b \
+    bytes                           1.10.0  f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9 \
     bytesize                         1.3.0  a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc \
     bzip2                            0.4.4  bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8 \
     bzip2                            0.5.0  bafdbf26611df8c14810e268ddceda071c297570a5fb360ceddf617fe417ef58 \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                              1.2.11  e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf \
+    cc                              1.2.13  c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
@@ -149,9 +149,9 @@ cargo.crates \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
-    clap                            4.5.27  769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796 \
+    clap                            4.5.28  3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff \
     clap_builder                    4.5.27  1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7 \
-    clap_derive                     4.5.24  54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c \
+    clap_derive                     4.5.28  bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     clap_mangen                     0.2.26  724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a \
     clru                             0.6.2  cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59 \
@@ -161,7 +161,7 @@ cargo.crates \
     color-spantrace                  0.2.1  cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2 \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     colored                          2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
-    comfy-table                      7.1.3  24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9 \
+    comfy-table                      7.1.4  4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a \
     confique                         0.3.0  d011f79ecb68498e94453e133c67cc5c35ab847684c59fa58b9ce0698e272e7b \
     confique-macro                  0.0.11  df20583fae327154743356c4896906bda1aa9b7df30c5aed73a54cf27fede9de \
     console                        0.15.10  ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b \
@@ -199,7 +199,7 @@ cargo.crates \
     der                              0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
-    derive_more                    0.99.18  5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce \
+    derive_more                    0.99.19  3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f \
     deunicode                        1.6.0  339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00 \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
@@ -443,12 +443,12 @@ cargo.crates \
     num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
-    once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
+    once_cell                       1.20.3  945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e \
     opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
-    openssl                        0.10.69  f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e \
+    openssl                        0.10.70  61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6 \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
-    openssl-sys                    0.9.104  45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741 \
+    openssl-sys                    0.9.105  8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     os-release                       0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
@@ -473,8 +473,8 @@ cargo.crates \
     phf_codegen                     0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
     phf_generator                   0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
     phf_shared                      0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
-    pin-project                      1.1.8  1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916 \
-    pin-project-internal             1.1.8  d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb \
+    pin-project                      1.1.9  dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d \
+    pin-project-internal             1.1.9  f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67 \
     pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
@@ -525,7 +525,7 @@ cargo.crates \
     rust-embed-utils                 8.5.0  2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
-    rustc-hash                       2.1.0  c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497 \
+    rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustls                         0.23.22  9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7 \
@@ -537,11 +537,11 @@ cargo.crates \
     ryu                             1.0.19  6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd \
     salsa20                         0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    scc                              2.3.0  28e1c91382686d21b5ac7959341fcb9780fa7c03773646995a87c950fa7be640 \
+    scc                              2.3.3  ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1 \
     schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scrypt                          0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
-    sdd                              3.0.5  478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9 \
+    sdd                              3.0.7  b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca \
     secrecy                          0.8.0  9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework               3.2.0  271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316 \
@@ -627,7 +627,7 @@ cargo.crates \
     tokio-rustls                    0.26.1  5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37 \
     tokio-util                      0.7.13  d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078 \
     toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
-    toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
+    toml                            0.8.20  cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148 \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                      0.22.23  02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee \
     tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
@@ -643,7 +643,7 @@ cargo.crates \
     type-map                         0.5.0  deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f \
     typeid                           1.0.2  0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
-    ubi                              0.4.1  771fe3d46f7fbcaf2a572ad253fea3a707e8e513d13de0cb4e40a5b7d6e198af \
+    ubi                              0.4.2  a08a0a4c8f895fee1e4533aa2817b029b8b3909e93c5a536db6156738326ea6d \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     uluru                            3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
     unic-char-property               0.9.0  a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221 \
@@ -689,7 +689,7 @@ cargo.crates \
     web-sys                         0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                    0.26.8  2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9 \
-    which                            7.0.1  fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028 \
+    which                            7.0.2  2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283 \
     widestring                       1.1.0  7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -725,7 +725,7 @@ cargo.crates \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     winnow                          0.6.26  1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28 \
-    winnow                           0.7.0  7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419 \
+    winnow                           0.7.1  86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     wit-bindgen-rt                  0.33.0  3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
@@ -738,9 +738,9 @@ cargo.crates \
     yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
-    zerocopy                        0.8.14  a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468 \
+    zerocopy                        0.8.17  aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713 \
     zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
-    zerocopy-derive                 0.8.14  d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1 \
+    zerocopy-derive                 0.8.17  06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626 \
     zerofrom                         0.1.5  cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e \
     zerofrom-derive                  0.1.5  595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808 \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
@@ -748,7 +748,7 @@ cargo.crates \
     zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
     zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
     zip                              2.2.2  ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45 \
-    zipsign-api                      0.1.2  6413a546ada9dbcd0b9a3e0b0880581279e35047bce9797e523b3408e1df607c \
+    zipsign-api                      0.1.3  8e7c724c3a8e5833aad6b7028f4f0989fa3a640ce799bf8c352f417b8ef9db3e \
     zopfli                           0.8.1  e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946 \
     zstd                            0.13.2  fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9 \
     zstd-safe                        7.2.1  54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.2.2

##### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
