### PR TITLE
iverilog: update to s20250103, split documentation, add libvvp patch

### DIFF
--- a/science/iverilog/Portfile
+++ b/science/iverilog/Portfile
@@ -1,20 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        steveicarus iverilog 12_0 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-version             [string map {_ .} ${github.version}]
+github.setup        steveicarus iverilog 20250103 s
+github.tarball_from archive
+
 revision            0
-set major           [lindex [split ${version} .] 0]
+set major           12
+set minor           0
+
 categories          science
 license             GPL-2+
 maintainers         {keeh.net:paf @padf} openmaintainer
-
 description         Icarus Verilog
-
 long_description    Icarus Verilog is a Verilog simulation and synthesis tool. \
                     It operates as a compiler, compiling source code writen in \
                     Verilog (IEEE-1364) into some target format. For batch \
@@ -26,17 +25,29 @@ long_description    Icarus Verilog is a Verilog simulation and synthesis tool. \
 
 homepage            http://iverilog.icarus.com/
 
-checksums           rmd160  56a9fa32ae1b8b5240b0770bff6dc7a72fb05f4f \
-                    sha256  8be4bc86aa97013dd16eb7d63c6a5bdd896eddcf760a05b309d633647b7eb2eb \
-                    size    2995764
+checksums           rmd160  41f0a34641ce8bf4955f2248ee606707deedbf92 \
+                    sha256  eed6e7569eb9111a6384ed2088e38b51541236a1806ed469208419f41b8224ae \
+                    size    3111119
 
-depends_lib-append  port:bzip2 \
-                    port:readline \
-                    port:zlib
+depends_lib-append      port:bzip2 \
+                        port:readline \
+                        port:zlib
 
-depends_build       port:bison
+depends_build-append    port:bison \
+                        port:autoconf \
+                        port:gperf
 
 use_autoconf        yes
+
+configure.args-append --enable-libvvp
+configure.ldflags-append -Wl,-rpath,${prefix}/lib
+
+patchfiles-append patch-vvp-Makefile.in.diff
+
+platform darwin {
+    #under MacOS, this is needed, the library references were incorrect as-is
+    configure.cxxflags-append -fPIC
+}
 
 compiler.cxx_standard 2011
 
@@ -50,15 +61,38 @@ test.target         check
 destroot.destdir    prefix=${destroot}${prefix}
 
 post-destroot {
-    set docdir ${destroot}${prefix}/share/doc/${name}
-    xinstall -d ${docdir}
-    copy ${worksrcpath}/examples ${docdir}
-    xinstall -m 644 {*}[glob ${worksrcpath}/*.txt] ${docdir}
-    xinstall -d ${docdir}/vvp
-    xinstall -m 644 {*}[glob ${worksrcpath}/vvp/*.txt] ${docdir}/vvp
-    xinstall -m 644 -W ${worksrcpath} cadpli/cadpli.txt ivlpp/ivlpp.txt \
-        ${docdir}
+    if {[file exists ${destroot}${prefix}/lib/libvvp.so]} {
+        # Fix just the library's install name
+        system "install_name_tool -id ${prefix}/lib/libvvp.so ${destroot}${prefix}/lib/libvvp.so"
+    }
 }
 
 # g++-4.2: -E, -S, -save-temps and -M options are not allowed with multiple -arch flags
 universal_variant   no
+
+subport ${name}-docs {
+    description         Documentation for Icarus Verilog
+    long_description    This subport provides the documentation for Icarus Verilog, \
+                        including user guides and API references.
+
+    depends_build-append       port:py312-sphinx \
+                               port:sphinx
+
+    worksrcdir          ${github.project}-${github.version}
+
+    pre-build {
+        reinplace "s|sphinx-build|sphinx-build-3.12|" ${worksrcpath}/Documentation/Makefile
+    }
+
+    build {
+        system -W ${worksrcpath}/Documentation "make html"
+    }
+
+    destroot {
+        set docdir ${destroot}${prefix}/share/doc/${name}
+        xinstall -d ${docdir}
+        system "cp -R ${worksrcpath}/Documentation/_build/html/* ${docdir}/"
+    }
+
+    depends_lib
+}

--- a/science/iverilog/files/patch-vvp-Makefile.in.diff
+++ b/science/iverilog/files/patch-vvp-Makefile.in.diff
@@ -1,0 +1,11 @@
+--- vvp/Makefile.in.orig	2025-02-19 14:26:54
++++ vvp/Makefile.in	2025-02-19 14:27:14
+@@ -159,7 +159,7 @@
+ 	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ main.o -L. -lvvp $(LIBS)
+ 
+ libvvp.so: $O
+-	$(CXX) -shared $(LDFLAGS) -o libvvp.so $O $(LIBS) $(dllib)
++	$(CXX) -shared $(LDFLAGS) -install_name $(libdir)/libvvp.so -o libvvp.so $O $(LIBS) $(dllib)
+ else
+ vvp@EXEEXT@: $O main.o
+ 	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ main.o $O $(LIBS) $(dllib)


### PR DESCRIPTION

#### Description

- Update iverilog from version 12.0 to tag s20250103 to support libvvp integration with ngspice.
- Split documentation into a new `iverilog-docs` port due to increased compile dependencies and source tree changes.
- Many text files, such as `cadpli.txt`, are no longer included upstream.
- Add patch for `libvvp.so` to ensure proper functionality.


###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.7.2 22H313 x86_64
Xcode 14.3.1 14E300c


###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?



