### PR TITLE
whisper: update to 1.7.5

### DIFF
--- a/audio/whisper/Portfile
+++ b/audio/whisper/Portfile
@@ -2,11 +2,11 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           makefile 1.0
+PortGroup           cmake 1.1
 
 name                whisper
 categories          audio
-github.setup        ggerganov whisper.cpp 1.6.2 v
+github.setup        ggerganov whisper.cpp 1.7.5 v
 github.tarball_from archive
 license             MIT
 maintainers         {ijams.me:nate @exprez135} \
@@ -24,36 +24,38 @@ output.wav` to convert the file first.
 "
 
 checksums           whisper.cpp-${version}.tar.gz \
-                    rmd160  26b0b29e46c990b13c9d10d95c11aa429fc8d56d \
-                    sha256  da7988072022acc3cfa61b370b3c51baad017f1900c3dc4e68cb276499f66894 \
-                    size    5088298
+                    rmd160  211e55a336132a878471382d8002425f069db683 \
+                    sha256  2fda42b57b7b8427d724551bd041616d85401fb9382e42b0349132a28920a34f \
+                    size    6216643 
 
-build.target        main
-makefile.has_destdir    no
 patchfiles          whisper-add-models.diff \
+                    whisper-add-depends.diff \
                     ggml-hard-coded.diff \
                     add-metal-path.diff
 
 post-patch {
     reinplace "s|__PREFIX__|${prefix}|" \
-        whisper.cpp \
-        ggml-metal.metal \
-        ggml-metal.m
-}
-
-post-build {
-    move ${worksrcpath}/main ${worksrcpath}/whisper
+        src/whisper.cpp \
+        ggml/src/ggml-metal/ggml-metal.metal \
+        ggml/src/ggml-metal/ggml-metal.m
 }
 
 destroot {
     xinstall -d ${destroot}${prefix}/bin
-    xinstall -m 755 ${worksrcpath}/whisper ${destroot}${prefix}/bin/whisper
+    xinstall -m 755 ${workpath}/build/bin/whisper-cli ${destroot}${prefix}/bin/whisper
 }
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/whisper/ggml
-    xinstall ${worksrcpath}/ggml-metal.metal ${destroot}${prefix}/share/whisper/ggml
-    xinstall ${worksrcpath}/ggml-common.h ${destroot}${prefix}/share/whisper/ggml
+    xinstall ${workpath}/build/bin/ggml-metal.metal ${destroot}${prefix}/share/whisper/ggml
+    xinstall ${workpath}/build/bin/ggml-common.h ${destroot}${prefix}/share/whisper/ggml
+    xinstall -d ${destroot}${prefix}/lib
+    xinstall ${workpath}/build/src/libwhisper.1.7.5.dylib ${destroot}${prefix}/lib/libwhisper.1.dylib
+    xinstall ${workpath}/build/ggml/src/libggml.dylib ${destroot}${prefix}/lib/libggml.dylib
+    xinstall ${workpath}/build/ggml/src/libggml-cpu.dylib ${destroot}${prefix}/lib/libggml-cpu.dylib
+    xinstall ${workpath}/build/ggml/src/libggml-base.dylib ${destroot}${prefix}/lib/libggml-base.dylib
+    xinstall ${workpath}/build/ggml/src/ggml-blas/libggml-blas.dylib ${destroot}${prefix}/lib/libggml-blas.dylib
+    xinstall ${workpath}/build/ggml/src/ggml-metal/libggml-metal.dylib ${destroot}${prefix}/lib/libggml-metal.dylib
 }
 
 

--- a/audio/whisper/files/add-metal-path.diff
+++ b/audio/whisper/files/add-metal-path.diff
@@ -1,14 +1,28 @@
---- ggml-metal.m	2024-05-27 02:35:09
-+++ CHANGED-ggml-metal.m	2024-08-09 10:44:38
-@@ -360,7 +360,10 @@
-             if (path_resource) {
-                 path_source = [path_resource stringByAppendingPathComponent:@"ggml-metal.metal"];
-             } else {
--                path_source = [bundle pathForResource:@"ggml-metal" ofType:@"metal"];
-+		path_resource = @"__PREFIX__/share/whisper/ggml";
-+		GGML_METAL_LOG_INFO("%s: GGML_METAL_PATH_RESOURCES = %s\n", __func__, path_resource ? [path_resource UTF8String] : "nil");
-+		path_source = [path_resource stringByAppendingPathComponent:@"ggml-metal.metal"];
-+		/* path_source = [bundle pathForResource:@"ggml-metal" ofType:@"metal"];*/
-             }
+--- ggml/src/ggml-metal/ggml-metal.m.orig	2025-04-12 18:27:34
++++ ggml/src/ggml-metal/ggml-metal.m	2025-04-13 17:03:44
+@@ -604,21 +604,24 @@
+         GGML_LOG_INFO("%s: default.metallib not found, loading from source\n", __func__);
  
-             if (path_source == nil) {
+         NSString * path_source;
+         NSString * path_resource = [[NSProcessInfo processInfo].environment objectForKey:@"GGML_METAL_PATH_RESOURCES"];
+ 
+         GGML_LOG_INFO("%s: GGML_METAL_PATH_RESOURCES = %s\n", __func__, path_resource ? [path_resource UTF8String] : "nil");
+ 
+         if (path_resource) {
+             path_source = [path_resource stringByAppendingPathComponent:@"ggml-metal.metal"];
+         } else {
+-            path_source = [bundle pathForResource:@"ggml-metal" ofType:@"metal"];
++	    path_resource = @"__PREFIX__/share/whisper/ggml";
++	    GGML_METAL_LOG_INFO("%s: GGML_METAL_PATH_RESOURCES = %s\n", __func__, path_resource ? [path_resource UTF8String] : "nil");
++	    path_source = [path_resource stringByAppendingPathComponent:@"ggml-metal.metal"];
++	    /* path_source = [bundle pathForResource:@"ggml-metal" ofType:@"metal"];*/
+         }
+ 
+         if (path_source == nil) {
+             GGML_LOG_WARN("%s: error: could not use bundle path to find ggml-metal.metal, falling back to trying cwd\n", __func__);
+             path_source = @"ggml-metal.metal";
+         }
+ 
+         GGML_LOG_INFO("%s: loading '%s'\n", __func__, [path_source UTF8String]);
+ 
+         src = [NSString stringWithContentsOfFile:path_source encoding:NSUTF8StringEncoding error:&error];

--- a/audio/whisper/files/ggml-hard-coded.diff
+++ b/audio/whisper/files/ggml-hard-coded.diff
@@ -1,10 +1,11 @@
---- ggml-metal.metal	2024-05-27 02:35:09
-+++ CHANGED-ggml-metal.metal	2024-08-09 10:44:53
-@@ -1,6 +1,6 @@
- #define GGML_COMMON_DECL_METAL
- #define GGML_COMMON_IMPL_METAL
+--- ggml/src/ggml-metal/ggml-metal.metal.orig	2025-04-12 18:00:39
++++ ggml/src/ggml-metal/ggml-metal.metal	2025-04-12 18:16:51
+@@ -3,7 +3,7 @@
+ #if defined(GGML_METAL_EMBED_LIBRARY)
+ __embed_ggml-common.h__
+ #else
 -#include "ggml-common.h"
 +#include "__PREFIX__/share/whisper/ggml/ggml-common.h"
- 
- #include <metal_stdlib>
+ #endif
+ #include "ggml-metal-impl.h"
  

--- a/audio/whisper/files/whisper-add-depends.diff
+++ b/audio/whisper/files/whisper-add-depends.diff
@@ -1,0 +1,35 @@
+--- src/whisper.cpp.orig	2025-04-13 16:33:17
++++ src/whisper.cpp	2025-04-13 16:53:25
+@@ -22,30 +22,32 @@
+ #include <climits>
+ #include <codecvt>
+ #include <cstdarg>
+ #include <cstdio>
+ #include <cstring>
+ #include <fstream>
+ #include <functional>
+ #include <map>
+ #include <mutex>
+ #include <random>
+ #include <regex>
+ #include <set>
+ #include <string>
+ #include <thread>
+ #include <vector>
++#include <dirent.h>
++#include <sys/types.h>
+ 
+ // dummy
+ 
+ #if defined(_MSC_VER)
+ #pragma warning(disable: 4244 4267) // possible loss of data
+ #endif
+ 
+ #if defined(WHISPER_BIG_ENDIAN)
+ template<typename T>
+ static T byteswap(T value) {
+     T value_swapped;
+     char * source = reinterpret_cast<char *>(&value);
+     char * target = reinterpret_cast<char *>(&value_swapped);
+     int size = sizeof(T);
+     for (int i = 0; i < size; i++) {

--- a/audio/whisper/files/whisper-add-models.diff
+++ b/audio/whisper/files/whisper-add-models.diff
@@ -1,15 +1,6 @@
---- whisper.cpp	2024-07-31 09:14:56
-+++ CHANGED.cpp	2024-08-09 10:45:42
-@@ -53,6 +53,8 @@
- #include <random>
- #include <functional>
- #include <codecvt>
-+#include <dirent.h>
-+#include <sys/types.h>
- 
- #if defined(_MSC_VER)
- #pragma warning(disable: 4244 4267) // possible loss of data
-@@ -3621,17 +3623,50 @@
+--- src/whisper.cpp.orig	2025-04-12 18:05:12
++++ src/whisper.cpp	2025-04-12 18:05:53
+@@ -3634,17 +3634,50 @@
  
  struct whisper_context * whisper_init_from_file_with_params_no_state(const char * path_model, struct whisper_context_params params) {
      WHISPER_LOG_INFO("%s: loading model from '%s'\n", __func__, path_model);


### PR DESCRIPTION
* updates to new version
* package now uses CMake to build
* now installs needed *.dylib files to lib/

Closes: https://trac.macports.org/ticket/72073

###### Tested on

macOS 15.2 24C101 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
