### PR TITLE
netcdf: removed reference to obsolete patch

### DIFF
--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -77,7 +77,6 @@ variant netcdf4 description {enable support for netcdf-4 API} {
 variant hdf4 description {enable support for hdf4} {
     depends_lib-append      port:hdf4 \
                             path:include/turbojpeg.h:libjpeg-turbo
-    patchfiles-append       patch-liblib-CMakeLists.txt.diff
     configure.args-append   -DENABLE_HDF4=ON
 }
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/72243

#### Description

Removed from the Portfile the reference to an already deleted obsolete patch.
This only applied to the `+hdf4` option.
Since the build for this failed, no need to revbump.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.2 24D81 x86_64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
