### PR TITLE
ruby-build: Update to 20250212

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250205 v
+github.setup        rbenv ruby-build 20250212 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  562d5968fd53335f6c5109f68ac974900cc3cc5c \
-                    sha256  1ac47d39c32b96be44d81abc3146f46e71d5a89adbb67de4d665f96d15ad1a28 \
-                    size    94953
+checksums           rmd160  c1eb0a57ac184d6de42e372c668c7c33f1ca7ac6 \
+                    sha256  af7a012e14585d6e9cd2a80e50bc31abc389e49f704302a2def40a74ccd145c0 \
+                    size    95016
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250212

##### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
