### PR TITLE
google-cloud-sdk: update to 514.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             513.0.0
+version             514.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  543e493dcb25770f44925435104e10fb71fe1c09 \
-                    sha256  a668fa4118ec5c42ef509f643d47414c756b4cd1ca0fc3f5398b492802807f95 \
-                    size    54042418
+    checksums       rmd160  3d71db6d738ccfde303432e55f82793441a4f7b4 \
+                    sha256  105ecf1db7be3c682595f9aff1cd54a7bc146e39bf65cddaeb2791973482bd70 \
+                    size    54115501
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3d495e1ab3763a5d4e8d581241f55b89601e2135 \
-                    sha256  733a133f8a1113b92d9ee1a63e2d04f0b20a600b792e2488a3f18169968521a7 \
-                    size    55516936
+    checksums       rmd160  7e7eec7fbfdbd3480c0cb3cd7f4dcc976888e6a7 \
+                    sha256  ecbedcfeb18625dba78782f095daddfd87bfab809f40c67b3474b223960b1631 \
+                    size    55584073
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  7c54bfd16c6f644b3e72637d92565132ef2ffd6f \
-                    sha256  c555a04054f732724202816524715ffb635a087c93827679c79dd40a2106abe1 \
-                    size    55452080
+    checksums       rmd160  01e9f6b62a28eae4f8b6db0e10a18e4e2b2aa2fe \
+                    sha256  fdd18b224bb66d721bc0abba177e9618ec3559f606c1dd9ae2aab5bbd7748fc2 \
+                    size    55523897
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -76,7 +76,6 @@ variant alpha description {Add gcloud CLI Alpha Commands} { dict set variant_to_
 variant anthos_auth description {Add Anthos auth} { dict set variant_to_component anthos_auth anthos-auth }
 variant app_engine_go description {Add App Engine Go Extensions} { dict set variant_to_component app_engine_go app-engine-go }
 variant app_engine_java description {Add gcloud app Java Extensions} { dict set variant_to_component app_engine_java app-engine-java }
-variant app_engine_php description {Add gcloud app PHP Extensions} { dict set variant_to_component app_engine_php app-engine-php }
 variant app_engine_python description {Add gcloud app Python Extensions} { dict set variant_to_component app_engine_python app-engine-python }
 variant app_engine_python_extras description {Add gcloud app Python Extensions (Extra Libraries)} { dict set variant_to_component app_engine_python_extras app-engine-python-extras }
 variant appctl description {Add Appctl} { dict set variant_to_component appctl appctl }
@@ -86,9 +85,8 @@ variant cbt description {Add Cloud Bigtable Command Line Tool} { dict set varian
 variant cloud_datastore_emulator description {Add Cloud Datastore Emulator} { dict set variant_to_component cloud_datastore_emulator cloud-datastore-emulator }
 variant cloud_firestore_emulator description {Add Cloud Firestore Emulator} { dict set variant_to_component cloud_firestore_emulator cloud-firestore-emulator }
 variant cloud_run_proxy description {Add Cloud Run Proxy} { dict set variant_to_component cloud_run_proxy cloud-run-proxy }
-variant cloud_sql_proxy description {Add Cloud SQL Proxy} { dict set variant_to_component cloud_sql_proxy cloud_sql_proxy }
+variant cloud_sql_proxy description {Add Cloud SQL Proxy} { dict set variant_to_component cloud_sql_proxy cloud-sql-proxy }
 variant config_connector description {Add config connector} { dict set variant_to_component config_connector config-connector }
-variant datalab description {Add Cloud Datalab Command Line Tool} { dict set variant_to_component datalab datalab }
 variant docker_credential_gcr description {Add Google Container Registry's Docker credential helper} { dict set variant_to_component docker_credential_gcr docker-credential-gcr }
 variant enterprise_certificate_proxy description {Add Enterprise certificate proxy} { dict set variant_to_component enterprise_certificate_proxy enterprise-certificate-proxy }
 variant gke_gcloud_auth_plugin description {Add GKE Google Cloud auth plugin} { dict set variant_to_component gke_gcloud_auth_plugin gke-gcloud-auth-plugin }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 514.0.0.

###### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?