### PR TITLE
nnn: update to 5.1

### DIFF
--- a/sysutils/nnn/Portfile
+++ b/sysutils/nnn/Portfile
@@ -6,9 +6,8 @@ PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 PortGroup               makefile 1.0
 
-github.setup            jarun nnn 5.0 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from     tarball
+github.setup            jarun nnn 5.1 v
+github.tarball_from     archive
 revision                0
 categories              sysutils
 license                 BSD
@@ -16,9 +15,9 @@ maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 description             tiny, lightning fast, feature-packed file manager
 long_description        ${name} is a tiny, lightning fast, feature-packed file manager.
 
-checksums               rmd160  15f8419dfdb2672590aebb1cb69ba3491dc90c12 \
-                        sha256  36c3d00d52905c1509e0d41f9a5ef8d466ef981c434e66b0b9b401b0bd948ead \
-                        size    258526
+checksums               rmd160  8fd8c56d6f7d152dd343358ed781a880ac672a30 \
+                        sha256  9faaff1e3f5a2fd3ed570a83f6fb3baf0bfc6ebd6a9abac16203d057ac3fffe3 \
+                        size    261313
 
 installs_libs           no
 


### PR DESCRIPTION
#### Description
https://github.com/jarun/nnn/releases/tag/v5.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

