### PR TITLE
minicom: Move kermit dep to an optional variant

### DIFF
--- a/comms/minicom/Portfile
+++ b/comms/minicom/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitlab 1.0
 
 gitlab.instance     https://salsa.debian.org
 gitlab.setup        minicom-team minicom 2.9
-revision            0
+revision            1
 categories          comms
 maintainers         nomaintainer
 license             GPL-2+
@@ -32,8 +32,11 @@ depends_lib         port:gettext \
                     port:libiconv \
                     port:ncurses
 
-depends_run         port:lrzsz \
-                    port:kermit
+depends_run         port:lrzsz
 
-configure.args      --enable-lock-dir=/tmp \
-                    --enable-kermit=${prefix}/bin
+configure.args      --enable-lock-dir=/tmp
+
+variant kermit description {Enable Kermit file transfer protocol} {
+    depends_run-append      port:kermit
+    configure.args-append   --enable-kermit=${prefix}/bin
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This was suggested in https://trac.macports.org/ticket/72226 , since kermit is currently broken (see https://trac.macports.org/ticket/71517 for that issue)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.3.1 24D70 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
