### PR TITLE
CLI11: update to 2.5.0

### DIFF
--- a/devel/CLI11/Portfile
+++ b/devel/CLI11/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        CLIUtils CLI11 2.4.2 v
+github.setup        CLIUtils CLI11 2.5.0 v
+github.tarball_from archive
 categories          devel
 license             BSD
 platforms           any
@@ -14,10 +15,9 @@ description         a command line parser for C++11
 long_description    CLI11 is a command line parser for C++11 and beyond that \
                     provides a rich feature set with a simple and intuitive interface.
 
-checksums           rmd160  1ff07574073d248898f5ce75496f45cd2320137a \
-                    sha256  f2d893a65c3b1324c50d4e682c0cdc021dd0477ae2c048544f39eed6654b699a \
-                    size    343478
-github.tarball_from archive
+checksums           rmd160  b5c378b359807d2f45d67e46dd89a14938914090 \
+                    sha256  17e02b4cddc2fa348e5dbdbb582c59a3486fa2b2433e70a0c3bacb871334fd55 \
+                    size    361527
 
 configure.args-append \
                     -DCLI11_BUILD_TESTS=OFF \


### PR DESCRIPTION
#### Description
https://github.com/CLIUtils/CLI11/releases/tag/v2.5.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
