### PR TITLE
mise: Update to 2025.4.2

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.4.1 v
+github.setup        jdx mise 2025.4.2 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ac4fe6e12f87c9eb3b2e7ee7be51e9e40fdb656f \
-                    sha256  755f34ea2b27b23db84ef4ed4cae1ff1afff1391b65d033b80b0ba03e4027d82 \
-                    size    4149619
+                    rmd160  86df4bfc2b4df7800910275369041ffa38c5b726 \
+                    sha256  bbe3fe4a6cfcc92717fa75d7596c1d4f65e0daff2cd79965ac8d7f57704a3842 \
+                    size    4150152
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -138,7 +138,7 @@ cargo.crates \
     bzip2-sys                 0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                              1.2.18  525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c \
+    cc                              1.2.19  8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
@@ -148,8 +148,8 @@ cargo.crates \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
-    clap                            4.5.35  d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944 \
-    clap_builder                    4.5.35  2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9 \
+    clap                            4.5.36  2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04 \
+    clap_builder                    4.5.36  132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5 \
     clap_derive                     4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     clap_mangen                     0.2.26  724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a \
@@ -472,7 +472,7 @@ cargo.crates \
     pest_derive                      2.8.0  d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5 \
     pest_generator                   2.8.0  db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841 \
     pest_meta                        2.8.0  7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0 \
-    petgraph                         0.7.1  3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772 \
+    petgraph                         0.8.1  7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06 \
     phf                             0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
     phf_codegen                     0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
     phf_generator                   0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
@@ -525,16 +525,16 @@ cargo.crates \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     rops                             0.1.4  cd8e93012c1b06c4e7b1582d5a86e64311c8347b7feaf406bbf04bc1235e792b \
     rowan                          0.15.16  0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d \
-    rust-embed                       8.6.0  0b3aba5104622db5c9fc61098de54708feb732e7763d7faa2fa625899f00bf6f \
-    rust-embed-impl                  8.6.0  1f198c73be048d2c5aa8e12f7960ad08443e56fd39cc26336719fdb4ea0ebaae \
-    rust-embed-utils                 8.6.0  5a2fcdc9f40c8dc2922842ca9add611ad19f332227fc651d015881ad1552bd9a \
+    rust-embed                       8.7.0  e5fbc0ee50fcb99af7cebb442e5df7b5b45e9460ffa3f8f549cd26b862bec49d \
+    rust-embed-impl                  8.7.0  6bf418c9a2e3f6663ca38b8a7134cc2c2167c9d69688860e8961e3faa731702e \
+    rust-embed-utils                 8.7.0  08d55b95147fe01265d06b3955db798bdaed52e60e2211c41137701b3aba8e21 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                           1.0.5  d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf \
-    rustls                         0.23.25  822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c \
+    rustls                         0.23.26  df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.11.0  917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c \
@@ -554,7 +554,7 @@ cargo.crates \
     security-framework-sys          2.14.0  49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     self_cell                       0.10.3  e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d \
-    self_cell                        1.1.0  c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe \
+    self_cell                        1.2.0  0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749 \
     self_update                     0.42.0  d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c \
     semver                          1.0.26  56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0 \
     serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.4.2

##### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
