### PR TITLE
google-cloud-sdk: update to 512.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             511.0.0
+version             512.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  7414f6c085882a9f2fe5b25ce117b77984b2318b \
-                    sha256  c0fdf1937563db114adebaefec229ebe08970108dffdd485d4c5a580b9a3fc11 \
-                    size    53846067
+    checksums       rmd160  d755daa1aeccf3d34eee66e4203f2118d6f8bd34 \
+                    sha256  a835e8b6deb3facc3b18d6eb17d491e7d643e314d63b358a2b2c5f44cc83612b \
+                    size    54003341
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  769566e14d3a591cce8c84ae6692cff48d74323d \
-                    sha256  564bb4d825fda5fcf1b893166e2ae2fb79dcffb354399ace6383a014580c6f28 \
-                    size    55317393
+    checksums       rmd160  5da9b106cf7eb4d942c5949fdae0b812572eb414 \
+                    sha256  956d2680dbcc533eaa434a204bb41b1e3ea5ec3dd688a6e2be641ed882f3935d \
+                    size    55471193
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  c4be212eae6f68de5ac1bf7e057c621700e3bc49 \
-                    sha256  d4e9a8654b9bc25abe42501bbde44299eb17535edf775b16a2a5861d4c77924f \
-                    size    55255981
+    checksums       rmd160  9696cafa0b771a1f33a2f8ecd2f89ea195078fdb \
+                    sha256  6f5bfbe962af402e8dfa65cc1c79d62b0a3e27931baaf13c7fca887ef12db87d \
+                    size    55409695
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 512.0.0.

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?