### PR TITLE
ipsw: Update to 3.1.590

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -7,7 +7,7 @@ PortGroup               golang 1.0
 # maintains a release schedule. Update every 5th release, unless
 # a hotfix is necessary, only.
 
-go.setup                github.com/blacktop/ipsw 3.1.585 v
+go.setup                github.com/blacktop/ipsw 3.1.590 v
 revision                0
 categories              security devel
 license                 MIT
@@ -21,9 +21,9 @@ long_description        {*}${description}. Everything you need to start \
 
 homepage                https://blacktop.github.io/ipsw
 
-checksums               rmd160  84cab2c3be07707ffe8f53a65b544088f89b5ab5 \
-                        sha256  652bff9bf127f1ea852c3dd2d663c83833ee297a7ae696a28d952fb88f39adcd \
-                        size    12721179
+checksums               rmd160  0c37a77d4601e8e427a202290c1f258d2a4a01b9 \
+                        sha256  a9e456ea25fe76a765d18a84a55e5d69c44972b4ab69bd0a1babd2be4e7bb01f \
+                        size    12743209
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, 3.1.590. [blacktop/ipsw@``v3.1.585...v3.1.590``](https://github.com/blacktop/ipsw/compare/v3.1.585...v3.1.590)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
