### PR TITLE
hamlib: Update to v4.6.2

### DIFF
--- a/science/hamlib/Portfile
+++ b/science/hamlib/Portfile
@@ -48,11 +48,12 @@ if {[string first "-devel" $subport] > 0} {
 
 } else {
 
-    github.setup    Hamlib Hamlib 4.5.5
+    github.setup    Hamlib Hamlib 4.6.2
     github.tarball_from releases
-    checksums       rmd160  c69dd7fdaa720dcd5ac30dd3f66e6d0cdd7e681b \
-                    sha256  601c89f32ed225e9527ade3d64d0d05d23202c05ae21ffa77e59d70ee4597fcd \
-                    size    2603846
+    checksums       rmd160  940a1977232d9ec75094681e139ba91618d49261 \
+                    sha256  b2ac73f44dd1161e95fdee6c95276144757647bf92d7fdb369ee2fe41ed47ae8 \
+                    size    2909790
+
     revision        0
 
     distname        hamlib-${version}


### PR DESCRIPTION
#### Description

Update hamlib to the latest stable version, v4.6.2.
NOTE: this fixes the compile issue created in v4.6.0 by reverting the change so we can safely move on.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
