### PR TITLE
mac-brightnessctl: new submission

### DIFF
--- a/sysutils/mac-brightnessctl/Portfile
+++ b/sysutils/mac-brightnessctl/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem 1.0
+PortGroup           github 1.0
+
+github.setup        rakalex mac-brightnessctl 0.2.1
+revision            0
+categories          sysutils
+maintainers         {breun.nl:nils @breun} openmaintainer
+license             MIT
+
+description mac-brightnessctl is a command line tool for controlling the keyboard backlight brightness on macOS.
+long_description {*}${description}
+
+github.tarball_from archive
+
+checksums    rmd160  e26e2fb15a4c16689ebf5cdabf2ee8025144259c \
+             sha256  b9445cca0e24c5f42c85e975ea124164edadf460421263d63ee06c6f68507aa7 \
+             size    5295
+
+use_configure    no
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+}

--- a/sysutils/mac-brightnessctl/Portfile
+++ b/sysutils/mac-brightnessctl/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
 github.setup        rakalex mac-brightnessctl 0.2.1
 revision            0
@@ -17,8 +18,6 @@ github.tarball_from archive
 checksums    rmd160  e26e2fb15a4c16689ebf5cdabf2ee8025144259c \
              sha256  b9445cca0e24c5f42c85e975ea124164edadf460421263d63ee06c6f68507aa7 \
              size    5295
-
-use_configure    no
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
#### Description

New port for [mac-brightnessctl](https://github.com/rakalex/mac-brightnessctl).

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?