### PR TITLE
symfony-cli: update to 5.10.9

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.10.7
+version             5.10.9
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  af58b064bbbc62de4a4007cc1607ca4644c6e21b \
-                        sha256  8b6eb9c520260a5bd2f50c3ad92440466576580f98c9a0f70be8ed66e05bf5c5 \
-                        size    274740
+    checksums           rmd160  60c60260ba40c44598221ea0005cf7f8cabd5cdb \
+                        sha256  1b08e646f8127436deeb7dab910248a061381e7a8e742c34e713d96d0ee30e3a \
+                        size    276226
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  4b054d20e6da7b6ab145ade8e9a39c86324bffd2 \
-                        sha256  bb37cc398007ecc603764dd1736e3a9c0c043520daced16e5c95cbb969df27b5 \
-                        size    11676164
+    checksums           rmd160  3554e0aa1e2f7f991b993040c0ed9429e20b3cf8 \
+                        sha256  12c407547dacf3025f67bc583fd2e7132351f074a061ad3a42b48236b77a4d5a \
+                        size    11685982
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.10.9

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
