### PR TITLE
mvnd2: update to 2.0.0-rc-3

### DIFF
--- a/java/mvnd2/Portfile
+++ b/java/mvnd2/Portfile
@@ -4,8 +4,8 @@ PortSystem      1.0
 PortGroup select 1.0
 
 # Until 2.0.0 is released, use a version that sorts before 2.0.0
-version         1.9.9-rc1
-set real_version 2.0.0-rc-1
+version         1.9.9-rc3
+set real_version 2.0.0-rc-3
 revision        0
 name            mvnd2
 categories      java
@@ -35,7 +35,7 @@ long_description mvnd aims at providing faster Maven builds using techniques kno
 homepage        https://github.com/apache/maven-mvnd
 supported_archs x86_64 arm64
 
-master_sites    https://archive.apache.org/dist/maven/mvnd/${real_version}/
+master_sites    https://downloads.apache.org/maven/mvnd/${real_version}/
 
 depends_run     port:mvnd_select
 
@@ -46,14 +46,14 @@ select.file     ${filespath}/${name}
 
 if {${configure.build_arch} eq "x86_64"} {
     distname        maven-mvnd-${real_version}-darwin-amd64
-    checksums       rmd160  1bcfec599f9c73d709b53b36464e798d8f57eb4c \
-                    sha256  4581214a672e649a2e5da55392911cd98f60d3e58d5763a953662696d06adf90 \
-                    size    29864805
+    checksums       rmd160  bd3ef67d264d5d67589165f51bccf2517aa26e0b \
+                    sha256  bc17fa11463bcd23ad1524a0f9a847042e0663cdde6db2be1f0683495eee4d29 \
+                    size    27151628
 } elseif {${configure.build_arch} eq "arm64"} {
     distname        maven-mvnd-${real_version}-darwin-aarch64
-    checksums       rmd160  7fcc2aa1ada75b6050a5417c31a47d9a064972be \
-                    sha256  e0da84ae20d71af11c63846aeabb0ef134d575348613706fa17a26cfd8840004 \
-                    size    29922827
+    checksums       rmd160  5442ca34d2365455f8ba3cae59b092995b212146 \
+                    sha256  359980623981dda8eb00a39761eb130adb88259e1b145330b53981c66a7600fd \
+                    size    27316340
 }
 
 build {}


### PR DESCRIPTION
#### Description

Update to mvnd 2.0.0-rc-3.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?