### PR TITLE
gtk-doc: add and default to python 3.13 variant

### DIFF
--- a/gnome/gtk-doc/Portfile
+++ b/gnome/gtk-doc/Portfile
@@ -83,32 +83,32 @@ proc py_setup {p_py_ver} {
                     port:py${py_ver_nodot}-mock
 }
 
-variant python38 conflicts python39 python310 python311 python312 description {Build using Python 3.8} {
-    py_setup 3.8
-}
-
-variant python39 conflicts python38 python310 python311 python312 description {Build using Python 3.9} {
+variant python39 conflicts python310 python311 python312 python313 description {Build using Python 3.9} {
     py_setup 3.9
 }
 
-variant python310 conflicts python38 python39 python311 python312 description {Build using Python 3.10} {
+variant python310 conflicts python39 python311 python312 python313 description {Build using Python 3.10} {
     py_setup 3.10
 }
 
-variant python311 conflicts python38 python39 python310 python312 description {Build using Python 3.11} {
+variant python311 conflicts python39 python310 python312 python313 description {Build using Python 3.11} {
     py_setup 3.11
 }
 
-variant python312 conflicts python38 python39 python310 python311 description {Build using Python 3.12} {
+variant python312 conflicts python39 python310 python311 python313 description {Build using Python 3.12} {
     py_setup 3.12
 }
 
-if {![variant_isset python38] &&
-    ![variant_isset python39] &&
+variant python313 conflicts python39 python310 python311 python312 description {Build using Python 3.13} {
+    py_setup 3.13
+}
+
+if {![variant_isset python39] &&
     ![variant_isset python310] &&
     ![variant_isset python311] &&
-    ![variant_isset python312] } {
-    default_variants +python312
+    ![variant_isset python312] &&
+    ![variant_isset python313] } {
+    default_variants +python313
 }
 
 # some tests are known to fail in gtk-doc 1.29+


### PR DESCRIPTION
remove python 3.8

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
