### PR TITLE
alacritty: update to 0.15.1

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        alacritty alacritty 0.15.0 v
+github.setup        alacritty alacritty 0.15.1 v
 github.tarball_from archive
 revision            0
 
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  067a7757bbf8cc34c386795cd329d0c4048938ed \
-                    sha256  aa4479c99547c0b6860760b5b704865f629ffe1f1ec374153c2cd84e53ce5412 \
-                    size    1644528
+                    rmd160  58fbde3ae2860cab54765ba354cced121052e504 \
+                    sha256  b814e30c6271ae23158c66e0e2377c3600bb24041fa382a36e81be564eeb2e36 \
+                    size    1644635
 
 depends_build-append \
                     port:scdoc
@@ -175,10 +175,10 @@ cargo.crates \
     gethostname                      0.4.3  0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818 \
     getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
     gl_generator                    0.14.0  1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d \
-    glutin                          0.32.1  ec69412a0bf07ea7607e638b415447857a808846c2b685a43c8aa18bc6d5e499 \
-    glutin_egl_sys                   0.7.0  cae99fff4d2850dbe6fb8c1fa8e4fead5525bab715beaacfccf3fb994e01c827 \
-    glutin_glx_sys                   0.6.0  9c2b2d3918e76e18e08796b55eb64e8fe6ec67d5a6b2e2a7e2edce224ad24c63 \
-    glutin_wgl_sys                   0.6.0  0a4e1951bbd9434a81aa496fe59ccc2235af3820d27b85f9314e279609211e2c \
+    glutin                          0.32.2  03642b8b0cce622392deb0ee3e88511f75df2daac806102597905c3ea1974848 \
+    glutin_egl_sys                   0.7.1  4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2 \
+    glutin_glx_sys                   0.6.1  8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185 \
+    glutin_wgl_sys                   0.6.1  2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e \
     hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
@@ -356,7 +356,7 @@ cargo.crates \
     windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winit                           0.30.8  f5d74280aabb958072864bff6cfbcf9025cf8bfacdde5e32b5e12920ef703b0f \
+    winit                           0.30.9  a809eacf18c8eca8b6635091543f02a5a06ddf3dad846398795460e6e0ae3cc0 \
     winnow                          0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
     winreg                          0.52.0  a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5 \
     wio                              0.2.2  5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5 \


### PR DESCRIPTION
#### Description

alacritty: update to 0.15.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
