### PR TITLE
mise: Update to 2025.3.2

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.3.1 v
+github.setup        jdx mise 2025.3.2 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  9edac8fcd192d8309b4878f61a282916796243a0 \
-                    sha256  ca1c8853792d28bc8b3ccbaff738199bcee2b1c7e7e09596800a73aacdd0c970 \
-                    size    4272714
+                    rmd160  3872da78153253e0f06acff6ebf0382a6ee907df \
+                    sha256  baf39e90d7990843f27850b39ac54e65be0c18444927ec802563be8af3a7274e \
+                    size    4273272
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -382,7 +382,7 @@ cargo.crates \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
     jiff                            0.1.29  c04ef77ae73f3cf50510712722f0c4e8b46f5aaa1bf5ffad2ae213e6495e78e5 \
-    jiff-tzdb                        0.1.2  cf2cec2f5d266af45a071ece48b1fb89f3b00b2421ac3a5fe10285a6caaa60d3 \
+    jiff-tzdb                        0.1.3  962e1dfe9b2d75a84536cf5bf5eaaa4319aa7906c7160134a22883ac316d5f31 \
     jiff-tzdb-platform               0.1.2  a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
@@ -397,6 +397,7 @@ cargo.crates \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
+    linux-raw-sys                    0.9.2  6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9 \
     litemap                          0.7.5  23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856 \
     litrs                            0.4.1  b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
@@ -513,7 +514,7 @@ cargo.crates \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     reqwest                        0.12.12  43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da \
-    ring                           0.17.11  da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73 \
+    ring                           0.17.12  ed9b823fa29b721a59671b41d6b06e66b29e0628e207e8b1c3ceeda701ec928d \
     rmp                             0.8.14  228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4 \
     rmp-serde                        1.3.0  52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
@@ -527,6 +528,7 @@ cargo.crates \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
+    rustix                           1.0.0  17f8dcd64f141950290e45c99f7710ede1b600297c91818bb30b3667c0f45dc0 \
     rustls                         0.23.23  47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
@@ -601,7 +603,7 @@ cargo.crates \
     tabled_derive                    0.9.0  931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1 \
     taplo                           0.13.2  010941ac4171eaf12f1e26dfc11dadaf78619ea2330940fef01fe6bb0442d14d \
     tar                             0.4.44  1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a \
-    tempfile                        3.17.1  22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230 \
+    tempfile                        3.18.0  2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567 \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                    0.4.1  5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9 \
@@ -613,7 +615,7 @@ cargo.crates \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                  2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
-    time                            0.3.38  bb041120f25f8fbe8fd2dbe4671c7c2ed74d83be2e7a77529bf7e0790ae3f472 \
+    time                            0.3.39  dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8 \
     time-core                        0.1.3  765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef \
     time-macros                     0.2.20  e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
@@ -730,16 +732,16 @@ cargo.crates \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     x25519-dalek                     2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
-    xattr                            1.4.0  e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909 \
+    xattr                            1.5.0  0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e \
     xx                               2.0.5  bbf219cc8899c850ca14e3e7c703cdd92331b5647011249dcf791700d6cb45c0 \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
-    zerocopy                        0.8.22  09612fda0b63f7cb9e0af7e5916fe5a1f8cdcb066829f10f36883207628a4872 \
+    zerocopy                        0.8.23  fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6 \
     zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
-    zerocopy-derive                 0.8.22  79f81d38d7a2ed52d8f034e62c568e111df9bf8aba2f7cf19ddc5bf7bd89d520 \
+    zerocopy-derive                 0.8.23  6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154 \
     zerofrom                         0.1.6  50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5 \
     zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \


### PR DESCRIPTION
#### Description

mise: Update to 2025.3.2

##### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
