### PR TITLE
micronaut: update to 4.7.5

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.7.4 v
+github.setup    micronaut-projects micronaut-starter 4.7.5 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  7253fb74b347473af3e5e25264586709ef847cd6 \
-                 sha256  4378e5a08c2c9b6537418c69eaeabdc70bd4307d7169bc87bd6f7202c8b23aa6 \
-                 size    27810802
+    checksums    rmd160  d232229c12dc111e1a2cfc3cbab2c3b9efb65fe9 \
+                 sha256  aa6dc09687bf645797d00572fe004a5b79f20a873359ccad291d4c78252a9d39 \
+                 size    27818531
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  1a17baf29782263692b1353da5cef16914a27c21 \
-                 sha256  aede660b49fdcafb393218d7279618bbb9dde40bdb8a0bad135b61235dd79167 \
-                 size    27595008
+    checksums    rmd160  02b99c1119117b4d95b62025bc321509ddf0bb51 \
+                 sha256  ea233ac21652c36324c423923be8648e9fa8eb1fce87f034ab1235cecf0d07b9 \
+                 size    27594529
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.7.5.

###### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?