### PR TITLE
turbovnc-viewer: update to 3.1.4

### DIFF
--- a/x11/turbovnc-viewer/Portfile
+++ b/x11/turbovnc-viewer/Portfile
@@ -6,9 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        TurboVNC turbovnc 2.2.6
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        TurboVNC turbovnc 3.1.4
 
 name                turbovnc-viewer
 license             GPL-2
@@ -17,9 +15,9 @@ categories          x11 net
 description         TurboVNC VNC viewer.
 long_description    {*}${description}
 
-checksums           rmd160  de684a6e9c2f2e1ef1f05b98229fd40269d17a7c \
-                    sha256  71a89600d1e4ffe67aa65e5ddc6b21b1659b9105892c07074e99181218dc33e8 \
-                    size    9023665
+checksums           rmd160  2a3b608aaf600d928b326210c3459decc01c047a \
+                    sha256  bfb8f059bde36d6e80a8d16fa758cbb264fe456930253ce444ce05961d980ee5 \
+                    size    9047653
 
 depends_lib-append  path:include/turbojpeg.h:libjpeg-turbo
 
@@ -34,11 +32,9 @@ pre-configure {
     configure.args \
         -DTVNC_BUILDSERVER=no \
         -DCMAKE_C_FLAGS=-I${prefix}/include \
-        -DTJPEG_JAR=${prefix}/share/java/turbojpeg.jar \
         -DJAVA_INCLUDE_PATH=${java.home}/include \
         -DJAVA_INCLUDE_PATH2=${java.home}/include/darwin \
         -DJAVA_AWT_INCLUDE_PATH=${java.home}/include \
-        -DTVNC_BUILDNATIVE=ON
 }
 
 patch {
@@ -46,7 +42,6 @@ patch {
     reinplace "s|@PKGVENDOR@|MacPorts|g" ${worksrcpath}/release/Info.plist.in
     reinplace "s|@BUILD@|${version}|g" ${worksrcpath}/release/Info.plist.in
     reinplace "s|@CMAKE_PROJECT_NAME@|TurboVNC|g" ${worksrcpath}/release/Info.plist.in
-    reinplace "s|^<dict>|<dict><key>NSHighResolutionCapable</key><true/>|" ${worksrcpath}/release/Info.plist.in
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

Update turbovnc-viewer to latest version 3.1.4. Present version 2.2.6 doesn't build on Mac OS 15.3.1 with the default java and libjpeg-turbo.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
