### PR TITLE
openjdk11-openj9: update to 11.0.26

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -15,11 +15,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.25
+version      ${feature}.0.26
 revision     0
 
-set build    9
-set openj9_version 0.48.0
+set build    4
+set openj9_version 0.49.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -29,14 +29,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  b5baf4b4b3981f726bec4acce1097cb6d30cc406 \
-                 sha256  059115dd6d00eed7ad04cf466b33bd22c71ec56f682b0a1863e09d9329a3134a \
-                 size    208171243
+    checksums    rmd160  7d41306d7c13efc20263c77de4ba3406be0811bd \
+                 sha256  2afb6848775d18bd9591f19e169f8071bdc63d19d9695f3cdff6cc5b690801e0 \
+                 size    208227426
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  1394708a7d76adbe6168bc10338987772364e830 \
-                 sha256  1e01ff2d62e5cfca84e431a1b5384c8ff7f6a9ba3f31c18784dd848196b2806f \
-                 size    202399507
+    checksums    rmd160  dda54239733767f3e26fce1270b90d1df402e540 \
+                 sha256  69c393fb7a9b916309198b94f8d60741b8224b718bba72d662cb1932830aafa8 \
+                 size    202442196
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.26.

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?