### PR TITLE
openjdk24-temurin: new submission

### DIFF
--- a/java/openjdk24-temurin/Portfile
+++ b/java/openjdk24-temurin/Portfile
@@ -1,0 +1,93 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+set feature      24
+name             openjdk${feature}-temurin
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+license          GPL-2+
+# This port uses prebuilt binaries for a particular architecture
+# They are not universal binaries
+universal_variant no
+
+# https://adoptium.net/temurin/releases/
+supported_archs  x86_64 arm64
+
+version      ${feature}
+set build    36
+revision     0
+
+description  Eclipse Temurin, based on OpenJDK ${feature} (Short Term Support until September 2025)
+long_description {*}${description} \
+    \n\nEclipse Temurin provides secure, TCK-tested and compliant, \
+    production-ready Java runtimes.
+
+master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk-${version}%2B${build}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
+    checksums    rmd160  39d7158e24c57ea2e70a51f956d74230cf2f2928 \
+                 sha256  07a99d4a81c4d5e0c4936bf4b9f901565213781c67e865f304a8d8eb75e880d8 \
+                 size    120238929
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
+    checksums    rmd160  8f8fe6a77861f3bd5a599e2d977fbb72e3c23544 \
+                 sha256  8e343d2aaa1d00fdee351d392a4a3f537d81fa4a36f5fdf05e2e2c26d5c50af9 \
+                 size    135758891
+}
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://adoptium.net
+
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin${feature}-binaries
+livecheck.regex     jdk-(${feature}\[\.0-9\]+)\+
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under
+# /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-${feature}-eclipse-temurin.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under
+    # /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Eclipse Temurin 24.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?