### PR TITLE
py-h5py: update build dependencies

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -12,7 +12,7 @@ name                    py-h5py
 
 # h5py needs to be re-built after hdf5 upgrades; it has its own version
 # check included.
-revision                1
+revision                2
 
 checksums \
     rmd160  bac3267da58389438559261fe4f393f1423adfe5 \
@@ -42,13 +42,10 @@ python.versions         39 310 311 312 313
 github.livecheck.regex      {([0-9.]+)}
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-pythran \
-                            port:py${python.version}-cython
+    depends_build-append    port:py${python.version}-cython \
+                            port:py${python.version}-pkgconfig
 
-    depends_lib-append      port:py${python.version}-cached-property \
-                            port:py${python.version}-numpy \
-                            port:py${python.version}-six \
-                            port:py${python.version}-pkgconfig \
+    depends_lib-append      port:py${python.version}-numpy \
                             port:hdf5
 
     build.env-append        HDF5_DIR=${prefix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- h5py is now compatible with cython 3.x
- h5py does not depend on pythran (did it ever? not in history on GitHub)
- pkgconfig is not a runtime dependency
- h5py does not depend on six any more
- build for Python 3.13

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
