### PR TITLE
rhyme: update fatalError signature

### DIFF
--- a/textproc/rhyme/Portfile
+++ b/textproc/rhyme/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    rhyme
 version                 0.9
-revision                6
+revision                7
 checksums               rmd160  5049ee3f2ad6d56d03fd28a7399129213f4ca808 \
                         sha256  11d4862cc3adfc18ea83ca233854c562fcebdc838fa7fb62de6ef3f63f992bd4 \
                         size    896013
@@ -26,7 +26,8 @@ depends_lib             port:gdbm \
                         port:ncurses \
                         port:readline
 
-patchfiles              patch-Makefile.diff
+patchfiles              patch-Makefile.diff \
+                        patch-fatalError.diff
 
 use_configure           no
 variant universal {}

--- a/textproc/rhyme/files/patch-fatalError.diff
+++ b/textproc/rhyme/files/patch-fatalError.diff
@@ -1,0 +1,24 @@
+--- setup.h.orig	2002-01-14 12:23:07
++++ setup.h	2025-03-03 16:01:15
+@@ -27,7 +27,7 @@
+ #define FLAG_MERGED 4
+ 
+ /*something to print if gdbm dies horribly*/
+-void fatalError(char s[]);
++void fatalError(const char *s);
+ 
+ /*The wordfile, rhymefile and multiplefile are set by this function
+   The flags are the bits set by the command-line arguments.
+--- setup.c.orig	2002-01-14 12:23:22
++++ setup.c	2025-03-03 16:00:50
+@@ -16,8 +16,8 @@
+   {0,0,0,0}
+ };
+ 
+-void fatalError(char s[]) {
+-  fprintf(stderr, s);
++void fatalError(const char *s) {
++  fprintf(stderr, "%s", s);
+   exit(1);
+ }
+ 


### PR DESCRIPTION
#### Description

This pull request updates the `fatalError` function signature in the rhyme port. Previously, `setup.h` declared

`void fatalError(char s[]);`

while setup.c defined it as

`void fatalError(const char *s) { … }`

This inconsistency caused a build error on macOS 15.3 when `fatalError` was passed to `gdbm_open` (which expects a function pointer taking a `const char *`). Changing the declaration in `setup.h` to use `const char *` brings both files into alignment and resolves the conflict. The port revision has been bumped to 7 accordingly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
