### PR TITLE
ruff: Update to 0.11.4

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.11.3
+github.setup        astral-sh ruff 0.11.4
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  758a102e092001901830056888e598cfebb267b1 \
-                    sha256  cd83fb7cef3c1df350e037fb6d183f29c7567048e1664159cc72c4d76bef9331 \
-                    size    6181545
+                    rmd160  5d9bbafc4edd695eac61cd76385624e9859881a8 \
+                    sha256  e2093c9b62a5ae3b48de7601dad616995d0877b7d6f1c209373bf4e9acfaa24b \
+                    size    6216374
 
 cargo.offline_cmd
 
@@ -89,7 +89,7 @@ cargo.crates \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                         2.9.0  5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    boxcar                          0.2.10  225450ee9328e1e828319b48a89726cffc1b0ad26fd9211ad435de9fa376acae \
+    boxcar                          0.2.11  6740c6e2fc6360fa57c35214c7493826aee95993926092606f27c983b40837be \
     bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
     bumpalo                         3.17.0  1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
@@ -114,7 +114,7 @@ cargo.crates \
     clearscreen                      4.0.1  8c41dc435a7b98e4608224bbf65282309f5403719df9113621b30f8b6f74e2f4 \
     codspeed                         2.9.1  60e744216bfa9add3b1f2505587cbbb837923232ed10963609f4a6e3cbd99c3e \
     codspeed-criterion-compat        2.9.1  d5926ca63222a35b9a2299adcaafecf596efe20a9a2048e4a81cb2fc3463b4a8 \
-    codspeed-criterion-compat-walltime     2.9.1  dbae4da05076cbc673e242400ac8f4353bdb686e48020edc6e36a5c36ae0878e \
+    codspeed-criterion-compat-walltime 2.9.1 dbae4da05076cbc673e242400ac8f4353bdb686e48020edc6e36a5c36ae0878e \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     colored                          2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
     colored                          3.0.0  fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e \
@@ -380,13 +380,14 @@ cargo.crates \
     test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
     test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
+    thin-vec                        0.2.14  144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
     thiserror                       2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                  2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     threadpool                       1.8.1  d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa \
-    tikv-jemalloc-sys             0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7  cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d \
+    tikv-jemalloc-sys 0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7 cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d \
     tikv-jemallocator                0.6.0  4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865 \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
@@ -436,8 +437,8 @@ cargo.crates \
     vte_generate_state_changes       0.1.2  2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e \
     wait-timeout                     0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
-    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasi                          0.14.2+wasi-0.2.4  9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3 \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasi                 0.14.2+wasi-0.2.4  9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3 \
     wasm-bindgen                   0.2.100  1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
     wasm-bindgen-backend           0.2.100  2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
     wasm-bindgen-futures            0.4.50  555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61 \
@@ -497,6 +498,6 @@ cargo.crates \
     zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
     zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
     zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261 \
-    zstd                          0.11.2+zstd.1.5.2  20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4 \
-    zstd-safe                     5.0.2+zstd.1.5.2  1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db \
-    zstd-sys                      2.0.14+zstd.1.5.7  8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5
+    zstd                 0.11.2+zstd.1.5.2  20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4 \
+    zstd-safe             5.0.2+zstd.1.5.2  1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db \
+    zstd-sys             2.0.14+zstd.1.5.7  8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.11.4

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
