### PR TITLE
tippecanoe: update to 2.77.0

### DIFF
--- a/gis/tippecanoe/Portfile
+++ b/gis/tippecanoe/Portfile
@@ -6,7 +6,7 @@ PortGroup               makefile 1.0
 PortGroup               legacysupport 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            felt tippecanoe 2.75.1
+github.setup            felt tippecanoe 2.77.0
 github.tarball_from     archive
 revision                0
 categories              gis
@@ -15,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             Build vector tilesets from large collections of GeoJSON features
 long_description        {*}${description}
 
-checksums               rmd160  186784752f5ae239a8119306301ce40239599e5d \
-                        sha256  892418c5c742cf371b7a66c5c8ce10fad9f922fc73f24fc07c6c05ac519445c1 \
-                        size    25706792
+checksums               rmd160  afcd082d6d1460f7baa82447c3fe724869362f8d \
+                        sha256  4cb152a705250ab37f09d02610df376599c4423efbda96b65ad26f41a966d29e \
+                        size    25722051
 
 # https://github.com/felt/tippecanoe/issues/304
 if {${configure.build_arch} in [list i386 ppc]} {


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/felt/tippecanoe/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
