### PR TITLE
sfeed: update to 2.2

### DIFF
--- a/net/sfeed/Portfile
+++ b/net/sfeed/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 name                sfeed
-version             2.1
+version             2.2
 revision            0
 license             ISC
 
@@ -18,9 +18,9 @@ homepage            https://git.codemadness.org/${name}/
 
 master_sites        https://codemadness.org/releases/${name}/
 
-checksums           rmd160  022b3dadaab821e71b5d6233e71757d7bbd143cc \
-                    sha256  dd54c9b3ff8c47a67ceae64b8cd62b064ebbf2f11715386d89603ecd276e3705 \
-                    size    68610
+checksums           rmd160  561df214e587fc5e77f68bb8aba32905d3f55219 \
+                    sha256  4270389c3cfa474caa3892271c3171a751490328cc52e502d8435de3c2e41cc5 \
+                    size    68969
 
 depends_lib-append  port:ncurses
 


### PR DESCRIPTION
#### Description
https://git.codemadness.org/sfeed/log.html

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
