### PR TITLE
mise: Update to 2025.4.1

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.4.0 v
+github.setup        jdx mise 2025.4.1 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  e6e44338972b62e3d8c86de426a916e9452c65d6 \
-                    sha256  4b62c436053444d3cd958c36c2a027d5429aa2ad084125db844e3487c24d714a \
-                    size    4148880
+                    rmd160  ac4fe6e12f87c9eb3b2e7ee7be51e9e40fdb656f \
+                    sha256  755f34ea2b27b23db84ef4ed4cae1ff1afff1391b65d033b80b0ba03e4027d82 \
+                    size    4149619
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -127,7 +127,7 @@ cargo.crates \
     bit-vec                          0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
     bitflags                         2.9.0  5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
+    bstr                            1.12.0  234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4 \
     built                            0.7.7  56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b \
     bumpalo                         3.17.0  1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf \
     bytecount                        0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
@@ -138,7 +138,7 @@ cargo.crates \
     bzip2-sys                 0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                              1.2.17  1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a \
+    cc                              1.2.18  525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
@@ -148,8 +148,8 @@ cargo.crates \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
-    clap                            4.5.34  e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff \
-    clap_builder                    4.5.34  83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489 \
+    clap                            4.5.35  d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944 \
+    clap_builder                    4.5.35  2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9 \
     clap_derive                     4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     clap_mangen                     0.2.26  724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a \
@@ -177,7 +177,7 @@ cargo.crates \
     crc                              3.2.1  69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636 \
     crc-catalog                      2.4.0  19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5 \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
-    crossbeam-channel               0.5.14  06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471 \
+    crossbeam-channel               0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
     crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
     crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
@@ -197,7 +197,7 @@ cargo.crates \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
     demand                           1.6.5  7abeb34924c8d59be6428a07f63a0bf5f9d5c15ccb6fd9ef4f4e8cd7f422abfe \
     der                              0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
-    deranged                         0.4.1  28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058 \
+    deranged                         0.4.0  9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e \
     derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
     derive_more                    0.99.19  3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f \
     deunicode                        1.6.1  dc55fe0d1f6c107595572ec8b107c0999bb1a2e0b75e37429a4fb0d6474a0e7d \
@@ -219,12 +219,12 @@ cargo.crates \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     env_filter                       0.1.3  186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0 \
     env_home                         0.1.0  c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe \
-    env_logger                      0.11.7  c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697 \
+    env_logger                      0.11.8  13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f \
     envmnt                          0.10.4  d73999a2b8871e74c8b8bc23759ee9f3d85011b24fafc91a4b3b5c8cc8185501 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     erased-serde                     0.4.6  e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7 \
     errno                            0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
-    errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
+    errno                           0.3.11  976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e \
     errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
     exec                             0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
     expr-lang                        0.3.0  8ecf48d3d55edfb3a2960f8cd3d13412af146b912446a9e04812af69761e3b56 \
@@ -236,7 +236,7 @@ cargo.crates \
     filetime_creation                0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
     find-crate                       0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
     fixedbitset                      0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
-    flate2                           1.1.0  11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc \
+    flate2                           1.1.1  7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece \
     fluent                          0.16.1  bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a \
     fluent-bundle                   0.15.3  7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493 \
     fluent-langneg                  0.13.0  2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94 \
@@ -263,60 +263,60 @@ cargo.crates \
     getrandom                        0.3.2  73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0 \
     ghash                            0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
-    gix                             0.70.0  736f14636705f3a56ea52b553e67282519418d9a35bb1e90b3a9637a00296b68 \
-    gix-actor                       0.33.2  20018a1a6332e065f1fcc8305c1c932c6b8c9985edea2284b3c79dc6fa3ee4b2 \
-    gix-archive                     0.19.0  3d22c6ecdb350461a975159ebe514294064b9542a4cbc4a12d00c3f46a1107ce \
-    gix-attributes                  0.24.0  f151000bf662ef5f641eca6102d942ee31ace80f271a3ef642e99776ce6ddb38 \
+    gix                             0.71.0  a61e71ec6817fc3c9f12f812682cfe51ee6ea0d2e27e02fc3849c35524617435 \
+    gix-actor                       0.34.0  f438c87d4028aca4b82f82ba8d8ab1569823cfb3e5bc5fa8456a71678b2a20e7 \
+    gix-archive                     0.20.0  9bc3a718dab8958d67a20d6d464daeea46a69b05d3cf0d369cb5c871dcd51a6e \
+    gix-attributes                  0.25.0  e4e25825e0430aa11096f8b65ced6780d4a96a133f81904edceebb5344c8dd7f \
     gix-bitmap                      0.2.14  b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540 \
     gix-chunk                       0.4.11  0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f \
-    gix-command                      0.4.1  cb410b84d6575db45e62025a9118bdbf4d4b099ce7575a76161e898d9ca98df1 \
-    gix-commitgraph                 0.26.0  e23a8ec2d8a16026a10dafdb6ed51bcfd08f5d97f20fa52e200bc50cb72e4877 \
-    gix-config                      0.43.0  377c1efd2014d5d469e0b3cd2952c8097bce9828f634e04d5665383249f1d9e9 \
-    gix-config-value               0.14.11  11365144ef93082f3403471dbaa94cfe4b5e72743bdb9560719a251d439f4cee \
-    gix-credentials                 0.27.0  cf950f9ee1690bb9c4388b5152baa8a9f41ad61e5cf1ba0ec8c207b08dab9e45 \
-    gix-date                         0.9.3  c57c477b645ee248b173bb1176b52dd528872f12c50375801a58aaf5ae91113f \
-    gix-diff                        0.50.0  62afb7f4ca0acdf4e9dad92065b2eb1bf2993bcc5014b57bc796e3a365b17c4d \
-    gix-dir                         0.12.0  c1d78db3927a12f7d1b788047b84efacaab03ef25738bd1c77856ad8966bd57b \
-    gix-discover                    0.38.0  d0c2414bdf04064e0f5a5aa029dfda1e663cf9a6c4bfc8759f2d369299bb65d8 \
-    gix-features                    0.40.0  8bfdd4838a8d42bd482c9f0cb526411d003ee94cc7c7b08afe5007329c71d554 \
-    gix-filter                      0.17.0  bdcc36cd7dbc63ed0ec3558645886553d1afd3cd09daa5efb9cba9cceb942bbb \
-    gix-fs                          0.13.0  182e7fa7bfdf44ffb7cfe7451b373cdf1e00870ac9a488a49587a110c562063d \
-    gix-glob                        0.18.0  4e9c7249fa0a78f9b363aa58323db71e0a6161fd69860ed6f48dedf0ef3a314e \
-    gix-hash                        0.16.0  e81c5ec48649b1821b3ed066a44efb95f1a268b35c1d91295e61252539fbe9f8 \
-    gix-hashtable                    0.7.0  189130bc372accd02e0520dc5ab1cef318dcc2bc829b76ab8d84bbe90ac212d1 \
-    gix-ignore                      0.13.0  4f529dcb80bf9855c0a7c49f0ac588df6d6952d63a63fefc254b9c869d2cdf6f \
-    gix-index                       0.38.0  acd12e3626879369310fffe2ac61acc828613ef656b50c4ea984dd59d7dc85d8 \
-    gix-lock                        16.0.0  9739815270ff6940968441824d162df9433db19211ca9ba8c3fc1b50b849c642 \
-    gix-mailmap                     0.25.2  017996966133afb1e631796d8cf32e43300f8f76233f2a15ce9af5be5069b0a6 \
-    gix-negotiate                   0.18.0  a6a8af1ef7bbe303d30b55312b7f4d33e955de43a3642ae9b7347c623d80ef80 \
-    gix-object                      0.47.0  ddc4b3a0044244f0fe22347fb7a79cca165e37829d668b41b85ff46a43e5fd68 \
-    gix-odb                         0.67.0  3e93457df69cd09573608ce9fa4f443fbd84bc8d15d8d83adecd471058459c1b \
-    gix-pack                        0.57.0  fc13a475b3db735617017fb35f816079bf503765312d4b1913b18cf96f3fa515 \
-    gix-packetline                  0.18.3  c7e5ae6bc3ac160a6bf44a55f5537813ca3ddb08549c0fd3e7ef699c73c439cd \
-    gix-packetline-blocking         0.18.2  c1cbf8767c6abd5a6779f586702b5bcd8702380f4208219449cf1c9d0cd1e17c \
-    gix-path                       0.10.14  c40f12bb65a8299be0cfb90fe718e3be236b7a94b434877012980863a883a99f \
-    gix-pathspec                     0.9.0  6430d3a686c08e9d59019806faa78c17315fe22ae73151a452195857ca02f86c \
-    gix-prompt                       0.9.1  79f2185958e1512b989a007509df8d61dca014aa759a22bee80cfa6c594c3b6d \
-    gix-protocol                    0.48.0  6c61bd61afc6b67d213241e2100394c164be421e3f7228d3521b04f48ca5ba90 \
-    gix-quote                       0.4.15  e49357fccdb0c85c0d3a3292a9f6db32d9b3535959b5471bb9624908f4a066c6 \
-    gix-ref                         0.50.0  47adf4c5f933429f8554e95d0d92eee583cfe4b95d2bf665cd6fd4a1531ee20c \
-    gix-refspec                     0.28.0  59650228d8f612f68e7f7a25f517fcf386c5d0d39826085492e94766858b0a90 \
-    gix-revision                    0.32.0  3fe28bbccca55da6d66e6c6efc6bb4003c29d407afd8178380293729733e6b53 \
-    gix-revwalk                     0.18.0  d4ecb80c235b1e9ef2b99b23a81ea50dd569a88a9eb767179793269e0e616247 \
-    gix-sec                        0.10.11  d84dae13271f4313f8d60a166bf27e54c968c7c33e2ffd31c48cafe5da649875 \
-    gix-shallow                      0.2.0  ab72543011e303e52733c85bef784603ef39632ddf47f69723def52825e35066 \
-    gix-status                      0.17.0  414cc1d85079d7ca32c3ab4a6479bf7e174cd251c74a82339c6cc393da3f4883 \
-    gix-submodule                   0.17.0  74972fe8d46ac8a09490ae1e843b4caf221c5b157c5ac17057e8e1c38417a3ac \
-    gix-tempfile                    16.0.0  2558f423945ef24a8328c55d1fd6db06b8376b0e7013b1bb476cc4ffdf678501 \
+    gix-command                      0.5.0  c0378995847773a697f8e157fe2963ecf3462fe64be05b7b3da000b3b472def8 \
+    gix-commitgraph                 0.27.0  043cbe49b7a7505150db975f3cb7c15833335ac1e26781f615454d9d640a28fe \
+    gix-config                      0.44.0  9c6f830bf746604940261b49abf7f655d2c19cadc9f4142ae9379e3a316e8cfa \
+    gix-config-value               0.14.12  8dc2c844c4cf141884678cabef736fd91dd73068b9146e6f004ba1a0457944b6 \
+    gix-credentials                 0.28.0  25322308aaf65789536b860d21137c3f7b69004ac4971c15c1abb08d3951c062 \
+    gix-date                         0.9.4  daa30058ec7d3511fbc229e4f9e696a35abd07ec5b82e635eff864a2726217e4 \
+    gix-diff                        0.51.0  a2c975dad2afc85e4e233f444d1efbe436c3cdcf3a07173984509c436d00a3f8 \
+    gix-dir                         0.13.0  5879497bd3815d8277ed864ec8975290a70de5b62bb92d2d666a4cefc5d4793b \
+    gix-discover                    0.39.0  f7fb8a4349b854506a3915de18d3341e5f1daa6b489c8affc9ca0d69efe86781 \
+    gix-features                    0.41.1  016d6050219458d14520fe22bdfdeb9cb71631dec9bc2724767c983f60109634 \
+    gix-filter                      0.18.0  cb2b2bbffdc5cc9b2b82fc82da1b98163c9b423ac2b45348baa83a947ac9ab89 \
+    gix-fs                          0.14.0  951e886120dc5fa8cac053e5e5c89443f12368ca36811b2e43d1539081f9c111 \
+    gix-glob                        0.19.0  20972499c03473e773a2099e5fd0c695b9b72465837797a51a43391a1635a030 \
+    gix-hash                        0.17.0  834e79722063958b03342edaa1e17595cd2939bb2b3306b3225d0815566dcb49 \
+    gix-hashtable                    0.8.0  f06066d8702a9186dc1fdc1ed751ff2d7e924ceca21cb5d51b8f990c9c2e014a \
+    gix-ignore                      0.14.0  9a27c8380f493a10d1457f756a3f81924d578fc08d6535e304dfcafbf0261d18 \
+    gix-index                       0.39.0  855bece2d4153453aa5d0a80d51deea1ce8cd6a3b4cf213da85ac344ccb908a7 \
+    gix-lock                        17.0.0  df47b8f11c34520db5541bc5fc9fbc8e4b0bdfcec3736af89ccb1a5728a0126f \
+    gix-mailmap                     0.26.0  ff80d086d2684d30c5785cc37eba9d2cf817cfb33797ed999db9a359d16ab393 \
+    gix-negotiate                   0.19.0  dad912acf5a68a7defa4836014337ff4381af8c3c098f41f818a8c524285e57b \
+    gix-object                      0.48.0  4943fcdae6ffc135920c9ea71e0362ed539182924ab7a85dd9dac8d89b0dd69a \
+    gix-odb                         0.68.0  50306d40dcc982eb6b7593103f066ea6289c7b094cb9db14f3cd2be0b9f5e610 \
+    gix-pack                        0.58.0  9b65fffb09393c26624ca408d32cfe8776fb94cd0a5cdf984905e1d2f39779cb \
+    gix-packetline                  0.18.4  123844a70cf4d5352441dc06bab0da8aef61be94ec239cb631e0ba01dc6d3a04 \
+    gix-packetline-blocking         0.18.3  1ecf3ea2e105c7e45587bac04099824301262a6c43357fad5205da36dbb233b3 \
+    gix-path                       0.10.15  f910668e2f6b2a55ff35a1f04df88a1a049f7b868507f4cbeeaa220eaba7be87 \
+    gix-pathspec                    0.10.0  fef8422c3c9066d649074b24025125963f85232bfad32d6d16aea9453b82ec14 \
+    gix-prompt                      0.10.0  fbf9cbf6239fd32f2c2c9c57eeb4e9b28fa1c9b779fa0e3b7c455eb1ca49d5f0 \
+    gix-protocol                    0.49.0  5678ddae1d62880bc30e2200be1b9387af3372e0e88e21f81b4e7f8367355b5a \
+    gix-quote                        0.5.0  1b005c550bf84de3b24aa5e540a23e6146a1c01c7d30470e35d75a12f827f969 \
+    gix-ref                         0.51.0  b2e1f7eb6b7ce82d2d19961f74bd637bab3ea79b1bc7bfb23dbefc67b0415d8b \
+    gix-refspec                     0.29.0  1d8587b21e2264a6e8938d940c5c99662779c13a10741a5737b15fc85c252ffc \
+    gix-revision                    0.33.0  342caa4e158df3020cadf62f656307c3948fe4eacfdf67171d7212811860c3e9 \
+    gix-revwalk                     0.19.0  2dc7c3d7e5cdc1ab8d35130106e4af0a4f9f9eca0c81f4312b690780e92bde0d \
+    gix-sec                        0.10.12  47aeb0f13de9ef2f3033f5ff218de30f44db827ac9f1286f9ef050aacddd5888 \
+    gix-shallow                      0.3.0  cc0598aacfe1d52575a21c9492fee086edbb21e228ec36c819c42ab923f434c3 \
+    gix-status                      0.18.0  605a6d0eb5891680c46e24b2ee7a63ef7bd39cb136dc7c7e55172960cf68b2f5 \
+    gix-submodule                   0.18.0  78c7390c2059505c365e9548016d4edc9f35749c6a9112b7b1214400bbc68da2 \
+    gix-tempfile                    17.0.0  3d6de439bbb9a5d3550c9c7fab0e16d2d637d120fcbe0dfbc538772a187f099b \
     gix-trace                       0.1.12  7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7 \
-    gix-transport                   0.45.0  11187418489477b1b5b862ae1aedbbac77e582f2c4b0ef54280f20cfe5b964d9 \
-    gix-traverse                    0.44.0  2bec70e53896586ef32a3efa7e4427b67308531ed186bb6120fb3eca0f0d61b4 \
-    gix-url                         0.29.0  29218c768b53dd8f116045d87fec05b294c731a4b2bdd257eeca2084cc150b13 \
-    gix-utils                       0.1.14  ff08f24e03ac8916c478c8419d7d3c33393da9bb41fa4c24455d5406aeefd35f \
-    gix-validate                     0.9.3  9eaa01c3337d885617c0a42e92823922a2aea71f4caeace6fe87002bdcadbd90 \
-    gix-worktree                    0.39.0  6673512f7eaa57a6876adceca6978a501d6c6569a4f177767dc405f8b9778958 \
-    gix-worktree-state              0.17.0  86f5e199ad5af972086683bd31d640c82cb85885515bf86d86236c73ce575bf0 \
-    gix-worktree-stream             0.19.0  f61b0463c3cf4d07f2c72a10bdb03a2e4d70a9c26416c639346ad67456834485 \
+    gix-transport                   0.46.0  b3f68c2870bfca8278389d2484a7f2215b67d0b0cc5277d3c72ad72acf41787e \
+    gix-traverse                    0.45.0  36c0b049f8bdb61b20016694102f7b507f2e1727e83e9c5e6dad4f7d84ff7384 \
+    gix-url                         0.30.0  48dfe23f93f1ddb84977d80bb0dd7aa09d1bf5d5afc0c9b6820cccacc25ae860 \
+    gix-utils                        0.2.0  189f8724cf903e7fd57cfe0b7bc209db255cacdcb22c781a022f52c3a774f8d0 \
+    gix-validate                     0.9.4  34b5f1253109da6c79ed7cf6e1e38437080bb6d704c76af14c93e2f255234084 \
+    gix-worktree                    0.40.0  f7760dbc4b79aa274fed30adc0d41dca6b917641f26e7867c4071b1fb4dc727b \
+    gix-worktree-state              0.18.0  490eb4d38ec2735b3466840aa3881b44ec1a4c180d6a658abfab03910380e18b \
+    gix-worktree-stream             0.20.0  0062d69b23f136ace0e6f8e5372a98bde89b9092a52d0996d89a75085489ea63 \
     glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
     globset                         0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
@@ -368,7 +368,7 @@ cargo.crates \
     impl-tools-lib                  0.11.1  2a391adcea096a89a593317881fb61ef4e68d3e7d9de9e2338e6e1557be29e10 \
     indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                         2.8.0  3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058 \
+    indexmap                         2.9.0  cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e \
     indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
     indoc                            2.0.6  f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
     inout                            0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
@@ -383,12 +383,11 @@ cargo.crates \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
-    jiff                            0.1.29  c04ef77ae73f3cf50510712722f0c4e8b46f5aaa1bf5ffad2ae213e6495e78e5 \
-    jiff                             0.2.5  c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260 \
-    jiff-static                      0.2.5  4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c \
+    jiff                             0.2.6  1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488 \
+    jiff-static                      0.2.6  43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19 \
     jiff-tzdb                        0.1.4  c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524 \
     jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
-    jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
+    jobserver                       0.1.33  38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a \
     js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
     junction                         1.2.0  72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16 \
     kdl                              6.3.4  12661358400b02cbbf1fbd05f0a483335490e8a6bd1867620f2eeb78f304a22f \
@@ -401,7 +400,7 @@ cargo.crates \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
-    linux-raw-sys                    0.9.3  fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413 \
+    linux-raw-sys                    0.9.4  cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
     litemap                          0.7.5  23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856 \
     litrs                            0.4.1  b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
@@ -425,7 +424,7 @@ cargo.crates \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     minisign-verify                  0.2.3  6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3 \
     miniz_oxide                      0.7.4  b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08 \
-    miniz_oxide                      0.8.5  8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5 \
+    miniz_oxide                      0.8.8  3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a \
     mio                              1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
     mlua                            0.10.3  d3f763c1041eff92ffb5d7169968a327e1ed2ebfe425dac0ee5a35f29082534b \
     mlua-sys                         0.6.7  1901c1a635a22fe9250ffcc4fcc937c16b47c2e9e71adba8784af8bca1f69594 \
@@ -450,10 +449,10 @@ cargo.crates \
     object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
     once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
     opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
-    openssl                        0.10.71  5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd \
+    openssl                        0.10.72  fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
-    openssl-sys                    0.9.106  8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd \
+    openssl-sys                    0.9.107  8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     os-release                       0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
@@ -512,7 +511,7 @@ cargo.crates \
     rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
-    redox_syscall                   0.5.10  0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1 \
+    redox_syscall                   0.5.11  d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3 \
     redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
@@ -534,7 +533,7 @@ cargo.crates \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
-    rustix                           1.0.4  7a04a32fb43fcdef85b977ce7f77a150805e4b2ea1f2656898d4a547dde78df6 \
+    rustix                           1.0.5  d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf \
     rustls                         0.23.25  822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
@@ -573,7 +572,7 @@ cargo.crates \
     serial_test_derive               3.2.0  5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef \
     sevenz-rust                      0.6.1  26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
-    sha1_smol                        1.0.1  bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d \
+    sha1-checked                    0.10.0  89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423 \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shared_child                     1.0.1  09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c \
@@ -588,7 +587,7 @@ cargo.crates \
     siphasher                        1.0.1  56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     slug                             0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
-    smallvec                        1.14.0  7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd \
+    smallvec                        1.15.0  8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9 \
     socket2                          0.5.9  4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
@@ -629,7 +628,7 @@ cargo.crates \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                          1.9.0  09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.44.1  f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a \
+    tokio                           1.44.2  e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48 \
     tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                    0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
@@ -698,7 +697,7 @@ cargo.crates \
     web-sys                         0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                    0.26.8  2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9 \
-    which                            7.0.2  2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283 \
+    which                            7.0.3  24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762 \
     widestring                       1.2.0  dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -747,7 +746,7 @@ cargo.crates \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
     winnow                          0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
-    winnow                           0.7.4  0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36 \
+    winnow                           0.7.6  63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10 \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.4.1

##### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
