### PR TITLE
chezmoi: Update to 2.60.0

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 2.59.1 v
+go.setup            github.com/twpayne/chezmoi 2.60.0 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
@@ -21,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  090729cdbc8d76ad504f5d0b96d96715c49bbd1f \
-                    sha256  577bce7c9038ca17cda2c61c1ff3df90c4b366b68629e3056e274cf4b319be30 \
-                    size    2522729
+checksums           rmd160  8a9b917a7da47e80883acea56d503c732cf96596 \
+                    sha256  70a077c9be09fc3f7dd684ab9f80c85f60702fea881789b7fb1b9b9b08bce275 \
+                    size    2548807
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

chezmoi: Update to 2.60.0

Added myself as a maintainer for chezmoi (I am a collaborator on chezmoi itself).

##### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
