### PR TITLE
kubie: Update to 0.25.2

### DIFF
--- a/sysutils/kubie/Portfile
+++ b/sysutils/kubie/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        sbstp kubie 0.25.1 v
+github.setup        sbstp kubie 0.25.2 v
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  4f935eb5a2ade39abc46124745f32dc4ac71b802 \
-                    sha256  b025db51bb95d1b585f3fbf5700deac592880904b67b32a30182c5d9af216b5a \
-                    size    41719
+                    rmd160  fd1e2500b28eb517b882b0e11a7ff74577b02548 \
+                    sha256  4d41e441eb006999f91f962b264730ec092a1352b16e45094f703144e855857e \
+                    size    41730
 
 destroot {
     set bashcomp_dir ${prefix}/share/bash-completion/completions
@@ -69,8 +69,8 @@ cargo.crates \
     attohttpc                       0.29.2  48404d931ab11b3a7a5267291b3b8f3590f09b86181381f8e82a7e562ed832c0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     aws-lc-fips-sys                 0.13.3  29003a681b2b9465c1139bfb726da452a841a8b025f35953f3bce71139f10b21 \
-    aws-lc-rs                       1.12.6  dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01 \
-    aws-lc-sys                      0.27.0  6bbe221bbf523b625a4dd8585c7f38166e31167ec2ca98051dbcb4c3b6e825d2 \
+    aws-lc-rs                       1.13.0  19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878 \
+    aws-lc-sys                      0.28.0  b9f7720b74ed28ca77f90769a71fd8c637a0137f6fae4ae947e1050229cff57f \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     beef                             0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
     bindgen                         0.69.5  271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088 \
@@ -86,8 +86,8 @@ cargo.crates \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chrono                          0.4.40  1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c \
     clang-sys                        1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    clap                            4.5.32  6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83 \
-    clap_builder                    4.5.32  22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8 \
+    clap                            4.5.35  d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944 \
+    clap_builder                    4.5.35  2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9 \
     clap_derive                     4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     cmake                           0.1.54  e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0 \
@@ -96,7 +96,7 @@ cargo.crates \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
     crossbeam                        0.8.4  1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8 \
-    crossbeam-channel               0.5.14  06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471 \
+    crossbeam-channel               0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
     crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
     crossbeam-queue                 0.3.12  0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115 \
@@ -223,7 +223,7 @@ cargo.crates \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     syn                             2.0.98  36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
-    tempfile                        3.18.0  2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567 \
+    tempfile                        3.19.1  7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf \
     term                             0.7.0  c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
     thiserror                       2.0.11  d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc \


### PR DESCRIPTION
#### Description

kubie: Update to 0.25.2

##### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
