### PR TITLE
opensc: Use OpenSSL 3

### DIFF
--- a/security/opensc/Portfile
+++ b/security/opensc/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 10
 name                    opensc
 github.setup            OpenSC OpenSC 0.26.1
 github.tarball_from     releases
-revision                0
+revision                1
 
 checksums               rmd160  fe5fd963c544bc013c99b32c6bad9b768603e6bd \
                         sha256  f16291a031d86e570394762e9f35eaf2fcbc2337a49910f3feae42d54e1688cb \
@@ -36,12 +36,6 @@ long_description        OpenSC provides a set of libraries and utilities to \
                         does so, too.
 
 distname                opensc-${version}
-
-# Upstream tested against 1.1, so use it as default.
-# (Overriding in variants not working as of 2021-11-13, hence the guard.)
-if {![variant_isset openssl3]} {
-    openssl.branch      1.1
-}
 
 patch.pre_args-replace  -p0 -p1
 patchfiles-append       patch-winscard.diff
@@ -106,12 +100,6 @@ post-destroot {
 variant eac description {Enable Extended Access Control (EAC) v2 support} {
     depends_lib-append      port:openpace
     configure.args-replace  --disable-openpace --enable-openpace
-}
-
-variant openssl3 description {Build against OpenSSL 3 (experimental)} {
-    openssl.branch          3
-    # There will be warnings due to use of deprecated methods so they must not be fatal:
-    configure.args-append   --disable-strict
 }
 
 variant p11kit description {Use p11-kit as default PKCS#11 module} {


### PR DESCRIPTION
#### Description

Remove the openssl3 variant and make it the default. Remove support for OpenSSL 1.1, which is no longer receiving security updates since September 2023.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
