### PR TITLE
rustscan: add nmap as runtime dep

### DIFF
--- a/net/rustscan/Portfile
+++ b/net/rustscan/Portfile
@@ -6,8 +6,8 @@ PortGroup           github  1.0
 
 github.setup        RustScan RustScan 2.4.1
 github.tarball_from archive
+revision            1
 name                rustscan
-revision            0
 
 description         The Modern Port Scanner
 
@@ -25,6 +25,8 @@ checksums           ${distname}${extract.suffix} \
                     rmd160  2e8a47c2e6511b3597d37970d2313589d5f8267b \
                     sha256  fa99c18a12d4c0939ab69ddb84ef7b85a1ea01d8fc86df227449d89473531765 \
                     size    3114776
+
+depends_run-append  port:nmap
 
 destroot {
     xinstall -m 0755 \


### PR DESCRIPTION
Without nmap it cannot run any scripts and will exit with an error after scanning

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
