### PR TITLE
pinact: Upgrade to 3.0.1

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 2.2.1 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.0.1 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,15 +16,23 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  8dd502619d5d7390e33bb641265c4ebb9500e397 \
-                    sha256  ff7a69e58f585830d25cd4af770c664927a7d03e4682ed3482743184b2e410f9 \
-                    size    33239
+                    rmd160  073bdd33dc198c3f686b4fae39defe3e75dfee39 \
+                    sha256  0eb2b41c97c5b301d723d213598a6d74f443ed61541b15446909866dbac6f0fe \
+                    size    33098
 
 build.args-append   -ldflags \"-X main.version=${version} -X main.commit=MacPorts \" \
                     ./cmd/pinact
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+notes {
+  pinact 3.0 introduces a new configuration file format version which is incompatible
+  with previous versions.
+
+  If you have an existing .pinact.yaml file, you will need to use pinact 2.2 and run
+  'pinact migrate' to fix the pinact configuration file for pinact 3.0.
 }
 
 go.vendors          gopkg.in/yaml.v3 \


### PR DESCRIPTION
#### Description

Add .pinact.yaml migration instructions on install.

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification 

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
