### PR TITLE
mise: Update to 2025.2.9

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.2.8 v
+github.setup        jdx mise 2025.2.9 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  93f3dc35f2708f7a0ec0d19064cf88883fe7a4b6 \
-                    sha256  38c2061303607543507474b8ff0b2cad979f1f4524a03ed854f5e656e1be654e \
-                    size    4269014
+                    rmd160  12bb25694d8aeaa58897afa92fca3d4c9d6df108 \
+                    sha256  a910298c69a1f374cd39b58aea269638d558f403ac811c17115bd83150bb57b4 \
+                    size    4269950
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -118,7 +118,7 @@ cargo.crates \
     backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
-    base64ct                         1.6.0  8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b \
+    base64ct                         1.7.0  c103cbbedac994e292597ab79342dbd5b306a362045095db54917d92a9fdfd92 \
     basic-toml                       0.1.9  823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8 \
     bech32                           0.9.1  d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445 \
     beef                             0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
@@ -134,7 +134,6 @@ cargo.crates \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                           1.10.0  f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9 \
     bytesize                         1.3.2  2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e \
-    bzip2                            0.4.4  bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8 \
     bzip2                            0.5.1  75b89e7c29231c673a61a46e722602bcd138298f6b9e81e71119693534585f5c \
     bzip2-sys                 0.1.12+1.0.8  72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9 \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
@@ -144,7 +143,7 @@ cargo.crates \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
     chacha20poly1305                0.10.1  10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35 \
-    chrono                          0.4.39  7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825 \
+    chrono                          0.4.40  1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c \
     chrono-tz                        0.9.0  93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
@@ -195,7 +194,7 @@ cargo.crates \
     dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     dashmap                          6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
-    demand                           1.6.3  12065e28d862390063a79c03b9a43c91f496d952c904e0ebb8975b7355aad71e \
+    demand                           1.6.4  5eac30167a2a17ad84c28a228aaeca8bc86f1cc137ef660bb4d1bc5ea943eced \
     der                              0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
     deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
@@ -520,9 +519,9 @@ cargo.crates \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     rops                             0.1.4  cd8e93012c1b06c4e7b1582d5a86e64311c8347b7feaf406bbf04bc1235e792b \
     rowan                          0.15.16  0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d \
-    rust-embed                       8.5.0  fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0 \
-    rust-embed-impl                  8.5.0  6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478 \
-    rust-embed-utils                 8.5.0  2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d \
+    rust-embed                       8.6.0  0b3aba5104622db5c9fc61098de54708feb732e7763d7faa2fa625899f00bf6f \
+    rust-embed-impl                  8.6.0  1f198c73be048d2c5aa8e12f7960ad08443e56fd39cc26336719fdb4ea0ebaae \
+    rust-embed-utils                 8.6.0  5a2fcdc9f40c8dc2922842ca9add611ad19f332227fc651d015881ad1552bd9a \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
@@ -699,6 +698,7 @@ cargo.crates \
     windows-core                    0.57.0  d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d \
     windows-implement               0.57.0  9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7 \
     windows-interface               0.57.0  29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7 \
+    windows-link                     0.1.0  6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3 \
     windows-registry                 0.2.0  e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0 \
     windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
     windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
@@ -746,7 +746,7 @@ cargo.crates \
     zeroize_derive                   1.4.2  ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69 \
     zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
     zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
-    zip                              2.2.2  ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45 \
+    zip                              2.2.3  b280484c454e74e5fff658bbf7df8fdbe7a07c6b2de4a53def232c15ef138f3a \
     zipsign-api                      0.1.3  8e7c724c3a8e5833aad6b7028f4f0989fa3a640ce799bf8c352f417b8ef9db3e \
     zopfli                           0.8.1  e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946 \
     zstd                            0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \


### PR DESCRIPTION
#### Description

mise: Update to 2025.2.9

##### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
