### PR TITLE
tlrc: Update to 1.11.0

### DIFF
--- a/net/tlrc/Portfile
+++ b/net/tlrc/Portfile
@@ -4,12 +4,12 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            tldr-pages tlrc 1.10.0 v
+github.setup            tldr-pages tlrc 1.11.0 v
 github.tarball_from     archive
 revision                0
 categories              net
 license                 MIT
-platforms               {darwin >= 16}
+platforms               {darwin >= 17}
 installs_libs           no
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
@@ -17,9 +17,11 @@ description             Official tldr client written in Rust
 long_description        {*}${description}.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  659daf9a5f07d3168cd44775a921368dfd71333d \
-                        sha256  bbed8b11214a0f1df82f82581efcd241b45c3d33dc5f46e488abb017239e7f74 \
-                        size    33342
+                        rmd160  9453b877e91d6b3b7872a9c958afbcd63821ed4f \
+                        sha256  8d40c00189fd4a0e359612507e1b8fccc38e82594243bbccdb294e1281c6387f \
+                        size    36718
+
+depends_lib-append      port:libiconv
 
 destroot {
     set bindir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -52,17 +54,17 @@ cargo.crates \
     assert_cmd                      2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
-    bitflags                         2.8.0  8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36 \
+    bitflags                         2.9.0  5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd \
     bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
     bumpalo                         3.17.0  1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                           1.10.0  f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9 \
-    cc                              1.2.13  c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda \
+    bytes                           1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
+    cc                              1.2.16  be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c \
     cesu8                            1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    clap                            4.5.28  3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff \
-    clap_builder                    4.5.27  1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7 \
-    clap_derive                     4.5.28  bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed \
+    clap                            4.5.32  6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83 \
+    clap_builder                    4.5.32  22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8 \
+    clap_derive                     4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     combine                          4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
@@ -76,41 +78,44 @@ cargo.crates \
     dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
-    equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
-    flate2                          1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
+    equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
+    errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
+    flate2                           1.1.0  11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
     hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
-    http                             1.2.0  f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea \
-    httparse                        1.10.0  f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a \
-    indexmap                         2.7.1  8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652 \
+    http                             1.3.1  f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565 \
+    httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
+    indexmap                         2.8.0  3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
-    itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
+    itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
     jni                             0.19.0  c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec \
     jni-sys                          0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
-    libc                           0.2.169  b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a \
+    libc                           0.2.171  c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
+    linux-raw-sys                    0.9.3  fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413 \
     lockfree-object-pool             0.1.6  9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e \
-    log                             0.4.25  04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f \
+    log                             0.4.26  30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
-    miniz_oxide                      0.8.3  b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924 \
+    miniz_oxide                      0.8.5  8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5 \
     num-bigint                       0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
     num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
-    once_cell                       1.20.3  945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e \
+    once_cell                       1.21.1  d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc \
     openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
     predicates                       3.1.3  a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573 \
     predicates-core                  1.0.9  727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa \
     predicates-tree                 1.0.12  72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c \
-    proc-macro2                     1.0.93  60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99 \
-    quote                           1.0.38  0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc \
+    proc-macro2                     1.0.94  a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84 \
+    quote                           1.0.40  1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
     redox_users                      0.5.0  dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b \
     regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
-    ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
-    rustls                         0.23.22  9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7 \
+    ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
+    rustix                           1.0.2  f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825 \
+    rustls                         0.23.23  47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395 \
     rustls-native-certs              0.7.3  e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.11.0  917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c \
@@ -121,28 +126,29 @@ cargo.crates \
     schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework-sys          2.14.0  49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32 \
-    serde                          1.0.217  02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70 \
-    serde_derive                   1.0.217  5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0 \
+    serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
+    serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \
     socks                            0.3.4  f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b \
-    spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
-    syn                             2.0.98  36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1 \
+    syn                            2.0.100  b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0 \
+    terminal_size                    0.4.2  45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed \
     termtree                         0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.11  d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc \
+    thiserror                       2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.11  26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2 \
+    thiserror-impl                  2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
     toml                            0.8.20  cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148 \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
-    toml_edit                      0.22.23  02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee \
-    unicode-ident                   1.0.16  a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034 \
+    toml_edit                      0.22.24  17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474 \
+    unicode-ident                   1.0.18  5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512 \
+    unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    ureq                             3.0.4  18250fd12e095bc29eb65b753431ae5d326f7c259a818cb3bf3faaf740ee3344 \
-    ureq-proto                       0.3.0  2c51fe73e1d8c4e06bb2698286f7e7453c6fc90528d6d2e7fc36bb4e87fe09b1 \
+    ureq                             3.0.9  46ad884f92873b83ae777744da5d8d6216d7ccc18bb9add8d2825c28e5c8695b \
+    ureq-proto                       0.3.5  ae239d0a3341aebc94259414d1dc67cfce87d41cbebc816772c91b77902fafa4 \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     wait-timeout                     0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
@@ -164,8 +170,8 @@ cargo.crates \
     windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                           0.7.1  86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f \
+    winnow                           0.7.4  0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
-    zip                              2.2.2  ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45 \
+    zip                              2.3.0  84e9a772a54b54236b9b744aaaf8d7be01b4d6e99725523cb82cb32d1c81b1d7 \
     zopfli                           0.8.1  e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946


### PR DESCRIPTION
#### Description

Update `tlrc` to its latest released, 1.11.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
