### PR TITLE
py-csvkit: add support for py313 (also dependencies)

### DIFF
--- a/python/py-agate-dbf/Portfile
+++ b/python/py-agate-dbf/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  8dfd67b33db6ed8b9d474cb04abf2e30fbeb6cf7 \
                     sha256  589682b78c5c03f2dc8511e6e3edb659fb7336cd118e248896bb0b44c2f1917b \
                     size    2863
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-agate \

--- a/python/py-agate-excel/Portfile
+++ b/python/py-agate-excel/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  3afd4d0df268d1742b5248b105a9c206171aea35 \
                     sha256  62315708433108772f7f610ca769996b468a4ead380076dbaf6ffe262831b153 \
                     size    161131
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-agate \

--- a/python/py-agate-sql/Portfile
+++ b/python/py-agate-sql/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  11e6b3b8198585aa1b2e1bd8b023ef3ec9b8c013 \
                     sha256  581e062ae878cc087d3d0948670d46b16589df0790bf814524b0587a359f2ada \
                     size    15182
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-agate \

--- a/python/py-agate/Portfile
+++ b/python/py-agate/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  f217d911e0cdcf28fb3c90901cae1f1bb5e071ed \
                     sha256  e0f2f813f7e12311a4cdccc97d6ba0a6781e9c1aa8eca0ab00d5931c0113a308 \
                     size    202102
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-babel \

--- a/python/py-csvkit/Portfile
+++ b/python/py-csvkit/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  e5c6c9829f98ea9fac4b59057a8df8566c342083 \
                     sha256  beddb7b78f6b22adbed6ead5ad5de4bfb31dd2c55f3211b2a2b3b65529049223 \
                     size    3792699
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-agate \

--- a/python/py-csvkit/files/py313-csvkit
+++ b/python/py-csvkit/files/py313-csvkit
@@ -1,0 +1,11 @@
+bin/csvclean-3.13
+bin/csvcut-3.13
+bin/csvgrep-3.13
+bin/csvjoin-3.13
+bin/csvjson-3.13
+bin/csvlook-3.13
+bin/csvsort-3.13
+bin/csvsql-3.13
+bin/csvstack-3.13
+bin/csvstat-3.13
+bin/in2csv-3.13

--- a/python/py-dbfread/Portfile
+++ b/python/py-dbfread/Portfile
@@ -21,4 +21,4 @@ checksums           rmd160  6599d0c691b9047c46ec75842ed380880c595567 \
 
 homepage            https://dbfread.readthedocs.io/
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313

--- a/python/py-isodate/Portfile
+++ b/python/py-isodate/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  b1ab88fc360f333f91aaee8ff30c63b695179188 \
                     sha256  48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9 \
                     size    28443
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-leather/Portfile
+++ b/python/py-leather/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  cdcbef561aacd19bc5ba0d35ec70cf65a1704141 \
                     sha256  b43e21c8fa46b2679de8449f4d953c06418666dc058ce41055ee8a8d3bb40918 \
                     size    30605
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-six \

--- a/python/py-pytimeparse/Portfile
+++ b/python/py-pytimeparse/Portfile
@@ -21,4 +21,4 @@ checksums           rmd160  e56358a299e95b6593e39f2b57013a4157a412b0 \
                     sha256  e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a \
                     size    9403
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313

--- a/python/py-slugify/Portfile
+++ b/python/py-slugify/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  32484f540d20cf100e24629126859c0687b7d5ee \
                     sha256  59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856 \
                     size    10921
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-xlrd/Portfile
+++ b/python/py-xlrd/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-xlrd
 version             2.0.1
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 supported_archs     noarch
 platforms           {darwin any}
 maintainers         {snc @nerdling} openmaintainer


### PR DESCRIPTION
#### Description

Add support for Python 3.13 to py-csvkit as well as to its dependencies:

* py-agate
* py-agate-dbf
* py-agate-excel
* py-agate-sql
* py-dbfread
* py-isodate
* py-leather
* py-pytimeparse
* py-slugify
* py-xlrd

No revision bump is needed since the py313-* variant was not available for any of these before, and nothing changes for the existing py*-* variants.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4 24E248 x86_64
Command Line Tools 16.3.0.0.1.1742442376


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
