### PR TITLE
uv: Update to 0.6.10

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -10,7 +10,7 @@ PortGroup               github 1.0
 #
 # See: https://github.com/macports/macports-ports/pull/27661#issuecomment-2660783907
 
-github.setup            astral-sh uv 0.6.1
+github.setup            astral-sh uv 0.6.10
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -22,16 +22,16 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  15138ae5b52a31946620d858e3c06052e190e0c4 \
-                        sha256  70118971a2b6b7b6ac8e028b2505178b6a75ae77c314a60ff8403645e1ef7d78 \
-                        size    3556201
+                        rmd160  73d71237abb656453253f60df073894643f31bc0 \
+                        sha256  cc32718b4cb84952a6d2ab1df670b61b002c8ca7f96d2c435ca11293dbd043e5 \
+                        size    3816981
 
 # Fix opportunistic linking with libiconv and xz
 #
 # Ideally, the rust PG should handle any opportunistic linking with
 # MacPorts' libiconv, but that's a ticket that someone else should
-# open. Almost any Rust port links with libiconv, so it should be a
-# depends_lib, not a depends_build.
+# open. Almost any Rust port links with libiconv for some unknown
+# reason, so it has to be manually specified for right now.
 depends_build-append    path:bin/pkg-config:pkgconfig
 depends_lib-append      port:xz \
                         port:libiconv
@@ -106,17 +106,18 @@ cargo.crates \
     anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                   3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
-    anyhow                          1.0.95  34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04 \
+    anyhow                          1.0.97  dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f \
+    arbitrary                        1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arcstr                           1.2.0  03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d \
     arrayref                         0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     assert_cmd                      2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     assert_fs                        1.1.2  7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674 \
-    astral-tokio-tar                 0.5.1  65152cbda42e8ab5ecff69e8811e8333d69188c7d5c41e3eedb8d127e3f23b27 \
+    astral-tokio-tar                 0.5.2  1abb2bfba199d9ec4759b797115ba6ae435bdd920ce99783bb53aeff57ba919b \
     async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
     async-compression               0.4.18  df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522 \
-    async-trait                     0.1.86  644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d \
+    async-trait                     0.1.88  e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
     async_http_range_reader          0.9.1  2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
@@ -124,15 +125,15 @@ cargo.crates \
     axoprocess                       0.2.0  4de46920588aef95658797996130bacd542436aee090084646521260a74bda7d \
     axotag                           0.2.0  d888fac0b73e64cbdf36a743fc5a25af5ae955c357535cb420b389bf1e1a6c54 \
     axoupdater                       0.9.0  bc194af960a8ddbc4f28be3fa14f8716aa22141fe40bf1762ae0948defadcce4 \
-    backon                           1.3.0  ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7 \
+    backon                           1.4.1  970d91570c01a8a5959b36ad7dd1c30642df24b6b3068710066f6809f7033bb7 \
     backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     bisection                        0.1.0  021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                         2.8.0  8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36 \
+    bitflags                         2.9.0  5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    boxcar                           0.2.9  b18a28f3926aa80dd1eeccb27b1ac5cfab9e823459fe0a7ba60366f5d983b413 \
+    boxcar                          0.2.11  6740c6e2fc6360fa57c35214c7493826aee95993926092606f27c983b40837be \
     bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
     bumpalo                         3.17.0  1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf \
     bytecheck                        0.8.1  50690fb3370fb9fe3550372746084c46f2ac8c9685c583d2be10eefd89d3d1a3 \
@@ -144,7 +145,7 @@ cargo.crates \
     bzip2                            0.4.4  bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8 \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     camino                           1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
-    cargo-util                      0.2.17  7cccd15f96a29696e13e1d5fa10dd1dbed2e172f58b6e6124a9a4fa695363fdd \
+    cargo-util                      0.2.18  932c5376dc904ef005f0d229a5edc1116f40a78a18d30cdc992ec5acbeffd4d9 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     cc                              1.2.11  e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
@@ -153,22 +154,21 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.29  8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184 \
-    clap_builder                    4.5.29  f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9 \
+    clap                            4.5.32  6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83 \
+    clap_builder                    4.5.32  22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8 \
     clap_complete                   4.5.44  375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.5  c6a8b1593457dfc2fe539002b795710d022dc62a65bf15023f039f9760c7b18a \
-    clap_derive                     4.5.28  bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed \
+    clap_derive                     4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
-    cmake                           0.1.53  e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6 \
-    codspeed                         2.8.0  25d2f5a6570db487f5258e0bded6352fa2034c2aeb46bb5cc3ff060a0fcfba2f \
-    codspeed-criterion-compat        2.8.0  f53a55558dedec742b14aae3c5fec389361b8b5ca28c1aadf09dd91faf710074 \
+    codspeed                         2.8.1  de4b67ff8985f3993f06167d71cf4aec178b0a1580f91a987170c59d60021103 \
+    codspeed-criterion-compat        2.8.1  68403d768ed1def18a87e2306676781314448393ecf0d3057c4527cabf524a3d \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     colored                          2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
     concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     configparser                     3.1.0  e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b \
-    console                        0.15.10  ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b \
+    console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
     core-foundation                 0.10.0  b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
@@ -188,6 +188,7 @@ cargo.crates \
     data-url                         0.2.0  8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5 \
     deadpool                        0.10.0  fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490 \
     deadpool-runtime                 0.1.4  092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b \
+    derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
@@ -198,7 +199,7 @@ cargo.crates \
     dotenvy                         0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.17  0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125 \
-    either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
+    either                          1.14.0  b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d \
     encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     encoding_rs_io                   0.1.7  1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83 \
@@ -206,14 +207,14 @@ cargo.crates \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     erased-serde                     0.4.5  24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d \
     errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
-    etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
+    etcetera                         0.9.0  5d14b66eac142247efb8561051ff0fb3d3f58a09801a541b89f46dcc4cc67b84 \
     event-listener                   5.4.0  3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae \
     event-listener-strategy          0.5.3  3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2 \
     fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     fdeflate                         0.3.7  1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     fixedbitset                      0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
-    flate2                          1.0.35  c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c \
+    flate2                           1.1.0  11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc \
     float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
     float-cmp                       0.10.0  b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
@@ -241,7 +242,7 @@ cargo.crates \
     gif                             0.12.0  80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045 \
     gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
-    globset                         0.4.15  15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19 \
+    globset                         0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     gloo-timers                      0.3.0  bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994 \
     goblin                           0.9.3  daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745 \
@@ -253,12 +254,12 @@ cargo.crates \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    home                            0.5.11  589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf \
+    home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
     homedir                          0.3.4  5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2 \
     html-escape                     0.2.13  6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476 \
     http                             1.2.0  f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
-    http-body-util                   0.1.2  793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f \
+    http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     http-content-range               0.2.1  b4aa8e0a9f1496d70bdd43b1e30ff373857c952609ad64b89f50569cfb8cbfca \
     httparse                        1.10.0  f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
@@ -282,8 +283,8 @@ cargo.crates \
     imagesize                       0.11.0  b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf \
     indexmap                         2.7.1  8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652 \
     indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
-    indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
-    insta                           1.42.1  71c1b125e30d93896b365e156c33dadfffab45ee8400afcbba4752f59de08a86 \
+    indoc                            2.0.6  f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
+    insta                           1.42.2  50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084 \
     instant                         0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
     ipnet                           2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
     is-terminal                     0.4.15  e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37 \
@@ -293,9 +294,10 @@ cargo.crates \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
-    jiff                             0.2.1  3590fea8e9e22d449600c9bbd481a8163bef223e4ff938e5f55899f8cf1adb93 \
-    jiff-tzdb                        0.1.2  cf2cec2f5d266af45a071ece48b1fb89f3b00b2421ac3a5fe10285a6caaa60d3 \
-    jiff-tzdb-platform               0.1.2  a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e \
+    jiff                             0.2.5  c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260 \
+    jiff-static                      0.2.5  4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c \
+    jiff-tzdb                        0.1.4  c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524 \
+    jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jpeg-decoder                     0.3.1  f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0 \
     js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
@@ -306,16 +308,17 @@ cargo.crates \
     libc                           0.2.169  b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a \
     libmimalloc-sys                 0.1.39  23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    libz-ng-sys                     1.1.16  4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438 \
-    libz-rs-sys                      0.4.1  a90e19106f1b2c93f1fa6cdeec2e56facbf2e403559c1e1c0ddcc6d46e979cdf \
+    libz-rs-sys                      0.4.2  902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
+    linux-raw-sys                    0.9.2  6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9 \
     litemap                          0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
+    lockfree-object-pool             0.1.6  9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e \
     log                             0.4.25  04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f \
     loom                             0.7.2  419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca \
     lzma-sys                        0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
-    mailparse                       0.16.0  cdd4a624f609f8ea7366324724b7ff41cb0f982eb665a54ac825bc1c0efc07a3 \
+    mailparse                       0.16.1  60819a97ddcb831a5614eb3b0174f3620e793e97e09195a395bfa948fd68ed2f \
     markdown                         0.3.0  ef3aab6a1d529b112695f72beec5ee80e729cb45af58663ec902c8fac764ecdd \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
@@ -327,7 +330,7 @@ cargo.crates \
     mimalloc                        0.1.43  68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     mime_guess                       2.0.5  f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e \
-    miniz_oxide                      0.8.3  b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924 \
+    miniz_oxide                      0.8.5  8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5 \
     mio                              1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
     miow                             0.6.0  359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044 \
     munge                            0.4.1  64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df \
@@ -347,7 +350,7 @@ cargo.crates \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     os_str_bytes                     6.6.1  e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
-    owo-colors                       4.1.0  fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56 \
+    owo-colors                       4.2.0  1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564 \
     parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
@@ -370,7 +373,6 @@ cargo.crates \
     pipeline                         0.5.0  d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0 \
     pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
     plain                            0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
-    platform-info                    2.0.5  7539aeb3fdd8cb4f6a331307cf71a1039cee75e94e8a71725b9484f4a0d9451a \
     png                            0.17.16  82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526 \
     poloto                          19.1.2  164dbd541c9832e92fa34452e9c2e98b515a548a3f8549fb2402fe1cd5e46b96 \
     portable-atomic                 1.10.0  280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6 \
@@ -381,7 +383,7 @@ cargo.crates \
     predicates-tree                 1.0.12  72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     priority-queue                   2.1.1  714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d \
-    proc-macro2                     1.0.93  60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99 \
+    proc-macro2                     1.0.94  a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84 \
     procfs                          0.17.0  cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f \
     procfs-core                     0.17.0  239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec \
     ptr_meta                         0.3.0  fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90 \
@@ -389,7 +391,7 @@ cargo.crates \
     quinn                           0.11.6  62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef \
     quinn-proto                     0.11.9  a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d \
     quinn-udp                        0.5.9  1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904 \
-    quote                           1.0.38  0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc \
+    quote                           1.0.40  1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
     quoted_printable                 0.5.1  640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73 \
     rancor                           0.1.0  caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
@@ -401,20 +403,20 @@ cargo.crates \
     redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
     redox_syscall                    0.5.8  03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834 \
     redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
-    reflink-copy                    0.1.23  fbd3533fd4222b8337470456ea84d80436b4c91c53db51c372461d5f7e6eb0b4 \
+    reflink-copy                    0.1.26  78c81d000a2c524133cc00d2f92f019d399e57906c3b7119271a2495354fe895 \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     rend                             0.5.2  a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215 \
-    reqwest                        0.12.12  43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da \
-    reqwest-middleware               0.4.0  d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3 \
+    reqwest                        0.12.15  d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb \
+    reqwest-middleware               0.4.1  64e8975513bd9a7a43aad01030e79b3498e05db14e9d945df6483e8cf9b8c4c4 \
     reqwest-retry                    0.7.0  29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178 \
     resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
     retry-policies                   0.4.0  5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c \
     rgb                             0.8.50  57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a \
-    ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
+    ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rkyv                            0.8.10  1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65 \
     rkyv_derive                     0.8.10  246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a \
     rmp                             0.8.14  228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4 \
@@ -426,6 +428,7 @@ cargo.crates \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
+    rustix                           1.0.1  dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657 \
     rustls                         0.23.22  9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
@@ -436,8 +439,8 @@ cargo.crates \
     ryu                             1.0.19  6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
-    schemars                        0.8.21  09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92 \
-    schemars_derive                 0.8.21  b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e \
+    schemars                        0.8.22  3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615 \
+    schemars_derive                 0.8.22  32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scroll                          0.12.0  6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6 \
@@ -447,11 +450,11 @@ cargo.crates \
     security-framework-sys          2.14.0  49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     semver                          1.0.25  f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03 \
-    serde                          1.0.217  02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70 \
-    serde-untagged                   0.1.6  2676ba99bd82f75cae5cbd2c8eda6fa0b8760f18978ea840e980dd5567b5c5b6 \
-    serde_derive                   1.0.217  5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0 \
+    serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
+    serde-untagged                   0.1.7  299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e \
+    serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
-    serde_json                     1.0.138  d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949 \
+    serde_json                     1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
@@ -470,7 +473,6 @@ cargo.crates \
     smawk                            0.3.2  b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c \
     socket2                          0.5.8  c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8 \
     spdx                            0.10.8  58b69356da67e2fc1f542c71ea7e654a361a79c938e4424392ecf4fa065d2193 \
-    spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     strict-num                       0.1.1  6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
@@ -482,15 +484,15 @@ cargo.crates \
     svgfilters                       0.4.0  639abcebc15fdc2df179f37d6f5463d660c1c79cd552c12343a4600827a04bce \
     svgtypes                         0.9.0  c9ee29c1407a5b18ccfe5f6ac82ac11bab3b14407e09c209a6c1a32098b19734 \
     svgtypes                        0.10.0  98ffacedcdcf1da6579c907279b4f3c5492fbce99fbbf227f5ed270a589c2765 \
-    syn                             2.0.98  36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1 \
+    syn                            2.0.100  b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     tagu                             0.1.6  eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a \
-    tar                             0.4.43  c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6 \
+    tar                             0.4.44  1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a \
     target-lexicon                  0.13.2  e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a \
     temp-env                         0.3.6  96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050 \
-    tempfile                        3.17.0  a40f762a77d2afa88c2d919489e390a12bdd261ed568e60cfa7e48d4e20f0d33 \
+    tempfile                        3.17.1  22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230 \
     terminal_size                    0.4.1  5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9 \
     termtree                         0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
@@ -498,11 +500,11 @@ cargo.crates \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
     test-log                        0.2.17  e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f \
     test-log-macros                 0.2.17  888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f \
-    textwrap                        0.16.1  23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9 \
+    textwrap                        0.16.2  c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.11  d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc \
+    thiserror                       2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.11  26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2 \
+    thiserror-impl                  2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tikv-jemalloc-sys 0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d \
     tikv-jemallocator                0.6.0  4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865 \
@@ -517,7 +519,7 @@ cargo.crates \
     tokio-rustls                    0.26.1  5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37 \
     tokio-socks                      0.5.2  0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f \
     tokio-stream                    0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
-    tokio-util                      0.7.13  d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078 \
+    tokio-util                      0.7.14  6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034 \
     toml                            0.8.20  cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148 \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                      0.22.24  17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474 \
@@ -587,23 +589,28 @@ cargo.crates \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     windows                         0.57.0  12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143 \
     windows                         0.58.0  dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6 \
-    windows                         0.59.0  7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1 \
+    windows                         0.61.1  c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419 \
+    windows-collections              0.2.0  3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8 \
     windows-core                    0.57.0  d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d \
     windows-core                    0.58.0  6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99 \
-    windows-core                    0.59.0  810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce \
+    windows-core                    0.61.0  4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980 \
+    windows-future                   0.2.0  7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32 \
     windows-implement               0.57.0  9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7 \
     windows-implement               0.58.0  2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b \
-    windows-implement               0.59.0  83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1 \
+    windows-implement               0.60.0  a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836 \
     windows-interface               0.57.0  29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7 \
     windows-interface               0.58.0  053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515 \
-    windows-interface               0.59.0  cb26fd936d991781ea39e87c3a27285081e3c0da5ca0fcbc02d368cc6f52ff01 \
-    windows-registry                 0.2.0  e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0 \
+    windows-interface               0.59.1  bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8 \
+    windows-link                     0.1.1  76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38 \
+    windows-numerics                 0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
     windows-registry                 0.4.0  4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3 \
+    windows-registry                 0.5.1  ad1da3e436dc7653dfdf3da67332e22bff09bb0e28b0239e1624499c7830842e \
     windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
     windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
-    windows-result                   0.3.0  d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34 \
+    windows-result                   0.3.2  c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252 \
     windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
-    windows-strings                  0.3.0  b888f919960b42ea4e11c2f408fadb55f78a9f236d5eef084103c8ce52893491 \
+    windows-strings                  0.3.1  87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319 \
+    windows-strings                  0.4.0  7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
@@ -634,10 +641,9 @@ cargo.crates \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
     winnow                           0.7.0  7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419 \
-    winreg                          0.53.0  89a47b489f8fc5b949477e89dca4d1617f162c6c53fbcbefde553ab17b342ff9 \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
-    winsafe                         0.0.22  7d6ad6cbd9c6e5144971e326303f0e453b61d82e4f72067fccf23106bccd8437 \
-    wiremock                         0.6.2  7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646 \
+    winsafe                         0.0.23  a096fc628cb2c601e13c401ca0c354806424a7f5716000d69b76044eb8e624b9 \
+    wiremock                         0.6.3  101681b74cd87b5899e87bcf5a64e83334dd313fcd3053ea72e6dba18928e301 \
     wit-bindgen-rt                  0.33.0  3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
@@ -654,8 +660,9 @@ cargo.crates \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
     zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
     zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
-    zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
-    zlib-rs                          0.4.1  aada01553a9312bad4b9569035a1f12b05e5ec9770a1a4b323757356928944f8 \
+    zip                              2.3.0  84e9a772a54b54236b9b744aaaf8d7be01b4d6e99725523cb82cb32d1c81b1d7 \
+    zlib-rs                          0.4.2  8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05 \
+    zopfli                           0.8.1  e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946 \
     zstd                            0.13.2  fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9 \
     zstd-safe                        7.2.1  54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059 \
     zstd-sys             2.0.13+zstd.1.5.6  38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.6.10. [Commit change of astral-sh/uv@`0.6.1...0.6.10`](https://github.com/astral-sh/uv/compare/0.6.1...0.6.10)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
