### PR TITLE
gdal: add HFA (ERDAS Imagine) driver

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -9,7 +9,7 @@ PortGroup           muniversal 1.0
 
 name                gdal
 version             3.10.2
-revision            1
+revision            2
 
 checksums           rmd160  35e3e3a75959d0ab949f4e68dcb39b947508046d \
                     sha256  67b4e08acd1cc4b6bd67b97d580be5a8118b586ad6a426b09d5853898deeada5 \
@@ -119,6 +119,7 @@ configure.args-append                                        \
                     -DGDAL_ENABLE_DRIVER_GRIB=ON             \
                     -DGDAL_ENABLE_DRIVER_GSG=ON              \
                     -DGDAL_ENABLE_DRIVER_GXF=ON              \
+                    -DGDAL_ENABLE_DRIVER_HFA=ON              \
                     -DGDAL_ENABLE_DRIVER_HF2=ON              \
                     -DGDAL_ENABLE_DRIVER_IDRISI=ON           \
                     -DGDAL_ENABLE_DRIVER_ILWIS=ON            \


### PR DESCRIPTION
#### Description

Add the HFA/ERDAS [driver](https://gdal.org/en/stable/drivers/raster/hfa.html#raster-hfa), which is usually built by default to GDAL.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
