### PR TITLE
ruff: Update to 0.9.10

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.9.9
+github.setup        astral-sh ruff 0.9.10
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  17ae3d46c923045bf19cd605473147853fb4653f \
-                    sha256  700561abc69eefbb5fa6a61cada7b4d3e1510004bc0783ace9bfea316a65a1e6 \
-                    size    6068332
+                    rmd160  b5f37a6831409e9d20467b3e7069467b1bf72f12 \
+                    sha256  2465e4085d54293e3a0474309dacf1cc41e3ef7063fd7d23d886674141b08ed2 \
+                    size    5987888
 
 cargo.offline_cmd
 
@@ -87,7 +87,7 @@ cargo.crates \
     base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
     bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                         2.8.0  8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36 \
+    bitflags                         2.9.0  5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     boxcar                          0.2.10  225450ee9328e1e828319b48a89726cffc1b0ad26fd9211ad435de9fa376acae \
     bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
@@ -101,20 +101,20 @@ cargo.crates \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chic                             1.2.2  a5b5db619f3556839cb2223ae86ff3f9a09da2c5013be42bc9af08c9589bf70c \
-    chrono                          0.4.39  7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825 \
+    chrono                          0.4.40  1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.30  92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d \
-    clap_builder                    4.5.30  a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c \
+    clap                            4.5.31  027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767 \
+    clap_builder                    4.5.31  5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863 \
     clap_complete                   4.5.44  375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.5  c6a8b1593457dfc2fe539002b795710d022dc62a65bf15023f039f9760c7b18a \
     clap_derive                     4.5.28  bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     clearscreen                      4.0.1  8c41dc435a7b98e4608224bbf65282309f5403719df9113621b30f8b6f74e2f4 \
-    codspeed                         2.8.0  25d2f5a6570db487f5258e0bded6352fa2034c2aeb46bb5cc3ff060a0fcfba2f \
-    codspeed-criterion-compat        2.8.0  f53a55558dedec742b14aae3c5fec389361b8b5ca28c1aadf09dd91faf710074 \
+    codspeed                         2.8.1  de4b67ff8985f3993f06167d71cf4aec178b0a1580f91a987170c59d60021103 \
+    codspeed-criterion-compat        2.8.1  68403d768ed1def18a87e2306676781314448393ecf0d3057c4527cabf524a3d \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     colored                          2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
     colored                          3.0.0  fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e \
@@ -179,7 +179,7 @@ cargo.crates \
     getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
     getrandom                        0.3.1  43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8 \
     glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
-    globset                         0.4.15  15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19 \
+    globset                         0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
@@ -214,7 +214,7 @@ cargo.crates \
     indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
     inotify                         0.11.0  f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3 \
     inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
-    insta                           1.42.1  71c1b125e30d93896b365e156c33dadfffab45ee8400afcbba4752f59de08a86 \
+    insta                           1.42.2  50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084 \
     insta-cmd                        0.6.0  ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6 \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-macro                         0.3.7  1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4 \
@@ -333,8 +333,8 @@ cargo.crates \
     rustversion                     1.0.19  f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4 \
     ryu                             1.0.19  6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    schemars                        0.8.21  09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92 \
-    schemars_derive                 0.8.21  b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e \
+    schemars                        0.8.22  3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615 \
+    schemars_derive                 0.8.22  32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
@@ -453,6 +453,7 @@ cargo.crates \
     windows-core                    0.58.0  6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99 \
     windows-implement               0.58.0  2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b \
     windows-interface               0.58.0  053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515 \
+    windows-link                     0.1.0  6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3 \
     windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
     windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.9.10

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
