### PR TITLE
dftd3: new package

### DIFF
--- a/science/dftd3/Portfile
+++ b/science/dftd3/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compilers 1.0
+
+name                dftd3
+version             3.2.0
+revision            0
+categories          science physics chemistry
+license             public-domain
+maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
+description         Dispersion Correction For Quantum Chemical Methods
+long_description    Dispersion correction for density functionals, Hartree-Fock \
+                    and semi-empirical quantum chemical methods
+homepage            https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3
+master_sites        ${homepage}
+extract.suffix      .tgz
+distfiles           ${name}${extract.suffix}
+checksums           sha256 d97cf9758f61aa81fd85425448fbf4a6e8ce07c12e9236739831a3af32880f59 \
+                    rmd160 291acd0a9facd4ac279a00454267cce9e782bbeb \
+                    size   555804
+dist_subdir         ${name}/${version}
+
+extract.mkdir       yes
+
+post-patch {
+    reinplace -W ${worksrcpath} "s|-static||g"                  Makefile
+    reinplace -W ${worksrcpath} "s|gfortran|${configure.f90}|g" Makefile
+}
+
+compilers.choose    f90
+compilers.setup     require_fortran
+use_configure       no
+
+use_parallel_build  no
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} ${name} \
+        ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0444 -W ${worksrcpath} man.pdf \
+        ${destroot}${prefix}/share/doc/${name}
+}
+
+livecheck.url   ${homepage}/get_dft-d3
+livecheck.type  md5
+livecheck.md5   779d268280dbff62dc1ca231fe426f69


### PR DESCRIPTION
#### Description

dftd3: Dispersion correction for quantum chemical methods

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
