### PR TITLE
wp2hugo: update to 1.11.0

### DIFF
--- a/www/wp2hugo/Portfile
+++ b/www/wp2hugo/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ashishb/wp2hugo 1.3.1
+go.setup            github.com/ashishb/wp2hugo 1.11.0
 go.offline_build    no
 revision            0
 
@@ -17,9 +17,9 @@ license             CC-BY-SA-4
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  bbe2ff2cff0c146be2de601dac7d936dc4003575 \
-                    sha256  f692cc2ce2ccb0e35e9919fc0e11529cc897b54145c9e269c15d0abc6a5b5c91 \
-                    size    35549
+checksums           rmd160  273f2baf9c96e96d099db48b29583a8cc6f7da66 \
+                    sha256  f4a879c8dd66812a82571ab92526a600dfdf98ccf7b793b9d4a556716470a334 \
+                    size    57732
 
 build.dir           ${worksrcpath}/src/${name}
 build.args          ./cmd/${name}


### PR DESCRIPTION
#### Description

wp2hugo: update to 1.11.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
