### PR TITLE
yt-dlp: Update to 2025.03.27

### DIFF
--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -37,11 +37,11 @@ if {${subport} eq ${name}} {
 }
 
 subport yt-dlp {
-    github.setup    yt-dlp ${subport} 2025.03.25
+    github.setup    yt-dlp ${subport} 2025.03.27
     revision        0
-    checksums       rmd160  09c2b8ee11d0b52446fe2ff892c13d3ff506b85d \
-                    sha256  2e5729077a75f262130823feb19e299c35138383e75d5695b80ba0d9af879447 \
-                    size    5907595
+    checksums       rmd160  2e517164750d360690c355a3f431cbb0330211cb \
+                    sha256  2a269ae3e9a4510a09c48970e6152223b0bd086c47e55291befda39c070f3756 \
+                    size    5909156
     dist_subdir     ${subport}/${version}
     distname        ${subport}
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.1 19B88 x86_64
Command Line Tools 11.2.0.0.1.1571444319

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
