### PR TITLE
legcord: update to 1.1.1

### DIFF
--- a/net/Legcord/Portfile
+++ b/net/Legcord/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Legcord Legcord 1.1.0 v
+github.setup        Legcord Legcord 1.1.1 v
 github.tarball_from archive
 
 categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  766035c29939b33f4e67d8fe5b867f8d43d85809 \
-                    sha256  ca3517df1992f7eed9bebe6d2f29d7ba0672e9e60a1eed70ed206fc2d069562c \
-                    size    3275508
+checksums           rmd160  0b187eb5ba20dd781231405dc5c3d90925219d6a \
+                    sha256  3b6215e28356426992f67db0bcaff992cc58779d6a3e684a284c6765a75c20f2 \
+                    size    3276910
 
 description         lightweight alternative to the regular Discord application
 long_description    ${name} is a {*}${description}. It wraps the Discord web \
@@ -24,7 +24,8 @@ supported_archs     arm64
 platforms           {darwin any}
 license             OSL-3.0
 
-depends_build       port:pnpm
+depends_build       port:pnpm \
+                    port:npm10
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

hopefully upstream node module updates will resolve our previous problem. allegedly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
