### PR TITLE
google-cloud-sdk: update to 515.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             514.0.0
+version             515.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3d71db6d738ccfde303432e55f82793441a4f7b4 \
-                    sha256  105ecf1db7be3c682595f9aff1cd54a7bc146e39bf65cddaeb2791973482bd70 \
-                    size    54115501
+    checksums       rmd160  9737516b261573128801be7629c9d8d4dfe61f90 \
+                    sha256  baa4f519e88880030ef47112255282024fff1e30603d7b54d05148d429b33725 \
+                    size    54191620
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  7e7eec7fbfdbd3480c0cb3cd7f4dcc976888e6a7 \
-                    sha256  ecbedcfeb18625dba78782f095daddfd87bfab809f40c67b3474b223960b1631 \
-                    size    55584073
+    checksums       rmd160  22fb229354732184cebb420bd32c55db38a42d8a \
+                    sha256  e74fe91bda20a464d9e69d5874bcd2713eb4a0ef591cbe8749ed41eb9787d229 \
+                    size    55659388
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  01e9f6b62a28eae4f8b6db0e10a18e4e2b2aa2fe \
-                    sha256  fdd18b224bb66d721bc0abba177e9618ec3559f606c1dd9ae2aab5bbd7748fc2 \
-                    size    55523897
+    checksums       rmd160  3a54a30956963ea0c9aa3be63792ee4e0d071fcc \
+                    sha256  e2b0913dbf1d47c79b956902007094b9aacab74eb1ce336e642cfc4c1f4155f4 \
+                    size    55596506
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 515.0.0.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?