### PR TITLE
ortep3: Fix lib path and add docs

### DIFF
--- a/science/ortep3/Portfile
+++ b/science/ortep3/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 
 name                ortep3
 version             1.0.3
-revision            0
+revision            1
 categories          science chemistry
 license             public-domain
 maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
@@ -13,12 +13,32 @@ description         Thermal ellipsoid plot program
 long_description    ortep3 is a thermal ellipsoid plot program for crystal \
                     structure illustrations
 homepage            https://ornl-ndav.github.io/ortep/ortep.html
-master_sites        https://github.com/ornl-ndav/ortep/raw/master/
-distfiles           ortep.f
-checksums           md5     76a252c8938e9b23abbfaf1f0b0a2647 \
-                    sha256  9935184a66d2b3bdadf20b4eba5c2e42e5dfb39ddd268956e417afb27d1a4c54 \
+
+set ccp14mirror     http://ccp14.cryst.bbk.ac.uk/ccp/ccp14/ftp-mirror/ornl-ortep/pub/ortep
+master_sites        https://github.com/ornl-ndav/ortep/raw/master:source \
+                    ${ccp14mirror}/man:instructions \
+                    ${ccp14mirror}/man/pdf:manual
+
+set source          ortep.f
+checksums           ${source} \
                     rmd160  edcac4b789916910f7cf08925413ace321863417 \
+                    sha256  9935184a66d2b3bdadf20b4eba5c2e42e5dfb39ddd268956e417afb27d1a4c54 \
                     size    177233
+
+set manual          manual.pdf
+checksums-append    ${manual} \
+                    rmd160  5cf60f83b5c28e0cfdba8f38eb62581e0e9bc526 \
+                    sha256  9648c4260d3cdf59eec0e3a60d8bc0136ffdd6d4efa4c51c7c855d1f9292971f \
+                    size    2320766
+
+set instructions    instrsum.pdf
+checksums-append    ${instructions} \
+                    rmd160  58dc34e5dd1524dc1e082a5d6deba05a99c10ea5 \
+                    sha256  e2dd60a5bfd7ca452c17d63014e58b41f511602a63e0954680f87a602d35376f \
+                    size    65818
+
+distfiles           ${source}:source ${manual}:manual ${instructions}:instructions
+
 depends_lib         port:aquaterm \
                     port:libpng \
                     port:pgplot \
@@ -44,9 +64,10 @@ use_parallel_build  no
 build {
     system -W ${worksrcpath} "${configure.f90} \
         -fdiagnostics-color=auto -std=legacy  \
+        -O2 \
         -F${frameworks_dir} -framework AquaTerm \
-        -L${prefix}/lib -lpng  -lpgplot \
-        -L/opt/X11/lib -lX11 \
+        -L${prefix}/lib \
+        -lpng -lpgplot -lX11 \
         -o ortep3 ortep.f"
 }
 
@@ -55,6 +76,10 @@ destroot {
         ${destroot}${prefix}/bin
     xinstall -d ${destroot}${prefix}/share/doc/ortep3
     xinstall -m 0444 -W ${worksrcpath} LICENSE \
+        ${destroot}${prefix}/share/doc/ortep3
+    xinstall -m 0444 -W ${worksrcpath} manual.pdf \
+        ${destroot}${prefix}/share/doc/ortep3
+    xinstall -m 0444 -W ${worksrcpath} instrsum.pdf \
         ${destroot}${prefix}/share/doc/ortep3
 }
 


### PR DESCRIPTION
#### Description

Closes: trac.macports.org/ticket/72308

removed options: -L/opt/X11/lib
added docs: manual.pdf, instrsum.pdf

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (Package has no tests)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
