### PR TITLE
openjdk21-openj9: update to 21.0.6

### DIFF
--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -20,11 +20,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.5
+version      ${feature}.0.6
 revision     0
 
-set build    11
-set openj9_version 0.48.0
+set build    7
+set openj9_version 0.49.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -34,14 +34,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  8423f7bbfef3553de74938e793113514c3efca84 \
-                 sha256  519aaa538606805a276ab518f15fad712a192085f6d478f66367785d1f150c11 \
-                 size    225038163
+    checksums    rmd160  45ad9737a5cdcd2dbf079b6290d00bd453d15332 \
+                 sha256  4b28782f35a963845f8cb10f6b70ca803bfbefce0375a1aa77b24b7575a76c06 \
+                 size    225212007
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  f3444037cd069639605796e46d00c919a4edcf54 \
-                 sha256  b8c158a54851c9e987c2bbbe23caaa9883db22dfbf04adab0fadb850899ff5d9 \
-                 size    218283716
+    checksums    rmd160  9b7d36c9c83f1b407727d556ca4dbf173646121c \
+                 sha256  7c8b65a0ecbdbde913f1096e839e5c5b48cd4175e33daa4a919ebabad82acb3b \
+                 size    218412220
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 21.0.6.

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?