### PR TITLE
gocryptfs: Remove @MarcelBochtler as maintainer

### DIFF
--- a/fuse/gocryptfs/Portfile
+++ b/fuse/gocryptfs/Portfile
@@ -10,8 +10,7 @@ github.tarball_from tarball
 revision            0
 
 categories          fuse
-maintainers         {bochtler.io:macports @MarcelBochtler} \
-                    openmaintainer
+maintainers         nomaintainer
 license             MIT
 platforms           darwin
 description         Encrypted overlay filesystem written in Go


### PR DESCRIPTION
I am no longer using gocryptfs and have no possibility to test new releases.