### PR TITLE
lldpd: new port

### DIFF
--- a/net/lldpd/Portfile
+++ b/net/lldpd/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem            1.0
+PortGroup             github 1.0
+
+github.setup          lldpd lldpd 1.0.19
+revision              0
+categories            net
+maintainers           {@akkornel stanford.edu:akkornel} openmaintainer
+license               ISC
+
+description           LLDP allows you to know exactly on which port is a \
+                      machine (and reciprocally).
+long_description      lldpd is an 802.1ab implementation (LLDP) to help you \
+                      locate neighbors of all your equipments.  Proprietary \
+                      protocols (like EDP and CDP) are supported.
+homepage              https://lldpd.github.io
+
+depends_build         path:bin/pkg-config:pkgconfig
+
+# The distribution does bring its own libevent, which we could use instead of
+# the port.
+depends_lib           port:libevent \
+                      port:libxml2 \
+                      port:readline
+
+github.tarball_from   releases
+
+checksums             rmd160  76faefbcc0587dd6b5563bdd8c16c450a1118c28 \
+                      sha256  4de17fe5137b4d44a7bd57f8dfc80cffe2c8bb3691b4ae3012b5a6ea20d79ee0 \
+                      size    1987102
+
+# libevent, libxml2, and readline are detected automatically by configure
+configure.args        --prefix=${prefix} \
+                      --with-privsep-chroot=/var/empty \
+                      --with-privsep-user=nobody \
+                      --with-privsep-group=nogroup \
+                      --with-launchddaemonsdir=no
+
+build.target           all-recursive
+
+installs_libs          no
+
+startupitem.create     yes
+startupitem.autostart  yes
+startupitem.executable ${prefix}/sbin/lldpd


### PR DESCRIPTION
#### Description

[lldpd](https://lldpd.github.io) is a daemon that implements LLDP and LLDP-MED.

LLDP (Link Layer Discovery Protocol) is a link-local protocol—that is, it's limited to the physical Ethernet connection between one device and another—that devices use to exchange information about how they are connected, and what their capabilities are, from a Layer-1 and Layer-2 perspective.

For example, say your Mac has a physical Ethernet connection that is plugged into a switch.  If both sides support LLDP, the switch might tell you:

* Its make, model, and OS.
* The name of the switch, and its management IP address.
* What type of Ethernet connections are supported (you may be on a port that can support 10-Gigabit Ethernet).
* What VLAN you are on, and for tagged (802.11q) VLANs, what VLANs are being provided.

It can be useful for sysadmins who are trying to figure out where an Ethernet cable goes (assuming you can unplug it): Plug one end into your Mac's Ethernet adapter, and within a minute you'll likely get the information.

VoIP phones are prominent users of LLDP, identifying themselves as IP phones.  Switches can react to this information by enabling VLAN tagging on a port, telling the phone which VLAN is to be used for voice traffic. These are examples of LLDP Media Endpoint Discovery (LLDP-MED).

lldpd also implements several related protocols—such as the proprietary Cisco Discovery Protocol (CDP)—that have largely been supplanted by LLDP.

There are three components:

* `lldpd` is a daemon that connects to all supportable (Ethernet) interfaces, sending out LLDP messages and listening for incoming messages.  It is launched via a LaunchDaemon.

* `lldpctl` can be used to see what information is known about connected devices.

* `lldpcli` can provide the same information as `lldpctl`, and can also be used to configure `lldpd`.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.3 24D60 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? — Trac tickets 50586 and 55122 will be closed by this PR.
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`? -- `sudo port -vs install` works.  `sudo port -vst install` dies with exit code 9 when trying to un-tar.
- [x] tested basic functionality of all binary files?