### PR TITLE
stimfit: update to version 0.16.6

### DIFF
--- a/science/stimfit/Portfile
+++ b/science/stimfit/Portfile
@@ -4,11 +4,10 @@ PortSystem          1.0
 PortGroup           wxWidgets 1.0
 
 name                stimfit
-version             0.16.2
-revision            3
-checksums           rmd160  bab67cce67e60bc8251942c83f73f643fae15a5c \
-                    sha256  309cd3381caabb2d2fdc258520d376e11f8ab2ab047ba7851c3e6ab3ee78e20f \
-                    size    2671190
+version             0.16.6
+checksums           rmd160  72a0675c28b133a55ee98ea882434fe7f94d4088 \
+                    sha256  8448e27fa48d7e04f788c8d636a07596ffeaddcfde15e8d6f41e6f356cb58d44 \
+                    size 1918670
 
 categories          science
 license             GPL-2
@@ -20,11 +19,11 @@ master_sites        ${homepage}
 
 wxWidgets.use       wxWidgets-3.2
 
+depends_build       port:gawk
+
 depends_lib         port:fftw-3 \
                     port:hdf5 \
                     port:${wxWidgets.port}
-
-patchfiles          isfinite.patch
 
 compiler.cxx_standard \
                     2017
@@ -35,11 +34,11 @@ configure.args      --disable-dependency-tracking \
                     --with-biosiglite \
                     --with-wx-config=${wxWidgets.wxconfig}
 
-if {![variant_isset python39] && ![variant_isset python310]} {
-    default_variants +python310
+if {![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312]} {
+    default_variants +python312
 }
 
-set python_branches {3.9 3.10}
+set python_branches {3.9 3.10 3.11 3.12}
 
 foreach python_branch ${python_branches} {
     set python_version [join [lrange [split ${python_branch} .] 0 1] ""]
@@ -72,8 +71,7 @@ foreach python_branch ${python_branches} {
         depends_lib-append \
             port:python${python_version} \
             port:py${python_version}-numpy \
-            port:py${python_version}-matplotlib \
-            port:py${python_version}-cvxopt
+            port:py${python_version}-matplotlib
 
         configure.python \
             ${prefix}/bin/python${python_branch}


### PR DESCRIPTION
#### Description
* update to version 0.16.6
* update file I/O
* update to latest numpy API

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3 24D60 x86_64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
