### PR TITLE
ruby-build: Update to 20250415

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250409 v
+github.setup        rbenv ruby-build 20250415 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  2256da6f3e170ae2bcadff59d18fdcd26051c8b0 \
-                    sha256  6f28a41b5c9557fa63061f9a060a2838f818fbe61bd3d0a7549f35c6513b28b1 \
-                    size    95773
+checksums           rmd160  2c5ee40b5060cec7aa7dfc40db018bd682063681 \
+                    sha256  57e8b37c70b67b9e746640e4b5fc171f07d11fe3fae2b80fd17207b05d8a030a \
+                    size    95977
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250415

##### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
