### PR TITLE
direnv: Update to 2.36.0

### DIFF
--- a/devel/direnv/Portfile
+++ b/devel/direnv/Portfile
@@ -19,7 +19,7 @@ long_description    \
 
 homepage            https://direnv.net/
 
-go.setup            github.com/direnv/direnv 2.35.0 v
+go.setup            github.com/direnv/direnv 2.36.0 v
 # Delete this on next update to use golang PortGroup's default ('archive')
 github.tarball_from tarball
 revision            0
@@ -29,9 +29,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  f4cc8310421f0bd057d56c9ff06921ea36a6527f \
-                        sha256  81fc69f12138bfe05f1b2983af1626acc5d96a820cd832fc7390719be8de8df0 \
-                        size    95139
+                        rmd160  2eb3b2eccdb8ff502156ee2c204065f54de5bfe3 \
+                        sha256  1538d5453a4bd49b9d08b9eb1b2a1c4dec8c7e408d4a6d540822d353e72a9379 \
+                        size    97213
 
 # see ${WORKSRCPATH}/gopath/src/github.com/direnv/direnv/go.sum
 # pick the most recent version of each and verify downloading and building


### PR DESCRIPTION
#### Description

direnv: Update to 2.36.0

##### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
