### PR TITLE
gitleaks: Update to 8.24.0

### DIFF
--- a/security/gitleaks/Portfile
+++ b/security/gitleaks/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/zricethezav/gitleaks 8.23.3 v
+go.setup            github.com/zricethezav/gitleaks 8.24.0 v
 go.package          github.com/zricethezav/gitleaks/v8
 go.offline_build    no
 github.tarball_from archive
@@ -25,9 +25,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  72c72402da52f25178369d346a67dd960af2115a \
-                    sha256  4b49931c46180954fd323eecd1aac1d91a6f742347fa173262ccc6769364a5cf \
-                    size    235275
+checksums           rmd160  94021563f20e0fab4e8a0fc68be69ed4433556d7 \
+                    sha256  a0c1e7c3b5d0ee621f1e48b3d502132f8a3e20f9ac2ce3f450c6fca55c702038 \
+                    size    240871
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

gitleaks: Update to 8.24.0

##### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
