### PR TITLE
pinact: New Port

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -1,0 +1,174 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/suzuki-shunsuke/pinact 2.2.0 v
+categories          security
+maintainers         {macports.halostatue.ca:austin @halostatue} \
+                    openmaintainer
+license             MIT
+
+description         A CLI to edit GitHub Workflow and Composite action files and pin \
+                    versions of Actions and Reusable Workflows. pinact can also update \
+                    their versions and verify version annotations.
+
+long_description    {*}${description}
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  376eaf6e2d61ca072f6142ee5d1cddae02cbecf1 \
+                    sha256  047745c193add771fb49f16dcfa49f7f186eb74b510296faf49b33a04a760090 \
+                    size    33143
+
+build.args-append   -ldflags \"-X main.version=${version} -X main.commit=MacPorts \" \
+                    ./cmd/pinact
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
+                    gopkg.in/check.v1 \
+                        lock    20d25e280405 \
+                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
+                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
+                        size    30360 \
+                    golang.org/x/text \
+                        lock    v0.23.0 \
+                        rmd160  febd99ac1a9d727290c467b44d1e4b6b90cf7c7d \
+                        sha256  fe8e1d49b2c470afa75311e5336594399227ddbb272cb0fb3dbef77efea30d63 \
+                        size    8974449 \
+                    golang.org/x/sys \
+                        lock    v0.29.0 \
+                        rmd160  0e6e5b718d234eea0fe889a67ce06d5ecd1be27d \
+                        sha256  ec9757aa9994bbc9a94472b49e3258eb2384d5c0c1c5e70c0bb945643fcba0f8 \
+                        size    1520458 \
+                    golang.org/x/oauth2 \
+                        lock    v0.28.0 \
+                        rmd160  784167167d978ec8e104f9cc638911d2488e52d4 \
+                        sha256  4ab29fbe50a6ab7bf9b12c85ab220b686187cdc643cbc21ed7096d0365955962 \
+                        size    98950 \
+                    github.com/xrash/smetrics \
+                        lock    686a1a2994c1 \
+                        rmd160  6eeddadc807945dd735d28b8e19a239a242d5ae4 \
+                        sha256  ad89cc64ab0ee4f8c8364b85027e507ce99a8e1a5d0ccda24c623be30757d918 \
+                        size    1823558 \
+                    github.com/wk8/go-ordered-map \
+                        lock    v2.1.8 \
+                        rmd160  3b679491f631b4900bfe3169517517b2731ebc35 \
+                        sha256  c7caff4ba164feeebdcc568d6598931a20719827e05dfa18ac7d7c495d36b883 \
+                        size    20797 \
+                    github.com/urfave/cli \
+                        lock    v2.27.6 \
+                        rmd160  955b534f7cc0bea403b138abd970aa81be0ea6d5 \
+                        sha256  0e68631caf7c4036f0cfc76fe9b36c3b76c4e485f85522e8d98499cca62559b6 \
+                        size    3485878 \
+                    github.com/suzuki-shunsuke/urfave-cli-help-all \
+                        lock    v0.0.4 \
+                        rmd160  ae41c42234d097b0b99e35d5be4945d93c0968e0 \
+                        sha256  0b7e83a6c6a8f40e374482f934df755492c0b5a309a02156fea1c0d9bff7cdd1 \
+                        size    6618 \
+                    github.com/suzuki-shunsuke/logrus-error \
+                        lock    v0.1.4 \
+                        rmd160  d52b0d1f07e0dde083a4deaea70d508880b724ba \
+                        sha256  41821b89bbdd6d73f2409d19f18cafac37e1f0830f0b8aa1867d780e71e99005 \
+                        size    5633 \
+                    github.com/suzuki-shunsuke/gen-go-jsonschema \
+                        lock    v0.1.0 \
+                        rmd160  ad4db317220fdeaef681a946073b64a7d352c1cb \
+                        sha256  c3383e9717a250e17c28de4845564d299ae7aa2160175169213f85647ebb1b35 \
+                        size    2506 \
+                    github.com/stretchr/testify \
+                        lock    v1.8.1 \
+                        rmd160  4d80635834e01b3ddb67babdd8de2eac2c5a7587 \
+                        sha256  9848272e238f98fc0555b514c4522e70c4df25331b4ee3f9cb9244a04935934e \
+                        size    97722 \
+                    github.com/spf13/afero \
+                        lock    v1.14.0 \
+                        rmd160  95180c509220d8ffdd6cfd9f9ca708ae3be7b1a5 \
+                        sha256  880c030de2ca2e4652a6d6cb3e17b14fe9a096077c8f0b5858bad0bfdca279f5 \
+                        size    93470 \
+                    github.com/sirupsen/logrus \
+                        lock    v1.9.3 \
+                        rmd160  db211aeb52d4a85a7dc8acf83f7475b5f4fa9092 \
+                        sha256  36a05391b8c6cef99e9a9c78b598f3a8da8feed318b385eadcdede08ae5cc229 \
+                        size    50327 \
+                    github.com/russross/blackfriday \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.20 \
+                        rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
+                        sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
+                        size    4717 \
+                    github.com/mattn/go-colorable \
+                        lock    v0.1.14 \
+                        rmd160  5b6117d2728f6478faf0be5b8790425fed6c4ad8 \
+                        sha256  6661917405b168f0c8b92a2be524e668ee1c29b393353639453cb8f9c2f7eff8 \
+                        size    9806 \
+                    github.com/mailru/easyjson \
+                        lock    v0.7.7 \
+                        rmd160  f40deae988781d59d399784445dc89fe84d69e37 \
+                        sha256  05481ab8b5f3709d4bd49b5459159b32856f426f021225774db000ec15792f2e \
+                        size    81411 \
+                    github.com/invopop/jsonschema \
+                        lock    v0.12.0 \
+                        rmd160  7e00a8f7d77808fd32c5718be18fa7963f982563 \
+                        sha256  31186f3d574b69f010532031dfa998c74be6e75935bea4252e4d24e70718a658 \
+                        size    32648 \
+                    github.com/hashicorp/go-version \
+                        lock    v1.7.0 \
+                        rmd160  f17baae769838015801830335bfd94a0849cd21f \
+                        sha256  70f6404c7d3d3dc84133e1e9870af211c526934cc49cabe1965ddd8982554cb7 \
+                        size    17088 \
+                    github.com/google/go-querystring \
+                        lock    v1.1.0 \
+                        rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
+                        sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
+                        size    10418 \
+                    github.com/google/go-github \
+                        lock    v70.0.0 \
+                        rmd160  d45ed31d1e506a35db5fec7b5b93cd988baa251f \
+                        sha256  1198d39a659059bddb72c0f682ec2ec4bd552c5eb7e369547b142dd378543bef \
+                        size    813286 \
+                    github.com/google/go-cmp \
+                        lock    v0.7.0 \
+                        rmd160  3f04a79c291d786f9c69c2944bdd521402052a5c \
+                        sha256  b621b304b529134076c9ebe09343aea7add039cd98e68be7e5a616245b0c3d03 \
+                        size    105180 \
+                    github.com/goccy/go-yaml \
+                        lock    v1.16.0 \
+                        rmd160  32f99e42845951f54bbc020ee4a0ebfcf5e176a2 \
+                        sha256  a635fd772a17d128f444f8d254d39ed7893f3ae10a912292d2bef0cacb75f924 \
+                        size    662220 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/cpuguy83/go-md2man \
+                        lock    v2.0.5 \
+                        rmd160  9af69f242ce0d508cc132b933960356f7c763b31 \
+                        sha256  ebb019c79ca6b8f331d256fe63eb7bb549b1b15fdfb7eb4f168969966df05734 \
+                        size    10941 \
+                    github.com/buger/jsonparser \
+                        lock    v1.1.1 \
+                        rmd160  35ad9d7a60f9fec3b2eb38c0b2f0268e421a0a5e \
+                        sha256  58868e15252ce4fd3a67233481fa55ba5b37c85257d8c6aec230e69abfab096f \
+                        size    55225 \
+                    github.com/bahlo/generic-list-go \
+                        lock    v0.2.0 \
+                        rmd160  da4b9f58b6734da97644fb565c81d1bc01ccd7f7 \
+                        sha256  aaa6a0719258985eddfa488155edd6a749c070a998d91c48182138115f5de069 \
+                        size    5054


### PR DESCRIPTION
#### Description

pinact is a CLI to edit GitHub Workflow and Composite action files and
pin versions of Actions and Reusable Workflows. pinact can also update
their versions and verify version annotations.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
