### PR TITLE
nginx: use pcre2

### DIFF
--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                nginx
 version             1.26.3
-revision            0
+revision            1
 categories          www mail
 license             BSD
 maintainers         {mps @Schamschula} openmaintainer
@@ -40,7 +40,7 @@ checksums           ${name}-${version}${extract.suffix} \
                     sha256  69ee2b237744036e61d24b836668aad3040dda461fe6f570f1787eab570c75aa \
                     size    1260179
 
-depends_lib         port:pcre \
+depends_lib         port:pcre2 \
                     port:zlib
 
 patchfiles          patch-auto__install.diff \
@@ -79,10 +79,6 @@ configure.args-append \
                     --http-fastcgi-temp-path=${nginx_rundir}/fastcgi_temp \
                     --http-uwsgi-temp-path=${nginx_rundir}/uwsgi_temp \
                     --with-compat
-
-# pcre2 breaks the lua module (https://trac.macports.org/ticket/65150)
-configure.args-append \
-                    --without-pcre2
 
 # remove --disable-dependency-tracking
 configure.universal_args-delete   --disable-dependency-tracking


### PR DESCRIPTION
The version of PCRE installed by the pcre port is EOL. The lua module for nginx has supported pcre2 since version 0.10.26.

See: https://github.com/openresty/lua-nginx-module/commit/cb83e33e26579788be0fe0282fa5976de6dfa6e3

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4 24E248 arm64
Xcode 16.3 16E140
