### PR TITLE
mariadb-10.{5,6,11}: update to 10.5.25, 10.6.21, 10.11.11

### DIFF
--- a/databases/mariadb-10.11/Portfile
+++ b/databases/mariadb-10.11/Portfile
@@ -7,7 +7,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-10.11
 set name_mysql      ${name}
-version             10.11.9
+version             10.11.11
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
@@ -31,17 +31,6 @@ if {$subport eq $name} {
 
     openssl.branch      3
 
-    # build configuration will incorrectly find and use the openssl shim port headers
-    # which are in the primary prefix, in preference to the openssl11 ones, due to a bug
-    # in the order that the compilation include paths are listed. i.e.
-    #    -I/opt/local/libexec/openssl11/include
-    # must come before any instance of
-    #    -I/opt/local/include
-    # Until the build configuration is fixed to avoid this (or the port is updated to be
-    # compatible with openssl3) use the openssl PG compiler wrap option to enforce the
-    # correct include order on the build
-    openssl.configure-append compiler_wrap
-
     # https://trac.macports.org/ticket/60805
     compiler.blacklist-append {clang < 900}
 
@@ -55,9 +44,9 @@ if {$subport eq $name} {
 
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160 73528c0e6735521f2f6ea4d0efffed704b9f2d2c \
-                    sha256 0a00180864cd016187c986faab8010de23a117b9a75f91d6456421f894e48d20 \
-                    size   101611566
+    checksums       rmd160  715741d6f86e0c0d1f60ae19b70c85b8cbb703db \
+                    sha256  6f29d4d7e40fc49af4a0fe608984509ef2d153df3cd8afe4359dce3ca0e27890 \
+                    size    105754084
 
     depends_build-append port:bison
     depends_lib-append  port:curl \
@@ -278,7 +267,9 @@ subport ${name_mysql}-server {
     notes "
 If this is a new install you might want to run:
 
-\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mysql_install_db
+\$ sudo mkdir -p ${prefix}/var/db/${name_mysql}
+\$ sudo chown ${mysqluser}:${mysqluser} ${prefix}/var/db/${name_mysql}
+\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mariadb_install_db
 "
 
     livecheck.type          none

--- a/databases/mariadb-10.5/Portfile
+++ b/databases/mariadb-10.5/Portfile
@@ -7,7 +7,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-10.5
 set name_mysql      ${name}
-version             10.5.26
+version             10.5.28
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
@@ -31,17 +31,6 @@ if {$subport eq $name} {
 
     openssl.branch      3
 
-    # build configuration will incorrectly find and use the openssl shim port headers
-    # which are in the primary prefix, in preference to the openssl11 ones, due to a bug
-    # in the order that the compilation include paths are listed. i.e.
-    #    -I/opt/local/libexec/openssl11/include
-    # must come before any instance of
-    #    -I/opt/local/include
-    # Until the build configuration is fixed to avoid this (or the port is updated to be
-    # compatible with openssl3) use the openssl PG compiler wrap option to enforce the
-    # correct include order on the build
-    openssl.configure-append compiler_wrap
-
     # https://trac.macports.org/ticket/60805
     compiler.blacklist-append {clang < 900}
 
@@ -55,9 +44,9 @@ if {$subport eq $name} {
 
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160 d708746c77ea40a4db66534f52ac47f22af7ca39 \
-                    sha256 dd5f99a1d30ae47365fc18b1deeff6dc0ab38ac84e7d9fd9c8c04ff6b01961f1 \
-                    size   116566259
+    checksums       rmd160  954542d01c8ca6e6b69a020e92a95b53054e1aba \
+                    sha256  0b5070208da0116640f20bd085f1136527f998cc23268715bcbf352e7b7f3cc1 \
+                    size    117755203
 
     depends_build-append port:bison
     depends_lib-append  port:curl \
@@ -275,7 +264,9 @@ subport ${name_mysql}-server {
     notes "
 If this is a new install you might want to run:
 
-\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mysql_install_db
+\$ sudo mkdir -p ${prefix}/var/db/${name_mysql}
+\$ sudo chown ${mysqluser}:${mysqluser} ${prefix}/var/db/${name_mysql}
+\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mariadb_install_db
 "
 
     livecheck.type          none

--- a/databases/mariadb-10.6/Portfile
+++ b/databases/mariadb-10.6/Portfile
@@ -7,7 +7,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-10.6
 set name_mysql      ${name}
-version             10.6.19
+version             10.6.21
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
@@ -31,17 +31,6 @@ if {$subport eq $name} {
 
     openssl.branch      3
 
-    # build configuration will incorrectly find and use the openssl shim port headers
-    # which are in the primary prefix, in preference to the openssl11 ones, due to a bug
-    # in the order that the compilation include paths are listed. i.e.
-    #    -I/opt/local/libexec/openssl11/include
-    # must come before any instance of
-    #    -I/opt/local/include
-    # Until the build configuration is fixed to avoid this (or the port is updated to be
-    # compatible with openssl3) use the openssl PG compiler wrap option to enforce the
-    # correct include order on the build
-    openssl.configure-append compiler_wrap
-
     # https://trac.macports.org/ticket/60805
     compiler.blacklist-append {clang < 900}
 
@@ -55,9 +44,9 @@ if {$subport eq $name} {
 
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160 f5e4271b5179213c5fd344b2cb1212d32c991a41 \
-                    sha256 bcecb0ff7b79a41344736fa994710787c15516d51eb7715f278c3f0fcb7e8703 \
-                    size   99979223
+    checksums       rmd160  e70ac80ebd93515ff9373e3bba561568ecd06d31 \
+                    sha256  8d7f97169b3ba2044858965b8cfc254364400df43e905042f92e24b8fa7b0d96 \
+                    size    103982296
 
     depends_build-append port:bison
     depends_lib-append  port:curl \
@@ -278,7 +267,9 @@ subport ${name_mysql}-server {
     notes "
 If this is a new install you might want to run:
 
-\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mysql_install_db
+\$ sudo mkdir -p ${prefix}/var/db/${name_mysql}
+\$ sudo chown ${mysqluser}:${mysqluser} ${prefix}/var/db/${name_mysql}
+\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mariadb_install_db
 "
 
     livecheck.type          none


### PR DESCRIPTION
```
On branch mariadb10
Changes to be committed:

	updated :
	modified:   databases/mariadb-10.5/Portfile @10.5.28
	modified:   databases/mariadb-10.6/Portfile @10.6.21
	modified:   databases/mariadb-10.11/Portfile @10.11.11
```
###### References
[https://mariadb.org/mariadb/all-releases/](https://mariadb.org/mariadb/all-releases/)
[https://endoflife.date/mariadb](https://endoflife.date/mariadb)

###### Tested on
Model Identifier: Macmini6,1
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e
Command Line Tools 12.4.0.0.1.1610135815

Model Identifier: MacPro5,1
macOS 14.7.4 23H420 x86_64
Xcode 16.2 16C5032a
Command Line Tools 16.2.0.0.1.1733547573

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

