### PR TITLE
neovim{,-devel}: prevent build-time fetching

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -60,12 +60,6 @@ notes {
 
 subport neovim-devel {}
 
-# create `deps` variable with:
-#
-# cat deps.txt \
-#     | perl -n -e '/(TREESITTER_.*)_URL https:\/\/github.com\/([^\/]*)\/([^\/]*)\/archive\/([^\d]*)((?:\d+\.){2}\d+)([^\d\.]*)/ && print join(" ", $2, $3, $4 || "\"\"", $5, $6 || "\"\"", lc($1), "\n")' \
-#     | column -t
-
 if {${subport} eq ${name}} {
     # stable
 
@@ -74,7 +68,9 @@ if {${subport} eq ${name}} {
     revision            1
     conflicts           neovim-devel
 
-    # see note above on how to regenerate
+    # cat cmake.deps/deps.txt \
+    #     | perl -n -e '/(TREESITTER_.*)_URL https:\/\/github.com\/([^\/]*)\/([^\/]*)\/archive\/([^\d]*)((?:\d+\.){2}\d+)([^\d\.]*)/ && print join(" ", $2, $3, $4 || "\"\"", $5, $6 || "\"\"", lc($1), "\n")' \
+    #     | column -t
     set deps {
         tree-sitter tree-sitter-c                  0.23.4  v  ""  treesitter_c
         tree-sitter-grammars tree-sitter-lua       0.3.0   v  ""  treesitter_lua
@@ -123,7 +119,7 @@ if {${subport} eq ${name}} {
     github.livecheck.branch \
                         nightly
 
-    # see note above on how to regenerate
+    # see stable's version of `deps` for how to regenerate
     set deps {
         tree-sitter tree-sitter-c                  0.23.4  v  ""  treesitter_c
         tree-sitter-grammars tree-sitter-lua       0.3.0   v  ""  treesitter_lua
@@ -163,13 +159,22 @@ if {${subport} eq ${name}} {
                         size    419261
 }
 
+# Add each dependency's master_site, tag it and associate it back to the distfile
+# e.g.: master_sites-append https://github.com/tree-sitter/tree-sitter-c/archive/v0.23.4:treesitter_c
+#       distfiles-append    tree-sitter-c-0.23.4.tar.gz:treesitter_c
 foreach {gh_author gh_project gh_version gh_tag_prefix gh_tag_suffix dirname} ${deps} {
     master_sites-append https://github.com/${gh_author}/${gh_project}/archive/[join ${gh_tag_prefix}]${gh_version}[join ${gh_tag_suffix}]:${dirname}
     distfiles-append    ${gh_project}-${gh_version}${extract.suffix}:${dirname}
 }
 
+# Only extract Neovim's source and not its dependencies
 extract.only        ${distname}${extract.suffix}
 post-extract {
+    # Create the file structure where the build job expects the dependencies
+    # e.g. file mkdir ${workpath}/build/build/downloads/treesitter_c
+    #      file copy \
+    #          ${distpath}/tree-sitter-c-0.23.4.tar.gz \
+    #          ${workpath}/build/build/downloads/treesitter_c/v0.23.4.tar.gz
     foreach {_ gh_project gh_version gh_tag_prefix gh_tag_suffix dirname} ${deps} {
         file mkdir ${workpath}/build/build/downloads/${dirname}
         file copy \

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -4,16 +4,13 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            neovim neovim 0.11.0 v
-revision                0
+name                    neovim
 categories              editors
 platforms               {darwin >= 15}
 maintainers             {l2dy @l2dy} \
                         {judaew @judaew} \
                         openmaintainer
 license                 Apache-2 Vim GPL-2+
-
-conflicts               neovim-devel
 
 description             Neovim is a aggressively refactored fork of Vim
 
@@ -22,11 +19,6 @@ long_description \
     a new plugin architecture, job control, and a remote API.
 
 homepage                https://neovim.io
-
-github.tarball_from     archive
-checksums               rmd160  454f3f3caeb1fa82b5f3396978efc0195c71577d \
-                        sha256  6826c4812e96995d29a98586d44fbee7c9b2045485d50d174becd6d5242b3319 \
-                        size    12901255
 
 depends_build-append    port:pkgconfig
 
@@ -57,21 +49,6 @@ post-patch {
     reinplace "s|lpeg.so lpeg\${CMAKE_SHARED_LIBRARY_SUFFIX}|lpeg\${CMAKE_SHARED_LIBRARY_SUFFIX} lpeg.so|g" ${worksrcpath}/cmake/FindLpeg.cmake
 }
 
-subport neovim-devel {
-    github.setup    neovim neovim ae98d0a560b08d901ee9aae85df634de0ae3fe0a
-    version         20250328-[string range ${github.version} 0 6]
-    revision        0
-
-    github.tarball_from tarball
-    checksums       rmd160  851cd14a3d5cde7eca7bfb98c2ebc40b323aa36e \
-                    sha256  eb8f99f501d587a9493dd526bc3e9109ff2c1783d85f34d2971b2a62b60de5dd \
-                    size    12909640
-
-    conflicts       neovim
-
-    livecheck.url   ${github.homepage}/commits/nightly.atom
-}
-
 notes {
     If you would like to re-use your existing Vim configuration with Neovim,
     follow the advice in `:help nvim-from-vim`:
@@ -79,4 +56,124 @@ notes {
         nvim -c 'tab h nvim-from-vim'
 
     For a full list of differences with Vim, read `:help vim-differences`.
+}
+
+subport neovim-devel {}
+
+# create `deps` variable with:
+#
+# cat deps.txt \
+#     | perl -n -e '/(TREESITTER_.*)_URL https:\/\/github.com\/([^\/]*)\/([^\/]*)\/archive\/([^\d]*)((?:\d+\.){2}\d+)([^\d\.]*)/ && print join(" ", $2, $3, $4 || "\"\"", $5, $6 || "\"\"", lc($1), "\n")' \
+#     | column -t
+
+if {${subport} eq ${name}} {
+    # stable
+
+    github.setup        neovim neovim 0.11.0 v
+    github.tarball_from archive
+    revision            1
+    conflicts           neovim-devel
+
+    # see note above on how to regenerate
+    set deps {
+        tree-sitter tree-sitter-c                  0.23.4  v  ""  treesitter_c
+        tree-sitter-grammars tree-sitter-lua       0.3.0   v  ""  treesitter_lua
+        neovim tree-sitter-vim                     0.5.0   v  ""  treesitter_vim
+        neovim tree-sitter-vimdoc                  3.0.1   v  ""  treesitter_vimdoc
+        tree-sitter-grammars tree-sitter-query     0.5.1   v  ""  treesitter_query
+        tree-sitter-grammars tree-sitter-markdown  0.4.1   v  ""  treesitter_markdown
+    }
+
+    checksums           neovim-0.11.0.tar.gz \
+                        rmd160  454f3f3caeb1fa82b5f3396978efc0195c71577d \
+                        sha256  6826c4812e96995d29a98586d44fbee7c9b2045485d50d174becd6d5242b3319 \
+                        size    12901255 \
+                        tree-sitter-c-0.23.4.tar.gz \
+                        rmd160  23c74c3b947bcda2e05921c06e65259f46a0c360 \
+                        sha256  b66c5043e26d84e5f17a059af71b157bcf202221069ed220aa1696d7d1d28a7a \
+                        size    380057 \
+                        tree-sitter-lua-0.3.0.tar.gz \
+                        rmd160  6d929ed4ee48e71204774ca1bd4cdc06d720193b \
+                        sha256  a34cc70abfd8d2d4b0fabf01403ea05f848e1a4bc37d8a4bfea7164657b35d31 \
+                        size    62157 \
+                        tree-sitter-vim-0.5.0.tar.gz \
+                        rmd160  971bc651fc62c5f18bdabc61da39620e8410eb87 \
+                        sha256  90019d12d2da0751c027124f27f5335babf069a050457adaed53693b5e9cf10a \
+                        size    357652 \
+                        tree-sitter-vimdoc-3.0.1.tar.gz \
+                        rmd160  cd3dd1aa3543b041e3c00dc0885e56c057125233 \
+                        sha256  76b65e5bee9ff78eb21256619b1995aac4d80f252c19e1c710a4839481ded09e \
+                        size    58427 \
+                        tree-sitter-query-0.5.1.tar.gz \
+                        rmd160  352bd633db597d87ff768dc379168105cd5b527f \
+                        sha256  fe8c712880a529d454347cd4c58336ac2db22243bae5055bdb5844fb3ea56192 \
+                        size    45070 \
+                        tree-sitter-markdown-0.4.1.tar.gz \
+                        rmd160  770039a4ed01fd69c102cff7b1717cdce3702a04 \
+                        sha256  e0fdb2dca1eb3063940122e1475c9c2b069062a638c95939e374c5427eddee9f \
+                        size    419261
+} else {
+    # devel
+
+    github.setup        neovim neovim e8785c2e94508eeabf6ff63e1fe1bcaecceef946
+    github.tarball_from archive
+    version             20250405-[string range ${github.version} 0 6]
+    revision            0
+    conflicts           neovim
+    github.livecheck.branch \
+                        nightly
+
+    # see note above on how to regenerate
+    set deps {
+        tree-sitter tree-sitter-c                  0.23.4  v  ""  treesitter_c
+        tree-sitter-grammars tree-sitter-lua       0.3.0   v  ""  treesitter_lua
+        neovim tree-sitter-vim                     0.5.0   v  ""  treesitter_vim
+        neovim tree-sitter-vimdoc                  3.0.1   v  ""  treesitter_vimdoc
+        tree-sitter-grammars tree-sitter-query     0.5.1   v  ""  treesitter_query
+        tree-sitter-grammars tree-sitter-markdown  0.4.1   v  ""  treesitter_markdown
+    }
+
+    checksums           neovim-e8785c2e94508eeabf6ff63e1fe1bcaecceef946.tar.gz \
+                        rmd160  32cb85b0aadb0345ea9ddc9e1dbb721be89c40c3 \
+                        sha256  9981bb8321171c69684e0e2796bae78858646e5603ed783dfa9eb5e948059839 \
+                        size    12949970 \
+                        tree-sitter-c-0.23.4.tar.gz \
+                        rmd160  23c74c3b947bcda2e05921c06e65259f46a0c360 \
+                        sha256  b66c5043e26d84e5f17a059af71b157bcf202221069ed220aa1696d7d1d28a7a \
+                        size    380057 \
+                        tree-sitter-lua-0.3.0.tar.gz \
+                        rmd160  6d929ed4ee48e71204774ca1bd4cdc06d720193b \
+                        sha256  a34cc70abfd8d2d4b0fabf01403ea05f848e1a4bc37d8a4bfea7164657b35d31 \
+                        size    62157 \
+                        tree-sitter-vim-0.5.0.tar.gz \
+                        rmd160  971bc651fc62c5f18bdabc61da39620e8410eb87 \
+                        sha256  90019d12d2da0751c027124f27f5335babf069a050457adaed53693b5e9cf10a \
+                        size    357652 \
+                        tree-sitter-vimdoc-3.0.1.tar.gz \
+                        rmd160  cd3dd1aa3543b041e3c00dc0885e56c057125233 \
+                        sha256  76b65e5bee9ff78eb21256619b1995aac4d80f252c19e1c710a4839481ded09e \
+                        size    58427 \
+                        tree-sitter-query-0.5.1.tar.gz \
+                        rmd160  352bd633db597d87ff768dc379168105cd5b527f \
+                        sha256  fe8c712880a529d454347cd4c58336ac2db22243bae5055bdb5844fb3ea56192 \
+                        size    45070 \
+                        tree-sitter-markdown-0.4.1.tar.gz \
+                        rmd160  770039a4ed01fd69c102cff7b1717cdce3702a04 \
+                        sha256  e0fdb2dca1eb3063940122e1475c9c2b069062a638c95939e374c5427eddee9f \
+                        size    419261
+}
+
+foreach {gh_author gh_project gh_version gh_tag_prefix gh_tag_suffix dirname} ${deps} {
+    master_sites-append https://github.com/${gh_author}/${gh_project}/archive/[join ${gh_tag_prefix}]${gh_version}[join ${gh_tag_suffix}]:${dirname}
+    distfiles-append    ${gh_project}-${gh_version}${extract.suffix}:${dirname}
+}
+
+extract.only        ${distname}${extract.suffix}
+post-extract {
+    foreach {_ gh_project gh_version gh_tag_prefix gh_tag_suffix dirname} ${deps} {
+        file mkdir ${workpath}/build/build/downloads/${dirname}
+        file copy \
+            ${distpath}/${gh_project}-${gh_version}${extract.suffix} \
+            ${workpath}/build/build/downloads/${dirname}/[join ${gh_tag_prefix}]${gh_version}[join ${gh_tag_suffix}]${extract.suffix}
+    }
 }


### PR DESCRIPTION
#### Description

Previously, during build-time Neovim's build system would fetch missing Tree-sitter syntaxes online. This introduces a change to leverage MacPorts ability to fetch more than one distfile and moves these new files to their expected place.

Also:

- bumped neovim-devel version

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.4 23H420 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
