### PR TITLE
net/cidr: Update master_sites, homepage

### DIFF
--- a/net/cidr/Portfile
+++ b/net/cidr/Portfile
@@ -1,7 +1,12 @@
-PortSystem          1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name                cidr
-version             2.3.2
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        404NotGone cidr 2.3.2
+revision            1
+
 categories          net
 license             GPL-2+
 maintainers         nomaintainer
@@ -13,26 +18,17 @@ long_description \
    outputs the network address, broadcast address, and a count (and \
    optionally a list) of valid host addresses for the corresponding subnet.
 
-platforms            darwin
-
-# This no longer works, but is here for whatever needs...
-homepage             http://geeksoul.com/robert/cidr.html
-master_sites         http://critical.ch/distfiles/ \
-                     http://energy.critical.ch/distfiles/
-
-checksums            md5 b349453a0196fddd3ffa0af5fbbacf54
-
-use_configure        no
+checksums           rmd160  5b46cedace27dc7dfa958426194c8e6e38d71466 \
+                    sha256  e2ea8dd2d79c39140d12d71e515014b086b275286c36c50a1df277401fc147fe \
+                    size    17675
 
 destroot {
-   xinstall -m 755 -d ${destroot}${prefix}/bin \
+   xinstall -m 0755 -d ${destroot}${prefix}/bin \
       ${destroot}${prefix}/share/man/man1 \
       ${destroot}${prefix}/share/doc/${name}
-   xinstall -m 755 -W ${worksrcpath} ${name} ${destroot}${prefix}/bin/
-   xinstall -m 644 -W ${worksrcpath} ${name}.1 \
+   xinstall -m 0755 -W ${worksrcpath} ${name} ${destroot}${prefix}/bin/
+   xinstall -m 0644 -W ${worksrcpath} ${name}.1 \
       ${destroot}${prefix}/share/man/man1/
-   xinstall -m 644 -W ${worksrcpath} README gpl.txt rfc1878.txt \
+   xinstall -m 0644 -W ${worksrcpath} README gpl.txt rfc1878.txt \
       ${destroot}${prefix}/share/doc/${name}/
 }
-
-livecheck.type      none


### PR DESCRIPTION
The homepage and the distfile from the master_sites are no longer available. Update them to a reliable mirror on github.