### PR TITLE
Fixed PHP 7 not found some symbols in dns.o problem when build

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -350,6 +350,8 @@ if {[is_sapi_subport]} {
         # JSON support is always on as of PHP 8.
         # https://github.com/php/php-src/pull/5495
         configure.args-append   --enable-json
+
+        configure.args-append   EXTRA_LIBS=-lresolv
     }
 
     if {[vercmp ${branch} < 7.4]} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

I got this error when build PHP 7.4 in my system :

```bash
"_res_9_dn_expand", referenced from:
      _php_parserr in dns.o
      _php_parserr in dns.o
      _php_parserr in dns.o
      _php_parserr in dns.o
      _php_parserr in dns.o
      _php_parserr in dns.o
      _zif_dns_get_mx in dns.o
      ...
  "_res_9_dn_skipname", referenced from:
      _zif_dns_get_record in dns.o
      _zif_dns_get_mx in dns.o
      _zif_dns_get_mx in dns.o
  "_res_9_init", referenced from:
      _zif_dns_check_record in dns.o
      _zif_dns_get_record in dns.o
      _zif_dns_get_mx in dns.o
  "_res_9_search", referenced from:
      _zif_dns_check_record in dns.o
      _zif_dns_get_record in dns.o
      _zif_dns_get_mx in dns.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This change `configure.args-append EXTRA_LIBS=-lresolv` can add `-lresolv` to `EXTRA_LIBS` in generated `Makefile` file.

After that, the compile with no error and PHP binary works well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3.2 24D81 x86_64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
