### PR TITLE
libffi: Fix build on Sequoia.

### DIFF
--- a/devel/libffi/Portfile
+++ b/devel/libffi/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           github 1.0
 
 github.setup        libffi libffi 3.4.6 v
-revision            1
+revision            2
 
 checksums           rmd160  8e927f6bc340564414a87cc5b6dffc9ce53eefd8 \
                     sha256  b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e \
@@ -25,7 +25,19 @@ long_description    The libffi library provides a portable, high level \
 
 homepage            https://www.sourceware.org/libffi/
 
-patchfiles          patch-pre-snowleopard.diff
+
+# Patches derived from MacPorts-enhanced GitHub fork at
+# github.com/fhgwright/libffi
+
+# patch-sources.diff: fixes for various issues.
+#
+# This includes one upstream fix for a build problem on Sequoia.  Although
+# v3.4.7 includes this fix, it also has more test failures than v3.4.6,
+# so for now we just cherry-pick the needed change.
+#
+# This diff is from v3.4.6 vs. macports-3.4.6r2.
+#
+patchfiles          patch-sources.diff
 
 # Don't use macports gcc or clang toolchains to build this due to dependency cycles
 compiler.blacklist-append macports-*

--- a/devel/libffi/files/patch-sources.diff
+++ b/devel/libffi/files/patch-sources.diff
@@ -1,5 +1,37 @@
+--- src/aarch64/sysv.S.orig	2024-02-15 04:54:35.000000000 -0800
++++ src/aarch64/sysv.S	2025-04-06 16:16:17.000000000 -0700
+@@ -89,8 +89,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    x5 closure
+ */
+ 
+-	cfi_startproc
+ CNAME(ffi_call_SYSV):
++	cfi_startproc
+ 	BTI_C
+ 	/* Sign the lr with x1 since that is where it will be stored */
+ 	SIGN_LR_WITH_REG(x1)
+@@ -347,8 +347,8 @@ CNAME(ffi_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_closure_SYSV):
++	cfi_startproc
+ 	BTI_C
+ 	SIGN_LR
+ 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+@@ -643,8 +643,8 @@ CNAME(ffi_go_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_go_closure_SYSV):
++	cfi_startproc
+ 	BTI_C
+ 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+ 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
 --- src/powerpc/darwin.S.orig	2023-03-15 07:19:45.000000000 -0700
-+++ src/powerpc/darwin.S	2024-02-26 18:37:38.000000000 -0800
++++ src/powerpc/darwin.S	2025-04-06 16:16:17.000000000 -0700
 @@ -31,8 +31,6 @@
  #define MODE_CHOICE(x, y) x
  #endif
@@ -10,7 +42,7 @@
  #define lgu		MODE_CHOICE(lwzu, ldu)
  #define lg		MODE_CHOICE(lwz,ld)
 --- src/powerpc/darwin_closure.S.orig	2023-03-15 07:19:45.000000000 -0700
-+++ src/powerpc/darwin_closure.S	2024-02-26 18:37:38.000000000 -0800
++++ src/powerpc/darwin_closure.S	2025-04-06 16:16:17.000000000 -0700
 @@ -34,7 +34,7 @@
  #define MODE_CHOICE(x, y) x
  #endif
@@ -21,7 +53,7 @@
  ; Define some pseudo-opcodes for size-independent load & store of GPRs ...
  #define lgu		MODE_CHOICE(lwzu, ldu)
 --- testsuite/lib/libffi.exp.orig	2023-03-15 07:19:45.000000000 -0700
-+++ testsuite/lib/libffi.exp	2024-02-26 18:37:38.000000000 -0800
++++ testsuite/lib/libffi.exp	2025-04-06 16:16:17.000000000 -0700
 @@ -516,7 +516,10 @@ proc run-many-tests { testcases extra_fl
          }
        }
@@ -35,7 +67,7 @@
  	  set optimizations [ list $env(LIBFFI_TEST_OPTIMIZATION) ]
          } else {
 --- testsuite/libffi.bhaible/bhaible.exp.orig	2023-03-15 07:19:45.000000000 -0700
-+++ testsuite/libffi.bhaible/bhaible.exp	2024-02-26 18:37:38.000000000 -0800
++++ testsuite/libffi.bhaible/bhaible.exp	2025-04-06 16:16:17.000000000 -0700
 @@ -24,7 +24,10 @@ global compiler_vendor
  # was done in a pretty lazy fashion, and requires the use of compiler
  # flags to disable warnings for now.


### PR DESCRIPTION
This cherry-picks an upstream fix for a build problem with a recent clang.  Although the fix is included in v3.4.7, the latter has significantly more test failures than v3.4.6.  Until that is investigated further, we stay on v3.4.6 with the cherry-picked fix, to avoid a possible functional regression.

Due to the (admittedly unlikely) possibility that this changes the installed content, it includes a revbump, which is not very expensive for this particular port.  No revbumping of dependents is needed.

Closes: https://trac.macports.org/ticket/72271

The unified patchfile is also renamed with a more generic name.

TESTED:
Successfuly built -/+universal on 10.4-10.5 ppc, 10.5-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-15.x arm64. Tests not included due to many known failures.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.5 22H527, arm64, Xcode 15.2 15C500b
macOS 14.7.5 23H527, arm64, Xcode 16.2 16C5032a
macOS 15.3.2 24D81, arm64, Xcode 16.3 16E140
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` Tests have issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
