### PR TITLE
gvisor-tap-vsock: update to 0.8.3

### DIFF
--- a/net/gvisor-tap-vsock/Portfile
+++ b/net/gvisor-tap-vsock/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/containers/gvisor-tap-vsock 0.7.4 v
+go.setup            github.com/containers/gvisor-tap-vsock 0.8.3 v
 github.tarball_from archive
 revision            0
 
@@ -17,9 +17,9 @@ long_description    \
     the network stack of gVisor. Compared to libslirp, gvisor-tap-vsock \
     brings a configurable DNS server and dynamic port forwarding.
 
-checksums           rmd160  e9a6f022b2236faaf183340b285a50e6fd57adde \
-                    sha256  22a68a0b0f8120c8d4dde29856e2cc38b292ced1b1d4cd8bf3b709acadbddc88 \
-                    size    10639002
+checksums           rmd160  c1014eaa9defe5717e5858da326ff9aeca9a2f37 \
+                    sha256  5dd666c3d599c80c15182f80d848446482bdd7937b780517e591f5681a0b6889 \
+                    size    11037284
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 go.offline_build no


### PR DESCRIPTION
#### Description

- Major motivation is a fix to keyring spam which is fixed in 0.7.5: https://github.com/podman-desktop/podman-desktop/issues/8452
- Adds a bunch of features (see their changelog).

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
