### PR TITLE
ctpv: add livecheck

### DIFF
--- a/graphics/ctpv/Portfile
+++ b/graphics/ctpv/Portfile
@@ -27,3 +27,5 @@ destroot.post_args  ${destroot.destdir} PREFIX=${prefix}
 
 # https://trac.macports.org/ticket/70170
 compiler.cxx_standard 2020
+
+github.livecheck.regex "(\\d+(?:\\.\\d+)+)"


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?