### PR TITLE
2048.c: Update to 1.0.3

### DIFF
--- a/games/2048.c/Portfile
+++ b/games/2048.c/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               makefile 1.0
 
-github.setup            mevdschee 2048.c 1.0.1 v
+github.setup            mevdschee 2048.c 1.0.3 v
 github.tarball_from     archive
 revision                0
 categories              games
@@ -14,9 +14,9 @@ maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 description             Terminal version of 2048
 long_description        {*}${description}.
 
-checksums               rmd160  65a91ba4572364f585afe1df830449c83fb5a8a6 \
-                        sha256  43a357a6d30859f2f6e797ddf96f35c278b5f0ad7dd1bfc70c3b6d3f24e89dcd \
-                        size    18710
+checksums               rmd160  a4587733c07d066767a7687520cde6c5056fad1e \
+                        sha256  f26b2af87c03e30139e6a509ef9512203f4e5647f3225b969b112841a9967087 \
+                        size    19190
 
 compiler.c_standard     1999
 


### PR DESCRIPTION
#### Description

Update `2048.c` to its latest released version, 1.0.3

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
