### PR TITLE
zizmor: Update to 1.5.2

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        woodruffw zizmor 1.5.1 v
+github.setup        woodruffw zizmor 1.5.2 v
 github.tarball_from archive
 revision            0
 
@@ -20,9 +20,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  5de1427e779ecd81d2060f1bbdf0e06102bfa432 \
-                    sha256  80d5a483a56601a6ad224dace459f303d0ca304c182d22f37ae157c1e8c7e2b4 \
-                    size    287436
+                    rmd160  fd78bc3b8937115d407d1e1cb6aae5d10ae53f94 \
+                    sha256  9789dca47e36ac8c124be5856c38acfac6169839c7fb3a0ce492776e47f1d880 \
+                    size    291839
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -60,10 +60,10 @@ cargo.crates \
     camino                              1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
     cc                                 1.2.16  be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c \
     cfg-if                              1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    clap                               4.5.31  027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767 \
+    clap                               4.5.32  6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83 \
     clap-verbosity-flag                 3.0.2  2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84 \
-    clap_builder                       4.5.31  5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863 \
-    clap_derive                        4.5.28  bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed \
+    clap_builder                       4.5.32  22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8 \
+    clap_derive                        4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     colorchoice                         1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     console                            0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
@@ -134,7 +134,7 @@ cargo.crates \
     idna                                1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                        1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                             0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
-    indexmap                            2.7.1  8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652 \
+    indexmap                            2.8.0  3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058 \
     indicatif                         0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
     insta                              1.42.2  50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084 \
     inventory                          0.3.15  f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767 \
@@ -142,7 +142,7 @@ cargo.crates \
     is_terminal_polyfill               1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                          0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                               1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
-    js-sys                             0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
+    js-sys                             0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
     lazy_static                         1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     libc                              0.2.169  b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a \
     libredox                            0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
@@ -202,7 +202,7 @@ cargo.crates \
     regex-automata                      0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                       0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    reqwest                           0.12.12  43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da \
+    reqwest                           0.12.14  989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254 \
     reqwest-middleware                  0.4.1  64e8975513bd9a7a43aad01030e79b3498e05db14e9d945df6483e8cf9b8c4c4 \
     ring                              0.17.13  70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee \
     rustc-demangle                     0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
@@ -264,7 +264,7 @@ cargo.crates \
     tinystr                             0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                             1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                      0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                              1.44.0  9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a \
+    tokio                              1.44.1  f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a \
     tokio-macros                        2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-rustls                       0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
     tokio-stream                       0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
@@ -280,10 +280,10 @@ cargo.crates \
     tracing-indicatif                   0.3.9  8201ca430e0cd893ef978226fd3516c06d9c494181c8bf4e5b32e30ed4b40aa1 \
     tracing-log                         0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber                 0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
-    tree-sitter                        0.24.7  a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75 \
+    tree-sitter                        0.25.3  b9ac5ea5e7f2f1700842ec071401010b9c59bf735295f6e9fa079c3dc035b167 \
     tree-sitter-bash                   0.23.3  329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e \
     tree-sitter-language                0.1.2  e8ddffe35a0e5eeeadf13ff7350af564c6e73993a24db62caee1822b185c2600 \
-    tree-sitter-powershell             0.24.5  1b6e2ce7339aafe36e69428d91d295cdf4ef6ba1ee5cc5dc8715dcbbc417cbc3 \
+    tree-sitter-powershell             0.25.2  377974a9bbd11ef11aa298d60def669f78b579d11745066a59bc4167e53d360b \
     tree-sitter-yaml                    0.7.0  d0c99f2b92b677f1a18b6b232fa9329afb5758118238a7d0b29cae324ef50d5e \
     try-lock                            0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     typed-builder                      0.20.0  7e14ed59dc8b7b26cacb2a92bad2e8b1f098806063898ab42a3bd121d7d45e75 \
@@ -310,12 +310,12 @@ cargo.crates \
     walkdir                             2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                                0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi        0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                       0.2.95  128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e \
-    wasm-bindgen-backend               0.2.95  cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358 \
+    wasm-bindgen                      0.2.100  1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
+    wasm-bindgen-backend              0.2.100  2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
     wasm-bindgen-futures               0.4.45  cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b \
-    wasm-bindgen-macro                 0.2.95  e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56 \
-    wasm-bindgen-macro-support         0.2.95  26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68 \
-    wasm-bindgen-shared                0.2.95  65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d \
+    wasm-bindgen-macro                0.2.100  7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407 \
+    wasm-bindgen-macro-support        0.2.100  8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de \
+    wasm-bindgen-shared               0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
     web-sys                            0.3.72  f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112 \
     web-time                            1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                       0.26.6  841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958 \
@@ -327,25 +327,37 @@ cargo.crates \
     windows-core                       0.58.0  6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99 \
     windows-implement                  0.58.0  2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b \
     windows-interface                  0.58.0  053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515 \
-    windows-registry                    0.2.0  e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0 \
+    windows-link                        0.1.0  6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3 \
+    windows-registry                    0.4.0  4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3 \
     windows-result                      0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
+    windows-result                      0.3.1  06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189 \
     windows-strings                     0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
+    windows-strings                     0.3.1  87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319 \
     windows-sys                        0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                        0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-targets                    0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-targets                    0.53.0  b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b \
     windows_aarch64_gnullvm            0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_gnullvm            0.53.0  86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
     windows_aarch64_msvc               0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_aarch64_msvc               0.53.0  c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c \
     windows_i686_gnu                   0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnu                   0.53.0  c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3 \
     windows_i686_gnullvm               0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_gnullvm               0.53.0  9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11 \
     windows_i686_msvc                  0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_i686_msvc                  0.53.0  581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d \
     windows_x86_64_gnu                 0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnu                 0.53.0  2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba \
     windows_x86_64_gnullvm             0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_gnullvm             0.53.0  0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
     windows_x86_64_msvc                0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
+    windows_x86_64_msvc                0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
     write16                             1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                           0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     xattr                               1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
     xxhash-rust                        0.8.12  6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984 \
-    yamlpath                           0.14.0  e41a4009f1260c7a08b722f096be598c00e3e0aa13f9bed662282acb5d2dbfa5 \
+    yamlpath                           0.15.0  796a3f441fd5a8d00a2dac6ca0ce0f0b07b7e1997e014a32d4f17a9d39fbdc9f \
     yansi                               1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                         0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.5.2

##### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
