### PR TITLE
neovim, -devel: update to 0.11.0 and 20250328

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -4,9 +4,10 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            neovim neovim 0.10.4 v
+github.setup            neovim neovim 0.11.0 v
 revision                0
 categories              editors
+platforms               {darwin >= 15}
 maintainers             {l2dy @l2dy} \
                         {judaew @judaew} \
                         openmaintainer
@@ -23,21 +24,20 @@ long_description \
 homepage                https://neovim.io
 
 github.tarball_from     archive
-checksums               rmd160  c5817b0b1c0ec7a82682d84f34453cf6443bc8e4 \
-                        sha256  10413265a915133f8a853dc757571334ada6e4f0aa15f4c4cc8cc48341186ca2 \
-                        size    12808381
+checksums               rmd160  454f3f3caeb1fa82b5f3396978efc0195c71577d \
+                        sha256  6826c4812e96995d29a98586d44fbee7c9b2045485d50d174becd6d5242b3319 \
+                        size    12901255
 
 depends_build-append    port:pkgconfig
 
 depends_lib             port:gettext \
                         port:libuv \
-                        port:libvterm \
                         port:unibilium \
-                        port:msgpack \
                         path:lib/libluajit-5.1.2.dylib:luajit \
                         port:lua51-lpeg \
                         port:luv-luajit \
                         port:libiconv \
+                        port:libutf8proc \
                         port:tree-sitter
 
 cmake.build_type        Release
@@ -52,38 +52,31 @@ patchfiles              0001-build-and-install-tree-sitter-parsers.patch \
 
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/CMakeLists.txt
+
+    # workaround for https://github.com/neovim/neovim/pull/30749
+    reinplace "s|lpeg.so lpeg\${CMAKE_SHARED_LIBRARY_SUFFIX}|lpeg\${CMAKE_SHARED_LIBRARY_SUFFIX} lpeg.so|g" ${worksrcpath}/cmake/FindLpeg.cmake
 }
 
 subport neovim-devel {
-    github.setup    neovim neovim a2b464944a4eb391fe6213304a4df5677845b52c
-    version         20250226-[string range ${github.version} 0 6]
+    github.setup    neovim neovim ae98d0a560b08d901ee9aae85df634de0ae3fe0a
+    version         20250328-[string range ${github.version} 0 6]
     revision        0
 
     github.tarball_from tarball
-    checksums       rmd160  470c893ebb6cc91104d10ccaf8713fc0ee085604 \
-                    sha256  f462eff2d0f32193ee353c394f42ff1caf3bb1079348bde6fbe82b05d7f76923 \
-                    size    12853137
+    checksums       rmd160  851cd14a3d5cde7eca7bfb98c2ebc40b323aa36e \
+                    sha256  eb8f99f501d587a9493dd526bc3e9109ff2c1783d85f34d2971b2a62b60de5dd \
+                    size    12909640
 
     conflicts       neovim
-
-    depends_lib-delete \
-                    port:libvterm \
-                    port:msgpack
-
-    depends_lib-append \
-                    port:libutf8proc
-
-    post-patch {
-        # workaround for https://github.com/neovim/neovim/pull/30749
-        reinplace "s|lpeg.so lpeg\${CMAKE_SHARED_LIBRARY_SUFFIX}|lpeg\${CMAKE_SHARED_LIBRARY_SUFFIX} lpeg.so|g" ${worksrcpath}/cmake/FindLpeg.cmake
-    }
 
     livecheck.url   ${github.homepage}/commits/nightly.atom
 }
 
 notes {
-    If you want to share your existing Vim configuration with Neovim, you can add these symlinks:
-        ln -s ~/.vim ~/.config/nvim
-        ln -s ~/.vimrc ~/.config/nvim/init.vim
-    For possible incompatible changes and differences to Vim check ':help nvim-intro' in nvim.
+    If you would like to re-use your existing Vim configuration with Neovim,
+    follow the advice in `:help nvim-from-vim`:
+
+        nvim -c 'tab h nvim-from-vim'
+
+    For a full list of differences with Vim, read `:help vim-differences`.
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- update neovim to 0.11.0
- update neovim-devel to 20250328

Also, restrict to MacOS >= 10.11 due to past build failures. See https://github.com/macports/macports-ports/commit/670a0f4eb6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.4 23H420 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
