### PR TITLE
openjdk17-openj9: update to 17.0.14

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -20,11 +20,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.13
+version      ${feature}.0.14
 revision     0
 
-set build    11
-set openj9_version 0.48.0
+set build    7
+set openj9_version 0.49.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -34,14 +34,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  f14babfd9bcdd67b4365fb8260b0e88e1f992df8 \
-                 sha256  eaed7a64d97a4320c737b1a51f036bcbd1a484c6e21d568073c56157c23c6589 \
-                 size    212579920
+    checksums    rmd160  3df56a2396048d829e2937e527d103cdc1967f47 \
+                 sha256  fddb7adfb499ba9ca015d7c255894f70dbac555d216c83abd7836342c44a1349 \
+                 size    212772429
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  da5ecb9c3ff395bb0dc003c4dcfb3d2cd9f3f49e \
-                 sha256  7471a2db121be72c173b12189770b357bda93e3c58c0b3248c4cd84a1c596925 \
-                 size    205841599
+    checksums    rmd160  914a356b9697104b6fb9b8b15856e67e845175cb \
+                 sha256  526590f79bc096535710f55b84385fee499b561cc1ab3ed024e1090b7ad37924 \
+                 size    206033035
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.14.

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?