### PR TITLE
openjdk24: new submission

### DIFF
--- a/java/openjdk24/Portfile
+++ b/java/openjdk24/Portfile
@@ -1,0 +1,182 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+set feature 24
+
+# See https://github.com/openjdk/jdk/blob/master/doc/building.md#boot-jdk-requirements
+set boot_feature 23
+
+name                openjdk${feature}
+# See https://github.com/openjdk/jdk24u/tags for the version and build number that matches the latest tag that ends with '-ga'
+version             ${feature}
+set build 36
+revision            0
+categories          java devel
+supported_archs     x86_64 arm64
+license             GPL-2+
+maintainers         {breun.nl:nils @breun} openmaintainer
+description         OpenJDK ${feature} (Short Term Support until September 2025)
+long_description    {*}${description} \
+    \n\nJDK ${feature} builds of OpenJDK, the Open-Source implementation \
+    of the Java Platform, Standard Edition, and related projects.
+homepage            https://openjdk.org/projects/jdk/${feature}/
+master_sites        https://github.com/openjdk/jdk${feature}u/archive/refs/tags
+distname            jdk-${version}-ga
+worksrcdir          jdk${feature}u-${distname}
+
+checksums           rmd160  de461bb8ca8bf3f7c852f7ad1ca8bdd5fc111fa5 \
+                    sha256  62cfe6846267a31edb1a4f451b1b1c6fddd25b7ec8522d32387f5450963b9996 \
+                    size    120680620
+
+set bootjdk_port    openjdk${boot_feature}-zulu
+
+depends_lib         port:freetype \
+                    port:libiconv
+depends_build       port:${bootjdk_port} \
+                    port:autoconf \
+                    port:gmake \
+                    port:bash
+
+# Boot JDK license/redistributability should not affect license/redistributability of this port
+license_noconflict  ${bootjdk_port}
+
+pre-patch {
+    reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4
+    reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
+}
+
+# Temporary workaround for clang 16.0-16.1: https://trac.macports.org/ticket/70819
+#patchfiles          JDK-8340341-clang-16-workaround.patch
+
+set tpath ${prefix}/Library/Java
+use_xcode           yes
+use_configure    yes
+configure.cmd       ${prefix}/bin/bash configure
+configure.pre_args  --prefix=${tpath}
+set bug_url "https://trac.macports.org/newticket?port=${name}"
+# default configure args
+configure.args      --with-debug-level=release \
+                    --with-native-debug-symbols=none \
+                    --with-version-string=${version}+${build} \
+                    --with-sysroot=`xcrun --sdk macosx --show-sdk-path` \
+                    --with-extra-cflags="${configure.cflags}" \
+                    --with-extra-cxxflags="${configure.cxxflags}" \
+                    --with-extra-ldflags="${configure.ldflags}" \
+                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/jdk-${boot_feature}-azul-zulu.jdk/Contents/Home \
+                    --with-freetype=system \
+                    --with-freetype-include=${prefix}/include/freetype2 \
+                    --with-freetype-lib=${prefix}/lib \
+                    --disable-warnings-as-errors \
+                    --disable-precompiled-headers \
+                    --with-vendor-name="MacPorts" \
+                    --with-vendor-url="https://www.macports.org" \
+                    --with-vendor-bug-url="${bug_url}" \
+                    --with-vendor-vm-bug-url="${bug_url}" \
+                    --with-conf-name=release
+
+if {[option configure.ccache]} {
+    # replace MacPorts ccache integration into JDK
+    configure.ccache        no
+    depends_build-append    path:bin/ccache:ccache
+    configure.args-append   --enable-ccache \
+                            --with-ccache-dir=${ccache_dir}
+}
+
+variant release \
+    conflicts debug optimized \
+    description {OpenJDK with no debug information, all optimizations and no asserts} {
+    configure.args-append   --with-debug-level=release
+}
+
+variant optimized \
+    conflicts debug release \
+    description {OpenJDK with no debug information, all optimizations, no asserts and HotSpot is 'optimized'} {
+    configure.args-append   --with-debug-level=optimized
+}
+
+variant debug \
+    conflicts optimized release \
+    description {OpenJDK with debug information, all optimizations and all asserts} {
+    configure.args-append   --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
+}
+
+variant client \
+    conflicts core minimal server zero \
+    description {JVM with normal interpreter, C1 and no C2 compiler} {
+    configure.args-append   --with-jvm-variants=client
+}
+
+variant server \
+    conflicts client core minimal zero \
+    description {JVM with normal interpreter, and a tiered C1/C2 compiler} {
+    configure.args-append   --with-jvm-variants=server
+}
+
+variant minimal \
+    conflicts client core server zero \
+    description {JVM with reduced form of normal interpreter having C1, no C2 compiler and optional features stripped out} {
+    configure.args-append   --with-jvm-variants=minimal
+}
+
+variant core \
+    conflicts client minimal server zero \
+    description {JVM with normal interpreter only and no compiler} {
+    configure.args-append   --with-jvm-variants=core
+}
+
+variant zero \
+    conflicts client core minimal server \
+    description {JVM with C++ based interpreter only, no compiler} {
+    configure.args-append   --with-jvm-variants=zero \
+                            --with-libffi=${prefix} \
+                            --enable-libffi-bundling
+    depends_lib-append         port:libffi
+}
+
+if {![variant_isset debug] && ![variant_isset optimized] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset client] && ![variant_isset core] && ![variant_isset minimal] && ![variant_isset server]} {
+    default_variants-append +server
+}
+
+build.type          gnu
+build.target        images
+use_parallel_build  no
+set jdkn jdk-${version}.jdk
+set bundle_dir build/release/images/jdk-bundle/${jdkn}/Contents
+
+test.run            yes
+test.cmd            ${bundle_dir}/Home/bin/java
+test.target         --version
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-${feature}-macports.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/${bundle_dir} ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree      yes
+
+post-destroot {
+    delete ${worksrcpath}
+}
+
+notes "
+If you want to make ${name} the default JDK, add this to shell profile:
+export JAVA_HOME=${jdk}/Contents/Home
+"
+    
+livecheck.type      regex
+livecheck.url       https://github.com/openjdk/jdk${feature}u/tags
+livecheck.regex     jdk-(${feature}\.\[0-9.\]+)-ga

--- a/java/openjdk24/Portfile
+++ b/java/openjdk24/Portfile
@@ -47,7 +47,7 @@ pre-patch {
 }
 
 # Temporary workaround for clang 16.0-16.1: https://trac.macports.org/ticket/70819
-#patchfiles          JDK-8340341-clang-16-workaround.patch
+patchfiles          JDK-8340341-clang-16-workaround.patch
 
 set tpath ${prefix}/Library/Java
 use_xcode           yes

--- a/java/openjdk24/files/JDK-8340341-clang-16-workaround.patch
+++ b/java/openjdk24/files/JDK-8340341-clang-16-workaround.patch
@@ -1,0 +1,14 @@
+--- make/hotspot/lib/JvmOverrideFiles.gmk.orig	2024-06-04 18:47:50
++++ make/hotspot/lib/JvmOverrideFiles.gmk	2024-09-22 23:45:41
+@@ -89,6 +89,11 @@
+     # for the clang bug was still needed.
+     BUILD_LIBJVM_loopTransform.cpp_CXXFLAGS := $(CXX_O_FLAG_NONE)
+ 
++    # See JDK-8340341
++    ifeq ($(firstword $(subst ., ,$(CXX_VERSION_NUMBER))), 16)
++      BUILD_LIBJVM_stackMapTable.cpp_CXXFLAGS := -O1
++    endif
++
+     # The following files are compiled at various optimization
+     # levels due to optimization issues encountered at the
+     # default level. The Clang compiler issues a compile


### PR DESCRIPTION
#### Description

New port for OpenJDK 24.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?