### PR TITLE
fpc: fix building on macOS 15 - x86_64, 2nd try

### DIFF
--- a/lang/fpc/files/rautils.patch
+++ b/lang/fpc/files/rautils.patch
@@ -1,5 +1,5 @@
---- rautils-orig.pas	2024-11-17 18:37:53
-+++ rautils.pas	2025-03-28 01:01:27
+--- compiler/rautils-orig.pas	2024-11-17 18:37:53
++++ compiler/rautils.pas	2025-03-28 01:01:27
 @@ -1781,6 +1781,11 @@
        begin
          if symtablestack.top.symtablelevel<>srsymtable.symtablelevel then


### PR DESCRIPTION
#### Description

fpc: fix building on macOS 15 - x86_64, 2nd try.
Now it has the correct the path to file rautils.pas in the patch file.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

Note: As before, this does not actually test the fix, as I have no access to macOS 15 on x86_64. So, the pipeline will show.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
