### PR TITLE
pta: new port, version 0.1

### DIFF
--- a/finance/pta/Portfile
+++ b/finance/pta/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               perl5 1.0
+
+perl5.require_variant   yes
+
+name                    pta
+version                 0.1
+categories              finance
+platforms               {darwin any}
+supported_archs         noarch
+maintainers             {@admacleod} \
+                        openmaintainer
+description             the plain text accounting program
+long_description        pta reads bookkeeping journals and writes account lists, \
+                        balances, and cost center assessments to standard output.
+license                 ISC
+homepage                https://mandoc.bsd.lv/pta/
+master_sites            ${homepage}release/
+checksums               rmd160  58e26090bd873a9f4b8481c05701919d72fdc058 \
+                        sha256  d2669b08eabac17cb4b737fe6b5c3d52533b825379db5655434487348c50c7cb \
+                        size    19943
+use_configure           no
+build                   {}
+destroot.destdir        DESTDIR=${destroot}${prefix}
+destroot.violate_mtree  yes

--- a/finance/pta/Portfile
+++ b/finance/pta/Portfile
@@ -24,4 +24,4 @@ checksums               rmd160  58e26090bd873a9f4b8481c05701919d72fdc058 \
 use_configure           no
 build                   {}
 destroot.destdir        DESTDIR=${destroot}${prefix}
-destroot.violate_mtree  yes
+patchfiles-append       patch-Makefile.diff

--- a/finance/pta/files/patch-Makefile.diff
+++ b/finance/pta/files/patch-Makefile.diff
@@ -1,0 +1,26 @@
+--- Makefile	2025-03-31 10:32:38
++++ Makefile	2025-03-31 10:33:22
+@@ -6,19 +6,12 @@
+ 
+ install:
+ 	@if test -z "$(DESTDIR)"; then echo "DESTDIR is not set"; exit 1; fi
+-	install -o root -g wheel -m 0755 -d $(DESTDIR)/bin
+-	install -o root -g wheel -m 0755 -d $(DESTDIR)/man
+-	install -o root -g wheel -m 0755 -d $(DESTDIR)/man/man1
+-	install -o root -g wheel -m 0755 -d $(DESTDIR)/man/man5
+-	install -o root -g wheel -m 0755 -d $(DESTDIR)/man/man7
+-	install -o root -g wheel -m 0755 -d $(DESTDIR)/share
+-	install -o root -g wheel -m 0755 -d $(DESTDIR)/share/examples
+ 	install -o root -g wheel -m 0755 -d $(DESTDIR)/share/examples/pta
+ 	install -o root -g bin -m 0555 pta.pl $(DESTDIR)/bin/pta 
+-	install -o root -g bin -m 0444 pta.1 $(DESTDIR)/man/man1/
+-	install -o root -g bin -m 0444 pta-accounts.5 $(DESTDIR)/man/man5/
+-	install -o root -g bin -m 0444 pta-journal.5 $(DESTDIR)/man/man5/
+-	install -o root -g bin -m 0444 pta-glossary.7 $(DESTDIR)/man/man7/
++	install -o root -g bin -m 0444 pta.1 $(DESTDIR)/share/man/man1/
++	install -o root -g bin -m 0444 pta-accounts.5 $(DESTDIR)/share/man/man5/
++	install -o root -g bin -m 0444 pta-journal.5 $(DESTDIR)/share/man/man5/
++	install -o root -g bin -m 0444 pta-glossary.7 $(DESTDIR)/share/man/man7/
+ 	install -o root -g wheel -m 0444 accounts.example.de \
+ 	    accounts.example.en journal.example.en \
+ 	    $(DESTDIR)/share/examples/pta/


### PR DESCRIPTION
#### Description

[pta](https://mandoc.bsd.lv/pta/) reads bookkeeping journals and writes account lists, balances, and cost center assessments to standard output. All input files are ASCII text files.
It is written in [Perl 5](https://www.perl.org/) and comes with an [ISC](https://www.isc.org/licenses/) license.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
