### PR TITLE
openjdk24-zulu: update to 24.28.83

### DIFF
--- a/java/openjdk24-zulu/Portfile
+++ b/java/openjdk24-zulu/Portfile
@@ -14,13 +14,13 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-# https://www.azul.com/downloads/?version=java-24-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.77
+# https://www.azul.com/downloads/?version=java-24&os=macos&package=jdk#zulu
+version      ${feature}.28.83
 revision     0
 
 set openjdk_version ${feature}.0.0
 
-description  Azul Zulu Community OpenJDK ${feature} (Early Access)
+description  Azul Zulu Community OpenJDK ${feature} (Short Term Support until September 2025)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
                  specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
                  verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
@@ -29,18 +29,15 @@ long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant 
 master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.34-macosx_x64
-    checksums    rmd160  595bfbb012255f556bf45b5ef41489384868a68b \
-                 sha256  cff7284aad88dec1afe5931e300b803b1dc987261631f658baf37594e8d03571 \
-                 size    224969512
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    checksums    rmd160  af30b2b5438fcfbfdc3082dbc7e8a8921e4fd7b2 \
+                 sha256  7bb289b49f7e98515274a0a3ebcb617d35e0b961f9cd769249bf698735dffe54 \
+                 size    225379276
 } elseif {${configure.build_arch} eq "arm64"} {
-    # No .tar.gz (yet?) for arm64
-    use_zip yes
-
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.34-macosx_aarch64
-    checksums    rmd160  fa6b17ae6b83b842a94420ebea7d177c0466b2bd \
-                 sha256  5bd8fee8257ce34566da3c79b9d962de9051f291b6fd5002b37c946ac924e06f \
-                 size    226015246
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+    checksums    rmd160  130a3fe7c543dea810b9ad1b9edd1fd7261299e7 \
+                 sha256  ef25cb38908ad1167c575bec7b1386c4647d340c22fe90a5f790653bc13c9c65 \
+                 size    222903791
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 24.28.83.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?