### PR TITLE
sshuttle: update to 1.3.1

### DIFF
--- a/net/sshuttle/Portfile
+++ b/net/sshuttle/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                sshuttle
-version             1.3.0
+version             1.3.1
 revision            0
 
 homepage            https://sshuttle.readthedocs.io/en/stable
@@ -21,12 +21,12 @@ supported_archs     noarch
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  95617793ad03fe37cd4375b367ac5c23db16ce00 \
-                    sha256  57af147d4c8d2fe978cbb2b8611aaee6a3521004e52650a85c7a82cd09c96224 \
-                    size    69755
+checksums           rmd160  3c40bdb321f6265abfc0e0d84f20accbf2bf375b \
+                    sha256  04c2b16164b4b2b5945ff17c4556a8a2f0d63fb1ea2ca032748f047852ff2fcb \
+                    size    166795
 
 python.default_version \
-                    312
+                    313
 
 test.run            yes
 test.env            PYTHONPATH=${worksrcpath}/build/lib
@@ -42,4 +42,4 @@ depends_test-append port:py${python.version}-flake8 \
                     port:py${python.version}-pytest-cov \
                     port:py${python.version}-pytest-runner
 
-python.pep517_backend poetry
+python.pep517_backend hatch


### PR DESCRIPTION
#### Description
https://github.com/sshuttle/sshuttle/releases/tag/v1.3.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
