### PR TITLE
Update quickjs to 2024-01-13

### DIFF
--- a/devel/quickjs/Portfile
+++ b/devel/quickjs/Portfile
@@ -10,7 +10,7 @@ license          MIT
 maintainers      nomaintainer
 description      A small and embeddable Javascript engine
 long_description ${name} is a small and embeddable Javascript engine. It \
-    supports the ES2020 specification including modules, asynchronous \
+    supports the ES2023 specification including modules, asynchronous \
     generators, proxies and BigInt.
 homepage         https://bellard.org/quickjs/
 
@@ -18,34 +18,34 @@ subport          ${name}-devel {}
 
 if {${subport} eq ${name}} {
     conflicts       ${name}-devel
-    github.setup    bellard ${name} b5e62895c619d4ffc75c9d822c8d85f1ece77e5b
+    github.setup    bellard ${name} 3f81070e573e3592728dbbbd04c84c498b20d6dc
     # Change github.tarball_from to 'releases' or 'archive' next update
     github.tarball_from tarball
-    version         20210327
+    version         20240113
     revision        0
-    checksums       rmd160  9a6bbc8c7900a77d181120cb498fa7cb51a41b94 \
-                    sha256  758df41d9864202c189040e7c5378f34a4c1c65bca3b1d0a54cbcf7650c35bb3 \
-                    size    597758
+    checksums       rmd160  0132951d0f78c50b10ade905ef82226ebbd23b64 \
+                    sha256  e8162d9e721c3d2846d8d0bef862c539b6e2853fbaf8e536f8e5c4d5dce548c8 \
+                    size    612907
 } else {
     # quickjs-devel
     conflicts       ${name}
-    github.setup    bellard ${name} 2788d71e823b522b178db3b3660ce93689534e6d
+    github.setup    bellard ${name} 00b709dfff9d858b53edfd9cb8a185b120e0cbd8
     # Change github.tarball_from to 'releases' or 'archive' next update
     github.tarball_from tarball
-    version         20220306
+    version         20250405
     revision        0
-    checksums       rmd160 548cedf046daaeaeb84cabfc11f5044757714412 \
-                    sha256 06f001604ae8df9bdc7377d088320e698a014ec3434283f49e2c84f609233102 \
-                    size   598937
+    checksums       rmd160 58aa581442bc5943729db9f9fbd468a2d602d67b \
+                    sha256 21692df389cdbe47147ced9b657380808c15dd9cb869cee75e5dde582986fb35 \
+                    size   560560
     post-extract {
         # `VERSION` is only updated for "real" releases.
-        reinplace "s|2021.03.27|${version}|" ${worksrcpath}/VERSION
+        reinplace "s|2024.01.13|${version}|" ${worksrcpath}/VERSION
     }
 }
 
 use_configure    no
 
-destroot.destdir prefix=${destroot}${prefix}
+destroot.destdir PREFIX=${destroot}${prefix}
 
 post-destroot {
     file mkdir ${destroot}${prefix}/lib/pkgconfig

--- a/devel/quickjs/Portfile
+++ b/devel/quickjs/Portfile
@@ -19,8 +19,7 @@ subport          ${name}-devel {}
 if {${subport} eq ${name}} {
     conflicts       ${name}-devel
     github.setup    bellard ${name} 3f81070e573e3592728dbbbd04c84c498b20d6dc
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    github.tarball_from tarball
+    github.tarball_from archive
     version         20240113
     revision        0
     checksums       rmd160  0132951d0f78c50b10ade905ef82226ebbd23b64 \
@@ -30,8 +29,7 @@ if {${subport} eq ${name}} {
     # quickjs-devel
     conflicts       ${name}
     github.setup    bellard ${name} 00b709dfff9d858b53edfd9cb8a185b120e0cbd8
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    github.tarball_from tarball
+    github.tarball_from archive
     version         20250405
     revision        0
     checksums       rmd160 58aa581442bc5943729db9f9fbd468a2d602d67b \


### PR DESCRIPTION
#### Description

Updates quickjs to 2024-01-13 and quickjs-devel to 2025-04-05

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.3.2 24D81 x86_64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
