### PR TITLE
buf: new Portfile

### DIFF
--- a/devel/buf/Portfile
+++ b/devel/buf/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/bufbuild/buf 1.50.1 v
+go.offline_build    no
+revision            0
+
+categories          devel
+license             Apache-2
+maintainers         @mikaoj openmaintainer
+description         Buf is a tool for working with Protocol Buffers.
+long_description    The Buf CLI is a helpful tool for managing Protobuf schemas. \
+                    It offers various features, including code generation, breaking change detection, linting, and formatting, \
+                    to assist with Protobuf development and maintenance. \
+                    It works with your choice of plugins and languages and gives you access to a vast library of certified plugins in the Buf Schema Registry.
+homepage            https://buf.build/
+
+checksums           rmd160  be72fcd551d797aeb73f26060569c282e383e785 \
+                    sha256  2dc0e7eae6a9cc206de4421162e0f5895b9488a1614b8bf30eebd5588cd08df5 \
+                    size    1590934
+
+build.args-append   -trimpath ./cmd/buf
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/buf ${destroot}${prefix}/bin/buf
+}
+


### PR DESCRIPTION
#### Description
Added a new port for Buf, a tool for working with Protocol Buffers.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
