### PR TITLE
duckdb: update to 1.2.0

### DIFF
--- a/databases/duckdb/Portfile
+++ b/databases/duckdb/Portfile
@@ -6,7 +6,7 @@ PortGroup           github          1.0
 PortGroup           legacysupport   1.0
 PortGroup           openssl         1.0
 
-github.setup        cwida duckdb 1.1.3 v
+github.setup        cwida duckdb 1.2.0 v
 github.tarball_from archive
 revision            0
 
@@ -27,9 +27,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  137bf10aa5fec0d82c574909135d2fe195b3b547 \
-                    sha256  2aea0af898ad753fee82b776fea1bf78ccbc9648986e7f7a87372df5e74cdb98 \
-                    size    90800198
+checksums           rmd160  51bb160749f465ef5ae7dac053a6d6511192035c \
+                    sha256  f22c97e18c071fa8e43b5e150c03c6ab4bcc510cca6e6b50cbe13af8535fa701 \
+                    size    89762895
 
 patchfiles-append   no-ccache.patch
 
@@ -38,7 +38,9 @@ set python_branch   \
     [string index ${python_version} 0].[string range ${python_version} 1 end]
 
 configure.args-append \
-                    -DBUILD_EXTENSIONS='parquet\;fts\;httpfs' \
+                    -DBUILD_EXTENSIONS='autocomplete\;icu\;parquet\;json' \
+                    -DENABLE_EXTENSION_AUTOLOADING=1 \
+                    -DENABLE_EXTENSION_AUTOINSTALL=1 \
                     -DOVERRIDE_GIT_DESCRIBE=v${version} \
                     -DPython3_EXECUTABLE=${prefix}/bin/python${python_branch}
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

duckdb: update to 1.2.0
https://github.com/duckdb/duckdb/releases

##### Build changes
* Enabled `ENABLE_EXTENSION_AUTOLOADING`
* Enabled `ENABLE_EXTENSION_AUTOINSTALL`
* Adjust `BUILD_EXTENSIONS` for built-in
  * As-is: `parquet;fts;httpfs`
    * `fts` and `httpfs`: no longer supported built-in
  * To-be: `autocomplete;icu;parquet;json`
    * Add reasonable plugins to built-in

##### Refs.
* https://github.com/duckdb/duckdb/tree/main/extension#building-extensions

<details>
<summary>Test binary for EXTENSION_AUTOINSTALL and EXTENSION_AUTOLOADING</summary>

```
$ duckdb
v1.2.0
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D FROM duckdb_extensions();
┌──────────────────┬─────────┬───────────┬──────────────┬─────────────────────────────────┬───────────────────┬───────────────────┬───────────────────┬────────────────┐
│  extension_name  │ loaded  │ installed │ install_path │           description           │      aliases      │ extension_version │   install_mode    │ installed_from │
│     varchar      │ boolean │  boolean  │   varchar    │             varchar             │     varchar[]     │      varchar      │      varchar      │    varchar     │
├──────────────────┼─────────┼───────────┼──────────────┼─────────────────────────────────┼───────────────────┼───────────────────┼───────────────────┼────────────────┤
│ arrow            │ false   │ false     │              │ A zero-copy data integration …  │ []                │                   │ NULL              │                │
│ autocomplete     │ true    │ true      │ (BUILT-IN)   │ Adds support for autocomplete…  │ []                │ v1.2.0            │ STATICALLY_LINKED │                │
│ aws              │ false   │ false     │              │ Provides features that depend…  │ []                │                   │ NULL              │                │
│ azure            │ false   │ false     │              │ Adds a filesystem abstraction…  │ []                │                   │ NULL              │                │
│ core_functions   │ true    │ true      │ (BUILT-IN)   │ Core function library           │ []                │ v1.2.0            │ STATICALLY_LINKED │                │
│ delta            │ false   │ false     │              │ Adds support for Delta Lake     │ []                │                   │ NULL              │                │
│ excel            │ false   │ false     │              │ Adds support for Excel-like f…  │ []                │                   │ NULL              │                │
│ fts              │ false   │ false     │              │ Adds support for Full-Text Se…  │ []                │                   │ NULL              │                │
│ httpfs           │ false   │ false     │              │ Adds support for reading and …  │ [http, https, s3] │                   │ NULL              │                │
│ iceberg          │ false   │ false     │              │ Adds support for Apache Iceberg │ []                │                   │ NULL              │                │
│ icu              │ true    │ true      │ (BUILT-IN)   │ Adds support for time zones a…  │ []                │ v1.2.0            │ STATICALLY_LINKED │                │
│ inet             │ false   │ false     │              │ Adds support for IP-related d…  │ []                │                   │ NULL              │                │
│ jemalloc         │ false   │ false     │              │ Overwrites system allocator w…  │ []                │                   │ NULL              │                │
│ json             │ true    │ true      │ (BUILT-IN)   │ Adds support for JSON operati…  │ []                │ v1.2.0            │ STATICALLY_LINKED │                │
│ motherduck       │ false   │ false     │              │ Enables motherduck integratio…  │ [md]              │                   │ NULL              │                │
│ mysql_scanner    │ false   │ false     │              │ Adds support for connecting t…  │ [mysql]           │                   │ NULL              │                │
│ parquet          │ true    │ true      │ (BUILT-IN)   │ Adds support for reading and …  │ []                │ v1.2.0            │ STATICALLY_LINKED │                │
│ postgres_scanner │ false   │ false     │              │ Adds support for connecting t…  │ [postgres]        │                   │ NULL              │                │
│ shell            │ true    │ true      │ (BUILT-IN)   │ Adds CLI-specific support and…  │ []                │ v1.2.0            │ STATICALLY_LINKED │                │
│ spatial          │ false   │ false     │              │ Geospatial extension that add…  │ []                │                   │ NULL              │                │
│ sqlite_scanner   │ false   │ false     │              │ Adds support for reading and …  │ [sqlite, sqlite3] │                   │ NULL              │                │
│ tpcds            │ false   │ false     │              │ Adds TPC-DS data generation a…  │ []                │                   │ NULL              │                │
│ tpch             │ false   │ false     │              │ Adds TPC-H data generation an…  │ []                │                   │ NULL              │                │
│ vss              │ false   │ false     │              │ Adds indexing support to acce…  │ []                │                   │ NULL              │                │
├──────────────────┴─────────┴───────────┴──────────────┴─────────────────────────────────┴───────────────────┴───────────────────┴───────────────────┴────────────────┤
│ 24 rows                                                                                                                                                    9 columns │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
D SELECT * FROM 'https://raw.githubusercontent.com/duckdb/duckdb-web/main/data/weather.csv';
┌───────────────┬─────────┬─────────┬─────────┬────────────┐
│    column0    │ column1 │ column2 │ column3 │  column4   │
│    varchar    │  int64  │  int64  │ double  │    date    │
├───────────────┼─────────┼─────────┼─────────┼────────────┤
│ San Francisco │      46 │      50 │    0.25 │ 1994-11-27 │
│ San Francisco │      43 │      57 │     0.0 │ 1994-11-29 │
│ Hayward       │      37 │      54 │    NULL │ 1994-11-29 │
└───────────────┴─────────┴─────────┴─────────┴────────────┘
D FROM duckdb_extensions() WHERE extension_name = 'httpfs';
┌────────────────┬─────────┬───────────┬──────────────────────┬────────────────────────────────┬───────────────────┬───────────────────┬──────────────┬────────────────┐
│ extension_name │ loaded  │ installed │     install_path     │          description           │      aliases      │ extension_version │ install_mode │ installed_from │
│    varchar     │ boolean │  boolean  │       varchar        │            varchar             │     varchar[]     │      varchar      │   varchar    │    varchar     │
├────────────────┼─────────┼───────────┼──────────────────────┼────────────────────────────────┼───────────────────┼───────────────────┼──────────────┼────────────────┤
│ httpfs         │ true    │ true      │ /Users/xxxxxxx/.du…  │ Adds support for reading and…  │ [http, https, s3] │ 85ac466           │ REPOSITORY   │ core           │
└────────────────┴─────────┴───────────┴──────────────────────┴────────────────────────────────┴───────────────────┴───────────────────┴──────────────┴────────────────┘
D .quit

$ tree ~/.duckdb/extensions
/Users/xxxxxxx/.duckdb/extensions
└── v1.2.0
    └── osx_arm64
        ├── httpfs.duckdb_extension
        └── httpfs.duckdb_extension.info
```
</details>


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
