### PR TITLE
SuiteSparse: update to version 7.10.1

### DIFF
--- a/math/SuiteSparse/Portfile
+++ b/math/SuiteSparse/Portfile
@@ -3,9 +3,8 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                DrTimothyAldenDavis SuiteSparse 7.7.0 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from         tarball
+github.setup                DrTimothyAldenDavis SuiteSparse 7.10.1 v
+github.tarball_from         archive
 # subports have independent revisions
 revision                    0
 epoch                       20200517
@@ -19,9 +18,9 @@ long_description            SuiteSparse is a single archive that contains all pa
 
 homepage                    https://people.engr.tamu.edu/davis/suitesparse.html
 
-checksums                   rmd160  7ec634d96c345144ec05069e74191ca22bc6552e \
-                            sha256  dc4ed0774b22b807252564922962ac8796a4abbcf7a5a407e1bf7f668ff74241 \
-                            size    85881814
+checksums                   rmd160  1bb5e26b6a007068f7aa1c8cdf39b70fef61d1b0 \
+                            sha256  9e2974e22dba26a3cffe269731339ae8e01365cfe921b06be6359902bd05862c \
+                            size    87776029
 
 configure.optflags          -O3
 
@@ -45,7 +44,7 @@ compiler.log_verbose_output no
 subport SuiteSparse_config {
     PortGroup               linear_algebra 1.0
 
-    version                 7.7.0
+    version                 7.10.1
     revision                0
     # from the README.txt:
     #    "[n]o licensing restrictions apply"
@@ -59,7 +58,7 @@ subport SuiteSparse_config {
 }
 
 subport SuiteSparse_AMD {
-    version                 3.3.2
+    version                 3.3.3
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -75,7 +74,7 @@ subport SuiteSparse_BTF {
 }
 
 subport SuiteSparse_CAMD {
-    version                 3.3.2
+    version                 3.3.3
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -83,7 +82,7 @@ subport SuiteSparse_CAMD {
 }
 
 subport SuiteSparse_CCOLAMD {
-    version                 3.3.3
+    version                 3.3.4
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -93,7 +92,7 @@ subport SuiteSparse_CCOLAMD {
 subport SuiteSparse_CHOLMOD {
     PortGroup               linear_algebra 1.0
 
-    version                 5.2.1
+    version                 5.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CAMD port:SuiteSparse_COLAMD port:SuiteSparse_CCOLAMD
     license                 LGPL-2.1+
@@ -107,7 +106,7 @@ subport SuiteSparse_CHOLMOD {
 }
 
 subport SuiteSparse_COLAMD {
-    version                 3.3.3
+    version                 3.3.4
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -115,7 +114,7 @@ subport SuiteSparse_COLAMD {
 }
 
 subport SuiteSparse_CXSparse {
-    version                 4.4.0
+    version                 4.4.1
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 LGPL-2.1+
@@ -123,7 +122,7 @@ subport SuiteSparse_CXSparse {
 }
 
 subport SuiteSparse_GraphBLAS {
-    version                 9.1.0
+    version                 10.0.1
     revision                0
     license                 Apache-2
     long_description-append ${subport}: graph algorithms in the language of linear algebra.
@@ -139,7 +138,7 @@ subport SuiteSparse_GraphBLAS {
 }
 
 subport SuiteSparse_KLU {
-    version                 2.3.3
+    version                 2.3.5
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_BTF port:SuiteSparse_COLAMD port:SuiteSparse_CHOLMOD
     license                 LGPL-2.1+
@@ -155,7 +154,7 @@ subport SuiteSparse_LDL {
 }
 
 subport SuiteSparse_LAGraph {
-    version                 1.1.3
+    version                 1.1.5
     revision                0
     depends_lib-append      port:SuiteSparse_GraphBLAS
     license                 BSD
@@ -166,7 +165,7 @@ subport SuiteSparse_LAGraph {
 }
 
 subport SuiteSparse_Mongoose {
-    version                 3.3.3
+    version                 3.3.4
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 GPL-3
@@ -174,8 +173,24 @@ subport SuiteSparse_Mongoose {
     compiler.cxx_standard   2011
 }
 
+subport SuiteSparse_ParU {
+    PortGroup               linear_algebra 1.0
+
+    version                 1.0.0
+    revision                0
+    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_CHOLMOD port:SuiteSparse_UMFPACK port:SuiteSparse_AMD port:SuiteSparse_COLAMD port:SuiteSparse_CAMD port:SuiteSparse_CCOLAMD
+    license                 GPL-3
+    long_description-append ${subport}: solving sparse linear system via parallel multifrontal LU factorization algorithms.
+    linalg.setup            noveclibfort
+    pre-configure {
+        configure.args-append   ${cmake_linalglib}
+    }
+    compiler.openmp_version 4.5
+    configure.args-append   -DPARU_USE_OPENMP=ON
+}
+
 subport SuiteSparse_RBio {
-    version                 4.3.2
+    version                 4.3.4
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 GPL-2+
@@ -183,7 +198,7 @@ subport SuiteSparse_RBio {
 }
 
 subport SuiteSparse_SPEX {
-    version                 3.1.0
+    version                 3.2.3
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD \
                             port:gmp \
@@ -195,7 +210,7 @@ subport SuiteSparse_SPEX {
 subport SuiteSparse_SPQR {
     PortGroup               linear_algebra 1.0
 
-    version                 4.3.3
+    version                 4.3.4
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD port:SuiteSparse_CHOLMOD
     license                 GPL-2+
@@ -210,7 +225,7 @@ subport SuiteSparse_SPQR {
 subport SuiteSparse_UMFPACK {
     PortGroup               linear_algebra 1.0
 
-    version                 6.3.3
+    version                 6.3.5
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CHOLMOD
     license                 GPL-2+
@@ -237,6 +252,7 @@ if {${subport} eq ${name}} {
                             port:SuiteSparse_LDL \
                             port:SuiteSparse_KLU \
                             port:SuiteSparse_UMFPACK \
+                            port:SuiteSparse_ParU \
                             port:SuiteSparse_RBio \
                             port:SuiteSparse_SPQR \
                             port:SuiteSparse_SPEX


### PR DESCRIPTION
* update to version 7.10.1
* add ParU subport

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.7.4 23H420 arm64
Xcode 16.2 16C5032a


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
