### PR TITLE
ov: Add completions on install

### DIFF
--- a/textproc/ov/Portfile
+++ b/textproc/ov/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/noborus/ov 0.39.0 v
 go.offline_build    no
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Feature rich terminal pager
 
@@ -28,11 +28,42 @@ build.pre_args-append \
                     LDFLAGS="\\\"-X main.Version=${version}\\\""
 build.args          build
 
+post-build {
+    set ov ${worksrcpath}/${name}
+
+    set bash_completions_dir ${worksrcpath}/share/bash-completion/completions
+    set fish_completions_dir ${worksrcpath}/share/fish/vendor_completions.d
+    set zsh_completions_dir ${worksrcpath}/share/zsh/site-functions
+
+    xinstall -d ${bash_completions_dir} ${fish_completions_dir} ${zsh_completions_dir}
+
+    system "${ov} --completion bash > ${bash_completions_dir}/${name}"
+    system "${ov} --completion fish > ${fish_completions_dir}/${name}.fish"
+    system "${ov} --completion zsh > ${zsh_completions_dir}/_${name}"
+}
+
 set ov_share_path   ${prefix}/share/${name}
+
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
     xinstall -d ${destroot}${ov_share_path}/
     xinstall -m 0644 ${worksrcpath}/${name}.yaml ${destroot}${ov_share_path}/
+
+    set bash_completions_dir share/bash-completion/completions
+    set fish_completions_dir share/fish/vendor_completions.d
+    set zsh_completions_dir share/zsh/site-functions
+
+    xinstall -d ${destroot}${prefix}/${bash_completions_dir}
+    xinstall ${worksrcpath}/${bash_completions_dir}/${name} \
+        ${destroot}${prefix}/${bash_completions_dir}
+
+    xinstall -d ${destroot}${prefix}/${fish_completions_dir}
+    xinstall ${worksrcpath}/${fish_completions_dir}/${name}.fish \
+        ${destroot}${prefix}/${fish_completions_dir}
+
+    xinstall -d ${destroot}${prefix}/${zsh_completions_dir}
+    xinstall ${worksrcpath}/${zsh_completions_dir}/_${name} \
+        ${destroot}${prefix}/${zsh_completions_dir}
 }
 
 notes "


### PR DESCRIPTION
#### Description

Add completions for `ov` on install.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
