### PR TITLE
cdo: update to 2.5.1

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,8 +5,8 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.0
 
 name                        cdo
-version                     2.5.0
-revision                    1
+version                     2.5.1
+revision                    0
 maintainers                 {takeshi @tenomoto} \
                             {me.com:remko.scharroo @remkos} \
                             openmaintainer
@@ -14,11 +14,11 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/29786
+master_sites                https://code.mpimet.mpg.de/attachments/download/29864
 
-checksums           rmd160  c135c339eb6902e0ccd1d777b9d22a94fb2bbe97 \
-                    sha256  e865c05c1b52fd76b80e33421554db81b38b75210820bdc40e8690f4552f68e2 \
-                    size    13553301
+checksums           rmd160  27ffd1da151af1697eb28929cfedbde91e8f0dba \
+                    sha256  418bf91e864cbfe547c3c8e150d31419cfa715e7d345508c5591b1abda5457d1 \
+                    size    13993648
 
 long_description \
     CDO is a collection of command line Operators               \
@@ -30,6 +30,7 @@ fetch.ignore_sslcert        yes
 
 # Since cdo 2.4.0, we need to select C++20 capable compilers.
 # On MacOS-13 compilation with /usr/bin/clang++ fails, so we blacklist it.
+
 compiler.cxx_standard       2020
 compiler.blacklist-append   clang
 


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.5.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.2 24D81 x86_64
Command Line Tools 16.2.0.0.1.1733547573
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
