### PR TITLE
vsftpd: update to replace old setrlimit call

### DIFF
--- a/net/vsftpd/Portfile
+++ b/net/vsftpd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                vsftpd
 version             3.0.5
-revision            0
+revision            1
 categories          net
 license             {GPL-2 OpenSSLException}
 platforms           darwin
@@ -26,7 +26,8 @@ checksums           rmd160  f308bbd0b214a1af7438b1f84e9b12cacf06858d \
 patchfiles          patch-sysdeputil.c.diff \
                     patch-vsf_findlibs.sh.diff \
                     patch-vsftpd.conf.diff \
-                    patch-Makefile.diff
+                    patch-Makefile.diff \
+                    patch-sysutil.c.diff
 
 configure {
     reinplace "s|/etc/|${prefix}/etc/|g" \

--- a/net/vsftpd/files/patch-sysutil.c.diff
+++ b/net/vsftpd/files/patch-sysutil.c.diff
@@ -1,0 +1,49 @@
+diff --git sysutil.c.old sysutil.c
+index ff8885b..c465b99 100644
+--- sysutil.c.old
++++ sysutil.c
+@@ -2792,6 +2792,7 @@ vsf_sysutil_getuid(void)
+ void
+ vsf_sysutil_set_address_space_limit(unsigned long bytes)
+ {
++#if! defined(__APPLE__)
+   /* Unfortunately, OpenBSD is missing RLIMIT_AS. */
+ #ifdef RLIMIT_AS
+   int ret;
+@@ -2807,12 +2808,14 @@ vsf_sysutil_set_address_space_limit(unsigned long bytes)
+     die("setrlimit");
+   }
+ #endif /* RLIMIT_AS */
++#endif
+   (void) bytes;
+ }
+
+ void
+ vsf_sysutil_set_no_fds()
+ {
++#if! defined(__APPLE__)
+   int ret;
+   struct rlimit rlim;
+   rlim.rlim_cur = 0;
+@@ -2822,11 +2825,13 @@ vsf_sysutil_set_no_fds()
+   {
+     die("setrlimit NOFILE");
+   }
++#endif
+ }
+
+ void
+ vsf_sysutil_set_no_procs()
+ {
++#if! defined(__APPLE__)
+ #ifdef RLIMIT_NPROC
+   int ret;
+   struct rlimit rlim;
+@@ -2838,6 +2843,7 @@ vsf_sysutil_set_no_procs()
+     die("setrlimit NPROC");
+   }
+ #endif
++#endif
+ }
+
+ void


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Closes: https://trac.macports.org/ticket/67134

I don't know if this will break macOS versions prior to Monterey. Currently Monterey and later are broken, which seems like a worse state to be in. Likely someone with more knowledge of the build environment could target the patch better.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.6.1 23G93 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x ] checked your Portfile with `port lint`?
- [x ] tried existing tests with `sudo port test`?
- [x ] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
