### PR TITLE
zizmor: Update to 1.5.0

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        woodruffw zizmor 1.4.1 v
+github.setup        woodruffw zizmor 1.5.0 v
 github.tarball_from archive
 revision            0
 
@@ -20,9 +20,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  7c57c095bfd5515dea5b38baca56c551c7a9ffe8 \
-                    sha256  4f881c11a15a465fa12a83faa48e4549db2c8b487b66a44dda93d4614572a79b \
-                    size    278037
+                    rmd160  cc8494d92cd7b1327e3048b2315cc79e020cc3dd \
+                    sha256  111eb6a2814a9eb0b68ed32f37b8727736de1e299c4d74aede4b833ea8c36ab2 \
+                    size    287286
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -41,7 +41,7 @@ cargo.crates \
     anstyle-parse                       0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                       1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                      3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
-    anyhow                             1.0.96  6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4 \
+    anyhow                             1.0.97  dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f \
     arrayvec                            0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert_cmd                         2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     async-trait                        0.1.86  644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d \
@@ -58,17 +58,20 @@ cargo.crates \
     bytes                               1.8.0  9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da \
     cacache                            13.1.0  5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b \
     camino                              1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
-    cc                                  1.2.1  fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47 \
+    cc                                 1.2.16  be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c \
     cfg-if                              1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    clap                               4.5.30  92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d \
+    clap                               4.5.31  027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767 \
     clap-verbosity-flag                 3.0.2  2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84 \
-    clap_builder                       4.5.30  a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c \
+    clap_builder                       4.5.31  5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863 \
     clap_derive                        4.5.28  bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     colorchoice                         1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     console                            0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
     cpufeatures                        0.2.16  16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3 \
     crc32fast                           1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
+    crossbeam-deque                     0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
+    crossbeam-epoch                    0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-utils                    0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
     crypto-common                       0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     deranged                           0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     diff                               0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
@@ -80,7 +83,7 @@ cargo.crates \
     encode_unicode                      0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
     equivalent                          1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                              0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
-    etcetera                            0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
+    etcetera                           0.10.0  26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6 \
     fastrand                            2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     filetime                           0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     flate2                              1.1.0  11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc \
@@ -99,6 +102,7 @@ cargo.crates \
     getrandom                          0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
     gimli                              0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     github-actions-models              0.26.0  63a17952a0374993a4c7f8df12bd75b3d1ed8fb9c78e8dbaa32cf451143faaaa \
+    globset                            0.4.15  15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19 \
     hashbrown                          0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                                0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                          0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
@@ -129,9 +133,10 @@ cargo.crates \
     icu_provider_macros                 1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
     idna                                1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                        1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
+    ignore                             0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
     indexmap                            2.7.1  8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652 \
     indicatif                         0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
-    insta                              1.42.1  71c1b125e30d93896b365e156c33dadfffab45ee8400afcbba4752f59de08a86 \
+    insta                              1.42.2  50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084 \
     inventory                          0.3.15  f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767 \
     ipnet                              2.10.1  ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708 \
     is_terminal_polyfill               1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
@@ -199,7 +204,7 @@ cargo.crates \
     regex-syntax                        0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     reqwest                           0.12.12  43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da \
     reqwest-middleware                  0.4.1  64e8975513bd9a7a43aad01030e79b3498e05db14e9d945df6483e8cf9b8c4c4 \
-    ring                               0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
+    ring                              0.17.13  70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee \
     rustc-demangle                     0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                          2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
     rustix                            0.38.42  f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85 \
@@ -212,10 +217,10 @@ cargo.crates \
     same-file                           1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schemafy_core                       0.6.0  2bec29dddcfe60f92f3c0d422707b8b56473983ef0481df8d5236ed3ab8fdf24 \
     schemafy_lib                        0.6.0  af3d87f1df246a9b7e2bfd1f4ee5f88e48b11ef9cfc62e63f0dead255b1a6f5f \
-    serde                             1.0.218  e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60 \
+    serde                             1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
     serde-sarif                         0.7.0  b39432f20e354de863582451c54bac03ffa63f7dd77f8b1e0ddee211950ab2a2 \
-    serde_derive                      1.0.218  f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b \
-    serde_json                        1.0.139  44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6 \
+    serde_derive                      1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
+    serde_json                        1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
     serde_json_path                     0.7.1  e176fbf9bd62f75c2d8be33207fa13af2f800a506635e89759e46f934c520f4d \
     serde_json_path_core                0.2.1  ea3bfd54a421bec8328aefede43ac9f18c8c7ded3b2afc8addd44b4813d99fd0 \
     serde_json_path_macros              0.1.5  ee05bac728cc5232af5c23896b34fbdd17cf0bb0c113440588aeeb1b57c6ba1f \
@@ -232,7 +237,6 @@ cargo.crates \
     slab                                0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     smallvec                           1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
     socket2                             0.5.7  ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c \
-    spin                                0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     ssri                                9.2.0  da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082 \
     stable_deref_trait                  1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     streaming-iterator                  0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
@@ -260,7 +264,7 @@ cargo.crates \
     tinystr                             0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                             1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                      0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                              1.43.0  3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e \
+    tokio                              1.44.0  9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a \
     tokio-macros                        2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-rustls                       0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
     tokio-stream                       0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
@@ -326,25 +330,16 @@ cargo.crates \
     windows-registry                    0.2.0  e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0 \
     windows-result                      0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
     windows-strings                     0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
-    windows-sys                        0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                        0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                        0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
-    windows-targets                    0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                    0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
-    windows_aarch64_gnullvm            0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
     windows_aarch64_gnullvm            0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
-    windows_aarch64_msvc               0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
     windows_aarch64_msvc               0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
-    windows_i686_gnu                   0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
     windows_i686_gnu                   0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
     windows_i686_gnullvm               0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
-    windows_i686_msvc                  0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
     windows_i686_msvc                  0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
-    windows_x86_64_gnu                 0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
     windows_x86_64_gnu                 0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
-    windows_x86_64_gnullvm             0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
     windows_x86_64_gnullvm             0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
-    windows_x86_64_msvc                0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc                0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     write16                             1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                           0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.5.0

##### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
