### PR TITLE
ddrescue: update to 1.29.1

### DIFF
--- a/sysutils/ddrescue/Portfile
+++ b/sysutils/ddrescue/Portfile
@@ -4,12 +4,11 @@ PortSystem      1.0
 PortGroup       gnu_info 1.0
 
 name            ddrescue
-version         1.28
+version         1.29.1
 revision        0
 categories      sysutils
-platforms       darwin
 license         GPL-2+
-maintainers     {raimue @raimue}
+maintainers     {@aeiouaeiouaeiouaeiouaeiouaeiou outlook.com:aeioudev} {raimue @raimue}
 description     GNU ddrescue is a data recovery tool.
 
 long_description \
@@ -22,9 +21,9 @@ master_sites    gnu:ddrescue
 
 use_lzip        yes
 
-checksums       rmd160  42c35f228eff7d5aef855103718c9f023fba9a22 \
-                sha256  6626c07a7ca1cc1d03cad0958522c5279b156222d32c342e81117cfefaeb10c1 \
-                size    93823
+checksums       rmd160  10771c106b33fc35bb09515c5e85ef1b28be2d3e \
+                sha256  ddd7d45df026807835a2ec6ab9c365df2ef19e8de1a50ffe6886cd391e04dd75 \
+                size    97623
 
 variant universal {}
 configure.args  CXX="${configure.cxx}" \


### PR DESCRIPTION
* remove platforms line
* add myself as co-maintainer

https://lists.gnu.org/archive/html/info-gnu/2025-03/msg00011.html

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
