### PR TITLE
symfony-cli: update to 5.11.0

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.10.9
+version             5.11.0
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  60c60260ba40c44598221ea0005cf7f8cabd5cdb \
-                        sha256  1b08e646f8127436deeb7dab910248a061381e7a8e742c34e713d96d0ee30e3a \
-                        size    276226
+    checksums           rmd160  da1f3a46d647090ba6718dc01bc7b3d6f7a355a1 \
+                        sha256  29996a4f7f2032fe1e3b1d8df734843f84ee7e2ac9db10e1e690ffc37df88713 \
+                        size    276515
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  3554e0aa1e2f7f991b993040c0ed9429e20b3cf8 \
-                        sha256  12c407547dacf3025f67bc583fd2e7132351f074a061ad3a42b48236b77a4d5a \
-                        size    11685982
+    checksums           rmd160  b02e90d27dcce76ef57372e16c8d34c3812985b6 \
+                        sha256  d7fc4d0c2e03d12f741c9dd71d7f3f441230a86285df84fd0c446e5251ccf74a \
+                        size    12171160
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.11.0

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
