### PR TITLE
kubecolor: new port

### DIFF
--- a/devel/kubecolor/Portfile
+++ b/devel/kubecolor/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubecolor/kubecolor v0.5.0
+go.setup            github.com/kubecolor/kubecolor 0.5.0 v
 revision            0
 
 categories          devel
@@ -25,7 +25,7 @@ checksums           rmd160  3a6db5c54c3c2cffba409a7df116eaea16309a4c \
                     size    1368381
 
 go.offline_build no
-build.args          -o ${name} -ldflags '-X main.Version=0.5.0' .
+build.args          -o ${name} -ldflags "-X main.Version=${version}" .
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/

--- a/devel/kubecolor/Portfile
+++ b/devel/kubecolor/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/kubecolor/kubecolor v0.5.0
+revision            0
+
+categories          devel
+maintainers         {semihbkgr @semihbkgr} openmaintainer
+license             MIT
+
+description         \
+    Kubecolor is a tool that colorizes the output of kubectl commands to \
+    improve readability.
+long_description    {*}${description} \
+    \nKubecolor is a command-line tool that improves the readability of \
+    Kubernetes command outputs by adding color to kubectl results. By \
+    highlighting important information, it makes output easier to interpret, \
+    helping users manage Kubernetes resources more efficiently and enhancing \
+    overall workflow productivity.
+
+checksums           rmd160  3a6db5c54c3c2cffba409a7df116eaea16309a4c \
+                    sha256  251b3e2e84bd3574a9c628961066c8b41c403de6ecfb83b7aebd0dd5d7018290 \
+                    size    1368381
+
+go.offline_build no
+build.args          -o ${name} -ldflags '-X main.Version=0.5.0' .
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}

--- a/devel/kubecolor/Portfile
+++ b/devel/kubecolor/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  3a6db5c54c3c2cffba409a7df116eaea16309a4c \
                     sha256  251b3e2e84bd3574a9c628961066c8b41c403de6ecfb83b7aebd0dd5d7018290 \
                     size    1368381
 
-build.args          -o ${name} -ldflags "-X main.Version=${version}" .
+build.args          -o ${name} -ldflags \"-X main.Version=${version}\" .
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/

--- a/devel/kubecolor/Portfile
+++ b/devel/kubecolor/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/kubecolor/kubecolor 0.5.0 v
+go.offline_build    no
 revision            0
 
 categories          devel
@@ -24,7 +25,6 @@ checksums           rmd160  3a6db5c54c3c2cffba409a7df116eaea16309a4c \
                     sha256  251b3e2e84bd3574a9c628961066c8b41c403de6ecfb83b7aebd0dd5d7018290 \
                     size    1368381
 
-go.offline_build no
 build.args          -o ${name} -ldflags "-X main.Version=${version}" .
 
 destroot {


### PR DESCRIPTION
#### Description

It adds `kubecolor` as a new `MacPorts` port.
https://github.com/kubecolor/kubecolor/issues/224

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.1.1 24B91 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
