### PR TITLE
mani: Update to 0.30.1

### DIFF
--- a/devel/mani/Portfile
+++ b/devel/mani/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/alajmo/mani 0.30.0 v
-revision            1
+go.setup            github.com/alajmo/mani 0.30.1 v
+revision            0
 
 homepage            https://manicli.com
 
@@ -24,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  04d75d17aedf2f58516d4968dfe6d390626c267e \
-                    sha256  c7b28ad1f58b862babd0aac8c47f71f3a06cb041056210290629de598823cf60 \
-                    size    923014
+checksums           rmd160  bdbd0ffbafb6235b36da2c2781575c25ea46ecdc \
+                    sha256  a75984fda15ac431424964fe0a1d2c936e123583f2482eb3147c1ef20ba85c80 \
+                    size    924900
 
 # Allow Go to fetch deps at build time
 go.offline_build no


### PR DESCRIPTION
#### Description

mani: Update to 0.30.1

##### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
