### PR TITLE
dagger: update to 0.17.1

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.15.1 v
+github.setup        dagger dagger 0.17.1 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  cab99c5c0762f524e42df80051078e3dc619920a \
-                            sha256  759156895c2076036837049aba208d185682b6be9e7a75bf91984fa2cb91ffbd \
-                            size    11258422
+        checksums           rmd160  b0a67cb7015adb5c2b89ca8ca7e345219465c9b6 \
+                            sha256  af941590fc982b7ad53eacd1813571763ffb4767954a7ac77837b74dbc178cb5 \
+                            size    18503591
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  f7c397dbc7c826ddf98ffbe043d5fbc64eb7b6b7 \
-                            sha256  d5f0f95690941b5845c1a4f60be8a3c8f79be18a786b6bd31354a587118cafa6 \
-                            size    10619160
+        checksums           rmd160  5fc9ded165061ddef225ed76fd03bce07bf6b10d \
+                            sha256  90ff1d9fa5403c6cd10f15268d49c01a349eb00635102440e9c7588409396200 \
+                            size    17683827
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Update to [latest release](https://github.com/dagger/dagger/releases/tag/v0.17.1).

###### Tested on
macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?