### PR TITLE
qgis3: add hdf5 as dependency

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -27,7 +27,7 @@ if {${subport} eq ${name}} {
     # Latest version
     github.setup    qgis QGIS 3_42_0 final-
     github.tarball_from archive
-    revision        0
+    revision        1
     set app_name    QGIS3
 
     checksums       rmd160  b89f5717b4daceb4a6c31634efc25eebe430187b \
@@ -37,7 +37,7 @@ if {${subport} eq ${name}} {
     # LTR version
     github.setup    qgis QGIS 3_40_4 final-
     github.tarball_from archive
-    revision        0
+    revision        1
     set app_name    QGIS3-LTR
     description     {*}${description} (LTR)
 
@@ -82,6 +82,7 @@ depends_lib-append  port:draco \
                     port:gdal-pdf \
                     port:geos \
                     port:gsl \
+                    port:hdf5 \
                     port:libiconv \
                     port:libtasn1 \
                     port:libzip \
@@ -125,23 +126,20 @@ post-patch {
 cmake.install_prefix    ${applications_dir}
 
 pre-configure {
-    # If GDAL is built with +hdf5 variant, QGIS needs to know the path to "mpi.h"
-    if {[active_variants gdal hdf5]} {
-        # Figure out HDF5's mpi include directory
-        set mpl_include_dir ""
-        if {![catch {set result [active_variants hdf5 openmpi]}]} {
-            if {$result} {
-                set mpl_include_dir "-I${prefix}/include/openmpi-mp"
-            }
+    # Figure out HDF5's mpi include directory
+    set mpl_include_dir ""
+    if {![catch {set result [active_variants hdf5 openmpi]}]} {
+        if {$result} {
+            set mpl_include_dir "-I${prefix}/include/openmpi-mp"
         }
-        if {![catch {set result [active_variants hdf5 mpich]}]} {
-            if {$result} {
-                set mpl_include_dir "-I${prefix}/include/mpich-mp"
-            }
+    }
+    if {![catch {set result [active_variants hdf5 mpich]}]} {
+        if {$result} {
+            set mpl_include_dir "-I${prefix}/include/mpich-mp"
         }
-        if {$mpl_include_dir ne ""} {
-            configure.cxxflags-append ${mpl_include_dir}
-        }
+    }
+    if {$mpl_include_dir ne ""} {
+        configure.cxxflags-append ${mpl_include_dir}
     }
 }
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

`hdf5` is opportunistically linked if found, so better add it as a dependency. Also make sure to find path to 'mpi.h'  if needed.

Closes: https://trac.macports.org/ticket/72100


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
