### PR TITLE
iverilog: transfer maintainers

### DIFF
--- a/science/iverilog/Portfile
+++ b/science/iverilog/Portfile
@@ -12,7 +12,10 @@ set minor           0
 
 categories          science
 license             GPL-2+
-maintainers         {keeh.net:paf @padf} openmaintainer
+maintainers         {gmail.com:degnan.68k @bpdegnan} \
+                    {mark @markemer} \
+                    openmaintainer
+                    
 description         Icarus Verilog
 long_description    Icarus Verilog is a Verilog simulation and synthesis tool. \
                     It operates as a compiler, compiling source code writen in \


### PR DESCRIPTION
Changed the maintainers to reflect those whom showed an interest.

#### Description

Removed the former maintainer as they are no longer active with Macports.  Added myself and markemer as we have an interest in the package.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 13.7.4 22H420 x86_64
Xcode 14.3.1 14E300c
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?


