### PR TITLE
zizmor: Update to 1.5.1

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        woodruffw zizmor 1.5.0 v
+github.setup        woodruffw zizmor 1.5.1 v
 github.tarball_from archive
 revision            0
 
@@ -20,9 +20,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  cc8494d92cd7b1327e3048b2315cc79e020cc3dd \
-                    sha256  111eb6a2814a9eb0b68ed32f37b8727736de1e299c4d74aede4b833ea8c36ab2 \
-                    size    287286
+                    rmd160  5de1427e779ecd81d2060f1bbdf0e06102bfa432 \
+                    sha256  80d5a483a56601a6ad224dace459f303d0ca304c182d22f37ae157c1e8c7e2b4 \
+                    size    287436
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release


### PR DESCRIPTION
#### Description

zizmor: Update to 1.5.1

##### Tested on

macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
