### PR TITLE
jsoncons: update to 1.2.0

### DIFF
--- a/devel/jsoncons/Portfile
+++ b/devel/jsoncons/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            danielaparker jsoncons 1.1.0 v
+github.setup            danielaparker jsoncons 1.2.0 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -15,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             A C++, header-only library for constructing JSON and JSON-like data formats
 long_description        {*}${description}
 
-checksums               rmd160  ac8c79ec3b538bcb431f35f94880aecc6c5216fe \
-                        sha256  073f6f40d92715f4540e43997df22a89018afb8f25914f9d889bb21be818532e \
-                        size    1487130
+checksums               rmd160  7c9ad61224f626cc55ea3fde49352df7fefba352 \
+                        sha256  3bdc0c8ceba1943b5deb889559911ebe97377971453a11227ed0a51a05e5d5d8 \
+                        size    1497730
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description
https://github.com/danielaparker/jsoncons/releases/tag/v1.2.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
