### PR TITLE
mpack: fix configure and build failures

### DIFF
--- a/mail/mpack/Portfile
+++ b/mail/mpack/Portfile
@@ -11,14 +11,18 @@ license			BSD
 description     	mime mail packing and unpacking
 long_description	mpack and munpack provide command line tools to \
 			pack and unpack multipart mime mail messages
-platforms       	darwin
 categories      	mail
 maintainers     	nomaintainer
 
 homepage		https://en.wikipedia.org/wiki/Mpack_(Unix)
 master_sites		macports_distfiles
 
-patchfiles		implicit.patch \
+patchfiles		cmulocal-bsd_sockets.m4.patch \
+			configure.in.patch \
+			implicit.patch \
 			patch-TMPDIR.diff
 
-configure.args  	--mandir=${prefix}/share/man
+# Regenerate configure to fix implicit int errors.
+# Also we are patching configure.in
+use_autoreconf          yes
+autoreconf.args     --install --verbose --force

--- a/mail/mpack/files/cmulocal-bsd_sockets.m4.patch
+++ b/mail/mpack/files/cmulocal-bsd_sockets.m4.patch
@@ -1,0 +1,26 @@
+--- cmulocal/bsd_sockets.m4~	2025-03-09 12:44:21
++++ cmulocal/bsd_sockets.m4	2025-03-09 12:50:47
+@@ -9,19 +9,10 @@
+ AC_DEFUN(CMU_SOCKETS, [
+ 	save_LIBS="$LIBS"
+ 	LIB_SOCKET=""
+-	AC_CHECK_FUNC(connect, :,
+-		AC_CHECK_LIB(nsl, gethostbyname,
+-			     LIB_SOCKET="-lnsl $LIB_SOCKET")
+-		AC_CHECK_LIB(socket, connect,
+-			     LIB_SOCKET="-lsocket $LIB_SOCKET")
+-	)
+-	LIBS="$LIB_SOCKET $save_LIBS"
+-	AC_CHECK_FUNC(res_search, :,
+-                AC_CHECK_LIB(resolv, res_search,
+-                              LIB_SOCKET="-lresolv $LIB_SOCKET") 
+-        )
+-	LIBS="$LIB_SOCKET $save_LIBS"
++	AC_SEARCH_LIBS([gethostbyname], [nsl])
++	AC_SEARCH_LIBS([connect], [socket])
++	AC_SEARCH_LIBS([res_search], [resolv])
+ 	AC_CHECK_FUNCS(dn_expand dns_lookup)
+ 	LIBS="$save_LIBS"
+-	AC_SUBST(LIB_SOCKET)
++	AC_SUBST([LIB_SOCKET])
+ 	])

--- a/mail/mpack/files/configure.in.patch
+++ b/mail/mpack/files/configure.in.patch
@@ -1,0 +1,10 @@
+--- configure.in~	2003-07-22 00:49:18
++++ configure.in	2025-03-09 12:09:56
+@@ -2,6 +2,7 @@
+ AM_INIT_AUTOMAKE(mpack,1.6)
+ AC_PROG_CC
+ 
++AC_CONFIG_MACRO_DIRS([cmulocal])
+ CMU_SOCKETS
+ 
+ AC_CHECK_FUNCS([strchr])


### PR DESCRIPTION
#### Description

`configure` was failing as its tests appear to be pre C99 requiring implicit int.

`Makefile.am` failed to build due to a local variable being null.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
