### PR TITLE
openjdk25-zulu: update to 25.0.29

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -15,32 +15,35 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.11
+version      ${feature}.0.29
 revision     0
 
 set openjdk_version ${feature}.0.0
 
 description  Azul Zulu Community OpenJDK ${feature} (Early Access)
-long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
-                 specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
-                 verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
-                 respective Java SE version.
+long_description {*}${description} \
+    \n\nAzul® Zulu® is a Java Development Kit (JDK), and a compliant \
+    implementation of the Java Standard Edition (SE) specification that \
+    contains all the Java components needed to build and run Java SE \
+    applications. Zulu has been verified by passing all tests of the OpenJDK \
+    Community Technology Compatibility Kit (TCK) as available for each \
+    respective Java SE version.
 
 master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.1-macosx_x64
-    checksums    rmd160  830b63dabe339080fcb0a36ec9cbc03e40428436 \
-                 sha256  f9c915a16b6a72f1290a322ae26eae881ac6039ccefcbe1eb2e0888a05b51d87 \
-                 size    224995197
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.12-macosx_x64
+    checksums    rmd160  6225a18467f3f228014398b04a53748c4e31ae6f \
+                 sha256  a9600dadecd7837fa59ad8d307f42147216cada0007624744b1ec29696009379 \
+                 size    224280537
 } elseif {${configure.build_arch} eq "arm64"} {
     # No .tar.gz (yet?) for arm64
     use_zip yes
 
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.1-macosx_aarch64
-    checksums    rmd160  4d51b7103d7324409be903753a48e0d42024bf5f \
-                 sha256  e79daed36ac8e8433227895d5b288ffc6a3d4f5d470a12fe6e50475a247f5709 \
-                 size    226050140
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.12-macosx_aarch64
+    checksums    rmd160  17ea5755fa78e4fcd87f07ce9a823af58eb436f0 \
+                 sha256  e2d4e17215710d1bf1ba2aa62a5f94f9197c3ab1319bd6b29e1997b9ad7437db \
+                 size    225303434
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.0.29.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?