### PR TITLE
R-Rnetcdf: change confusing comment in Portfile

### DIFF
--- a/R/R-RNetCDF/Portfile
+++ b/R/R-RNetCDF/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-# Only works on macos-14 and later after g95 fix: https://trac.macports.org/ticket/71068
+# For this to build on macos-14 or later, a recent fix to g95 is required: https://trac.macports.org/ticket/71068
 R.setup             github mjwoods RNetCDF 2.9-2 v
 revision            2
 extract.rename      yes


### PR DESCRIPTION
#### Description

This PR just changes a comment on a required patch to g95. The original was found to be confusing. See #27710.

There is no change to the source code, version number, nor the package. So no revbump.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.1 24D70 x86_64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
