### PR TITLE
ghostscript: update to 10.05.0

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                ghostscript
-version             10.04.0
+version             10.05.0
 revision            0
 
 categories          print
@@ -21,8 +21,6 @@ master_sites        https://github.com/ArtifexSoftware/ghostpdl-downloads/releas
                     sourceforge:project/gs-fonts/gs-fonts/8.11%20%28base%2035%2C%20GPL%29/:stdfonts \
                     https://github.com/adobe-type-tools/mapping-resources-pdf/archive/:misc
 
-# Note: please update ghostscript-fonts-hiragino Portfile to keep version in sync
-
 # Note: this needs to be manually updated for new upstream commits
 set mappingresources_commit \
                     2dd5e53fb74a01718b9dfd448a0d1cce6fff2aa5
@@ -34,9 +32,9 @@ distfiles           ${distname}.tar.gz:source \
                     ${mappingresources_commit}.zip:misc
 
 checksums           ${distname}.tar.gz \
-                    rmd160  ab1bac9af5538bf441f7ec309a63513af427a96d \
-                    sha256  8b1594b067e00e386f818270a255eef6baba593197173725951d5f0c316dc205 \
-                    size    98270469 \
+                    rmd160  cff18f243131d666e127f4aee0801f6325a67f97 \
+                    sha256  1ee32af7183e6a1c7909f847c8045956b792c4c24bedfa2b9c0d0394241a7460 \
+                    size    98829869 \
                     ghostscript-fonts-other-6.0.tar.gz \
                     rmd160  ab60dbf71e7d91283a106c3df381cadfe173082f \
                     sha256  4fa051e341167008d37fe34c19d241060cd17b13909932cd7ca7fe759243c2de \
@@ -111,7 +109,7 @@ configure.checks.implicit_function_declaration.whitelist-append strchr
 # tell ghostscript it's OK to use the system pkg-config even when cross-compiling
 # see https://trac.macports.org/ticket/66627
 configure.env-append \
-		    DARWIN_LDFLAGS_SO_PREFIX="${prefix}/lib/" \
+                    DARWIN_LDFLAGS_SO_PREFIX="${prefix}/lib/" \
                     PKGCONFIG=${prefix}/bin/pkg-config
 
 # https://trac.macports.org/ticket/56137


### PR DESCRIPTION
#### Description

Relatively simple update to upstream version 10.05.0

Also:
* Replaced tabs in the Portfile by spaces.
* Removed comment to also "update ghostscript-fonts-hiragino Portfile to keep version in sync". In fact, that Portfile is broken as the referenced fonts from ghostscript no longer exist. This was likely broken since ghostscript version 10, as that Portfile still refers to version 9.54.0.
* `mappingresources_commit` did not need to be updated; it is the latest version.

The library version did not change, so no dependencies need to be bumped.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.2 24D81 x86_64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
