### PR TITLE
groovy: update to 4.0.26

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         4.0.25
+version         4.0.26
 revision        0
 
 categories      lang java
@@ -25,14 +25,14 @@ long_description Apache Groovy is a powerful, optionally typed and dynamic \
                  Domain-Specific Language authoring, runtime and compile-time \
                  meta-programming and functional programming.
 
-homepage        https://groovy-lang.org/
+homepage        https://groovy.apache.org
 master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  3462d405d44e9e9dfb4e7bb985aa11c31fb378e0 \
-                sha256  822cad8e03388f23bf613d37f990b813bb4165fe389fd3fcc24f8b96476c30ef \
-                size    30031188
+checksums       rmd160  e0b3803826abe88104c0a186e0a59a92f3149e52 \
+                sha256  3be6880c6de70eada2f3f5c69e1e94953e0b0c4e33c4604c1040d05dddeaed92 \
+                size    30108372
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 4.0.26.

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?