### PR TITLE
py-igraph: depend on external plfit

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -4,10 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-igraph
-python.rootname     igraph
-python.pep517       yes
 version             0.11.8
-revision            0
+revision            1
 categories-append   math science
 license             GPL-2+
 
@@ -54,7 +52,8 @@ if {${name} ne ${subport}} {
         depends_lib-append      port:arpack \
                                 port:glpk \
                                 port:gmp \
-                                port:libxml2
+                                port:libxml2 \
+                                port:plfit
 
         depends_build-append    path:bin/cmake:cmake
 
@@ -69,7 +68,7 @@ if {${name} ne ${subport}} {
             -DIGRAPH_USE_INTERNAL_GLPK=OFF
             -DIGRAPH_USE_INTERNAL_GMP=OFF
             -DIGRAPH_USE_INTERNAL_LAPACK=OFF
-            -DIGRAPH_USE_INTERNAL_PLFIT=ON
+            -DIGRAPH_USE_INTERNAL_PLFIT=OFF
             -DIGRAPH_OPENMP_SUPPORT=OFF
             -DBLA_VENDOR=Apple
         }


### PR DESCRIPTION
 - depend on external plfit with the -external_igraph variant
 - remove no-longer-necessary settings from portfile

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
