### PR TITLE
hyfetch: Use Python 3.13

### DIFF
--- a/python/hyfetch/Portfile
+++ b/python/hyfetch/Portfile
@@ -6,7 +6,7 @@ PortGroup               python 1.0
 python.rootname         HyFetch
 name                    [string tolower ${python.rootname}]
 version                 1.99.0
-revision                0
+revision                1
 categories-append       sysutils
 platforms               {darwin any}
 supported_archs         noarch
@@ -23,7 +23,7 @@ checksums               rmd160  8e652106a8ca71d3a2a35d62510972db747daefe \
                         size    440751
 
 # This should stay consistent with the python PG default
-python.default_version  312
+python.default_version  313
 
 variant fastfetch description {Use fastfetch backend} {
     depends_run-append  path:bin/fastfetch:fastfetch


### PR DESCRIPTION
#### Description

Upgrade `hyfetch` to Python 3.13, following the `python` PG default Python version

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
