### PR TITLE
py-codestyle: Fix select for py313

### DIFF
--- a/python/py-codestyle/Portfile
+++ b/python/py-codestyle/Portfile
@@ -11,7 +11,7 @@ python.rootname     pycodestyle
 # Please DO NOT update without cross-checking version compatibility and
 # perform updates in a coordinated way.
 version             2.12.1
-revision            0
+revision            1
 
 categories-append   devel
 supported_archs     noarch

--- a/python/py-codestyle/files/pycodestyle-py313
+++ b/python/py-codestyle/files/pycodestyle-py313
@@ -1,1 +1,1 @@
-bin/pycodestyle-3.12
+bin/pycodestyle-3.13


### PR DESCRIPTION
pycodestyle-py313 installs bin/pycodestyle-3.13, not bin/pycodestyle-3.12

#### Description

`port select --set pycodestyle pycodestyle-py313` currently fails:

> Selecting 'pycodestyle-py313' for 'pycodestyle' failed: could not create new link "/opt/local/bin/pycodestyle": target "/opt/local/bin/pycodestyle-3.12" doesn't exist

The reason is that the file `files/pycodestyle-py313` contains a pointer to `bin/pycodestyle-3.12`, while instead it should contain `bin/pycodestyle-3.13`.

###### Type(s)

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.3 24D60 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?

