### PR TITLE
qt6-qtcreator: use llvm 20 for macOS 15+

### DIFF
--- a/devel/qt6-qtcreator/Portfile
+++ b/devel/qt6-qtcreator/Portfile
@@ -7,7 +7,7 @@ PortGroup           qt6 1.0
 name                qt6-qtcreator
 
 version             16.0.0
-revision            0
+revision            1
 categories          devel aqua
 # qt creator 16.0.0 requires qt 6.5.3
 # from qt6 PortGroup:
@@ -36,14 +36,20 @@ compiler.cxx_standard \
 
 if {([vercmp ${xcodeversion} 15] >= 0)} {
     # cmake 3.29~3.31 adds -no_warn_duplicated_libraries to linker, works with xcode 15 or later
-    set llvm_version    17
+    # Do not update all versions to clang 18+ until https://trac.macports.org/ticket/72064 is resolved
+    if {${os.major} >= 24} {
+        set llvm_version    20
+    } else {
+        set llvm_version    17
+    }
 
-    set llvm_dir        ${prefix}/libexec/llvm-${llvm_version}
+    set llvm_dir            ${prefix}/libexec/llvm-${llvm_version}
 
     depends_build-append    port:llvm-${llvm_version}
     depends_lib-append      port:clang-${llvm_version}
 
-    cmake.install_rpath-append  ${llvm_dir}/lib
+    cmake.install_rpath-append \
+                            ${llvm_dir}/lib
 
     configure.compiler      macports-clang-${llvm_version}
     configure.args-append   -DLLVM_DIR=${llvm_dir}/lib/cmake/llvm \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
