### PR TITLE
antlr: Switch to working JDK, fix builds

### DIFF
--- a/lang/antlr/Portfile
+++ b/lang/antlr/Portfile
@@ -5,10 +5,10 @@ PortGroup             java 1.0
 
 name                  antlr
 version               2.7.7
-revision              4
+revision              5
 categories            lang java
 license               public-domain
-platforms             darwin
+supported_archs       noarch
 maintainers           {@Dave-Allured noaa.gov:dave.allured} \
                       openmaintainer
 
@@ -19,7 +19,7 @@ long_description      ANTLR, ANother Tool for Language Recognition, is a \
                       from grammatical descriptions containing Java, C#, or \
                       C++ actions.
 
-homepage              http://www.antlr2.org/
+homepage              https://www.antlr2.org/
 master_sites          ${homepage}download/ \
                       https://www.mirrorservice.org/sites/distfiles.finkmirrors.net/
 
@@ -36,7 +36,9 @@ variant               universal {}
 java.version          1.4+
 
 # LTS JDK port to install if required java not found
-java.fallback         openjdk8
+# Currently can not build openjdk8 from source (2025 March 14).
+# Use bootstrap port instead, actually is the Zulu binary install.
+java.fallback         openjdk8-bootstrap
 
 # JDK only needed at build time, but java PG sets lib dependency.
 # So declare no conflict to allow redistribution of binaries.


### PR DESCRIPTION
#### Description

* Switch JDK from broken openjdk8 to working openjdk-bootstrap.
* Rev bump to clean up binary packages and port health.
* Update home page URL.
* Fix platform.
* Fix supported_archs.

Fixes: https://trac.macports.org/ticket/72201

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 14.6.1
Xcode 16.2
Command Line Tools 16.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?