### PR TITLE
k9s: update to 0.40.5

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.40.3 v
+go.setup            github.com/derailed/k9s 0.40.5 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {breun.nl:nils @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  82ec002a63bc949889c9c7c36245bbfedd73cf23 \
-                    sha256  81159b9232859eff41e90b529550b38f39b1416ca1a317a829984c789df21abe \
-                    size    6781466
+checksums           rmd160  305e64211eddd5a089d794f78a1c56b0226192af \
+                    sha256  e8f886bd95de67b8239b5444776604d45530aee8bb779229425855e7e1d37d4e \
+                    size    6782975
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
#### Description

Update to k9s 0.40.5.

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?