### PR TITLE
rsgislib: update to 5.1.8

### DIFF
--- a/gis/rsgislib/Portfile
+++ b/gis/rsgislib/Portfile
@@ -153,6 +153,8 @@ if {[string match "py*" ${subport}]} {
         move ${destroot_sel_dir}/py-rsgislib ${destroot_sel_dir}/py${python.version}-rsgislib
     }
 
+    livecheck.type      none
+
     select.group        ${github.project}
     select.file         ${filespath}/py-rsgislib
 }

--- a/gis/rsgislib/Portfile
+++ b/gis/rsgislib/Portfile
@@ -11,8 +11,8 @@ PortGroup           active_variants   1.1
 # Same std::__and_ error as in: https://trac.macports.org/ticket/68014
 boost.version       1.81
 
-github.setup        remotesensinginfo rsgislib 5.1.7
-revision            2
+github.setup        remotesensinginfo rsgislib 5.1.8
+revision            0
 categories          gis
 license             GPL-3
 maintainers         {yahoo.com:n_larsson @nilason} {vince @Veence} openmaintainer
@@ -24,9 +24,9 @@ homepage            http://www.rsgislib.org
 
 github.tarball_from archive
 
-checksums           rmd160  5e0c2a9ce2a5a273eb4f48a48d57c2525c3b2a33 \
-                    sha256  22750fc1023492e0349703202ae6c8c20644a64bcb81ee9656702d97590aec8c \
-                    size    126214481
+checksums           rmd160  826a45b4a01cbb871f36f8fc7175f0ec1032a0c3 \
+                    sha256  f99cd4773ab617545fbff5fb7ab177659b2f9258cdd926602004831ed1112f07 \
+                    size    126238244
 
 depends_lib-append  port:gdal
 depends_lib-append  port:gsl


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- `rsgislib`: update to 5.1.8
- `py-rsgislib`: no livecheck for python subports

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
