### PR TITLE
openjdk25-zulu: update to 25.0.31

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -15,7 +15,8 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.29
+version      ${feature}.0.31
+set build    15
 revision     0
 
 set openjdk_version ${feature}.0.0
@@ -31,19 +32,19 @@ long_description {*}${description} \
 
 master_sites https://cdn.azul.com/zulu/bin/
 
-if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.12-macosx_x64
-    checksums    rmd160  6225a18467f3f228014398b04a53748c4e31ae6f \
-                 sha256  a9600dadecd7837fa59ad8d307f42147216cada0007624744b1ec29696009379 \
-                 size    224280537
-} elseif {${configure.build_arch} eq "arm64"} {
-    # No .tar.gz (yet?) for arm64
-    use_zip yes
+# No .tar.gz (yet?) for arm64
+use_zip yes
 
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.12-macosx_aarch64
-    checksums    rmd160  17ea5755fa78e4fcd87f07ce9a823af58eb436f0 \
-                 sha256  e2d4e17215710d1bf1ba2aa62a5f94f9197c3ab1319bd6b29e1997b9ad7437db \
-                 size    225303434
+if {${configure.build_arch} eq "x86_64"} {
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_x64
+    checksums    rmd160  fa5e9cb5029e7c189719bda9cfa900eafa19d990 \
+                 sha256  1430844cf3bc63e0aa0e7b860d1eb5c20b2b90a32b6e245ee973250285a59e3a \
+                 size    227746627
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_aarch64
+    checksums    rmd160  85dbd5d8ca624e0278a592f039c4bbd337a3b626 \
+                 sha256  2b459cf4c9d504e4f6dbaec5811d37a03da71ed9082c052fc4e53f8f05e91e09 \
+                 size    225286637
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.0.31.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?