### PR TITLE
openjdk23-openj9: update to 23.0.2

### DIFF
--- a/java/openjdk23-openj9/Portfile
+++ b/java/openjdk23-openj9/Portfile
@@ -15,11 +15,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.1
+version      ${feature}.0.2
 revision     0
 
-set build    11
-set openj9_version 0.48.0
+set build    7
+set openj9_version 0.49.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Short Term Support until March 2025)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -29,14 +29,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  3b590fa1dadb73a6489037461343da3144fc9695 \
-                 sha256  5478b6656138b21eb173c0cf4e7bad738df84a4fe0be132ef71dcbf0753d629a \
-                 size    231788789
+    checksums    rmd160  53865a2d92109259553fe3046389e28872cc14de \
+                 sha256  7cf0d6d6c6b1450a9ef8a5674b9e68bb7ee7015e8d5f49c29119ad6518fb92de \
+                 size    232000802
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  05d0d327460d0cb8d20605b15e56e2944b2ccae1 \
-                 sha256  1ce5105ed9140b181ff517e62b733d025b0906e56674049bc493997720ef1dc2 \
-                 size    225087559
+    checksums    rmd160  8006eb99db9618f6250ad08cf0c3f8152fe50d32 \
+                 sha256  1e9a802694934aa4de3be333f0a525f5d6cb692f5b15f805f782ffb84244e2d6 \
+                 size    225264418
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 23.0.2.

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?