### PR TITLE
ipatool: Update to 2.1.6

### DIFF
--- a/sysutils/ipatool/Portfile
+++ b/sysutils/ipatool/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/majd/ipatool 2.1.5 v
+go.setup                github.com/majd/ipatool 2.1.6 v
 github.tarball_from     archive
 revision                0
 categories              sysutils
@@ -15,9 +15,9 @@ maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 description             CLI for searching and downloading iOS app packages from the App Store
 long_description        {*}${description}.
 
-checksums               rmd160  ff327072385cb3ee40caf65458bd23e3fceb015e \
-                        sha256  cc2371353bb00a8050e0d2ba2f4819b6401e26ba3aede5d8ed40812037b59638 \
-                        size    135014
+checksums               rmd160  c34ee1eed32c2ccf3f4fe3c9af1bd72ae6f07bb9 \
+                        sha256  7527e6896185c10a8c009124e1d3c62276ebf06915701f90b123afcffd03d480 \
+                        size    135037
 
 # Vendored libraries cause failure, fetch them at build time
 go.offline_build        no


### PR DESCRIPTION
#### Description

Update `ipatool` to its latest released version, 2.1.6, which fixes a critical feature involving purchasing apps on the App Store

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
