### PR TITLE
pinact: Update to 2.2.1

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 2.2.0 v
+go.setup            github.com/suzuki-shunsuke/pinact 2.2.1 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,9 +16,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  376eaf6e2d61ca072f6142ee5d1cddae02cbecf1 \
-                    sha256  047745c193add771fb49f16dcfa49f7f186eb74b510296faf49b33a04a760090 \
-                    size    33143
+                    rmd160  8dd502619d5d7390e33bb641265c4ebb9500e397 \
+                    sha256  ff7a69e58f585830d25cd4af770c664927a7d03e4682ed3482743184b2e410f9 \
+                    size    33239
 
 build.args-append   -ldflags \"-X main.version=${version} -X main.commit=MacPorts \" \
                     ./cmd/pinact


### PR DESCRIPTION
#### Description

pinact: Update to 2.2.1

##### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
