### PR TITLE
eigen3[-devel]: Tweaks to builds, bump -devel

### DIFF
--- a/math/eigen3/Portfile
+++ b/math/eigen3/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           compilers 1.0
+PortGroup           muniversal 1.1
 PortGroup           cmake 1.1
 PortGroup           gitlab 1.0
 
@@ -34,9 +35,9 @@ if {${subport} eq ${name}} {
 }
 
 subport eigen3-devel {
-    gitlab.setup        libeigen eigen 8ad4344c
+    gitlab.setup        libeigen eigen 68f4e58c
     # For when there is no current development version (other than rolling snapshot)
-    version             3.4-tracking-20241122
+    version             3.4-tracking-20250224
     revision            0
     epoch               3
     gitlab.livecheck.branch master
@@ -46,16 +47,15 @@ subport eigen3-devel {
     long_description    {*}${description} This (-devel) version tracks \
                         development of the current (3.4) branch.
 
-    checksums           rmd160  c7891fe0d6b45c82bb938a0fa596803148456abb \
-                        sha256  2550f496965bc1409f421f3fb20e4b3adecb374712cdb3e57f173e1f4f23a97c \
-                        size    2278889
+    checksums           rmd160  9589a3d9f069391023b5ba572e3e64d4c18c86c6 \
+                        sha256  80949929d5c0268b7c192845871875035c59c2fb2f72b3cb4ed3d191ec5f1eb1 \
+                        size    2156682
 
     # Eigen's source code specifically checks the version of Apple Clang.
     compiler.blacklist-append \
                         {clang < 900}
     compiler.cxx_standard \
                         2014
-    compilers.setup     require_fortran
 }
 
 # Exclude pre-release versions
@@ -73,8 +73,6 @@ variant doc description \
 
 variant blas description \
     {Build eigen's blas (libeigen_blas*) : needs +gccNN, +g95, or +gfortran} {
-        PortGroup               muniversal 1.0
-
         build.target-append     blas
         universal_variant       yes
         configure.universal_args ""
@@ -104,7 +102,6 @@ if {[variant_isset blas]} {
     # No architecture-dependent files installed; set noarch
     supported_archs     noarch
     platforms           any
-    compilers.setup
 }
 
 ### Extra phases
@@ -164,6 +161,6 @@ post-destroot {
 }
 
 notes "
-This product includes software developed by the University of Chicago, as\
-Operator of Argonne National Laboratory.
+This product includes software developed by the University of Chicago,\
+as Operator of Argonne National Laboratory.
 "


### PR DESCRIPTION
Hopefully addresses https://trac.macports.org/ticket/72163. Move muniversal out of a variant; don't bother configuring compilers PG for default (header-only) install.
