### PR TITLE
netatalk4: Add port

### DIFF
--- a/net/netatalk4/Portfile
+++ b/net/netatalk4/Portfile
@@ -29,7 +29,7 @@ long_description    Netatalk is a freely-available Open Source AFP fileserver. \
 
 homepage            https://netatalk.io
 
-depends_build       path:bin/pkg-config:pkgconfig
+depends_build-append       path:bin/pkg-config:pkgconfig
 
 depends_lib         port:db48 \
                     port:libevent \

--- a/net/netatalk4/Portfile
+++ b/net/netatalk4/Portfile
@@ -26,9 +26,10 @@ long_description    Netatalk is a freely-available Open Source AFP fileserver. \
 
 homepage            https://netatalk.io
 
+depends_build       path:bin/pkg-config:pkgconfig
+
 depends_lib         port:db48 \
                     port:libevent \
-                    port:pkgconfig \
                     port:libgcrypt
 
 platform darwin {
@@ -43,9 +44,9 @@ platform darwin {
     }
 }
 
-configure.args      -Dwith-init-style=none \
-                    -Dwith-pam-config-path=${prefix}/etc/pam.d \
-                    -Dwith-lockfile-path=${prefix}/var/run
+configure.args-append -Dwith-init-style=none \
+                      -Dwith-pam-config-path=${prefix}/etc/pam.d \
+                      -Dwith-lockfile-path=${prefix}/var/run
 
 startupitem.create  yes
 startupitem.executable  ${prefix}/sbin/netatalk -d -F ${prefix}/etc/afp.conf

--- a/net/netatalk4/Portfile
+++ b/net/netatalk4/Portfile
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           meson 1.0
+
+name                netatalk4
+conflicts           netatalk
+
+github.setup        Netatalk netatalk netatalk-4-1-2
+github.tarball_from archive
+revision            0
+
+checksums           rmd160  b6953e69144d6542c1b426015635d58f695cdba9 \
+                    sha256  012f2a32c4904f4010c1b924e5c01cf16dfc628cb32965be54479721f30aa30d \
+                    size    1327961
+
+categories          net
+license             GPL-2+
+maintainers         {openmaintainer github:trodemaster}
+
+description         Netatalk is a freely-available Open Source AFP fileserver.
+long_description    Netatalk is a freely-available Open Source AFP fileserver. \
+                    It allows Unix-like operating systems to serve as file \
+                    servers for Macintosh computers.
+
+homepage            https://netatalk.io
+
+depends_lib         port:db48 \
+                    port:libevent \
+                    port:pkgconfig \
+                    port:libgcrypt
+
+platform darwin {
+    if {${os.major} < 10} {
+         variant appletalk description {Build with AppleTalk support} {
+              configure.args-append -Dwith-appletalk=true
+         }
+    } else {
+         variant appletalk description {Build with AppleTalk support (removed)} {
+             error "AppleTalk support has been removed from macOS versions greater than 10.5.x ."
+         }
+    }
+}
+
+configure.args      -Dwith-init-style=none \
+                    -Dwith-pam-config-path=${prefix}/etc/pam.d \
+                    -Dwith-lockfile-path=${prefix}/var/run
+
+startupitem.create  yes
+startupitem.executable  ${prefix}/sbin/netatalk -d -F ${prefix}/etc/afp.conf
+startupitem.logfile ${prefix}/var/log/${name}.log
+startupitem.logfile.stderr ${prefix}/var/log/${name}-stderr.log
+startupitem.logevents yes
+startupitem.debug          yes
+
+livecheck.type      regex
+livecheck.url       https://github.com/Netatalk/netatalk/releases
+livecheck.regex     {Latest release.*?v?(\d+(?:\.\d+)+)}
+
+notes "
+
+    Configuration files can be found in:
+        ${prefix}/etc/
+    
+    Log files can be found in:
+        ${prefix}/var/log/
+    
+"

--- a/net/netatalk4/Portfile
+++ b/net/netatalk4/Portfile
@@ -7,17 +7,20 @@ PortGroup           meson 1.0
 name                netatalk4
 conflicts           netatalk
 
-github.setup        Netatalk netatalk netatalk-4-1-2
-github.tarball_from archive
+github.setup        Netatalk netatalk 4-1-2 netatalk-
+version             [string map {- .} ${github.version}]
+github.tarball_from releases
+distname            netatalk-${version}
+use_xz              yes
 revision            0
 
-checksums           rmd160  b6953e69144d6542c1b426015635d58f695cdba9 \
-                    sha256  012f2a32c4904f4010c1b924e5c01cf16dfc628cb32965be54479721f30aa30d \
-                    size    1327961
+checksums           rmd160  69db6dd990911f3de81c7e49ca6908bfb2d62c9d \
+                    sha256  a825f6ff7efedb09bb9ca75727ab43126797000f89775db72c8d9520bf481e9c \
+                    size    922960
 
 categories          net
 license             GPL-2+
-maintainers         {openmaintainer github:trodemaster}
+maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
 
 description         Netatalk is a freely-available Open Source AFP fileserver.
 long_description    Netatalk is a freely-available Open Source AFP fileserver. \
@@ -32,18 +35,6 @@ depends_lib         port:db48 \
                     port:libevent \
                     port:libgcrypt
 
-platform darwin {
-    if {${os.major} < 10} {
-         variant appletalk description {Build with AppleTalk support} {
-              configure.args-append -Dwith-appletalk=true
-         }
-    } else {
-         variant appletalk description {Build with AppleTalk support (removed)} {
-             error "AppleTalk support has been removed from macOS versions greater than 10.5.x ."
-         }
-    }
-}
-
 configure.args-append -Dwith-init-style=none \
                       -Dwith-pam-config-path=${prefix}/etc/pam.d \
                       -Dwith-lockfile-path=${prefix}/var/run
@@ -55,16 +46,10 @@ startupitem.logfile.stderr ${prefix}/var/log/${name}-stderr.log
 startupitem.logevents yes
 startupitem.debug          yes
 
-livecheck.type      regex
-livecheck.url       https://github.com/Netatalk/netatalk/releases
-livecheck.regex     {Latest release.*?v?(\d+(?:\.\d+)+)}
-
 notes "
-
     Configuration files can be found in:
         ${prefix}/etc/
     
     Log files can be found in:
         ${prefix}/var/log/
-    
 "


### PR DESCRIPTION
#### Description

New major version of netatalk is from a new upstream maintainer. https://netatalk.io/

###### Tested on
macOS 15.3 24D60 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`? trace option doesn't work on Apple Silicon
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
