### PR TITLE
fossil: update to 2.25, fix livecheck and config

### DIFF
--- a/devel/fossil/Portfile
+++ b/devel/fossil/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           openssl 1.0
 
 name                fossil
-version             2.22
+version             2.25
 revision            0
 epoch               20110901182519
 categories          devel
@@ -22,11 +22,14 @@ long_description    Fossil is a distributed software configuration management wh
 
 homepage            https://fossil-scm.org/home/
 
-master_sites        ${homepage}tarball/version-${version}/
+# see https://fossil-scm.org/home/uv/releases.md
+set hash            8f798279d5f7c3288099915f2ea88c57b6d6039f3f05eac5e237897af33376dc
+master_sites        ${homepage}tarball/${hash}/
+distname            fossil-src-${version}
 
-checksums           rmd160  99e144282ede18d8f2221d0752cdd16935b2d09e \
-                    sha256  81d823ff6f5d175b384dfa84eeba0d052da73a37cd66cd72b786e71671210d6b \
-                    size    6730169
+checksums           rmd160  1484fd5f625c8f9db9f312277e8e28b8d5dff26f \
+                    sha256  611cfa50d08899eb993a5f475f988b4512366cded82688c906cf913e5191b525 \
+                    size    7007907
 
 test.run            yes
 
@@ -44,7 +47,6 @@ configure.args-append       --disable-fusefs \
                             --with-zlib=${prefix}/lib \
                             --with-th1-docs \
                             --with-th1-hooks \
-                            --with-exec-rel-paths \
                             --json
 
 configure.env-append "CC_FOR_BUILD=${configure.cc} [get_canonical_archflags]"
@@ -70,5 +72,5 @@ not harm the integrity of a repository.
 "
 
 livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     {Latest Release: ([\d.]+)}
+livecheck.url       ${homepage}uv/releases.md
+livecheck.regex     {([\d.]+) .rarr; [0-9a-z]+ .latest.}


### PR DESCRIPTION
- update live check URL to point to the page recommended
  by the fossil maintainers.
- remove the `--with-exec-rel-paths` flag

Related Trac tickets:

- [69920](https://trac.macports.org/ticket/69920): original submission
- [65516](https://trac.macports.org/ticket/65516): abandoned port

Discussion related to the `--with-exec-rel-paths` flag:

- https://fossil-scm.org/forum/forumpost/06fd5536c1
- [65085](https://trac.macports.org/ticket/65085)

Closes: https://trac.macports.org/ticket/69920

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (5 failures, consistent with trunk)
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
