### PR TITLE
google-cloud-sdk: update to 517.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             516.0.0
+version             517.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  09d48e0703db1406d7059550751ce37b98f08bac \
-                    sha256  a52b5b58da4b91add5634f59a0f7dcdef49567a3b5fe65ae9db1d750b6585921 \
-                    size    54252010
+    checksums       rmd160  6ad23eb68b8c77d40f03be76bff1f05e7cbe6cbf \
+                    sha256  aed6bbb89a1ed713bd0da36011130c20e990aae78b44d1b3cf528770c121d84a \
+                    size    54312622
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3a11dea5b45155e2004d5a2901195bbd23f4dec6 \
-                    sha256  af0d2ef3231a3e2581a1b18f74d754a0345b63389428cc29e1a4059931fa7836 \
-                    size    55720024
+    checksums       rmd160  4bd65600fec7ff6ccd9629fbad25f91c6560fae4 \
+                    sha256  ed5e74ecef3c4a7e1bb6d8857327fa0f5b564f980dd4d982f40fae4dbc4ff3b8 \
+                    size    55781755
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  415de24b686bfdf2095d1a6b36d687bc3e1e567c \
-                    sha256  ac7e1a3d9db90e6dd2543921f2be0acc797757c885f6f4bebf912ee77ab8a976 \
-                    size    55656307
+    checksums       rmd160  f5af3ad49c83bf8b98f148eca172ce8fa9518e26 \
+                    sha256  1145bd806cac0954a6b5709b34c2da3d830f952129c12e4b68adfcd951313ffd \
+                    size    55723130
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 517.0.0.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?