### PR TITLE
lima: Update to 1.0.6

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 1.0.3 v
+go.setup            github.com/lima-vm/lima 1.0.6 v
 go.offline_build    no
 github.tarball_from archive
-revision            1
+revision            0
 
 homepage            https://lima-vm.io
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  60a71868460fe544be7e44f0ec10bc3d66198a10 \
-                    sha256  c36e803f4faf41607220df4c1d7a61977a7d492facf03e0b67f1f69390840a90 \
-                    size    7381537
+checksums           rmd160  ffbf90669e10985ea61020ec26fdf1e1185a93be \
+                    sha256  16077e869cf525003c9aacd2290dadd5e966b0d0ab8ffdb69c13836610526526 \
+                    size    7382304
 
 build.cmd           make
 


### PR DESCRIPTION
#### Description

lima: Update to 1.0.6

##### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
