### PR TITLE
ruby33: update to 3.3.8

### DIFF
--- a/lang/ruby33/Portfile
+++ b/lang/ruby33/Portfile
@@ -17,7 +17,7 @@ legacysupport.newest_darwin_requires_legacy 14
 # This property should be preserved.
 
 set ruby_ver        3.3
-set ruby_patch      7
+set ruby_patch      8
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
@@ -42,9 +42,9 @@ master_sites        ruby:${ruby_ver}
 distname            ruby-${version}
 dist_subdir         ruby${ruby_ver_nodot}
 
-checksums           rmd160  b1cd4784744213af706c973f705dd859e6688928 \
-                    sha256  9c37c3b12288c7aec20ca121ce76845be5bb5d77662a24919651aaf1d12c8628 \
-                    size    22163173
+checksums           rmd160  9e5f4c3991719f70adbf231d1d51d05adc60d2aa \
+                    sha256  5ae28a87a59a3e4ad66bc2931d232dbab953d0aa8f6baf3bc4f8f80977c89cab \
+                    size    22197497
 
 # Universal builds don't currently work, including via the approach used
 # in ruby30.
@@ -69,7 +69,7 @@ select.file         ${filespath}/ruby${ruby_ver_nodot}
 
 # patch-sources.diff: fixes for various issues.
 #
-# This diff is from v3_3_7 vs. macports-3_3_7.
+# This diff is from v3_3_8 vs. macports-3_3_8.
 #
 patchfiles-append   patch-sources.diff
 

--- a/lang/ruby33/files/patch-sources.diff
+++ b/lang/ruby33/files/patch-sources.diff
@@ -1,5 +1,5 @@
 --- .gdbinit.orig	2025-01-14 23:22:35.000000000 -0800
-+++ .gdbinit	2025-01-20 13:54:57.000000000 -0800
++++ .gdbinit	2025-04-13 12:32:57.000000000 -0700
 @@ -1,4 +1,5 @@
 -set startup-with-shell off
 +# Move this to end, so failure on older gdbs doesn't blow the rest
@@ -15,7 +15,7 @@
 +# Moved from beginning, since it fails on older gdbs
 +set startup-with-shell off
 --- ext/digest/md5/md5cc.h.orig	2025-01-14 23:22:35.000000000 -0800
-+++ ext/digest/md5/md5cc.h	2025-01-20 13:54:57.000000000 -0800
++++ ext/digest/md5/md5cc.h	2025-04-13 12:32:57.000000000 -0700
 @@ -17,3 +17,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(MD5
  #undef MD5_Finish
  #define MD5_Update rb_digest_MD5_update
@@ -29,7 +29,7 @@
 +#undef MD5_Init
 +#define MD5_Init CC_MD5_Init
 --- ext/digest/sha1/sha1cc.h.orig	2025-01-14 23:22:35.000000000 -0800
-+++ ext/digest/sha1/sha1cc.h	2025-01-20 13:54:57.000000000 -0800
++++ ext/digest/sha1/sha1cc.h	2025-04-13 12:32:57.000000000 -0700
 @@ -12,3 +12,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(SHA
  #undef SHA1_Finish
  #define SHA1_Update rb_digest_SHA1_update
@@ -43,7 +43,7 @@
 +#undef SHA1_Init
 +#define SHA1_Init CC_SHA1_Init
 --- ext/digest/sha2/sha2cc.h.orig	2025-01-14 23:22:35.000000000 -0800
-+++ ext/digest/sha2/sha2cc.h	2025-01-20 13:54:57.000000000 -0800
++++ ext/digest/sha2/sha2cc.h	2025-04-13 12:32:57.000000000 -0700
 @@ -1,6 +1,33 @@
  #define COMMON_DIGEST_FOR_OPENSSL 1
  #include <CommonCrypto/CommonDigest.h>
@@ -95,7 +95,7 @@
 +#undef SHA512_Init
 +#define SHA512_Init CC_SHA512_Init
 --- file.c.orig	2025-01-14 23:22:35.000000000 -0800
-+++ file.c	2025-01-20 13:54:57.000000000 -0800
++++ file.c	2025-04-13 12:32:57.000000000 -0700
 @@ -299,10 +299,30 @@ rb_CFString_class_initialize_before_fork
      long len = sizeof(small_str) - 1;
  
@@ -148,7 +148,7 @@
      long oldlen = RSTRING_LEN(str);
  
 --- lib/bundler/gem_helper.rb.orig	2025-01-14 23:22:35.000000000 -0800
-+++ lib/bundler/gem_helper.rb	2025-01-20 13:54:57.000000000 -0800
++++ lib/bundler/gem_helper.rb	2025-04-13 12:32:57.000000000 -0700
 @@ -231,7 +231,7 @@ module Bundler
      end
  
@@ -159,7 +159,7 @@
    end
  end
 --- signal.c.orig	2025-01-14 23:22:35.000000000 -0800
-+++ signal.c	2025-01-20 13:54:57.000000000 -0800
++++ signal.c	2025-04-13 12:32:57.000000000 -0700
 @@ -803,7 +803,8 @@ check_stack_overflow(int sig, const uint
      const greg_t bp = mctx->gregs[REG_EBP];
  #   endif
@@ -171,7 +171,7 @@
  #   else
  #     define MCTX_SS_REG(reg) ss.reg
 --- thread_pthread.c.orig	2025-01-14 23:22:35.000000000 -0800
-+++ thread_pthread.c	2025-01-20 13:54:57.000000000 -0800
++++ thread_pthread.c	2025-04-13 12:32:57.000000000 -0700
 @@ -42,6 +42,22 @@
  
  #if defined __APPLE__
@@ -196,7 +196,7 @@
  
  #if defined(HAVE_SYS_EVENTFD_H) && defined(HAVE_EVENTFD)
 --- vm_dump.c.orig	2025-01-14 23:22:35.000000000 -0800
-+++ vm_dump.c	2025-01-20 13:54:57.000000000 -0800
++++ vm_dump.c	2025-04-13 12:32:57.000000000 -0700
 @@ -490,7 +490,8 @@ rb_vmdebug_thread_dump_state(FILE *errou
  }
  


### PR DESCRIPTION
See:
https://www.ruby-lang.org/en/news/2025/04/09/ruby-3-3-8-released/

TESTED:
Built successfully on OSX 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-15.x arm64.  Included all variants compatible with available dependencies on the respective platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.5 22H527, arm64, Xcode 15.2 15C500b
macOS 14.7.5 23H527, arm64, Xcode 16.2 16C5032a
macOS 15.3.2 24D81, arm64, Xcode 16.3 16E140
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [NO] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - The test framework has issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
