### PR TITLE
netdata: update to 2.3.2

### DIFF
--- a/sysutils/netdata/Portfile
+++ b/sysutils/netdata/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake           1.1
 PortGroup               github          1.0
 PortGroup               legacysupport   1.1
 
-github.setup            netdata netdata 2.2.6 v
+github.setup            netdata netdata 2.3.2 v
 github.tarball_from     releases
 revision                0
 
@@ -29,7 +29,6 @@ compiler.thread_local_storage \
 depends_build-append    port:pkgconfig
 
 depends_lib-append      bin:curl:curl \
-                        bin:go:go \
                         lib:libuuid:libuuid \
                         path:lib/libssl.dylib:openssl \
                         path:lib/pkgconfig/libuv.pc:libuv \
@@ -45,9 +44,9 @@ depends_lib-append      bin:curl:curl \
 
 distname                ${name}-v${version}
 
-checksums               rmd160  7e7d6ce35a93901114cd73a8f1f77c03d0302eba \
-                        sha256  bd98c146aa6d0c25f80cb50b1447b8aca8a17f0995b28a11a23e843b8f210f42 \
-                        size    50395963
+checksums               rmd160  6f5bbdfab0de6a86088e3c3f7b846d2a4b586fea \
+                        sha256  ae0ff66a4f9ea44ef4e51fbb331040508f1c12c7f6311bff347fe139870e5dd4 \
+                        size    41176742
 
 set netdata_user        netdata
 set netdata_group       netdata
@@ -59,9 +58,23 @@ set netdata_log_dir     ${prefix}/var/log/${name}
 set netdata_lib_dir     ${prefix}/var/lib/${name}
 set netdata_web_dir     ${prefix}/${netdata_web_subpath}
 
-configure.args-append   -DWEB_DIR=${netdata_web_subpath}
+configure.args-append   -DENABLE_PLUGIN_GO=NO \
+                        -DWEB_DIR=${netdata_web_subpath}
 
 add_users ${netdata_user} group=${netdata_group}
+
+variant go_plugin description {Enable Go plugin} {
+    configure.args-append   -DENABLE_PLUGIN_GO=YES
+    depends_build-append    port:go
+}
+
+notes "
+    Go plugin is now a variant. To install, use \"+go\":
+
+    Ie.,
+
+    $ sudo port install netdata +go
+"
 
 if { ${name} eq ${subport} } {
     startupitem.create      yes


### PR DESCRIPTION
- move Go plugin to variant

CC: @barracuda156 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
