### PR TITLE
symfony-cli: update to 5.10.7

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.10.6
+version             5.10.7
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  10251c98e25675209fb25c9f2a4e2b4e5a1ad8bb \
-                        sha256  3bec4c11bee6776113ddc55b72238541ab558524b0ad10ad7d1d21c5c35b2409 \
-                        size    274053
+    checksums           rmd160  af58b064bbbc62de4a4007cc1607ca4644c6e21b \
+                        sha256  8b6eb9c520260a5bd2f50c3ad92440466576580f98c9a0f70be8ed66e05bf5c5 \
+                        size    274740
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  4442a8f30f81e88769369eced910a1cae29016bd \
-                        sha256  c9f5fe5996f8ea68629c72cd3297b3514654cbc4be42e2ac682292de041c652e \
-                        size    11676254
+    checksums           rmd160  4b054d20e6da7b6ab145ade8e9a39c86324bffd2 \
+                        sha256  bb37cc398007ecc603764dd1736e3a9c0c043520daced16e5c95cbb969df27b5 \
+                        size    11676164
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.10.7

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
