### PR TITLE
qemu: Update to 9.2.2

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -8,7 +8,7 @@ PortGroup               legacysupport               1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
-version                 9.2.1
+version                 9.2.2
 revision                0
 categories              emulators
 license                 GPL-2+
@@ -26,9 +26,9 @@ homepage                https://www.qemu.org
 master_sites            https://download.qemu.org/
 use_xz                  yes
 
-checksums               rmd160  5269b46f818f9f3625ead3bed256b932f979027b \
-                        sha256  b7b0782ead63a5373fdfe08e084d3949a9395ec196180286b841f78a464d169c \
-                        size    135203616
+checksums               rmd160  79458545fadc4ec3bcf76919dd7ce55b2719329c \
+                        sha256  752eaeeb772923a73d536b231e05bcc09c9b1f51690a41ad9973d900e4ec9fbf \
+                        size    134756816
 
 set py_version          313
 set py_branch           \


### PR DESCRIPTION
#### Description

* qemu: Update 9.2.1 --> 9.2.2
* Also resolves previous checksum error due to stealth update.

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
