### PR TITLE
nco: update to 5.3.2

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.3.1
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-revision            1
+github.setup        nco nco 5.3.2
+github.tarball_from archive
+revision            0
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
                     openmaintainer
@@ -22,9 +21,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  e43524a5dd26d70ccc2f28713e33e870858ac5f7 \
-                    sha256  e7d95ce692a4b9e1286610fbc00fb6a09d993a1f6a7b3b26fda45cae21e338d9 \
-                    size    6860305
+checksums           rmd160  17f937a01081f54644e5f9895973e1ca24f56b91 \
+                    sha256  645179433e0f54e7e6fefa9fcc74c1866ad55dd69f0fccbc262c550fcc186385 \
+                    size    6862079
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Simple update to upstream version 5.3.2.

It also replaces `github.tarball_from tarball` to `github.tarball_from archive`, as requested by comment in the `Portfile` for `nco-5.3.1-1`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.1 24D70 x86_64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
