### PR TITLE
skaffold: update to 2.14.2

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.14.1 v
+github.setup        GoogleContainerTools skaffold 2.14.2 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  154e30cd05fda809c12c4dd0b7dc7c04070f907d \
-                    sha256  a0628bf50581110ba691c23ec67f4479c0ed4c1bfef99ddd2511dc2054d21d0d \
-                    size    63094675
+checksums           rmd160  73be0dd145f0796f70f055dad314b717a67042de \
+                    sha256  0837ac43e6b207ec72fdc620a20dba404737e1edd4de69e376659f0da273e01d \
+                    size    63087453
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.14.2.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?