### PR TITLE
osmium-tool: update to 1.18.0

### DIFF
--- a/gis/osmium-tool/Portfile
+++ b/gis/osmium-tool/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0
 
-github.setup        osmcode osmium-tool 1.16.0 v
+github.setup        osmcode osmium-tool 1.18.0 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ long_description    A multipurpose command line tool for working with \
 
 homepage            https://osmcode.org/osmium-tool/
 
-checksums           rmd160  9f0442c2ea00f5714835ea8f29f2e4a056fd318f \
-                    sha256  f98454d9f901be42e0b6751aef40106d734887ee35190c224b174c2f27ef1c0f \
-                    size    491176
+checksums           rmd160  fc5f82dad5f74ce8abb19d129bf66dcdc8ca4995 \
+                    sha256  5438f57043c9df05137ca4bd1b1e4a5fb1c9c8c49cb4bec43a5f1ef30ed68fb5 \
+                    size    379204
 
 compiler.cxx_standard 2014
 
@@ -36,11 +36,7 @@ depends_build-append \
                     port:libosmium \
                     port:pandoc \
                     port:protozero \
-                    port:rapidjson
-
-post-patch {
-    file delete -force ${worksrcpath}/include/rapidjson
-}
+                    port:nlohmann-json
 
 test.run            yes
 test.cmd            ctest --output-on-failure


### PR DESCRIPTION
#### Description
Changelog: https://github.com/osmcode/osmium-tool/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
