### PR TITLE
legacy-support: update to v1.4.0.

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -22,7 +22,7 @@ long_description    {*}${description}
 epoch               1
 
 # Primary release version
-set release_ver     1.3.0
+set release_ver     1.4.0
 
 # Binary compatibility version
 set compat_ver      1.0.0
@@ -34,19 +34,9 @@ subport ${name} {
     # N.B.: That's a nice theory, but neither choice works correctly
     github.tarball_from tarball
     revision            0
-    checksums           rmd160  7d17aa039df1dd3e6d769a570bae703cea111e74 \
-                        sha256  cc0f2c5d6d2dfe1b8cfa15b1f590856552df22dc9cfa1b2b796557ed2f54e3e1 \
-                        size    95241
-
-    # Until this can be fixed disable parallel builds...
-    # https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/141962/steps/install-port/logs/stdio
-    use_parallel_build  no
-
-    pre-patch {
-        # until upstream can be fixed, do not include atexit symbols
-        # under certain circumstances, infinite recursive loops can form
-        delete ${worksrcpath}/src/macports_legacy_atexit.c
-    }
+    checksums           rmd160  7869ee1f847476a90364b00550006608d008d653 \
+                        sha256  336e98b306fd3d928b43342664daa550953f8f25233467670486c62544c80f67 \
+                        size    163812
 }
 
 subport ${name}-devel {
@@ -64,35 +54,20 @@ subport ${name}-devel {
                         size    163812
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
-
-    # Include Leopard-specific additions
-    platform darwin 9 {
-        build.target-append     leopard-bins
-        destroot.target-append  install-leopard
-    }
 }
 
 # The makefile PG brings in the unnecessary compiler_wrapper PG.
 # Disable it to reduce logfile clutter and obfuscation.
+#
 compwrap.compilers_to_wrap
 
-# NOTE: Update this comment on the next release (C++ tests are gone).
+# This port doesn't use C++ at all, except for three obsolete tests that
+# are now manual-only.  Disabling cxx_stdlib avoids unnessary compiler
+# constraints on some platforms.
 #
-# This port doesn't use C++ at all, except for a couple of tests which may
-# fail to build with a non-OS-default stdlib setting.  Since the cxx_stdlib
-# selection is unimportant for the tests (which are actually only testing
-# the C-only interface to the library), we disable the cxx_stlib setting.
-# This also avoids depending on a MacPorts compiler in some OS versions.
-
 configure.cxx_stdlib
 
-# NOTE: The variables LD, LIPO, and PLATFORM are no longer used by the
-# latest code.  Their definitions should be removed once that code becomes the
-# release version.
-build.env-append    LD=ld \
-                    "LIPO=/usr/bin/lipo" \
-                    PLATFORM=${os.major} \
-                    SOCURVERSION=${release_ver} \
+build.env-append    SOCURVERSION=${release_ver} \
                     SOCOMPATVERSION=${compat_ver}
 
 # Include Tiger-specific additions
@@ -101,11 +76,10 @@ platform darwin 8 {
     destroot.target-append  install-tiger
 }
 
-# NOTE: The variable FORCE_ARCH is no longer used by the
-# latest code.  Its definition should be removed once that becomes the
-# release version.
-foreach arch ${muniversal.architectures} {
-    build.env.${arch}-append    FORCE_ARCH=${arch}
+# Include Leopard-specific additions
+platform darwin 9 {
+    build.target-append     leopard-bins
+    destroot.target-append  install-leopard
 }
 
 test.env            {*}${build.env}


### PR DESCRIPTION
Notable changes since v1.3.0:

    - Works around Apple's broken versioning in the macOS 15 SDK
    - Implements scandir() compatibility feature
    - Fixes dprintf() bug and implements vdprintf() See: https://trac.macports.org/ticket/67598 See: https://trac.macports.org/ticket/70118

    - Mismatched SDK compatibility is extended to include 15.x SDK.
    - Broken 10.4 CLOCK_MONOTONIC is fixed.

    - Fixes stat inconsistency in some 32-bit 10.4 builds.
    - Adds stat64 header support for 10.4 SDK.
    - Adds INODE64 support for *stat*() on 10.4.
    - Reworks fstatat*() support, similar to previous item, fixing buffer overrun in some cases.
    - Backports 10.5 'which' to 10.4.

    - Adds support for code that can't tolerate the normal scandir() compatibility feature.
    - Replaces broken 10.4/10.5 copyfile wrapper with full 10.6 copyfile.
    - Extends 10.4 INODE64 support to *statx_np() functions.
    - Expands TARGET_* defaults. See: https://trac.macports.org/ticket/70824

    - Fixes 10.4 Rosetta bug in fstatx_np()
    - Makes renameat() available via stdio.h See: https://trac.macports.org/ticket/71842
    - Implements interim clock_gettime_nsec_np() See: https://trac.macports.org/ticket/61691
    - Implements clock_settime() See: https://trac.macports.org/ticket/71399
    - Adds net/if_tun.h for <10.6 See: https://trac.macports.org/ticket/70231
    - Provides pthread_[f]chdir_np() for 10.5+ See: https://trac.macports.org/ticket/71265
    - Adds CPU_TYPE_ARM definition for 10.4 See: https://trac.macports.org/ticket/71621

TESTED:
Tested both normal and -devel versions -/+universal on 10.4-10.5 ppc, 10.5-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-15.x arm64.
Builds and passes all tests on all tested platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.3 22H417, arm64, Xcode 15.2 15C500b
macOS 14.7.3 23H417, arm64, Xcode 16.2 16C5032a
macOS 15.3 24D60, arm64, Xcode 16.2 16C5032a
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
