### PR TITLE
pascal-p5: update

### DIFF
--- a/lang/pascal-p5/Portfile
+++ b/lang/pascal-p5/Portfile
@@ -6,7 +6,6 @@ name                pascal-p5
 version             1.4
 revision            0
 categories          lang
-platforms           darwin
 license             GPL-2
 maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
 
@@ -14,19 +13,29 @@ description         P5, Zuerich type ISO 7185 Pascal compiler
 long_description    This is the 5th version of the Pascal-P compiler from Zuerich. \
                     It is modified to be ISO 7185 Pascal compliant, both in \
                     the implementation language, and in the language it processes.
-homepage            http://www.standardpascal.org/p5.html
+homepage            https://www.standardpascal.org/p5.html
 
 fetch.type          git
 git.url             https://git.code.sf.net/p/pascalp5/code
-git.branch          75a0a8
+git.branch          f730c1
 
 depends_build       port:fpc
 
-supported_archs     x86_64 ppc
+supported_archs     x86_64 arm64
 
 installs_libs       no
 use_configure       no
 universal_variant   no
+
+# Directives in fpc start with "$" instead of "#"
+# Also convert !, && and || to NOT, AND and OR
+post-patch {
+    reinplace  "s|^#if !defined(WRDSIZ16) && !defined(WRDSIZ32) && !defined(WRDSIZ64)|\{\$if (NOT defined(WRDSIZ16)) AND (NOT defined(WRDSIZ32)) AND (NOT defined(WRDSIZ64))\}| \
+                             g" ${worksrcpath}/source/pint.pas ${worksrcpath}/source/pcom.pas
+    reinplace  "s|^#|$|g"       ${worksrcpath}/source/pint.pas ${worksrcpath}/source/pcom.pas
+    reinplace  "s|^$.*|\{&\}|g" ${worksrcpath}/source/pint.pas ${worksrcpath}/source/pcom.pas
+    reinplace  "s/||/OR/g"      ${worksrcpath}/source/pint.pas
+}
 
 # patching the Makefile is more involved.
 build {


### PR DESCRIPTION
#### Description

pascal-p5: update to newer upstream version
Also enable on arm64

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
