### PR TITLE
openjdk24-zulu: include short description in long_description

### DIFF
--- a/java/openjdk24-zulu/Portfile
+++ b/java/openjdk24-zulu/Portfile
@@ -21,10 +21,13 @@ revision     0
 set openjdk_version ${feature}.0.0
 
 description  Azul Zulu Community OpenJDK ${feature} (Short Term Support until September 2025)
-long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
-                 specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
-                 verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
-                 respective Java SE version.
+long_description {*}${description}\
+    \n\nAzul® Zulu® is a Java Development Kit (JDK), and a compliant \
+    implementation of the Java Standard Edition (SE) specification that \
+    contains all the Java components needed to build and run Java SE \
+    applications. Zulu has been verified by passing all tests of the OpenJDK \
+    Community Technology Compatibility Kit (TCK) as available for each \
+    respective Java SE version.
 
 master_sites https://cdn.azul.com/zulu/bin/
 


### PR DESCRIPTION
#### Description

Update description.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?