### PR TITLE
qt6,qt76: provide "upgrade" path on systems where the port is no longer supported

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -819,6 +819,19 @@ array set sql_plugins {
 
 foreach {module module_info} [array get modules] {
     subport ${name}-${module} {
+
+        # minimum supported versions have changed over time and new qtXY ports were added
+        # this attempts to provide a clean "upgrade" path for user who had  "qt6-XY" (sub)ports installed
+        # on a system that is no longer supported
+        # REMOVE after 2026-02-19
+        if {${os.platform} eq "darwin" && ${os.major} < 23 && ${os.major} >= 21} {
+            PortGroup               obsolete 1.0
+            replaced_by             qt67-${module}
+        } elseif {${os.platform} eq "darwin" && ${os.major} < 21 && ${os.major} >= 18} {
+            PortGroup               obsolete 1.0
+            replaced_by             qt64-${module}
+        }
+
         distname                            ${module}-everywhere-src-${version}
 
         revision                            [regexp -inline {[0-9]+} [lindex ${module_info} 7]]
@@ -894,6 +907,19 @@ foreach {module module_info} [array get modules] {
     if { [lsearch -exact [lindex ${module_info} 6] "~docs"] != -1 } { continue }
 
     subport ${name}-${module}-docs {
+
+        # minimum supported versions have changed over time and new qtXY ports were added
+        # this attempts to provide a clean "upgrade" path for user who had  "qt6-XY" (sub)ports installed
+        # on a system that is no longer supported
+        # REMOVE after 2026-02-19
+        if {${os.platform} eq "darwin" && ${os.major} < 23 && ${os.major} >= 21} {
+            PortGroup               obsolete 1.0
+            replaced_by             qt67-${module}
+        } elseif {${os.platform} eq "darwin" && ${os.major} < 21 && ${os.major} >= 18} {
+            PortGroup               obsolete 1.0
+            replaced_by             qt64-${module}
+        }
+
         distname                            ${module}-everywhere-src-${version}
 
         revision                            [regexp -inline {[0-9]+} [lindex ${module_info} 7]]
@@ -947,6 +973,19 @@ foreach {driver driver_info} [array get sql_plugins] {
     set sql_variants                        [lindex ${driver_info} 3]
 
     subport ${name}-${driver}-plugin {
+
+        # minimum supported versions have changed over time and new qtXY ports were added
+        # this attempts to provide a clean "upgrade" path for user who had  "qt6-XY" (sub)ports installed
+        # on a system that is no longer supported
+        # REMOVE after 2026-02-19
+        if {${os.platform} eq "darwin" && ${os.major} < 23 && ${os.major} >= 21} {
+            PortGroup               obsolete 1.0
+            replaced_by             qt67-${driver}-plugin
+        } elseif {${os.platform} eq "darwin" && ${os.major} < 21 && ${os.major} >= 18} {
+            PortGroup               obsolete 1.0
+            replaced_by             qt64-${driver}-plugin
+        }
+
         distname                            qtbase-everywhere-src-${version}
 
         revision                            ${revision_string}

--- a/aqua/qt67/Portfile
+++ b/aqua/qt67/Portfile
@@ -799,6 +799,16 @@ array set sql_plugins {
 
 foreach {module module_info} [array get modules] {
     subport ${name}-${module} {
+
+        # minimum supported versions have changed over time and new qtXY ports were added
+        # this attempts to provide a clean "upgrade" path for user who had  "qt67-XY" (sub)ports installed
+        # on a system that is no longer supported
+        # REMOVE after 2026-02-19
+        if {${os.platform} eq "darwin" && ${os.major} < 21 && ${os.major} >= 18} {
+            PortGroup               obsolete 1.0
+            replaced_by             qt64-${module}
+        }
+
         distname                            ${module}-everywhere-src-${version}
 
         revision                            [regexp -inline {[0-9]+} [lindex ${module_info} 7]]
@@ -874,6 +884,16 @@ foreach {module module_info} [array get modules] {
     if { [lsearch -exact [lindex ${module_info} 6] "~docs"] != -1 } { continue }
 
     subport ${name}-${module}-docs {
+
+        # minimum supported versions have changed over time and new qtXY ports were added
+        # this attempts to provide a clean "upgrade" path for user who had  "qt67-XY" (sub)ports installed
+        # on a system that is no longer supported
+        # REMOVE after 2026-02-19
+        if {${os.platform} eq "darwin" && ${os.major} < 21 && ${os.major} >= 18} {
+            PortGroup               obsolete 1.0
+            replaced_by             qt64-${module}
+        }
+
         distname                            ${module}-everywhere-src-${version}
 
         revision                            [regexp -inline {[0-9]+} [lindex ${module_info} 7]]
@@ -927,6 +947,16 @@ foreach {driver driver_info} [array get sql_plugins] {
     set sql_variants                        [lindex ${driver_info} 3]
 
     subport ${name}-${driver}-plugin {
+
+        # minimum supported versions have changed over time and new qtXY ports were added
+        # this attempts to provide a clean "upgrade" path for user who had  "qt67-XY" (sub)ports installed
+        # on a system that is no longer supported
+        # REMOVE after 2026-02-19
+        if {${os.platform} eq "darwin" && ${os.major} < 21 && ${os.major} >= 18} {
+            PortGroup               obsolete 1.0
+            replaced_by             qt64-${driver}-plugin
+        }
+
         distname                            qtbase-everywhere-src-${version}
 
         revision                            ${revision_string}


### PR DESCRIPTION
#### Description
The initial Qt6 port (and updates to newer versions I committed) had the supported versions incorrectly listed. That issue was corrected a while ago, but there are users who had the `qt6` port installed on a system that is no longer supported. So instead they should install the `qt67` or `qt64` (sub)ports. 

To provide an "upgrade" path for these situations I added some logic to the Portfiles that will set `replaced_by` on systems that no longer support the versions provided by the `qt6` or `qt67` ports.  


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->