### PR TITLE
mise: Update to 2025.4.0

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.3.11 v
+github.setup        jdx mise 2025.4.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fba1d94bfaf6334520c0205aa9fc88bde45f266c \
-                    sha256  6bce862d0df0ba9bd509cb72dca6ae6944ee153985a3b073676c91014f87de72 \
-                    size    4278675
+                    rmd160  e6e44338972b62e3d8c86de426a916e9452c65d6 \
+                    sha256  4b62c436053444d3cd958c36c2a027d5429aa2ad084125db844e3487c24d714a \
+                    size    4148880
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -133,7 +133,7 @@ cargo.crates \
     bytecount                        0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                           1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
-    bytesize                         1.3.2  2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e \
+    bytesize                         1.3.3  2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659 \
     bzip2                            0.5.2  49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47 \
     bzip2-sys                 0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
@@ -189,9 +189,9 @@ cargo.crates \
     ctr                              0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
-    darling                        0.20.10  6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989 \
-    darling_core                   0.20.10  95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5 \
-    darling_macro                  0.20.10  d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806 \
+    darling                        0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
+    darling_core                   0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
+    darling_macro                  0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
     dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     dashmap                          6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
@@ -342,12 +342,12 @@ cargo.crates \
     hyper                            1.6.0  cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80 \
     hyper-rustls                    0.27.5  2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2 \
     hyper-tls                        0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
-    hyper-util                      0.1.10  df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4 \
+    hyper-util                      0.1.11  497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2 \
     i18n-config                      0.4.7  8e88074831c0be5b89181b05e6748c4915f77769ecc9a4c372f88b169a8509c9 \
     i18n-embed                      0.14.1  94205d95764f5bb9db9ea98fa77f89653365ca748e27161f5bbea2ffd50e459c \
     i18n-embed-fl                    0.7.0  9fc1f8715195dffc4caddcf1cf3128da15fe5d8a137606ea8856c9300047d5a2 \
     i18n-embed-impl                  0.8.4  0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2 \
-    iana-time-zone                  0.1.62  b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127 \
+    iana-time-zone                  0.1.63  b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
     icu_locid                        1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
@@ -498,7 +498,7 @@ cargo.crates \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro2                     1.0.94  a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84 \
     prodash                         29.0.1  9ee7ce24c980b976607e2d6ae4aae92827994d23fed71659c3ede3f92528b58b \
-    quick-xml                       0.37.3  bf763ab1c7a3aa408be466efc86efe35ed1bd3dd74173ed39d6b0d0a6f0ba148 \
+    quick-xml                       0.37.4  a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369 \
     quinn                           0.11.7  c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012 \
     quinn-proto                    0.11.10  b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc \
     quinn-udp                       0.5.11  541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5 \
@@ -534,7 +534,7 @@ cargo.crates \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
-    rustix                           1.0.3  e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96 \
+    rustix                           1.0.4  7a04a32fb43fcdef85b977ce7f77a150805e4b2ea1f2656898d4a547dde78df6 \
     rustls                         0.23.25  822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
@@ -589,7 +589,7 @@ cargo.crates \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     slug                             0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
     smallvec                        1.14.0  7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd \
-    socket2                          0.5.8  c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8 \
+    socket2                          0.5.9  4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
@@ -705,15 +705,18 @@ cargo.crates \
     winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     windows                         0.57.0  12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143 \
-    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
     windows-core                    0.57.0  d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d \
+    windows-core                    0.61.0  4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980 \
     windows-implement               0.57.0  9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7 \
+    windows-implement               0.60.0  a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836 \
     windows-interface               0.57.0  29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7 \
+    windows-interface               0.59.1  bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8 \
     windows-link                     0.1.1  76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38 \
     windows-registry                 0.4.0  4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3 \
     windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
     windows-result                   0.3.2  c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252 \
     windows-strings                  0.3.1  87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319 \
+    windows-strings                  0.4.0  7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \


### PR DESCRIPTION
#### Description

mise: Update to 2025.4.0

##### Tested on

macOS 15.3.2 24D81 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
