### PR TITLE
google-cloud-sdk: update to 510.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             509.0.0
+version             510.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  2d2b738f1ea9f4648170d71fa6096c8daa7369ba \
-                    sha256  a8b7fe597b4202a8c7687c83105fb22209996dd5279611f90a2732e0d5476b26 \
-                    size    53724765
+    checksums       rmd160  daf7bc81c9f11a60b8e667b5d41d7b89617a486b \
+                    sha256  87c3f16b6bf951876ff2fdd099730fe033c20dd7e2d42f5e8d8ebc40523884dd \
+                    size    53754651
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3c8ad577d9ba11301af4557d4b84f9ddc6e91e41 \
-                    sha256  53ab02f03cfcd15f5c6be8001686711d109bb665eb3e921ec9cddf550e627ac3 \
-                    size    55191627
+    checksums       rmd160  234efa213c9fdcb14274da404e5c91eb14197469 \
+                    sha256  fe9ad9ba28f2cc1e7d5ea26731544855b945a14021e339edbbd9fb3e59db2678 \
+                    size    55223062
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  fc11f03d1940ba7689533c405e94e59e144dace5 \
-                    sha256  575e571ea07de9a0cd08dc1008ee4feca7c2d95a0510c903bff0bfe726746f4c \
-                    size    55133447
+    checksums       rmd160  4ffb05b5d78b1a8a8d8eca7dd77b18f34bb6da4d \
+                    sha256  afab9cca64ef77fe9deb1d4efa680695631fc8d4548c867d777098d4b574b932 \
+                    size    55162908
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 510.0.0.

###### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?