### PR TITLE
google-cloud-sdk: update to 516.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             515.0.0
+version             516.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  9737516b261573128801be7629c9d8d4dfe61f90 \
-                    sha256  baa4f519e88880030ef47112255282024fff1e30603d7b54d05148d429b33725 \
-                    size    54191620
+    checksums       rmd160  09d48e0703db1406d7059550751ce37b98f08bac \
+                    sha256  a52b5b58da4b91add5634f59a0f7dcdef49567a3b5fe65ae9db1d750b6585921 \
+                    size    54252010
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  22fb229354732184cebb420bd32c55db38a42d8a \
-                    sha256  e74fe91bda20a464d9e69d5874bcd2713eb4a0ef591cbe8749ed41eb9787d229 \
-                    size    55659388
+    checksums       rmd160  3a11dea5b45155e2004d5a2901195bbd23f4dec6 \
+                    sha256  af0d2ef3231a3e2581a1b18f74d754a0345b63389428cc29e1a4059931fa7836 \
+                    size    55720024
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  3a54a30956963ea0c9aa3be63792ee4e0d071fcc \
-                    sha256  e2b0913dbf1d47c79b956902007094b9aacab74eb1ce336e642cfc4c1f4155f4 \
-                    size    55596506
+    checksums       rmd160  415de24b686bfdf2095d1a6b36d687bc3e1e567c \
+                    sha256  ac7e1a3d9db90e6dd2543921f2be0acc797757c885f6f4bebf912ee77ab8a976 \
+                    size    55656307
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 516.0.0.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?