### PR TITLE
zlog: new port

### DIFF
--- a/devel/zlog/Portfile
+++ b/devel/zlog/Portfile
@@ -1,0 +1,18 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               cmake 1.1
+
+github.setup            HardySimpson zlog 1.2.18
+github.tarball_from     archive
+revision                0
+categories              devel
+license                 Apache-2
+maintainers             {@sikmir disroot.org:sikmir} openmaintainer
+description             Reliable, high-performance, thread safe, flexible, clear-model, pure C logging library
+long_description        {*}${description}
+
+checksums               rmd160  f9969c546b2008b5aa9e3fdb01afb1facb8f239b \
+                        sha256  3977dc8ea0069139816ec4025b320d9a7fc2035398775ea91429e83cb0d1ce4e \
+                        size    130997


### PR DESCRIPTION
#### Description
**[zlog](https://github.com/HardySimpson/zlog)** is a reliable, high-performance, thread safe, flexible, clear-model, pure C logging library.

[![Packaging status](https://repology.org/badge/tiny-repos/zlog.svg)](https://repology.org/project/zlog/versions)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

