### PR TITLE
Add dart, pub portgroups, relevant ports

### DIFF
--- a/_resources/port1.0/group/dart-1.0.tcl
+++ b/_resources/port1.0/group/dart-1.0.tcl
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+#
+# This PortGroup supports the Dart build system
+
+options dart.bin
+
+default dart.bin          {${prefix}/bin/dart}
+
+default supported_archs   {arm64 x86_64}
+default universal_variant no
+default use_configure     no
+
+default depends_build     port:dart-sdk
+
+default build.cmd         {${dart.bin} compile exe}
+default build.args        {-o bin/${name}}
+default build.target      bin/main.dart
+
+default test.cmd          {${dart.bin} test}
+default test.args         ""
+default test.target       ""
+
+destroot {
+    ui_error "No destroot phase in the Portfile!"
+    ui_msg "Here is an example destroot phase:"
+    ui_msg
+    ui_msg "destroot {"
+    ui_msg {    xinstall -m 0755 ${worksrcpath}/bin/${name} ${destroot}${prefix}/bin/}
+    ui_msg "}"
+    ui_msg
+    ui_msg "Please check if there are additional files (configuration, documentation, etc.) that need to be installed."
+    error "destroot phase not implemented"
+}

--- a/_resources/port1.0/group/pub-1.0.tcl
+++ b/_resources/port1.0/group/pub-1.0.tcl
@@ -1,0 +1,115 @@
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+#
+# This PortGroup supports the Dart pub build system
+#
+# Usage:
+#
+# PortGroup     pub 1.0
+#
+# pub.packages \
+#     foo  1.0.1  abcdef123456... \
+#     bar  2.5.0  fedcba654321...
+#
+# The pub.packages option expects a list with 3-tuples consisting of name,
+# version, and sha256 checksum. Only sha256 is supported at this time as the
+# checksum will be reused by pub internally.
+#
+# The list of packages and their checksums can be found in the pubspec.lock file
+# in the upstream source code. The pub2port generator can be used to automate
+# updates of this list for new releases.
+#
+# https://github.com/amake/pub2port
+#
+# Dependencies on packages not published on pub.dev are currently unsupported.
+
+PortGroup                 dart 1.0
+
+options \
+    pub.home \
+    pub.get_args \
+    pub.packages
+
+default pub.home          {${workpath}/.home/.pub-cache}
+default pub.get_args      {--offline --enforce-lockfile}
+default pub.packages      {}
+
+set pub_env {PUB_CACHE=${pub.home}}
+
+default build.env         ${pub_env}
+default test.env          ${pub_env}
+
+# The distfiles of the main port will also be stored in this directory, but this
+# is the only way to allow reusing the same packages across multiple ports.
+default dist_subdir  {[expr {[llength ${pub.packages}] > 0 ? "pub-packages" : ${name}}]}
+default extract.only {[pub::disttagclean ${distfiles}]}
+
+####################################################################################################################################
+# Internal procedures
+####################################################################################################################################
+
+namespace eval pub {}
+
+# Based on rust::disttagclean from cargo_fetch-1.0.tcl
+proc pub::disttagclean {list} {
+    if {$list eq ""} {
+        return $list
+    }
+    foreach fname $list {
+        set name [getdistname ${fname}]
+
+        set is_pkg no
+        foreach {pname pversion chksum} [option pub.packages] {
+            set pubfile ${pname}-${pversion}.tar.gz
+            if {${name} eq ${pubfile}} {
+                set is_pkg yes
+            }
+        }
+        if {!${is_pkg}} {
+            lappend val ${name}
+        }
+    }
+    return $val
+}
+
+proc pub::handle_packages {} {
+    foreach {pname pversion chksum} [option pub.packages] {
+        # The same package name can appear with multiple versions. Use a
+        # combination of crate name and checksum as unique identifier. As the
+        # :disttag cannot contain dots, the version number cannot be used.
+        set pubfile         ${pname}-${pversion}.tar.gz
+        set pubtag          pub-${pname}-${chksum}
+        distfiles-append    ${pubfile}:${pubtag}
+        master_sites-append https://pub.dev/api/archives/:${pubtag}
+        checksums-append    ${pubfile} sha256 ${chksum}
+    }
+}
+port::register_callback pub::handle_packages
+
+proc pub::extract_package {pname pversion pubfile} {
+    set targetdir "[option pub.home]/hosted/pub.dev/${pname}-${pversion}"
+    file mkdir ${targetdir}
+    set tar [findBinary tar ${portutil::autoconf::tar_path}]
+    system -W ${targetdir} "${tar} -xf [shellescape [option distpath]/${pubfile}]"
+}
+
+proc pub::import_package {pname pversion chksum pubfile} {
+    global pub.home
+
+    pub::extract_package ${pname} ${pversion} ${pubfile}
+
+    set chkfile [open "${pub.home}/hosted-hashes/pub.dev/${pname}-${pversion}.sha256" "w"]
+    puts -nonewline ${chkfile} ${chksum}
+    close ${chkfile}
+}
+
+post-extract {
+    if {[llength ${pub.packages}] > 0} {
+        file mkdir ${pub.home}/hosted/pub.dev ${pub.home}/hosted-hashes/pub.dev
+
+        foreach {pname pversion chksum} [option pub.packages] {
+            set pubfile ${pname}-${pversion}.tar.gz
+            pub::import_package ${pname} ${pversion} ${chksum} ${pubfile}
+        }
+        system -W ${worksrcpath} "PUB_CACHE=${pub.home} ${dart.bin} pub get ${pub.get_args}"
+    }
+}

--- a/devel/fvm/Portfile
+++ b/devel/fvm/Portfile
@@ -1,0 +1,134 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           pub 1.0
+PortGroup           github 1.0
+
+github.setup        leoafarias fvm 3.2.1
+github.tarball_from archive
+
+categories          devel
+maintainers         {amake @amake} openmaintainer
+license             MIT
+
+description         A simple CLI to manage Flutter SDK versions
+
+long_description    ${description}
+
+test.run            yes
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  7d01ee0d98dc9c8c204ece8faab2ec546a375196 \
+                        sha256  d4d524a5e1d7c5160b17ee9c3b2dd4482224d2e1c27c8d494fa0290ae818cd41 \
+                        size    524280
+
+pub.packages \
+    _fe_analyzer_shared            67.0.0  0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7 \
+    analyzer                        6.4.1  37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d \
+    ansicolor                       2.0.3  50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f \
+    archive                         3.6.1  cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d \
+    args                            2.5.0  7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a \
+    async                          2.11.0  947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c \
+    boolean_selector                2.1.1  6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66 \
+    build                           2.4.1  80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0 \
+    build_config                    1.1.1  bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1 \
+    build_daemon                    4.0.1  0343061a33da9c5810b2d6cee51945127d8f4c060b7fbdd9d54917f0a3feaaa1 \
+    build_resolvers                 2.4.2  339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a \
+    build_runner                    2.4.9  3ac61a79bfb6f6cc11f693591063a7f19a7af628dc52f141743edac5c16e8c22 \
+    build_runner_core               7.3.0  4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799 \
+    build_verify                    3.1.0  abbb9b9eda076854ac1678d284c053a5ec608e64da741d0801f56d4bbea27e23 \
+    build_version                   2.1.1  4e8eafbf722eac3bd60c8d38f108c04bd69b80100f8792b32be3407725c7fa6a \
+    built_collection                5.1.1  376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100 \
+    built_value                     8.9.2  c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb \
+    characters                      1.3.0  04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605 \
+    charcode                        1.3.1  fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306 \
+    checked_yaml                    2.0.3  feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff \
+    cli_completion                  0.5.0  158deec74a75cdc69bce061645fea08f94190dd6833f988f517c2dfcb45e9117 \
+    cli_pkg                        2.10.0  f812467b5d6a5f26ad0fba5dcfc95133df02edbae47dfa4ade3df5d2b5afdcf2 \
+    cli_util                        0.4.1  c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19 \
+    clock                           1.1.1  cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf \
+    code_builder                   4.10.0  f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37 \
+    collection                     1.18.0  ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a \
+    convert                         3.1.1  0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592 \
+    coverage                        1.8.0  3945034e86ea203af7a056d98e98e42a5518fff200d6e8e6647e1886b07e936e \
+    crypto                          3.0.3  ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab \
+    dart_code_metrics_presets      2.15.0  f67df47fe3297617e0cf5d632aa257e17517ad9fdd605e152bdc80dd526f0c5b \
+    dart_console                    1.2.0  dfa4b63eb4382325ff975fdb6b7a0db8303bb5809ee5cb4516b44153844742ed \
+    dart_mappable                   4.2.2  47269caf2060533c29b823ff7fa9706502355ffcb61e7f2a374e3a0fb2f2c3f0 \
+    dart_mappable_builder           4.2.3  ab5cf9086862d3fceb9773e945b5f95cc5471a28c782a4fc451bd400a4e0c64e \
+    dart_style                      2.3.6  99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9 \
+    date_format                     2.0.9  a48254e60bdb7f1d5a15cac7f86e37491808056c0a99dbdc850841def4754ddc \
+    equatable                       2.0.5  c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2 \
+    ffi                             2.1.3  16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6 \
+    file                            7.0.0  5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c \
+    fixnum                          1.1.0  25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1 \
+    frontend_server_client          4.0.0  f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694 \
+    git                             2.2.1  1982737427ef1ef2bb69027ea0234469774495e86afe202de81ee46d37364e55 \
+    glob                            2.1.2  0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63 \
+    graphs                          2.3.1  aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19 \
+    grinder                         0.9.5  e1996e485d2b56bb164a8585679758d488fbf567273f51c432c8733fee1f6188 \
+    http                            1.2.2  b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010 \
+    http_multi_server               3.2.1  97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b \
+    http_parser                     4.0.2  2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b \
+    interact                        2.2.0  b1abf79334bec42e58496a054cb7ee7ca74da6181f6a1fb6b134f1aa22bc4080 \
+    intl                           0.18.1  3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d \
+    io                              1.0.4  2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e \
+    js                              0.6.7  f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3 \
+    json_annotation                 4.9.0  1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1 \
+    jsonc                           0.0.3  326a3c5c774a77c3c4e327f359e0268bff34135d0c16078beee6d921c49a16ed \
+    lints                           2.1.1  0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452 \
+    logging                         1.2.0  623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340 \
+    mason_logger                   0.2.16  1fdf5c76870eb6fc3611ed6fbae1973a3794abe581ea5e22e68af2f73c688b93 \
+    matcher                     0.12.16+1  d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb \
+    meta                           1.15.0  bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7 \
+    mime                            1.0.5  2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2 \
+    native_stack_traces             0.5.7  64d2f4bcf3b69326fb9bc91b4dd3a06f94bb5bbc3a65e25ae6467ace0b34bfd3 \
+    node_interop                    2.1.0  3af2420c728173806f4378cf89c53ba9f27f7f67792b898561bff9d390deb98e \
+    node_preamble                   2.0.2  6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db \
+    package_config                  2.1.0  1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd \
+    path                            1.9.0  087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af \
+    petitparser                     6.0.2  c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27 \
+    platform                        3.1.5  9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65 \
+    pool                            1.5.1  20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a \
+    process                         5.0.2  21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32 \
+    pub_semver                      2.1.4  40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c \
+    pub_updater                     0.4.0  54e8dc865349059ebe7f163d6acce7c89eb958b8047e6d6e80ce93b13d7c9e60 \
+    pubspec                         2.3.0  f534a50a2b4d48dc3bc0ec147c8bd7c304280fff23b153f3f11803c4d49d927e \
+    pubspec_parse                   1.3.0  c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8 \
+    quiver                          3.2.1  b1c1ac5ce6688d77f65f3375a9abb9319b3cb32486bdc7a1e0fdf004d7ba4e47 \
+    retry                           3.1.2  822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc \
+    scope                           5.1.0  0b056e5b64ca16a2db9e1eb35cf7fd05a9e99a6b15140f82bfa651d081e4819b \
+    shelf                           1.4.1  ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4 \
+    shelf_packages_handler          3.0.2  89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e \
+    shelf_static                    1.1.2  a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e \
+    shelf_web_socket                1.0.4  9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1 \
+    source_gen                      1.5.0  14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832 \
+    source_map_stack_trace          2.1.2  c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b \
+    source_maps                   0.10.12  708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703 \
+    source_span                    1.10.0  53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c \
+    stack_trace                    1.11.1  73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b \
+    stream_channel                  2.1.2  ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7 \
+    stream_transform                2.1.0  14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f \
+    string_scanner                  1.3.0  688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3 \
+    term_glyph                      1.2.1  a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84 \
+    test                           1.25.7  7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e \
+    test_api                        0.7.2  5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb \
+    test_core                       0.6.4  55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696 \
+    test_process                    2.1.0  217f19b538926e4922bdb2a01410100ec4e3beb4cc48eae5ae6b20037b07bbd6 \
+    timing                          1.0.1  70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32 \
+    tint                            2.0.1  9652d9a589f4536d5e392cf790263d120474f15da3cf1bee7f1fdb31b4de5f46 \
+    type_plus                       2.1.1  d5d1019471f0d38b91603adb9b5fd4ce7ab903c879d2fbf1a3f80a630a03fcc9 \
+    typed_data                      1.3.2  facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c \
+    uri                             1.0.0  889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a \
+    vm_service                     14.2.5  5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d \
+    watcher                         1.1.0  3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8 \
+    web                             0.5.1  97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27 \
+    web_socket_channel              2.4.5  58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42 \
+    webkit_inspection_protocol      1.2.1  87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572 \
+    win32                           5.5.4  68d1e89a91ed61ad9c370f9f8b6effed9ae5e0ede22a270bdfa6daf79fc2290a \
+    xml                             6.5.0  b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226 \
+    yaml                            3.1.2  75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/bin/${name} ${destroot}${prefix}/bin
+}

--- a/sysutils/pub2port/Portfile
+++ b/sysutils/pub2port/Portfile
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           pub 1.0
+PortGroup           github 1.0
+
+github.setup        amake pub2port e7128241c3e97424acae8351ab28af737fb56b03
+version             20250218
+categories          sysutils macports
+maintainers         {amake @amake} openmaintainer
+license             BSD
+
+description         A tool for creating MacPorts portfiles for Dart projects
+
+long_description    ${description}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  b8b0f89d543db4350f204ed0892524e6487554e0 \
+                        sha256  2142da92ce3144dcc099acfe76aaf0affc568f5a829faced1842aa5aba13e168 \
+                        size    8683
+
+pub.packages \
+    _fe_analyzer_shared          80.0.0  dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57 \
+    analyzer                      7.3.0  192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e \
+    args                          2.6.0  bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6 \
+    async                        2.13.0  758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb \
+    boolean_selector              2.1.2  8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea \
+    collection                   1.19.1  2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76 \
+    convert                       3.1.2  b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68 \
+    coverage                     1.11.1  e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43 \
+    crypto                        3.0.6  1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855 \
+    file                          7.0.1  a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4 \
+    frontend_server_client        4.0.0  f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694 \
+    functional_data               1.2.0  76d17dc707c40e552014f5a49c0afcc3f1e3f05e800cd6b7872940bfe41a5039 \
+    glob                          2.1.3  c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de \
+    http_multi_server             3.2.2  aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8 \
+    http_parser                   4.1.2  178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571 \
+    io                            1.0.5  dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b \
+    js                            0.7.2  53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc \
+    json2yaml                     3.0.1  da94630fbc56079426fdd167ae58373286f603371075b69bf46d848d63ba3e51 \
+    lints                         5.1.1  c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7 \
+    logging                       1.3.0  c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61 \
+    matcher                     0.12.17  dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2 \
+    meta                         1.16.0  e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c \
+    mime                          2.0.0  41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6 \
+    node_preamble                 2.0.2  6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db \
+    package_config                2.1.1  92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67 \
+    path                          1.9.1  75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5 \
+    pool                          1.5.1  20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a \
+    pub_semver                    2.1.5  7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd \
+    pubspec_lock                  3.0.2  ed5fc1ecd0cdc0e14475a091afcb2c4cbb00e74cebff17635e9abbec18d76cc4 \
+    shelf                         1.4.2  e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12 \
+    shelf_packages_handler        3.0.2  89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e \
+    shelf_static                  1.1.3  c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3 \
+    shelf_web_socket              3.0.0  3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925 \
+    source_map_stack_trace        2.1.2  c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b \
+    source_maps                 0.10.13  190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812 \
+    source_span                  1.10.1  254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c \
+    stack_trace                  1.12.1  8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1 \
+    stream_channel                2.1.4  969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d \
+    string_scanner                1.4.1  921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43 \
+    sum_types                     0.3.5  c0a0fad9a518d011987e1d9f27fc336194294e55dafdc3699363e52aa5776e09 \
+    term_glyph                    1.2.2  7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e \
+    test                        1.25.15  301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e \
+    test_api                      0.7.4  fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd \
+    test_core                     0.6.8  84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa \
+    typed_data                    1.4.0  f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006 \
+    vm_service                   15.0.0  ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02 \
+    watcher                       1.1.1  69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104 \
+    web                           1.1.0  cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb \
+    web_socket                    0.1.6  3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83 \
+    web_socket_channel            3.0.2  0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5 \
+    webkit_inspection_protocol    1.2.1  87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572 \
+    yaml                          3.1.3  b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+
+
+build.cmd           make
+build.args
+build.target        build
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/dist/${name} ${destroot}${prefix}/bin
+}


### PR DESCRIPTION
#### Description

This enables building Dart/pub projects in the same vein as Rust/cargo projects.

This PR is for feedback and CI testing.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
