### PR TITLE
app-1.0: Quote icon filenames when installing.

### DIFF
--- a/_resources/port1.0/group/app-1.0.tcl
+++ b/_resources/port1.0/group/app-1.0.tcl
@@ -306,7 +306,7 @@ platform macosx {
 
                 # If app.icon is an .icns file, copy it.
                 if {[file extension ${icon}] eq ".icns"} {
-                    xinstall -m 0644 ${icon} ${destroot}${applications_dir}/${app.name}.app/Contents/Resources/${app.name}.icns
+                    xinstall -m 0644 ${icon} "${destroot}${applications_dir}/${app.name}.app/Contents/Resources/${app.name}.icns"
 
                 # If app.icon is svg, rasterize and convert it.
                 } elseif {[file extension ${icon}] eq ".svg"} {


### PR DESCRIPTION
#### Description
Quote the destination filename in case it contains spaces.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14 x86_64
macOS 15.4 24E5228e x86_64
Xcode 16.3 16E5104o

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?