### PR TITLE
pinact: Update to 3.0.3

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.0.1 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.0.3 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,9 +16,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  073bdd33dc198c3f686b4fae39defe3e75dfee39 \
-                    sha256  0eb2b41c97c5b301d723d213598a6d74f443ed61541b15446909866dbac6f0fe \
-                    size    33098
+                    rmd160  c46018fd687291ae9a9a1af4be4205762c1bf2e0 \
+                    sha256  199149e6b379786d7786948ccaae62b72453f83e9de9ccabf30d2c6a743f8b9c \
+                    size    32493
 
 build.args-append   -ldflags \"-X main.version=${version} -X main.commit=MacPorts \" \
                     ./cmd/pinact
@@ -60,26 +60,21 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  784167167d978ec8e104f9cc638911d2488e52d4 \
                         sha256  4ab29fbe50a6ab7bf9b12c85ab220b686187cdc643cbc21ed7096d0365955962 \
                         size    98950 \
-                    github.com/xrash/smetrics \
-                        lock    686a1a2994c1 \
-                        rmd160  6eeddadc807945dd735d28b8e19a239a242d5ae4 \
-                        sha256  ad89cc64ab0ee4f8c8364b85027e507ce99a8e1a5d0ccda24c623be30757d918 \
-                        size    1823558 \
                     github.com/wk8/go-ordered-map \
                         lock    v2.1.8 \
                         rmd160  3b679491f631b4900bfe3169517517b2731ebc35 \
                         sha256  c7caff4ba164feeebdcc568d6598931a20719827e05dfa18ac7d7c495d36b883 \
                         size    20797 \
                     github.com/urfave/cli \
-                        lock    v2.27.6 \
-                        rmd160  955b534f7cc0bea403b138abd970aa81be0ea6d5 \
-                        sha256  0e68631caf7c4036f0cfc76fe9b36c3b76c4e485f85522e8d98499cca62559b6 \
-                        size    3485878 \
-                    github.com/suzuki-shunsuke/urfave-cli-help-all \
-                        lock    v0.0.4 \
-                        rmd160  ae41c42234d097b0b99e35d5be4945d93c0968e0 \
-                        sha256  0b7e83a6c6a8f40e374482f934df755492c0b5a309a02156fea1c0d9bff7cdd1 \
-                        size    6618 \
+                        lock    v3.1.1 \
+                        rmd160  cdb8c38c49211c80fe9b3479e3e6570ca4b3db2a \
+                        sha256  bafc806faca3ad2f5b314a3405382ca690ecd691cfc9dd4bbbccb3abc62222f4 \
+                        size    6788461 \
+                    github.com/suzuki-shunsuke/urfave-cli-v3-util \
+                        lock    v0.0.1 \
+                        rmd160  b3a7f9ccfdf98d9810c1a6194191b67a75e7a6db \
+                        sha256  c5350681a8dfffed4e430d68e0a972fd138094c74102b8bf0df6b6eec004a7ed \
+                        size    7780 \
                     github.com/suzuki-shunsuke/logrus-error \
                         lock    v0.1.4 \
                         rmd160  d52b0d1f07e0dde083a4deaea70d508880b724ba \
@@ -91,10 +86,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  c3383e9717a250e17c28de4845564d299ae7aa2160175169213f85647ebb1b35 \
                         size    2506 \
                     github.com/stretchr/testify \
-                        lock    v1.8.1 \
-                        rmd160  4d80635834e01b3ddb67babdd8de2eac2c5a7587 \
-                        sha256  9848272e238f98fc0555b514c4522e70c4df25331b4ee3f9cb9244a04935934e \
-                        size    97722 \
+                        lock    v1.10.0 \
+                        rmd160  43f142561513d8f10ce4971bf91cabbad9a021cc \
+                        sha256  be33d85711f2b92b7269a39574af64701ed5b2c4e4446547ea75ea046ec97629 \
+                        size    112769 \
                     github.com/spf13/afero \
                         lock    v1.14.0 \
                         rmd160  95180c509220d8ffdd6cfd9f9ca708ae3be7b1a5 \
@@ -105,11 +100,6 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  db211aeb52d4a85a7dc8acf83f7475b5f4fa9092 \
                         sha256  36a05391b8c6cef99e9a9c78b598f3a8da8feed318b385eadcdede08ae5cc229 \
                         size    50327 \
-                    github.com/russross/blackfriday \
-                        lock    v2.1.0 \
-                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
-                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
-                        size    92950 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -156,20 +146,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  b621b304b529134076c9ebe09343aea7add039cd98e68be7e5a616245b0c3d03 \
                         size    105180 \
                     github.com/goccy/go-yaml \
-                        lock    v1.16.0 \
-                        rmd160  32f99e42845951f54bbc020ee4a0ebfcf5e176a2 \
-                        sha256  a635fd772a17d128f444f8d254d39ed7893f3ae10a912292d2bef0cacb75f924 \
-                        size    662220 \
+                        lock    v1.17.1 \
+                        rmd160  7f85a843b0f541b5d327d7f882a53ee345f60e6f \
+                        sha256  d938ecb6f9e781ecd2af5401e186536e6dcd7a744602ff5d8cc31bbf988608df \
+                        size    663056 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
-                    github.com/cpuguy83/go-md2man \
-                        lock    v2.0.5 \
-                        rmd160  9af69f242ce0d508cc132b933960356f7c763b31 \
-                        sha256  ebb019c79ca6b8f331d256fe63eb7bb549b1b15fdfb7eb4f168969966df05734 \
-                        size    10941 \
                     github.com/buger/jsonparser \
                         lock    v1.1.1 \
                         rmd160  35ad9d7a60f9fec3b2eb38c0b2f0268e421a0a5e \


### PR DESCRIPTION
#### Description

Upgrade pinact to v3.0.3.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
