### PR TITLE
mise: Update to 2025.4.3

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.4.2 v
+github.setup        jdx mise 2025.4.3 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  86df4bfc2b4df7800910275369041ffa38c5b726 \
-                    sha256  bbe3fe4a6cfcc92717fa75d7596c1d4f65e0daff2cd79965ac8d7f57704a3842 \
-                    size    4150152
+                    rmd160  dd3a6de8e3fb9da4ceba6b74193f7364250378f2 \
+                    sha256  23ebc24548f74bce291e2145564221ab3727593b1526ff55d157a23a87864d0f \
+                    size    4153332
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -105,7 +105,7 @@ cargo.crates \
     anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                   3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
-    anyhow                          1.0.97  dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f \
+    anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
     arbitrary                        1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arrayvec                         0.5.2  23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b \
@@ -134,6 +134,7 @@ cargo.crates \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                           1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
     bytesize                         1.3.3  2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659 \
+    bytesize                         2.0.1  a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba \
     bzip2                            0.5.2  49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47 \
     bzip2-sys                 0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
@@ -320,7 +321,7 @@ cargo.crates \
     glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
     globset                         0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
-    h2                               0.4.8  5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2 \
+    h2                               0.4.9  75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
@@ -383,8 +384,8 @@ cargo.crates \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
-    jiff                             0.2.6  1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488 \
-    jiff-static                      0.2.6  43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19 \
+    jiff                             0.2.8  e5ad87c89110f55e4cd4dc2893a9790820206729eaf221555f742d540b0724a0 \
+    jiff-static                      0.2.8  d076d5b64a7e2fe6f0743f02c43ca4a6725c0f904203bfe276a5b3e793103605 \
     jiff-tzdb                        0.1.4  c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524 \
     jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jobserver                       0.1.33  38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a \
@@ -496,7 +497,7 @@ cargo.crates \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro2                     1.0.94  a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84 \
-    prodash                         29.0.1  9ee7ce24c980b976607e2d6ae4aae92827994d23fed71659c3ede3f92528b58b \
+    prodash                         29.0.2  f04bb108f648884c23b98a0e940ebc2c93c0c3b89f04dbaf7eb8256ce617d1bc \
     quick-xml                       0.37.4  a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369 \
     quinn                           0.11.7  c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012 \
     quinn-proto                    0.11.10  b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc \


### PR DESCRIPTION
#### Description

mise: Update to 2025.4.3

##### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
