### PR TITLE
xorg-cf-files: update to 1.0.8

### DIFF
--- a/x11/xorg-cf-files/Portfile
+++ b/x11/xorg-cf-files/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                xorg-cf-files
-version             1.0.7
+version             1.0.8
 categories          x11 devel
 license             X11
 platforms           any
@@ -17,11 +17,11 @@ long_description    {*}${description}
 homepage            https://xorg.freedesktop.org/wiki/
 master_sites        xorg:individual/util/
 
-use_bzip2           yes
+use_xz              yes
 
-checksums           rmd160  dc9d2fefc5cefcdde97332cd7c6ef6527ec8b17c \
-                    sha256  74a771d5bb2189020399998dfa2329c3e038aa2e14dd3d4056144ed9a5976308 \
-                    size    345575
+checksums           rmd160 9571b3a662c914da410c5bdab8598fe7c047effa \
+                    sha256 7408955defcfab0f44d1bedd4ec0c20db61914917ad17bfc1f1c9bf56acc17b9 \
+                    size   290280
 
 patchfiles          empty-char-constant.patch \
                     allow-overriding-darwin-compiler.patch


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/62895

###### Tested on
macOS 15.3.1 24D70 x86_64
Xcode 16.2 16C5032a
