### PR TITLE
certbot 3.2.0 wrong paths

### DIFF
--- a/python/py-acme/Portfile
+++ b/python/py-acme/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 name                py-acme
 github.setup        certbot certbot 3.2.0 v
 github.tarball_from releases
-revision            0
+revision            1
 categories-append   security
 license             Apache-2
 maintainers         {mps @Schamschula} openmaintainer

--- a/python/py-acme/Portfile
+++ b/python/py-acme/Portfile
@@ -53,9 +53,9 @@ if {${name} ne ${subport}} {
 
         post-destroot {
             xinstall -d ${destroot}${prefix}/share/man/man1
-            xinstall -m 640 ${worksrcpath}/acme/docs/_build/man/acme-python.1 \
+            xinstall -m 640 ${worksrcpath}/docs/_build/man/acme-python.1 \
                 ${destroot}${prefix}/share/man/man1/
-            xinstall -m 640 ${worksrcpath}/acme/docs/_build/man/jws.1 \
+            xinstall -m 640 ${worksrcpath}/docs/_build/man/jws.1 \
                 ${destroot}${prefix}/share/man/man1/
         }
     }

--- a/python/py-josepy/Portfile
+++ b/python/py-josepy/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-josepy
+# don't upgrade to v 2.0.0 until certbot 4.0.0 is released
 version             1.15.0
 revision            0
 epoch               2
@@ -20,9 +21,9 @@ python.versions     39 310 311 312 313
 
 python.pep517_backend   poetry
 
-checksums           rmd160  5b999de9bb7ce497d6ed828532fdb3621a696deb \
-                    sha256  e7d7acd2fe77435cda76092abe4950bb47b597243a8fb733088615fa6de9ec40 \
-                    size    55767
+checksums           rmd160  113cc85bf0bee1a5673e848651e267597b717d3a \
+                    sha256  46c9b13d1a5104ffbfa5853e555805c915dcde71c2cd91ce5386e84211281223 \
+                    size    59310
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-josepy/Portfile
+++ b/python/py-josepy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-josepy
-version             2.0.0
+version             1.15.0
 revision            0
 epoch               1
 categories-append   security

--- a/python/py-josepy/Portfile
+++ b/python/py-josepy/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-josepy
 version             1.15.0
 revision            0
-epoch               1
+epoch               2
 categories-append   security
 license             Apache-2
 maintainers         {mps @Schamschula} openmaintainer

--- a/security/certbot/Portfile
+++ b/security/certbot/Portfile
@@ -52,6 +52,11 @@ depends_lib-append  port:py${python.version}-acme \
                     port:py${python.version}-pyrfc3339 \
                     port:py${python.version}-tz
 
+    post-patch {
+        reinplace "s|/etc/|${prefix}/etc/|" ${worksrcpath}/certbot/compat/misc.py
+        reinplace "s|/var/lib/|${prefix}/var/db/|" ${worksrcpath}/certbot/compat/misc.py
+        reinplace "s|/var/log/|${prefix}/var/log/|" ${worksrcpath}/certbot/compat/misc.py
+    }
 
 subport ${name} {
     variant docs description {Build man pages} {

--- a/security/certbot/Portfile
+++ b/security/certbot/Portfile
@@ -5,7 +5,6 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        certbot certbot 3.2.0 v
-epoch               1
 revision            0
 categories          security
 license             Apache-2

--- a/security/certbot/Portfile
+++ b/security/certbot/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
+# upgrade py-josepy to v 2.0.0 when certbot v 4.0.0 is released
 github.setup        certbot certbot 3.2.0 v
 revision            0
 categories          security
@@ -52,13 +53,13 @@ depends_lib-append  port:py${python.version}-acme \
                     port:py${python.version}-pyrfc3339 \
                     port:py${python.version}-tz
 
-post-patch {
-    reinplace "s|/etc/|${prefix}/etc/|" ${worksrcpath}/certbot/compat/misc.py
-    reinplace "s|/var/lib/|${prefix}/var/db/|" ${worksrcpath}/certbot/compat/misc.py
-    reinplace "s|/var/log/|${prefix}/var/log/|" ${worksrcpath}/certbot/compat/misc.py
-}
-
 subport ${name} {
+    post-patch {
+        reinplace "s|/etc/|${prefix}/etc/|" ${worksrcpath}/certbot/compat/misc.py
+        reinplace "s|/var/lib/|${prefix}/var/db/|" ${worksrcpath}/certbot/compat/misc.py
+        reinplace "s|/var/log/|${prefix}/var/log/|" ${worksrcpath}/certbot/compat/misc.py
+    }
+
     variant docs description {Build man pages} {
         depends_lib-append \
             port:py${python.version}-repoze.sphinx.autointerface \

--- a/security/certbot/Portfile
+++ b/security/certbot/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        certbot certbot 3.2.0 v
+epoch               1
 revision            0
 categories          security
 license             Apache-2

--- a/security/certbot/Portfile
+++ b/security/certbot/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 # upgrade py-josepy to v 2.0.0 when certbot v 4.0.0 is released
 github.setup        certbot certbot 3.2.0 v
-revision            0
+revision            1
 categories          security
 license             Apache-2
 maintainers         {mps @Schamschula} openmaintainer

--- a/security/certbot/Portfile
+++ b/security/certbot/Portfile
@@ -52,11 +52,11 @@ depends_lib-append  port:py${python.version}-acme \
                     port:py${python.version}-pyrfc3339 \
                     port:py${python.version}-tz
 
-    post-patch {
-        reinplace "s|/etc/|${prefix}/etc/|" ${worksrcpath}/certbot/compat/misc.py
-        reinplace "s|/var/lib/|${prefix}/var/db/|" ${worksrcpath}/certbot/compat/misc.py
-        reinplace "s|/var/log/|${prefix}/var/log/|" ${worksrcpath}/certbot/compat/misc.py
-    }
+post-patch {
+    reinplace "s|/etc/|${prefix}/etc/|" ${worksrcpath}/certbot/compat/misc.py
+    reinplace "s|/var/lib/|${prefix}/var/db/|" ${worksrcpath}/certbot/compat/misc.py
+    reinplace "s|/var/log/|${prefix}/var/log/|" ${worksrcpath}/certbot/compat/misc.py
+}
 
 subport ${name} {
     variant docs description {Build man pages} {

--- a/security/certbot/Portfile
+++ b/security/certbot/Portfile
@@ -65,14 +65,8 @@ subport ${name} {
             port:py${python.version}-sphinx \
             port:py${python.version}-sphinx_rtd_theme
 
-        post-patch {
-            reinplace "s|/etc/|${prefix}/etc/|" ${worksrcpath}/certbot/compat/misc.py
-            reinplace "s|/var/lib/|${prefix}/var/db/|" ${worksrcpath}/certbot/compat/misc.py
-            reinplace "s|/var/log/|${prefix}/var/log/|" ${worksrcpath}/certbot/compat/misc.py
-        }
-
         post-build {
-            set env(doc_path) ${worksrcpath}/${name}/docs
+            set env(doc_path) ${worksrcpath}/docs
             set env(python_branch) ${python.branch}
             exec sh -c {cd $doc_path && sphinx-build-$python_branch -N -b man . _build/man} >@stdout
         }
@@ -80,9 +74,9 @@ subport ${name} {
         post-destroot {
             xinstall -d ${destroot}${prefix}/share/man/man1
             xinstall -d ${destroot}${prefix}/share/man/man7
-            xinstall -m 640 ${worksrcpath}//${name}/docs/_build/man/certbot.1 \
+            xinstall -m 640 ${worksrcpath}/docs/_build/man/certbot.1 \
                 ${destroot}${prefix}/share/man/man1/
-            xinstall -m 640 ${worksrcpath}//${name}/docs/_build/man/certbot.7 \
+            xinstall -m 640 ${worksrcpath}/docs/_build/man/certbot.7 \
                 ${destroot}${prefix}/share/man/man7/
         }
     }


### PR DESCRIPTION
#### Description
certbot 3.2.0 is looking for the certificates in the wrong place:
        Saving debug log to /var/log/letsencrypt/letsencrypt.log
        certificate path : /etc/letsencrypt/

The problem w/ the paths was introduced in
    https://github.com/macports/macports-ports/commit/408ad4d

Lines 56-61 were removed ; but only line 56 ought to have been removed. lines 58-62 ought only to have had their paths corrected

On branch certbot
Changes to be committed:
	modified:   security/certbot/Portfile

###### Type(s)
- [ x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

macOS 14.7.3 23H417 x86_64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
