### PR TITLE
eso-flames-fposs: new port

### DIFF
--- a/science/eso-flames-fposs/Portfile
+++ b/science/eso-flames-fposs/Portfile
@@ -1,0 +1,87 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compilers 1.0
+
+# Place holder for future Port group for ESO packages
+#PortGroup           eso 1.0
+
+set eso.prefix      ${prefix}/libexec/eso
+
+name                eso-flames-fposs
+
+version             115.0.3
+revision            0
+
+categories          science
+license             GPL-2+
+maintainers         eso.org:john.pritchard
+homepage            http://www.eso.org/sci/observing/phase2/SMGuidelines/FPOSS.FLAMES.html
+description         ESO FLAMES Observation Preparation software
+long_description    ESO FLAMES Observation Preparation software.
+                 
+master_sites        https://ftp.eso.org/pub/usg/fposs/
+
+distname            fposs-${version}
+
+checksums           rmd160 065a65f558317661d1356bfeee579f8790c14ecb \
+                    sha256 9d16463dacfaa493a2221c352b2aa323bd0edd2f86c3d1fcafe6588a11f0989b \
+                    size 2319171
+
+compilers.choose    cc cxx
+compilers.setup     gcc
+
+compiler.c_standard  2011
+
+use_parallel_build  no
+
+depends_run         port:tk port:tcl \
+                    port:ncurses \
+                    port:xorg-server
+
+patchfiles          Makefile_Darwin.diff \
+                    fposs.sh.tpl.diff \
+                    pafchk.makefile.novlt.diff
+
+configure {
+  # Update the @@ESO_...@@ placeholders set in patchfiles with Portfile variables
+  reinplace "s?@@ESO_CC@@?${configure.cc}?g" \
+    ${worksrcpath}/fposs/src/Makefile_Darwin
+  reinplace "s?@@ESO_CC@@?${configure.cc}?g" \
+    ${worksrcpath}/pafchk/src/makefile.novlt
+  reinplace "s?@@ESO_PREFIX@@?${eso.prefix}?g" \
+    ${worksrcpath}/fposs/scripts/fposs.sh.tpl
+}
+
+build {
+  # Non-standard build of pafchk...
+  system -W "${worksrcpath}/pafchk/src" \
+      "\
+        CC=${configure.cc} CXX=${configure.cxx} \
+        CFLAGS='[get_canonical_archflags cc] ${configure.cflags}' CXXFLAGS='[get_canonical_archflags cxx] ${configure.cxxflags}' \
+        make -f makefile.novlt \
+      "
+  # Non-stadnard build of fposs...
+  system -W "${worksrcpath}/fposs/src" \
+      "\
+        CC=${configure.cc} CXX=${configure.cxx} \
+        CFLAGS='[get_canonical_archflags cc] ${configure.cflags}' CXXFLAGS='[get_canonical_archflags cxx] ${configure.cxxflags}' \
+        make \
+      "
+}
+
+destroot {
+  system -W "${worksrcpath}/fposs/src" "make INTROOT='${destroot}${eso.prefix}' install"
+  xinstall                                                      -d  ${destroot}${prefix}/bin
+  xinstall                                                      -d  ${destroot}${prefix}/share
+  xinstall                                                      -d  ${destroot}${eso.prefix}/bin
+  xinstall ${worksrcpath}/fposs/scripts/fposs.sh.tpl                ${destroot}${eso.prefix}/bin/fposs.sh
+  xinstall ${worksrcpath}/fposs/scripts/bash_library.sh             ${destroot}${eso.prefix}/bin
+  xinstall ${worksrcpath}/fposs/scripts/fposs_fixINSfilename.sh     ${destroot}${eso.prefix}/bin
+  ln -s ${eso.prefix}/bin/fposs.sh                                  ${destroot}${prefix}/bin
+  ln -s ${eso.prefix}/share/fposs                                   ${destroot}${prefix}/share/fposs
+}
+
+livecheck.type          regex
+livecheck.url           https://ftp.eso.org/pub/usg/fposs/ver_info.html
+livecheck.regex         ".*https://ftp.eso.org/pub/usg/fposs/eso-fposs-\"(\\d+(?:\\.\\d+)*)\.tar.gz.*"

--- a/science/eso-flames-fposs/files/Makefile_Darwin.diff
+++ b/science/eso-flames-fposs/files/Makefile_Darwin.diff
@@ -1,0 +1,22 @@
+--- fposs.orig/src/Makefile_Darwin	2025-01-22 16:38:33
++++ fposs/src/Makefile_Darwin	2025-03-14 08:03:29
+@@ -67,9 +67,7 @@
+ CWARNINGS = -Wall -ansi -DUSE_COMPAT_CONST -DUSE_INTERP_RESULT
+ CINCLUDES = -I$(SDS_SRC) -I$(DRAMA_SRC) -I$(SLA_SRC) -I$(FPCOL_SRC) -I$(PAFCHK_MODULE)/include -I$(X11_DIR) -I$(TCL_DIR) -I.
+ CFLAGS = -DFLAMES_ONLY -DDRAMA_BUILD $(CWARNINGS) $(COPT) $(CINCLUDES)
+-CC = /opt/local/bin/clang-mp-14
+-CC = /opt/local/bin/gcc-mp-12
+-CC = gcc
++CC ?= @@ESO_CC@@
+ 
+ #*******************************************************************************
+ #  'configure' - the default taget for this Makefile - builds the
+@@ -219,7 +219,7 @@
+              $(SDS_SRC)/sds.h tdFconvert.h conf_err.h
+ 
+ pafchkChecksum.o : $(PAFCHK_MODULE)/src/pafchkChecksum.c $(PAFCHK_MODULE)/include/pafchk.h 
+-	$(CC) $(CFLAGS) -c $(PAFCHK_MODULE)/src/pafchkChecksum.c
++	$(CC) -DFLAMES_ONLY -DDRAMA_BUILD $(CWARNINGS) $(COPT) -I$(PAFCHK_MODULE)/include -c $(PAFCHK_MODULE)/src/pafchkChecksum.c
+ 
+ crc32.o :  $(PAFCHK_MODULE)/src/crc32.c $(PAFCHK_MODULE)/include/zconf.h $(PAFCHK_MODULE)/include/zlib.h
+ 	$(CC)  -DFLAMES_ONLY -DDRAMA_BUILD $(CWARNINGS) $(COPT) -I$(PAFCHK_MODULE)/include -c $(PAFCHK_MODULE)/src/crc32.c

--- a/science/eso-flames-fposs/files/fposs.sh.tpl.diff
+++ b/science/eso-flames-fposs/files/fposs.sh.tpl.diff
@@ -1,0 +1,44 @@
+--- fposs.orig/scripts/fposs.sh.tpl	2025-01-22 16:38:33
++++ fposs/scripts/fposs.sh.tpl	2025-03-14 08:03:29
+@@ -101,7 +101,7 @@
+ #
+ # Include BASH library
+ #
+-bashlib=`dirname $0`/bash_library.sh
++bashlib=@@ESO_PREFIX@@/bin/bash_library.sh
+ if [ -f "$bashlib" ]; then
+     source $bashlib 2>&-
+     status=$?
+@@ -419,9 +419,9 @@
+ # Main Algorithm BEGIN
+ #
+ # Receive installation paths from installer script
+-FPOSS_BASE_PATH=@@FPOSSBASEPATH@@
+-BINPATH=@@BINPATH@@
+-LIBPATH=@@LIBPATH@@
++FPOSS_BASE_PATH=@@ESO_PREFIX@@/lib/fposs
++BINPATH=@@ESO_PREFIX@@/lib/fposs/bin
++LIBPATH=@@ESO_PREFIX@@/lib/fposs/lib
+ BIN_PATH=`echo ${BINPATH} | sed s/[/]/\\\\\\\\\\\\\\\\\\\\\\\\\\\//g`
+ LIB_PATH=`echo ${LIBPATH} | sed s/[/]/\\\\\\\\\\\\\\\\\\\\\\\\\\\//g`
+ 
+@@ -449,7 +449,7 @@
+ export TCLLIBPATH=@@TCLPATH@@
+ export VLTROOT=@@VLTPATH@@
+ export INSROOT=@@INSPATH@@
+-export INSUSER=@@USER@@
++export INSUSER=.fposs
+ export FPOSSROOT=$FPOSS_BASE_PATH
+ export ISF_DIR=$FPOSS_BASE_PATH/../config
+ export PREP_DIR=$HOME/$INSUSER/PREP
+@@ -490,8 +490,8 @@
+ fi
+ 
+ # Find out component versions
+-if [ -a $FPOSS_BASE_PATH/../doc/fposs_svn.txt ]; then
+-    SVN_INFO=`cat $FPOSS_BASE_PATH/../doc/fposs_svn.txt`
++if [ -a $FPOSS_BASE_PATH/doc/fposs_svn.txt ]; then
++    SVN_INFO=`cat $FPOSS_BASE_PATH/doc/fposs_svn.txt`
+ else
+     SVN_INFO="Path: unknown URL: unknown Repository Root: unknown Repository UUID: 00000000-0000-0000-0000-000000000000 Revision: 000000 Node Kind: directory Schedule: normal Last Changed Author: unknown Last Changed Rev: 000000 Last Changed Date: 0000-00-00 00:00:00 +0000 (Dow, 00 Mon 0000)"
+ fi

--- a/science/eso-flames-fposs/files/pafchk.makefile.novlt.diff
+++ b/science/eso-flames-fposs/files/pafchk.makefile.novlt.diff
@@ -1,0 +1,14 @@
+--- pafchk.orig/src/makefile.novlt	2025-01-22 16:38:33
++++ pafchk/src/makefile.novlt	2025-03-14 09:55:38
+@@ -23,10 +23,7 @@
+ # --------------------------
+ # Makros : Flags 
+ # --------------------------
+-CC = $(shell (test "`uname`" == "Darwin" && echo 'gcc') || echo gcc)
+-CC = /opt/local/bin/clang-mp-14
+-CC = /opt/local/bin/gcc-mp-12
+-CC = gcc
++CC ?= @@ESO_CC@@
+ CCFLAG = -c -g -O0 -std=c11
+ COFLAG = -o 
+ OPFLAG = -g -Wall 


### PR DESCRIPTION
#### Description

New Portfile eso-flames-fposs
FPOSS is the Observation preparation Software for the FLAMES instrument on the European Southern Observatory's Very large telescope.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? ```port -vst install``` fails, but ```port -vs install``` succeeds.
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

