### PR TITLE
chezmoi: Update to 2.62.0

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 2.61.0 v
+go.setup            github.com/twpayne/chezmoi 2.62.0 v
 go.offline_build    no
 revision            0
 
@@ -20,9 +20,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  c9b7c0e378366133e45e51842e173131866793cb \
-                    sha256  7a2a5ab782b2d6cd521451a258d9ffc6965a1541a4bbe10c6b9a4fd87dd700be \
-                    size    2542912
+checksums           rmd160  cb165decec9c2a5f5640a659c73fbfb57307fa3d \
+                    sha256  d8f553d871d35caf3d446b6f1032f4cad81a75fc41955bd3d71216a2aa6e17a4 \
+                    size    2538587
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

chezmoi: Update to 2.62.0

##### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
