### PR TITLE
postgresql16 : fix powerppc depends_build-append for perl

### DIFF
--- a/databases/postgresql16/Portfile
+++ b/databases/postgresql16/Portfile
@@ -34,17 +34,6 @@ checksums           rmd160  2b092de673595c7db5f4fbd9c9b5b81d402d5da5 \
 
 use_bzip2           yes
 
-# https://trac.macports.org/ticket/66060
-# https://trac.macports.org/ticket/67365
-# https://postgrespro.ru/list/thread-id/2551610
-# The problem is specific to PPC: https://github.com/macports/macports-ports/pull/16460
-platform darwin powerpc {
-    patchfiles-append  patch-icu.diff \
-                       patch-fix-ppc-asm.diff
-    depends_build-append \
-                        path:bin/perl:perl5
-}
-
 depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib \
                     port:libxml2 port:libxslt \
                     path:lib/pkgconfig/icu-uc.pc:icu \
@@ -55,6 +44,17 @@ depends_build       port:bison port:pkgconfig \
                     port:docbook-xml-4.5 port:docbook-xsl-nons
 depends_run         port:postgresql_select-16 \
                     path:share/curl/curl-ca-bundle.crt:certsync
+
+# https://trac.macports.org/ticket/66060
+# https://trac.macports.org/ticket/67365
+# https://postgrespro.ru/list/thread-id/2551610
+# The problem is specific to PPC: https://github.com/macports/macports-ports/pull/16460
+platform darwin powerpc {
+    patchfiles-append  patch-icu.diff \
+                       patch-fix-ppc-asm.diff
+    depends_build-append \
+                        path:bin/perl:perl5
+}
 
 legacysupport.newest_darwin_requires_legacy \
                     15


### PR DESCRIPTION
```
Changes to be committed:
	modified:   databases/postgresql16/Portfile
```
#### Description

Since the port used depends_build without -append, our powerpc chunk has no effect on dependencies requirements, and perl5 is ignored, so the clean build still fails. Either powerpc chunk should be moved below, after initial depends_build, or in both cases -append should be used.

###### Type(s)

- [x] bugfix

