### PR TITLE
alacritty: Fix nerdfont variant

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        alacritty alacritty 0.15.1 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         A cross-platform, GPU-accelerated terminal emulator
 
@@ -30,6 +30,7 @@ checksums           ${distname}${extract.suffix} \
 depends_build-append \
                     port:scdoc
 
+# To verify nerdfont variant, just ensure the patch still applies cleanly
 variant nerdfont description {Use Nerd Font Symbols as default fallback} {
     patchfiles              crossfont-nerd-symbols.patch
 }

--- a/aqua/alacritty/files/crossfont-nerd-symbols.patch
+++ b/aqua/alacritty/files/crossfont-nerd-symbols.patch
@@ -1,6 +1,6 @@
 index 13acd4c..b1ca472 100644
---- ../.home/.cargo/macports/crossfont-0.7.0/src/darwin/mod.rs
-+++ ../.home/.cargo/macports/crossfont-0.7.0/src/darwin/mod.rs
+--- ../.home/.cargo/macports/crossfont-0.8.0/src/darwin/mod.rs
++++ ../.home/.cargo/macports/crossfont-0.8.0/src/darwin/mod.rs
 @@ -77,6 +77,10 @@ impl Descriptor {
                  .map(|desc| desc.to_font(size, false))
                  .collect::<Vec<_>>();


### PR DESCRIPTION
#### Description

Alacritty variant `+nerdfont` patches alacritty dependency `crossfont`, which had its version number bumped. Reflect the change in patch to fix the variant.

###### Type(s)
- [x] bugfix