### PR TITLE
google-cloud-sdk: update to 511.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             510.0.0
+version             511.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  daf7bc81c9f11a60b8e667b5d41d7b89617a486b \
-                    sha256  87c3f16b6bf951876ff2fdd099730fe033c20dd7e2d42f5e8d8ebc40523884dd \
-                    size    53754651
+    checksums       rmd160  7414f6c085882a9f2fe5b25ce117b77984b2318b \
+                    sha256  c0fdf1937563db114adebaefec229ebe08970108dffdd485d4c5a580b9a3fc11 \
+                    size    53846067
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  234efa213c9fdcb14274da404e5c91eb14197469 \
-                    sha256  fe9ad9ba28f2cc1e7d5ea26731544855b945a14021e339edbbd9fb3e59db2678 \
-                    size    55223062
+    checksums       rmd160  769566e14d3a591cce8c84ae6692cff48d74323d \
+                    sha256  564bb4d825fda5fcf1b893166e2ae2fb79dcffb354399ace6383a014580c6f28 \
+                    size    55317393
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  4ffb05b5d78b1a8a8d8eca7dd77b18f34bb6da4d \
-                    sha256  afab9cca64ef77fe9deb1d4efa680695631fc8d4548c867d777098d4b574b932 \
-                    size    55162908
+    checksums       rmd160  c4be212eae6f68de5ac1bf7e057c621700e3bc49 \
+                    sha256  d4e9a8654b9bc25abe42501bbde44299eb17535edf775b16a2a5861d4c77924f \
+                    size    55255981
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 511.0.0.

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?