### PR TITLE
lazarus: Fix 3.8 on macOS 10.13 (High Sierra) and lower

### DIFF
--- a/devel/lazarus/Portfile
+++ b/devel/lazarus/Portfile
@@ -95,6 +95,15 @@ post-patch {
         reinplace "s|/sw/lib;/sw/lib/pango-ft219|${prefix}|g" ${worksrcpath}/lcl/interfaces/lcl.lpk
         reinplace "s|/sw/lib|${prefix}/lib|g"                 ${worksrcpath}/lcl/interfaces/lcl.lpk
     }
+
+# macOS 10.13 (High Sierra) and lower has no separate framework UserNotifications
+    if {${os.major} <= 17} {
+        reinplace "s| -k-weak_framework -kUserNotifications||g" ide/Makefile
+        reinplace "s| -k-weak_framework -kUserNotifications||g" ide/Makefile.fpc
+        reinplace "s| -k-weak_framework -kUserNotifications||g" components/chmhelp/lhelp/Makefile
+        reinplace "s| -k-weak_framework -kUserNotifications||g" components/chmhelp/lhelp/Makefile.fpc
+        reinplace "s| -weak_framework UserNotifications||g" lcl/interfaces/lcl.lpk
+    }
 }
 
 build.target       bigide


### PR DESCRIPTION
#### Description

lazarus: Fix 3.8 on macOS 10.13 (High Sierra) and lower
There is no separate framework Usernotifications on macOS 10.13 and lower

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

Note this test only tests that the package is not broken on the most recent version of macOS. The pipelines will show, whether the fix actually works. Unfortunately, I have no older systems available.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
