### PR TITLE
fpc: fix building for macOS 15 and x86_64

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -82,6 +82,11 @@ if {${os.platform} eq "darwin" && ${os.major} >= 22} { # macOS 13, Ventura
     patchfiles-append   t_darwin.pas.patch
 }
 
+if {${os.platform} eq "darwin" && ${os.major} >= 24 && ${build_arch} eq "x86_64"} { # macOS 15, Sequoia
+# this fix will be part of version 3.2.4
+    patchfiles-append   rautils.patch
+}
+
 subport "chmcmd-${name}" {
     revision        0
 

--- a/lang/fpc/files/rautils.patch
+++ b/lang/fpc/files/rautils.patch
@@ -1,0 +1,14 @@
+--- rautils-orig.pas	2024-11-17 18:37:53
++++ rautils.pas	2025-03-28 01:01:27
+@@ -1781,6 +1781,11 @@
+       begin
+         if symtablestack.top.symtablelevel<>srsymtable.symtablelevel then
+           begin
++{$ifndef LLVM}
++            { LLVM compiler requires that the static label RawThunkEnd
++             in packages/rtl-objpas/src/rtti.pp unit is set to nonlocal }
++            if (srsymtable.symtabletype=globalsymtable) or create_smartlink_library then
++{$endif LLVM}
+             Tlabelsym(sym).nonlocal:=true;
+             if emit then
+               include(current_procinfo.flags,pi_has_interproclabel);


### PR DESCRIPTION
#### Description

fix taking from this commit:
https://gitlab.com/freepascal.org/fpc/source/-/commit/e749c81040070d3e8cb0c070e6e63f2f9b54fef4
Expected to be part of version 3.2.4


###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
