### PR TITLE
Drop maintainership for muchsync & notmuch

### DIFF
--- a/mail/muchsync/Portfile
+++ b/mail/muchsync/Portfile
@@ -7,7 +7,7 @@ version             7
 categories          mail
 platforms           darwin
 license             GPL-2+
-maintainers         {seichter.de:macports @rseichter} openmaintainer
+maintainers         nomaintainer
 description         Synchronize mail messages and notmuch tags across machines.
 long_description    Muchsync brings Notmuch to all of your computers by \
                     synchronizing your mail messages and Notmuch tags across \

--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -13,7 +13,7 @@ checksums           rmd160  5dec7b4dc2db2c731ad106ab1f15c6b911fb4a40 \
 
 categories          mail
 license             GPL-3+
-maintainers         {seichter.de:macports @rseichter} openmaintainer
+maintainers         nomaintainer
 description         Fast, global-search and tag-based email system
 long_description    \"Not much mail\" is what Notmuch thinks about your email \
                     collection, even if you receive 12000 messages per month or have on the \


### PR DESCRIPTION
Drop out of maintainership for the `muchsync` and `notmuch` ports. No other changes are included in this pull request.