### PR TITLE
skaffold: update to 2.15.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.14.2 v
+github.setup        GoogleContainerTools skaffold 2.15.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  73be0dd145f0796f70f055dad314b717a67042de \
-                    sha256  0837ac43e6b207ec72fdc620a20dba404737e1edd4de69e376659f0da273e01d \
-                    size    63087453
+checksums           rmd160  7fa8afd77bfc5ff2c57dd2b894376efb866ec6c2 \
+                    sha256  e4ed90073d89460bb028742e8c79154366b0980da610faaf8aa0c2e1f025b2e3 \
+                    size    63245312
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.15.0.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?