### PR TITLE
zmq: Re-enable CURVE encryption

### DIFF
--- a/devel/zmq/Portfile
+++ b/devel/zmq/Portfile
@@ -29,7 +29,7 @@ if {${name} eq ${subport}} {
     checksums       rmd160  b26b2c2368d76e93b67607e0e8703714f8c0c4eb \
                     sha256  5c7ec9f212ff04e196c126464661764d3f054107e0ceac3b030f748106d53424 \
                     size    875612
-    revision        0
+    revision        1
 
     conflicts zmq-devel zmq22 zmq3
 
@@ -188,7 +188,7 @@ if {${subport} eq "zmq" || ${subport} eq "zmq-devel"} {
         }
     }
 
-    variant sodium description "Use libsodium instead of built-in tweetnacl" {
+    variant sodium description "Build with libsodium support" {
         depends_lib-append \
                     port:libsodium
         configure.args-replace \
@@ -198,7 +198,12 @@ if {${subport} eq "zmq" || ${subport} eq "zmq-devel"} {
                     -DWITH_LIBSODIUM_STATIC=OFF
     }
 
-    default_variants    +sodium
+    variant curve requires sodium description "Enable CURVE security support" {
+        configure.args-append \
+                    -DENABLE_CURVE=ON
+    }
+
+    default_variants    +sodium +curve
 
     variant tests description "Build and run tests" {
         configure.args-replace \


### PR DESCRIPTION
#### Description

zeromq 4.3.5 changed the default for the ENABLE_CURVE option to false instead of true while removing the tweetnacl implementation because of an inability to license (see https://github.com/zeromq/libzmq/pull/4554).  The macports 4.3.5 version bump, however, didn't specify the option and so currently doesn't support secure zmq connections at all, while 4.3.4 and earlier *always* supported CURVE regardless of the variant (either via libsodium or the build-in tweetnacl, depending on whether the sodium variant was used).

This reenables it behind a new, default-enabled `curve` variant (which depends on the already-default `libsodium` as that is now the only supported zeromq curve implementation) so that the default variant zmq package supports curve encryption, as it did for versions before 4.3.5.

I kept it distinct from the sodium variant because zmq technically can make use of libsodium even when curve is disabled.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.7 23H124 arm64
Xcode 16.0 16A242d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
