### PR TITLE
miniflux: update to 2.2.6

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.2.4
+go.setup            github.com/miniflux/v2 2.2.6
 go.package          miniflux.app/v2
 go.offline_build    no
+github.tarball_from archive
 name                miniflux
 revision            0
 categories          net
@@ -18,9 +19,9 @@ description         Minimalist and opinionated feed reader
 long_description    {*}${description}
 homepage            https://miniflux.app
 
-checksums           rmd160  c083167c1e22cfc9e269a6c8914332d55c20dd83 \
-                    sha256  69ba49e6dc008b29c70f59d9783cc80766ff973573495506a33f7046c18c2b83 \
-                    size    766145
+checksums           rmd160  799cc32e11fd8d907c2a64f96e15c16425f56a19 \
+                    sha256  2e2ad2369095089a666cf8dc5bb77955ffbd9f579a9cdab9168b0ee4afa5ba2c \
+                    size    791352
 
 build.args-append   \
     -ldflags=\"-s -w -X \


### PR DESCRIPTION
#### Description
https://github.com/miniflux/v2/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
