### PR TITLE
emacs/editors: update to emacs-30.1

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -54,7 +54,6 @@ configure.args  --disable-silent-rules \
                 --without-tree-sitter \
                 --with-libgmp \
                 --with-gnutls \
-                --with-json \
                 --with-xml2 \
                 --with-modules \
                 --with-sqlite3 \
@@ -71,7 +70,6 @@ depends_build-append   port:pkgconfig \
                        port:texinfo
 depends_lib-append     port:gmp \
                        path:lib/pkgconfig/gnutls.pc:gnutls \
-                       port:jansson \
                        port:libxml2 \
                        port:ncurses \
                        port:sqlite3 \
@@ -110,11 +108,11 @@ platform darwin {
 }
 
 if {$subport eq $name || $subport eq "emacs-app"} {
-    version         29.4
-    revision        2
-    checksums       rmd160  b32b86be6f600ba745ad023efd7238088dfa5952 \
-                    sha256  1adb1b9a2c6cdb316609b3e86b0ba1ceb523f8de540cfdda2aec95b6a5343abf \
-                    size    78519074
+    version         30.1
+    revision        0
+    checksums           rmd160  d84d527bb0db3d56d558e8f4bed80af5e3eddef3 \
+                    sha256  54404782ea5de37e8fcc4391fa9d4a41359a4ba9689b541f6bc97dd1ac283f6c \
+                    size    82678582
 
     patchfiles-append \
                     patch-allow-powerpc.diff


### PR DESCRIPTION
Works for me for emacs-app on aarch64-macos-14.7.4, but perhaps needs more testing?  

Should nativecomp be "aot" or "yes"?


