### PR TITLE
py-scamper: add scamper python modules as subports of net/scamper

### DIFF
--- a/net/scamper/Portfile
+++ b/net/scamper/Portfile
@@ -29,13 +29,61 @@ distname            ${name}-cvs-${version}
 
 livecheck.regex     ${name}-cvs-(\[0-9\]+\[a-z\]*)${extract.suffix}
 
-configure.args-append \
+if {${subport} eq ${name}} {
+    configure.args-append \
                     --enable-sc_hoiho \
                     --enable-sc_minrtt \
                     --enable-sc_uptime \
                     --with-pcre2
 
-depends_lib-append  path:lib/liblzma.dylib:xz \
+    depends_lib-append  path:lib/liblzma.dylib:xz \
                     path:lib/libbz2.dylib:bzip2 \
                     port:pcre2 \
                     port:sqlite3
+}
+
+# Python subports
+set python_versions {39 310 311 312 313}
+foreach v ${python_versions} {
+    subport py${v}-${name} {
+        PortGroup           python 1.0
+
+        categories          net python
+
+        depends_lib-append  port:${name}
+
+        use_configure       yes
+
+        python.default_version ${v}
+        python.add_dependencies no
+        build.cmd           make
+        build.target
+        destroot.cmd        make install
+        destroot.destdir    DESTDIR=${destroot}
+
+        livecheck.type      none
+    }
+}
+
+# Python bindings for supported Python versions
+if {[string match "py*" ${subport}]} {
+    description             Python ${python.branch} bindings for scamper
+    long_description        {*}${description}.
+
+    depends_lib-append      port:python${python.version}
+
+    configure.args-append   --with-python
+    configure.env           PYTHON=${python.bin}
+    configure.env-append    PYTHON_SITE_PKG=${python.pkgd}
+
+    post-patch {
+        reinplace "s|\$(scamper_la_DEPENDENCIES)||g" \
+            ${worksrcpath}/lib/python/Makefile.in
+        reinplace "s|../libscamperfile/libscamperfile.la|-lscamperfile|g" \
+            ${worksrcpath}/lib/python/Makefile.in
+        reinplace "s|../libscamperctrl/libscamperctrl.la|-lscamperctrl|g" \
+            ${worksrcpath}/lib/python/Makefile.in
+    }
+
+    build.dir              ${worksrcpath}/lib/python
+}


### PR DESCRIPTION
#### Description

add py-scamper subports to net/scamper Portfile.  The Portfile follows the approach that I took in https://github.com/freebsd/freebsd-ports/blob/main/net/py-scamper/Makefile but adapted to MacPorts.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
