### PR TITLE
netcdf: Configure cxx compiler, too.

### DIFF
--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -32,7 +32,7 @@ checksums           rmd160  0d5048ac645b4373372d538b8b3c92588da8ea3a \
                     sha256  990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff \
                     size    25619216
 
-compilers.choose            cc cpp
+compilers.choose            cc cpp cxx
 mpi.setup
 
 cmake.out_of_source         yes


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/70185

When not adding cxx to the list, it won't find mpicxx.