### PR TITLE
dart-sass: update to 1.86.3

### DIFF
--- a/www/dart-sass/Portfile
+++ b/www/dart-sass/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        sass dart-sass 1.57.1
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        sass dart-sass 1.86.3
+github.tarball_from archive
 categories          www textproc
 supported_archs     x86_64 arm64
 license             MIT
@@ -16,16 +15,16 @@ long_description    Dart Sass is the primary implementation of Sass, which means
                     easy to install, and it compiles to pure JavaScript which makes it \
                     easy to integrate into modern web development workflows.
 homepage            https://sass-lang.com/dart-sass
-
-checksums           rmd160  1b34fea3af9ecce52eb390b19f93e6af3fac130b \
-                    sha256  7c7c97f2cdc45f53eaa9bd118c6a4635047fa2937e8e5856798660fdac739226 \
-                    size    411329
+checksums           rmd160  044117f24274bcd26cf0ad98b26837f91ba9e1e8 \
+                    sha256  b168902cfed5560084f86d3f8a1a9c13fc31ed840644b1ca8a20975f94e21cd0 \
+                    size    729880
 
 use_configure       no
 
-depends_build       port:dart-sdk
+depends_build       port:dart-sdk port:buf
 build               {
     system -W ${worksrcpath} "dart pub get"
+    system -W ${worksrcpath} "dart run grinder protobuf"
     system -W ${worksrcpath} "dart compile exe -Dversion=${version} bin/sass.dart"
 }
 


### PR DESCRIPTION
#### Description

Updates dart-sass to 1.86.3

Requires new port: https://github.com/macports/macports-ports/pull/28024

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
