### PR TITLE
eccodes: Fix builds for macos <= 10.12

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -13,7 +13,7 @@ legacysupport.use_mp_libcxx yes
 
 name                ecCodes
 version             2.40.0
-revision            1
+revision            0
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
                     openmaintainer

--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -3,10 +3,17 @@
 PortSystem          1.0
 PortGroup cmake     1.1
 PortGroup compilers 1.0
+PortGroup           legacysupport 1.1
+
+# Fix builds for macos <= 10.12.
+# Fix for undefined symbols for std::bad_optional_access::~bad_optional_access
+# Copied from https://trac.macports.org/ticket/69638
+legacysupport.newest_darwin_requires_legacy 16
+legacysupport.use_mp_libcxx yes
 
 name                ecCodes
 version             2.40.0
-revision            0
+revision            1
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
                     openmaintainer


### PR DESCRIPTION
#### Description

* Use legacy support PG to fix builds for macos <= 10.12.
* Fixes undefined symbols for "std::bad_optional_access::~bad_optional_access()".

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?