### PR TITLE
paho.mqtt.cpp: update to 1.5.1

### DIFF
--- a/net/paho.mqtt.cpp/Portfile
+++ b/net/paho.mqtt.cpp/Portfile
@@ -5,9 +5,8 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           openssl 1.0
 
-github.setup        eclipse paho.mqtt.cpp 1.5.0 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        eclipse paho.mqtt.cpp 1.5.1 v
+github.tarball_from archive
 revision            0
 categories          net
 maintainers         nomaintainer
@@ -31,9 +30,9 @@ configure.args-append \
                     -DPAHO_BUILD_STATIC=ON \
                     -DPAHO_WITH_SSL=ON
 
-checksums           rmd160  079f4514d00a17cf653a9ad59e3efb999842782d \
-                    sha256  afc703dc0373a69959a6a34562e1f7e32d794e426981b4856a58fe61e968bf4e \
-                    size    264677
+checksums           rmd160  549175a4721ef07446ff875418bfdfc8805e0476 \
+                    sha256  1deb281ca75b49f605d6018cec594771905ea3ba9632a072c329a5ac23fc8c97 \
+                    size    265099
 
 # Since 1.5.0 a C++17 compiler is required
 compiler.cxx_standard   2017


### PR DESCRIPTION
#### Description
https://github.com/eclipse-paho/paho.mqtt.cpp/releases/tag/v1.5.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
