### PR TITLE
OCRmyPDF: update to 16.9, fix note

### DIFF
--- a/textproc/ocrmypdf/Portfile
+++ b/textproc/ocrmypdf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                ocrmypdf
-version             16.8.0
+version             16.9.0
 revision            0
 categories          textproc
 
@@ -12,9 +12,9 @@ homepage            https://github.com/ocrmypdf/OCRmyPDF
 
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 
-checksums           rmd160  fda01f4a6f39c807a593041b94b2317369070377 \
-                    sha256  007f2c536415ff570d43aabc01996578d3d07f277c585be446da771aff6d9a48 \
-                    size    6802277
+checksums           rmd160  66eff2231761ddb0a4d0f0169fd83f72d931b722 \
+                    sha256  d000a2294cd1478d4bbfe15df5172327f77f4139bb5307404bc53be9bd81f039 \
+                    size    6804849
 
 description         ${name} adds an OCR text layer to scanned PDF files, \
                     allowing them to be searched
@@ -76,6 +76,6 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx" && ${os.major} <
 notes "
 English support is enabled by default.
 To enable support for other languages you will need to install corresponding tesseract language ports.
-e.g., to add and German support:
+e.g., to add German support:
 
     port install tesseract-deu"


### PR DESCRIPTION
#### Description

OCRmyPDF: update to 16.9, fix note

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
