### PR TITLE
micronaut: update to 4.8.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.7.6 v
+github.setup    micronaut-projects micronaut-starter 4.8.0 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  30115f6f716128d3d9773c57e17a403400e73a03 \
-                 sha256  249c7e7128a877601b86158bb08a1461adc7c024aeff3d90a6929503ddbea249 \
-                 size    27861555
+    checksums    rmd160  426dcb89f8558b81d4b9708404b5035f18cfd626 \
+                 sha256  78f4d2138904a8bbc4af0d4e2642efe64ff49fbe31df34a394bdcb43c6fee26b \
+                 size    28097964
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  ec0e295d854a23f027de66dd78a5fb3367fdf346 \
-                 sha256  b6a7162a9a3327a5cfa42453fab8c801d85d8b0248904931b519b4e93c8d7534 \
-                 size    27645402
+    checksums    rmd160  a3d841bef6f2f7113e38123e4519489023e5e438 \
+                 sha256  116ff6f15ce2710d5a5cfb7e7b1f2c5d1eaeb510a4cdd37373eb4350ff2c52b5 \
+                 size    27865367
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.8.0.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?