### PR TITLE
csvtk: New Port

### DIFF
--- a/textproc/csvtk/Portfile
+++ b/textproc/csvtk/Portfile
@@ -1,0 +1,380 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/shenwei356/csvtk 0.33.0 v
+categories          textproc
+maintainers         {macports.halostatue.ca:austin @halostatue} \
+                    openmaintainer
+license             MIT
+
+description         A cross-platform, efficient and practical CSV/TSV toolkit in Golang
+
+long_description    {*}${description}
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  ab9ed11f5512297510eb44ef86d68cffa0480511 \
+                    sha256  f325933dd2e2c4f8b83fac59df1a06b4b5b914c23c23acfa5658b676936dde9f \
+                    size    2505674
+
+build.args          -C ${name}
+
+post-build {
+    set csvtk ${worksrcpath}/${name}/${name}
+
+    set bash_completions_dir ${worksrcpath}/share/bash-completion/completions
+    set fish_completions_dir ${worksrcpath}/share/fish/vendor_completions.d
+    set zsh_completions_dir ${worksrcpath}/share/zsh/site-functions
+
+    xinstall -d ${bash_completions_dir} ${fish_completions_dir} ${zsh_completions_dir}
+
+    system "${csvtk} genautocomplete --shell bash --file ${bash_completions_dir}/${name}"
+    system "${csvtk} genautocomplete --shell fish --file ${fish_completions_dir}/${name}.fish"
+    system "${csvtk} genautocomplete --shell zsh --file ${zsh_completions_dir}/_${name}"
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name}/${name} ${destroot}${prefix}/bin/
+
+    set bash_completions_dir share/bash-completion/completions
+    set fish_completions_dir share/fish/vendor_completions.d
+    set zsh_completions_dir share/zsh/site-functions
+
+    xinstall -d ${destroot}${prefix}/${bash_completions_dir}
+    xinstall ${worksrcpath}/${bash_completions_dir}/${name} \
+        ${destroot}${prefix}/${bash_completions_dir}
+
+    xinstall -d ${destroot}${prefix}/${fish_completions_dir}
+    xinstall ${worksrcpath}/${fish_completions_dir}/${name}.fish \
+        ${destroot}${prefix}/${fish_completions_dir}
+
+    xinstall -d ${destroot}${prefix}/${zsh_completions_dir}
+    xinstall ${worksrcpath}/${zsh_completions_dir}/_${name} \
+        ${destroot}${prefix}/${zsh_completions_dir}
+}
+
+go.vendors          rsc.io/pdf \
+                        repo    github.com/rsc/pdf \
+                        lock    v0.1.1 \
+                        rmd160  a3f7299bbe04d73f24d7360f85b503de5bb9f5ba \
+                        sha256  4c4bcf92a55412ba5b8e2657c42981385feeeb1907a7f9dfcf90646d35b78559 \
+                        size    49278 \
+                    gopkg.in/yaml.v3 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
+                    gopkg.in/check.v1 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
+                    gonum.org/v1/plot \
+                        repo    github.com/gonum/plot \
+                        lock    v0.14.0 \
+                        rmd160  586a3ce6b0922d63a37bb1a7d8f2ed9905afdadd \
+                        sha256  1a996cc7bbe6b5cf4335755b311b6ec842421355b5e8b724470835d593971e95 \
+                        size    4237275 \
+                    gonum.org/v1/gonum \
+                        repo    github.com/gonum/gonum \
+                        lock    v0.14.0 \
+                        rmd160  13e5031d4842302003c01fb5ed49078a468949fe \
+                        sha256  5036ad6eec61036907d9d2fc2a04a9662237ecf78ad0336aaf53409cf6f2c219 \
+                        size    3461978 \
+                    golang.org/x/text \
+                        lock    v0.16.0 \
+                        rmd160  ad16ff67d5532f40acbed01650b05611f16b9179 \
+                        sha256  7d2a383b1ec6abcd1a6d29d65fcc8f8adaf42afc9ebe39ba38a7673bbc20a2fa \
+                        size    8972461 \
+                    golang.org/x/term \
+                        lock    v0.18.0 \
+                        rmd160  c183fe023094cf41b6a66e88cd765d97a35f439c \
+                        sha256  3441bd395a6788d71ab9d7fb4e16df2975c41f252cc21b5c8706feb92b9df47a \
+                        size    14742 \
+                    golang.org/x/sys \
+                        lock    v0.18.0 \
+                        rmd160  f2df5cddcd4f72d2eb7f75309ed3c1c821e05d66 \
+                        sha256  d8d4c0874ddc66e9fb0c1264b4eeb8b8625153740b751eae59220eb5ff17eacb \
+                        size    1448593 \
+                    golang.org/x/net \
+                        lock    v0.23.0 \
+                        rmd160  314021a9d4fc510f2acfbfa131810944101c66bf \
+                        sha256  7c2b7d3c9062bc8cd529f8f1b2aa16d5a8616a90cb3cbdbf326bd5c6f0fb51f1 \
+                        size    1509183 \
+                    golang.org/x/image \
+                        lock    v0.18.0 \
+                        rmd160  13fc4b75e7303ea2f86d0076bc0dc5d150fab938 \
+                        sha256  0b4ee7752f6eb6c3609a9978502cb1365a86808631722072c84ede42ce18b447 \
+                        size    5104083 \
+                    golang.org/x/exp \
+                        lock    d63ba01acd4b \
+                        rmd160  df80c9ffa72cfc983916d55f14e91e930af0e3a3 \
+                        sha256  d9ff524c65ef8882ce01f0c8fd5db836d34e741caf162696fb496fdeb198d6e0 \
+                        size    1633716 \
+                    golang.org/x/crypto \
+                        lock    v0.21.0 \
+                        rmd160  af2d1cfcc2e0b235f432863286fe666e2eec3f58 \
+                        sha256  98e51eb5ad0dc5f9e1ea49804661e9c6db076dda540dc239a1e301b57bbd1090 \
+                        size    1810842 \
+                    gitlab.com/metakeule/fmtdate \
+                        lock    v1.2.2 \
+                        rmd160  f5a0bbc69e2304c7db7b08f94113936d17189214 \
+                        sha256  83f87e10a28cce12f4bf98c54f0664ed9c10b0eb05a22b2d679bf5905436dcd5 \
+                        size    4527 \
+                    github.com/xuri/nfp \
+                        lock    dc951e3ffe1a \
+                        rmd160  a70432956b9bc41577142b19bb5ebd5e62afa6a0 \
+                        sha256  431e1dbf9e09c03899ee6246efc84bb1c0b770dbd736068be3ebe014945edcab \
+                        size    19307 \
+                    github.com/xuri/excelize \
+                        repo    github.com/qax-os/excelize \
+                        lock    v2.8.0 \
+                        rmd160  045627af5a3a4480d02c0242673a3deaf9feee42 \
+                        sha256  119df3f9a9e719f942abb01a9e27300834635e6dbeaefadac20ad8d5b58f63be \
+                        size    775786 \
+                    github.com/xuri/efp \
+                        lock    ad255f2331ca \
+                        rmd160  a4afeaf715c3eed4f5d38833c0cfd548f6435b5e \
+                        sha256  3fb9c1a3f5989c74026aa479c118d41266f077e0ec10630eac6b9e1c3f602f1a \
+                        size    11510 \
+                    github.com/ulikunitz/xz \
+                        lock    v0.5.10 \
+                        rmd160  ba4a3b2c8049d86688c50648bc06f8969133ee43 \
+                        sha256  c237e2956881ae1eee019d3c39b3d8fbff2a8b4631082e156f67272b577f72f8 \
+                        size    479677 \
+                    github.com/twotwotwo/sorts \
+                        lock    bf5c1f2b8553 \
+                        rmd160  81221d359f55a5186e7f1b696f95628d8a6c83e2 \
+                        sha256  530f714cc0ecceaa69bcd87e8be6fe4d4784680926b5838bc93ba96efb7e4be8 \
+                        size    20277 \
+                    github.com/tatsushid/go-prettytable \
+                        lock    ed2d14c29939 \
+                        rmd160  1162d1e246583d70f6e3b987132432fd6ddb7011 \
+                        sha256  fe68cb18a21c008206e75b16dfb5a94bbd30ea37565dcd469289f13adbe1a416 \
+                        size    4767 \
+                    github.com/stretchr/testify \
+                        lock    v1.8.4 \
+                        rmd160  8e1645055c9b1d8e117df7974034e74b7f600d27 \
+                        sha256  6d0a77075bbe0f8f1c0cbed51dd4d174579db976fef39d9ae6b500aab8917d6a \
+                        size    104469 \
+                    github.com/spf13/pflag \
+                        lock    v1.0.5 \
+                        rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
+                        sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
+                        size    50815 \
+                    github.com/spf13/cobra \
+                        lock    v1.8.0 \
+                        rmd160  d506ddb57519970c8227ded6411adb8153fc8278 \
+                        sha256  f35c4dd06645b4bca315c7d7f9a245f9d8851bb5fd43331fcb2aadbd585149e9 \
+                        size    189731 \
+                    github.com/shenwei356/xopen \
+                        lock    v0.3.1 \
+                        rmd160  359d0385bdc2acbd868c2ec4d90d4a9d7910c9c0 \
+                        sha256  292d2be18d2578466536471422735990af70c619955e8b2f9a739954a440a072 \
+                        size    5277 \
+                    github.com/shenwei356/util \
+                        lock    v0.5.3 \
+                        rmd160  eb4d2a7a42934eed2b8025149ca2a4bc7b8ca06c \
+                        sha256  1a61f51c50b883bb4c170f305208fb55ecc2ec9cc45d2b07d9f87a5d179d48fb \
+                        size    19496 \
+                    github.com/shenwei356/stable \
+                        lock    v0.2.0 \
+                        rmd160  096ae4a56ed852316880da0483b2d57a5c25142a \
+                        sha256  9bc1c65454ccf0cd15145e5fc0f00d45e3d77dfa462b2d3a619a79a560b0e40a \
+                        size    43455 \
+                    github.com/shenwei356/natsort \
+                        lock    580176ad49fb \
+                        rmd160  0895f459577bb437b4b6836bffdd00b1e4b11f51 \
+                        sha256  5310034a71ddf52f579c6f7a15dd52b10b7baf61ca5010f3e4946165d308c39e \
+                        size    2977 \
+                    github.com/shenwei356/go-logging \
+                        lock    c6b9702d88ba \
+                        rmd160  a2783cef9aae20774bc57487a24399ba0bc73a34 \
+                        sha256  0c63959d52155df093c489ac2d57c83e9a628ebf531b1cfe8789d70f3f591787 \
+                        size    36404 \
+                    github.com/shenwei356/breader \
+                        lock    v0.3.2 \
+                        rmd160  19ed4ee111083c37cba50e4c814033f173abcbe8 \
+                        sha256  fc88db9d953723faf2eec3301436fe1aaf79b599bf63d65e0f8c65b8d1855ced \
+                        size    5519 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.9.0 \
+                        rmd160  acb8f644e5634bdae632cdb61ea736422aeb88f0 \
+                        sha256  65b0852e5c78fa920fef2176fa17180bf1f7f32a1163baacb44c2aa480845a16 \
+                        size    133682 \
+                    github.com/rivo/uniseg \
+                        lock    v0.4.7 \
+                        rmd160  a9056dc9a2a80aa9c46d0ff9e54f9e2e5a498c41 \
+                        sha256  abc6a2f17b64b34b8a0c56eb9d0b53886ebbe0c88d467755c09c7fa696a16677 \
+                        size    458166 \
+                    github.com/richardlehane/msoleps \
+                        lock    v1.0.3 \
+                        rmd160  412c9505988ff67b259e47f1b10a93707871ba75 \
+                        sha256  773d1dbfff297a4139f936708f2ee9dccfcbb1c06a39c827b4eef8cf38df5ca1 \
+                        size    16728 \
+                    github.com/richardlehane/mscfb \
+                        lock    v1.0.4 \
+                        rmd160  f91167d1b6c6bf27c4cda48479ef6a6ea15b487e \
+                        sha256  c5ee215cbe1724dbf3617ed4891b1438a2b352c4b5f954fe80fe36280c5d57c8 \
+                        size    213277 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/mohae/deepcopy \
+                        lock    c48cc78d4826 \
+                        rmd160  fc86fa598a05041fd926c16aeabc2ddfdf3768d9 \
+                        sha256  304235d66e943c2ae5a3b165c30df0fd711b03e2c611e71141be7d85fbec94f5 \
+                        size    9603 \
+                    github.com/mitchellh/go-homedir \
+                        lock    v1.1.0 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.16 \
+                        rmd160  297825c4365b5f723ae485e726259ebb620ecd66 \
+                        sha256  6c9e81a6b46220612b97ebc35e8d29d1907fd225a9ce3e40b7cebd64cc58d09c \
+                        size    18496 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.16 \
+                        rmd160  dcdf01553caa079315f2293c109de17fc72f0c6b \
+                        sha256  391d25a98e2cc92a2ed5c6abd07cde1053411706bb24e5843562931e6085ab46 \
+                        size    4693 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.13 \
+                        rmd160  c9e8ab9d0773c0984f36235e3c9f8c033552ac1a \
+                        sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
+                        size    9778 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kr/pretty \
+                        lock    v0.3.1 \
+                        rmd160  8c08579b4c56cdc958794e77afe3413e80aa67c3 \
+                        sha256  7fcea475d6280976cf4a838e75d2b3a4105827316e588a80e49e8063d950c999 \
+                        size    10232 \
+                    github.com/klauspost/pgzip \
+                        lock    v1.2.6 \
+                        rmd160  fd9f702d2a491731aaf2fe6e3d2feb72af478064 \
+                        sha256  74a375eafe83f302924d00ad5a59825b12e3f325e992f300e421ede9ada1c608 \
+                        size    125971 \
+                    github.com/klauspost/compress \
+                        lock    v1.15.12 \
+                        rmd160  a0cd57e7a52ad58f71d332e80b10d12d9ffcf5bf \
+                        sha256  d06cd928f1224a260c007bc6a7731f537fb399c6564faf93086b98d6588836c7 \
+                        size    36241338 \
+                    github.com/inconshreveable/mousetrap \
+                        lock    v1.1.0 \
+                        rmd160  88f9577df93ac0f8801d8960adc7f28e38867f3e \
+                        sha256  f69af10ff08c0e87f92dac3ee5172d8ed02463725b74edfc8943ef018a1a632d \
+                        size    5343 \
+                    github.com/golang/freetype \
+                        lock    e2365dfdc4a0 \
+                        rmd160  636766006da15c3fc745a5a914252dd38d57916f \
+                        sha256  0e403fc2de539573a6759940993d4132177f47507ed760c8e827c8381871136f \
+                        size    466227 \
+                    github.com/go-pdf/fpdf \
+                        lock    v0.8.0 \
+                        rmd160  f89d3923f06602497eb46d48a627ac264f1dda84 \
+                        sha256  dee5f7cbc2ca76675eb94c57a08db5530d05fda5780ca5580e619c3929bc0cf9 \
+                        size    2803538 \
+                    github.com/go-latex/latex \
+                        lock    12ec69307ad9 \
+                        rmd160  d29cd8c5c48c3de7178d17ff665b33c8ac503bb8 \
+                        sha256  cdb0339228ac5942b83678f3e8f38d374c9236ec5184299212e111f80e60b5bf \
+                        size    460739 \
+                    github.com/go-fonts/liberation \
+                        lock    v0.3.1 \
+                        rmd160  d0601e26bc17a7c93730b91ac8b4d91904d06d4f \
+                        sha256  8efda4a80a304b91842d9e38acb06cffa9614cdf2f79e004ed1c42200ba2f9a5 \
+                        size    2391407 \
+                    github.com/go-fonts/latin-modern \
+                        lock    v0.3.1 \
+                        rmd160  7141390dafd136c515a65c4627022b6b9c5fc732 \
+                        sha256  88d4c50224c1c60a5d3404dde7c566889310a0390c74dd87c9a184ddac2acdde \
+                        size    4399475 \
+                    github.com/go-fonts/dejavu \
+                        lock    v0.1.0 \
+                        rmd160  76805c0af65ed3fbb5e8330ab65d8115a195292f \
+                        sha256  1113bb98489f9d2053fdf52ecb71771ce34d0350028cbd3b7648e8e80026a4dd \
+                        size    9393112 \
+                    github.com/fatih/color \
+                        lock    v1.13.0 \
+                        rmd160  0c56533948a292eb8c5181e9a88a45fbd1267bf5 \
+                        sha256  a65b114bfe507384e1660730803ffb4437c63a24dd11a5d7f61c77f048caa55f \
+                        size    10828 \
+                    github.com/expr-lang/expr \
+                        lock    v1.16.3 \
+                        rmd160  de8be62a8f3fd105a573fcac3bee75629bb9f76b \
+                        sha256  7ae00ecc7e1ece356cc928b6e63c3a4ee1e7244b985da29b0e854dbe51eb85f4 \
+                        size    5717339 \
+                    github.com/dustin/go-humanize \
+                        lock    v1.0.1 \
+                        rmd160  3c799a1cbda2e82f3d35ec20e539581fd9c24b9d \
+                        sha256  aa5a5059ebd8fffc9e9b9e3c888d85cdb1f4c8f7b73944a6c027647039a83df7 \
+                        size    17709 \
+                    github.com/dsnet/compress \
+                        lock    v0.0.1 \
+                        rmd160  44a9ba6d99a11d15815c3600f997b48abfec5bd5 \
+                        sha256  42eac045c3c85d633e26d3dfdf62ff0a2c7b970397baaa0de85f5de783489705 \
+                        size    9963201 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/cheggaaa/pb \
+                        lock    v3.1.0 \
+                        rmd160  c82f646500f1c2607e7c17a1453745d7ad5c5476 \
+                        sha256  e9f947d1b2b89ed8c2f4a0e72a81b09fd92788103987db4d24f74c168a4297e6 \
+                        size    33170 \
+                    github.com/campoy/embedmd \
+                        lock    v1.0.0 \
+                        rmd160  ae5742221def8027c7fb6d9e5daa53534970c0ee \
+                        sha256  6737eed330b1c1af5733d81751b7a6a93074f04729b7e03582157050692b5357 \
+                        size    14936 \
+                    github.com/botond-sipos/thist \
+                        lock    v1.1.0 \
+                        rmd160  e60b880062b1b59d54a6b6d5cb613413fcaf4258 \
+                        sha256  de4734ce88e5f57f02abc184dd3c3b6d1f0a8458de7dc01b97f4acf26185d2d5 \
+                        size    14913 \
+                    github.com/araddon/dateparse \
+                        lock    6b43995a97de \
+                        rmd160  6917dfacee739f408b18077506c4e1cd0506365f \
+                        sha256  d99c72ffd8aa7d2077d1a9e844efbc3237bc018cd05aec11cc44e216ddabed4d \
+                        size    27524 \
+                    github.com/ajstarks/svgo \
+                        lock    1546f124cd8b \
+                        rmd160  39b4251f452797d58210d87d8447920538efa7a7 \
+                        sha256  74022529279b2604998256b3d6188563ea4344bd17bdc1851442cfdce81879f5 \
+                        size    2544087 \
+                    github.com/VividCortex/ewma \
+                        lock    v1.2.0 \
+                        rmd160  1d2cef6a9d902902ce305b922b0e8e53a3527860 \
+                        sha256  1b2d004974f53c07d0cf960cf663d8b1264750f6636cdd7288b6d3875bf50bc6 \
+                        size    6693 \
+                    github.com/Knetic/govaluate \
+                        lock    v3.0.0 \
+                        rmd160  60c7cfe26e7cd48a41ec07d19f2ea8cb42ea90a7 \
+                        sha256  83712df8e07f8ce8d89151d0778b57900ecb52fa98f2a17d6497f269e3a13e48 \
+                        size    39407 \
+                    git.sr.ht/~sbinet/gg \
+                        lock    v0.5.0 \
+                        rmd160  4dfb097cf39d0c991fca06cbe6ca69c84744949c \
+                        sha256  cebbab941d67a3f78d1b7c4548205157d063a0cf25df7024c64f0233696cd11b \
+                        size    7293867 \
+                    git.sr.ht/~sbinet/cmpimg \
+                        lock    v0.1.0 \
+                        rmd160  177f488d557dca2cc4db9c83c52c2317be5e4fac \
+                        sha256  fb13ae7a19cde0a2f4a85e1691db457cbb1d568915ed93e2349d5dd2efad834c \
+                        size    525237


### PR DESCRIPTION
#### Description

csvtk is a toolkit for manipulating CSV files.

###### Tested on

macOS 15.3.2 24D81 arm64 Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
