### PR TITLE
gum: Update to 0.15.2

### DIFF
--- a/devel/gum/Portfile
+++ b/devel/gum/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/charmbracelet/gum 0.14.5 v
+go.setup            github.com/charmbracelet/gum 0.15.2 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
@@ -18,9 +18,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  faeebf002f650fb4d04e4d2f90b661b56273d377 \
-                    sha256  b2c8101bb6f93acba420808df65b3f9acfe8cc9de283c1d9d94311123f43f271 \
-                    size    58905
+checksums           rmd160  0c75583866430712189842168a4566a82d9a5e22 \
+                    sha256  c1950ef71284189436712f385adbf1a3d8df20a8735c9add5344601aedb97ac1 \
+                    size    69748
 
 build.pre_args-append \
     -ldflags \"-X main.Version=${version}\"


### PR DESCRIPTION
#### Description

gum: Update to 0.15.2

##### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
