### PR TITLE
wine-devel,wine-staging: Update to 10.1

### DIFF
--- a/emulators/wine-devel/Portfile
+++ b/emulators/wine-devel/Portfile
@@ -7,7 +7,7 @@ PortGroup                   muniversal 1.1
 
 # Keep the wine-stable, wine-devel and wine-crossover portfiles as similar as possible.
 
-github.setup                wine-mirror wine 10.0 wine-
+github.setup                wine-mirror wine 10.1 wine-
 github.tarball_from         archive
 name                        wine-devel
 conflicts                   wine-stable wine-staging wine-crossover
@@ -38,9 +38,9 @@ long_description \
 
 checksums \
     ${distname}${extract.suffix} \
-    rmd160  0807d7f380af0851151b7abd04490a9636b187f1 \
-    sha256  b3edf134a5698d55bd210f11c3ae833c943abcece75810f6aa8cbd7a9f293ff7 \
-    size    51935194
+    rmd160  e7d90b40c213d9d4c242eaaefb1d23c6a0b5cfd7 \
+    sha256  d997ee279514dffe0541ecfd30c1f48ef97659b745c07b2e57fffc109aa6c57f \
+    size    51982659
 
 depends_build \
     port:bison \
@@ -145,9 +145,9 @@ subport wine-staging {
 
     checksums-append \
         ${wine_staging_distfile} \
-        rmd160  7c2cac03da0a1d90ae866f28499c53115e3f72b6 \
-        sha256  59eb36a2d9786d28242901458b282d49430bdbacf801af575566dcfc6c2943ea \
-        size    9490601
+        rmd160  d1588e87c643987301422bfc46fd06dca25f16a9 \
+        sha256  029009c52a0eb428451d8381992bbcabe50bed4527f3a9c73d00f55c7f3af9cc \
+        size    9542987
 
     depends_patch-append    port:autoconf
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 x86_64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
