### PR TITLE
hdf5: 1.14.6 py-h5py: Add 313

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -12,7 +12,7 @@ name                    py-h5py
 
 # h5py needs to be re-built after hdf5 upgrades; it has its own version
 # check included.
-revision                0
+revision                1
 
 checksums \
     rmd160  bac3267da58389438559261fe4f393f1423adfe5 \
@@ -36,7 +36,7 @@ long_description  \
 
 homepage                https://www.h5py.org
 
-python.versions         39 310 311 312
+python.versions         39 310 311 312 313
 
 # Only check against releases.
 github.livecheck.regex      {([0-9.]+)}

--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -42,18 +42,14 @@ python.versions         39 310 311 312 313
 github.livecheck.regex      {([0-9.]+)}
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-pythran
+    depends_build-append    port:py${python.version}-pythran \
+                            port:py${python.version}-cython
 
     depends_lib-append      port:py${python.version}-cached-property \
                             port:py${python.version}-numpy \
                             port:py${python.version}-six \
                             port:py${python.version}-pkgconfig \
                             port:hdf5
-
-    # Not compatible with Cython 3 as of 3.10.0
-    depends_build-append    port:py${python.version}-cython-compat
-    set compat_path [string replace ${python.pkgd} 0 [string length ${python.prefix}]-1 ${prefix}/lib/py${python.version}-cython-compat]
-    build.env-append        PYTHONPATH=${compat_path}
 
     build.env-append        HDF5_DIR=${prefix}
     destroot.env-append     HDF5_DIR=${prefix}

--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -7,18 +7,9 @@ PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        HDFGroup hdf5 1.14.5 hdf5_
-set distversion     1.14.5
+github.setup        HDFGroup hdf5 1.14.6 hdf5_
+set distversion     $version
 revision            0
-
-# A temporary fix for non-MPI version.
-# Please remove this with the next update.
-# https://trac.macports.org/ticket/67893
-if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libc++"} {
-    if {![mpi_variant_isset]} {
-        incr revision
-    }
-}
 
 #set mainversion     [lindex [split ${distversion} -] 0]
 #set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
@@ -43,9 +34,9 @@ github.tarball_from releases
 distname            ${name}-${distversion}
 
 checksums \
-    rmd160  c76f89f3d1055a2c81f35865ce313f38bc371c2a \
-    sha256  ec2e13c52e60f9a01491bb3158cb3778c985697131fc6a342262d32a26e58e44 \
-    size    37879624
+    rmd160  25870c7e455e7f83bd043ed60ed6662c94ac90d5 \
+    sha256  e4defbac30f50d64e1556374aa49e574417c9e72c6b1de7a4ff88c4b1bea6e9b \
+    size    39289609
 
 mpi.setup           -gcc44 -gcc45
 


### PR DESCRIPTION
Maintainer update.

Most hdf5-dependent ports no longer need rev-bumps for HDF5, by py-h5py has its own version warning baked in.

add py313 flavor of hdf5 and drop cython-compat (builds with Cython 3.x since 3.11; missed earlier).