### PR TITLE
netcdf-fortran: update to 4.6.2

### DIFF
--- a/science/netcdf-fortran/Portfile
+++ b/science/netcdf-fortran/Portfile
@@ -21,10 +21,9 @@ PortGroup                   github 1.0
 #        I/O feature disabled. Abort.
 mpi.enforce_variant         netcdf
 
-github.setup                Unidata netcdf-fortran 4.6.1 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from         tarball
-revision                    5
+github.setup                Unidata netcdf-fortran 4.6.2 v
+github.tarball_from         archive
+revision                    0
 maintainers                 {takeshi @tenomoto} \
                             {@Dave-Allured noaa.gov:dave.allured} \
                             openmaintainer
@@ -42,9 +41,9 @@ long_description \
     This software package provides Fortran application interfaces \
     for accessing netCDF data.
 
-checksums           rmd160  12bf9c7ba84f60f77e7d77e069e9365bfd3c4659 \
-                    sha256  921be559e162d90370faecba7d60fa12dc4534600807a519520c277de5e7691c \
-                    size    2046635
+checksums           rmd160  010ee748868ba6349d16d179b1edb607fe9c8ce6 \
+                    sha256  44cc7b5626b0b054a8503b8fe7c1b0ac4e0a79a69dad792c212454906a9224ca \
+                    size    8087390
 
 patchfiles          patch-nf03_test4-Makefile.in.diff \
                     patch-nf-config.diff \
@@ -79,6 +78,7 @@ post-patch {
 compiler.blacklist-append \
                     {clang < 500}
 
+configure.args-append       HDF5_PLUGIN_PATH=${prefix}/hdf5/lib/plugin
 configure.cppflags-append   -DNDEBUG \
                             -DpgiFortran
 configure.cflags-append     -fno-common

--- a/science/netcdf-fortran/files/patch-nf-config.diff
+++ b/science/netcdf-fortran/files/patch-nf-config.diff
@@ -20,24 +20,3 @@
  version="@PACKAGE_NAME@ @PACKAGE_VERSION@"
  
  usage()
---- nf-config.cmake.in.orig	2023-05-19 22:19:16
-+++ nf-config.cmake.in	2023-09-19 18:40:21
-@@ -12,15 +12,15 @@
- #
- cc="@CMAKE_C_COMPILER@"
- fc="@CMAKE_Fortran_COMPILER@"
--cflags="-I@CMAKE_INSTALL_PREFIX@/include @CMAKE_C_FLAGS@ @CMAKE_CPP_FLAGS@"
--fflags="-I${includedir} @MOD_FLAG@${fmoddir}"
-+cflags="-I${includedir}"
-+fflags="-I${includedir}"
- #
- has_dap="@HAS_DAP@"
- has_nc2="@HAS_NC2@"
- has_nc4="@HAS_NC4@"
- has_f90="@HAS_F90@"
- has_f03="@HAS_F03@"
--flibs="-L${libdir} @NC_FLIBS@"
-+flibs="-L${libdir} -lnetcdff"
- version="@PACKAGE_NAME@ @PACKAGE_VERSION@"
- 
-  usage()


### PR DESCRIPTION
#### Description

Update to upstream version 4.6.2

* Changes `tarball` to `archive` as requested in Portfile
* Ensures that `zstd` is supported when it is so in `netcdf`
* Removes part of patch as original file has been removed

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.2 24D81 x86_64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
