### PR TITLE
docker-machine-parallels: fix build

### DIFF
--- a/devel/docker-machine-parallels/Portfile
+++ b/devel/docker-machine-parallels/Portfile
@@ -4,12 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        Parallels docker-machine-parallels 2.0.1 v
-revision            0
+revision            1
 github.tarball_from archive
 
 # stealth update; remove for next version
 dist_subdir         ${name}/${version}_1
 
+platforms           {darwin >= 17}
 categories          devel
 license             Apache-2
 maintainers         {danchr @danchr} openmaintainer
@@ -20,6 +21,9 @@ long_description    A plugin for Docker Machine allowing to create \
 checksums           rmd160  b020e17f6d5dabec0031663bdcb9338da1ad006f \
                     sha256  af52903482bff0f13200cc5aca39037cd8625cc663120e1e4d3be13aeda2720d \
                     size    17425
+
+# Fix go build args; ultimately port should be simplified via pg golang
+patchfiles-append   patch-makefile.diff
 
 depends_build-append \
                     port:go

--- a/devel/docker-machine-parallels/Portfile
+++ b/devel/docker-machine-parallels/Portfile
@@ -1,41 +1,50 @@
-
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        Parallels docker-machine-parallels 2.0.1 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+revision            0
+github.tarball_from archive
+
+# stealth update; remove for next version
+dist_subdir         ${name}/${version}_1
+
 categories          devel
 license             Apache-2
 maintainers         {danchr @danchr} openmaintainer
 description         Parallels driver for Docker Machine
-long_description    A plugin for Docker Machine allowing to \
-                    create Docker hosts locally on Parallels Desktop \
-                    for Mac
+long_description    A plugin for Docker Machine allowing to create \
+                    Docker hosts locally on Parallels Desktop for Mac
 
-depends_build       port:go
-
-depends_lib         port:docker-machine
-
-checksums           rmd160  f73c598447ed4266a28ee2d4ed738b4ec75ea509 \
-                    sha256  d815f1229f76a5b636eddf8806163c34482c992946ff8590094f4fab05d61628 \
+checksums           rmd160  b020e17f6d5dabec0031663bdcb9338da1ad006f \
+                    sha256  af52903482bff0f13200cc5aca39037cd8625cc663120e1e4d3be13aeda2720d \
                     size    17425
+
+depends_build-append \
+                    port:go
+
+depends_lib-append \
+                    port:docker-machine
+
+set port_src_path_author \
+                    src/github.com/${github.author}
+set port_src_path_project \
+                    ${port_src_path_author}/${github.project}
 
 build.target        build
 build.env           GOPATH=${workpath}/go
-build.dir           ${workpath}/go/src/github.com/${github.author}/${github.project}
+build.dir           ${workpath}/go/${port_src_path_project}
 
 # what kind of tool does this?
 configure {
-    file mkdir ${workpath}/go/src/github.com/${github.author}
-    ln -sf ${worksrcpath} ${workpath}/go/src/github.com/${github.author}/${github.project}
-    file mkdir ${worksrcpath}/src/github.com/${github.author}
-    ln -sf ${worksrcpath} ${worksrcpath}/src/github.com/${github.author}/${github.project}
+    file mkdir ${workpath}/go/${port_src_path_author}
+    ln -sf ${worksrcpath} ${workpath}/go/${port_src_path_project}
+    file mkdir ${worksrcpath}/${port_src_path_author}
+    ln -sf ${worksrcpath} ${worksrcpath}/${port_src_path_project}
 }
 
 destroot {
     xinstall -d ${destroot}${prefix}/bin
-    xinstall -m 755 {*}[glob ${worksrcpath}/bin/*] ${destroot}${prefix}/bin/
+    xinstall -m 755 {*}[glob ${worksrcpath}/bin/docker-machine-driver-parallels] ${destroot}${prefix}/bin/
 }

--- a/devel/docker-machine-parallels/files/patch-makefile.diff
+++ b/devel/docker-machine-parallels/files/patch-makefile.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2025-02-27 16:26:18.000000000 -0500
++++ Makefile	2025-02-27 16:26:31.000000000 -0500
+@@ -4,7 +4,7 @@
+ default: build
+ 
+ bin/docker-machine-driver-parallels:
+-	go build -i -ldflags "$(GO_LDFLAGS)" \
++	go build -ldflags "$(GO_LDFLAGS)" \
+ 	-o ./bin/docker-machine-driver-parallels ./bin
+ 
+ build: clean bin/docker-machine-driver-parallels


### PR DESCRIPTION
### Description

Port currently fails to build for some macOS releases. Try to fix for all.

Fixes: https://trac.macports.org/ticket/65384