### PR TITLE
py-openstackclient: update to 8.0.0; bump dependencies

### DIFF
--- a/python/py-autopage/Portfile
+++ b/python/py-autopage/Portfile
@@ -17,4 +17,4 @@ checksums           rmd160  03ed2cf74f3e59d9fc72eba08ba6d947ec13bced \
                     sha256  826996d74c5aa9f4b6916195547312ac6384bac3810b8517063f293248257b72 \
                     size    33031
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313

--- a/python/py-cinderclient/Portfile
+++ b/python/py-cinderclient/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-cinderclient
 python.rootname     python-cinderclient
-version             9.3.0
+version             9.7.0
 revision            0
 
 categories-append   net
@@ -21,12 +21,13 @@ long_description    Client for the OpenStack Volume API. There’s a \
                     of the OpenStack Volume API.
 
 homepage            https://docs.openstack.org/python-cinderclient/latest/
+distname            python_cinderclient-${version}
 
-checksums           rmd160  51e3ca99a9aa7bde5f20adbd74413f0897b31705 \
-                    sha256  9a6aa30feff48c0c0fd188e6d5150dbdd91e3fd5b10d2db9d78b9812ab14af88 \
-                    size    236158
+checksums           rmd160  06a6d91da018eca932ecc41b373f1a435e46d903 \
+                    sha256  18c4501e549677984d85b0b10fd074efbd265e30add2a796d28176055a8d7dcf \
+                    size    236901
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
@@ -35,9 +36,8 @@ if {${subport} ne ${name}} {
     depends_run-append \
                     port:py${python.version}-prettytable \
                     port:py${python.version}-keystoneauth1 \
-                    port:py${python.version}-simplejson \
-                    port:py${python.version}-six \
                     port:py${python.version}-oslo-i18n \
                     port:py${python.version}-oslo-utils \
-                    port:py${python.version}-requests
+                    port:py${python.version}-requests \
+                    port:py${python.version}-stevedore
 }

--- a/python/py-cliff/Portfile
+++ b/python/py-cliff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cliff
-version             4.7.0
+version             4.9.1
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -16,11 +16,11 @@ long_description    cliff is a framework for building command line \
                     provide subcommands, output formatters, and other \
                     extensions.
 homepage            https://docs.openstack.org/cliff/latest/
-checksums           rmd160  370f093748ab5b28e5f6776cadde5e23e717826b \
-                    sha256  6ca45f8df519bbc0722c61049de7b7e442a465fa7f3f552b96d735fa26fd5b26 \
-                    size    84250
+checksums           rmd160  33964049398bddf401aff938257c58648ba5e580 \
+                    sha256  5b392198293c0b9225d459be8ba710cf8248f1ee33006bdeb3d92fb0012592b4 \
+                    size    86597
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
@@ -37,4 +37,3 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-stevedore \
                     port:py${python.version}-yaml
 }
-

--- a/python/py-cmd2/Portfile
+++ b/python/py-cmd2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cmd2
-version             2.4.3
+version             2.5.11
 revision            0
 
 maintainers         nomaintainer
@@ -16,18 +16,21 @@ description         Tool for building interactive command line applications in P
 long_description    {*}${description}
 homepage            https://github.com/python-cmd2/cmd2
 
-checksums           rmd160  ae288a0e0921eb5d23480d44259f35e176d6458b \
-                    sha256  71873c11f72bd19e2b1db578214716f0d4f7c8fa250093c601265a9a717dee52 \
-                    size    678661
+checksums           rmd160  244ba71e0648f479448ef4de1c414c96837334cf \
+                    sha256  30a0d385021fbe4a4116672845e5695bbe56eb682f9096066776394f954a7429 \
+                    size    883350
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
                     port:py${python.version}-setuptools_scm
 
+    if {${python.version} < 310} {
+        depends_lib-append  port:py${python.version}-importlib-metadata
+    }
+
     depends_run-append \
-                    port:py${python.version}-attrs \
                     port:py${python.version}-pyperclip \
                     port:py${python.version}-wcwidth
 }

--- a/python/py-debtcollector/Portfile
+++ b/python/py-debtcollector/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-debtcollector
-version             2.5.0
+version             3.0.0
 revision            0
 
 maintainers         nomaintainer
@@ -27,17 +27,16 @@ long_description    A collection of Python deprecation patterns and \
                     developers using libraries (or potentially \
                     applications) about future deprecations.
 homepage            https://docs.openstack.org/debtcollector/latest/
-checksums           rmd160  46f841d202dbb52713d31ada0562b4a2ffa52485 \
-                    sha256  dc9d1ad3f745c43f4bbedbca30f9ffe8905a8c028c9926e61077847d5ea257ab \
-                    size    31334
+checksums           rmd160  307c5fb65e20cf7ac4be792d72a897deba091bab \
+                    sha256  2a8917d25b0e1f1d0d365d3c1c6ecfc7a522b1e9716e8a1a4a915126f7ccea6f \
+                    size    31322
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
                     port:py${python.version}-pbr
 
     depends_run-append \
-                    port:py${python.version}-six \
                     port:py${python.version}-wrapt
 }

--- a/python/py-dogpile-cache/Portfile
+++ b/python/py-dogpile-cache/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-dogpile-cache
 python.rootname     dogpile.cache
-version             1.0.1
+version             1.4.0
 revision            0
 
 maintainers         nomaintainer
@@ -16,14 +16,20 @@ platforms           {darwin any}
 description         Caching front-end based on the Dogpile lock
 long_description    {*}${description}
 homepage            https://github.com/sqlalchemy/dogpile.cache
+distname            dogpile_cache-${version}
 
-checksums           rmd160  e2543c06ee36c130b689911fcf0021a72ae958df \
-                    sha256  695dd61f32d97233d5c5e1d7ac1238f5116391ea990b4b24a239229e280bf36e \
-                    size    339926
+checksums           rmd160  4c26ce100274c6988e491f7b77dc3942d0598926 \
+                    sha256  b00a9e2f409cf9bf48c2e7a3e3e68dac5fa75913acbf1a62f827c812d35f3d09 \
+                    size    937468
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
+
+    if {${python.version} < 311} {
+        depends_run-append  port:py${python.version}-typing_extensions
+    }
+
     depends_run-append \
                     port:py${python.version}-decorator \
                     port:py${python.version}-stevedore

--- a/python/py-iso8601/Portfile
+++ b/python/py-iso8601/Portfile
@@ -11,7 +11,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 python.pep517_backend   poetry
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-jsonpatch/Portfile
+++ b/python/py-jsonpatch/Portfile
@@ -21,7 +21,7 @@ checksums           sha256  9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e
                     rmd160  145324deef48fce7f871b4603b8f23ee3686c67a \
                     size    21699
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_run-append \

--- a/python/py-keystoneauth1/Portfile
+++ b/python/py-keystoneauth1/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keystoneauth1
-version             5.2.1
+version             5.10.0
 categories-append   net
 maintainers         nomaintainer
 license             Apache-2
@@ -14,21 +14,20 @@ platforms           {darwin any}
 description         Tools for authenticating to an OpenStack-based cloud
 long_description    {*}${description}
 homepage            https://docs.openstack.org/keystoneauth/latest/
-checksums           rmd160  4b86b0db42314591fb9bb6e6219ec2ff193b2f0f \
-                    sha256  f79b1c27ed5a69be4d03a5bc4967df3dfab0c5d76e85226fa2060cffadff74a1 \
-                    size    273214
+checksums           rmd160  5d44b7032737895a18ff07e9f628e976c00232c0 \
+                    sha256  34b870dbbcf806cdb5aec98483b62820a6568d364eca7b1174ca6a8b5a9c77ed \
+                    size    288360
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
-                    port:py${python.version}-setuptools \
                     port:py${python.version}-pbr
 
     depends_run-append \
                     port:py${python.version}-iso8601 \
                     port:py${python.version}-requests \
-                    port:py${python.version}-six \
                     port:py${python.version}-stevedore \
-                    port:py${python.version}-os-service-types
+                    port:py${python.version}-os-service-types \
+                    port:py${python.version}-typing_extensions
 }

--- a/python/py-keystoneclient/Portfile
+++ b/python/py-keystoneclient/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keystoneclient
-version             5.1.0
+version             5.6.0
 categories-append   net
 platforms           {darwin any}
 maintainers         nomaintainer
@@ -15,12 +15,13 @@ description         Client for the OpenStack Identity API
 long_description    {*}${description}
 homepage            https://docs.openstack.org/python-keystoneclient/latest/
 python.rootname     python-keystoneclient
-checksums           md5     11ed4119004ba511e616afd75411a4d4 \
-                    rmd160  927c8c4ae1532c7b60af1fd2b739502ca745ede9 \
-                    sha256  ba09bdfeafa2a2196450a327cd3f46f2a8a9dd9d21b838f8cb9b17a99740c6a1 \
-                    size    325232
+distname            python_keystoneclient-${version}
+checksums           md5     fd5336428ed27a1413365c662cdce9c9 \
+                    rmd160  26b80b1869b3dbad0bf2ccd0d21fc9361b601bb6 \
+                    sha256  721de2aec7710076389c674ee27b6712e97d86c7e0ff487b0b4409c8fcee10e7 \
+                    size    322179
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
@@ -33,7 +34,7 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-oslo-i18n \
                     port:py${python.version}-oslo-serialization \
                     port:py${python.version}-oslo-utils \
+                    port:py${python.version}-packaging \
                     port:py${python.version}-requests \
-                    port:py${python.version}-six \
                     port:py${python.version}-stevedore
 }

--- a/python/py-novaclient/Portfile
+++ b/python/py-novaclient/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-novaclient
 python.rootname     python-novaclient
-version             18.3.0
+version             18.9.0
 revision            0
 
 categories-append   net
@@ -19,12 +19,13 @@ long_description    This is a client for the OpenStack Nova API. There's a Pytho
                     API (the novaclient module), and a command-line script (nova). \
                     Each implements 100% of the OpenStack Nova API.
 homepage            https://docs.openstack.org/python-novaclient/latest/
-checksums           md5     7277ceb8253253f19fcb0e327dbb9fc6 \
-                    rmd160  8587db8e8641ddc77009403429a364ce6098c984 \
-                    sha256  50f7587c7a2b2528f73505817f9437ac5c1d04d576e9be264d2deeffdb745a76 \
-                    size    339238
+distname            python_novaclient-${version}
+checksums           md5     49eaec2c5e8c671c2e21144fc24c0e9b \
+                    rmd160  8b564b91f928effe399e86afe93e637ec1fdefb2 \
+                    sha256  cf6a4b8f01ec543d5a75c01c218474ba9b063bd9fd3743821fedc68a845cab4e \
+                    size    340629
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
@@ -37,6 +38,5 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-oslo-serialization \
                     port:py${python.version}-oslo-utils \
                     port:py${python.version}-prettytable \
-                    port:py${python.version}-simplejson \
                     port:py${python.version}-stevedore
 }

--- a/python/py-openstackclient/Portfile
+++ b/python/py-openstackclient/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-openstackclient
-version             6.2.0
+version             8.0.0
 categories-append   net
 platforms           {darwin any}
 maintainers         nomaintainer
@@ -19,26 +19,27 @@ long_description    OpenStackClient (aka OSC) is a command-line \
                     shell with a uniform command structure.
 homepage            https://docs.openstack.org/python-openstackclient/latest/
 python.rootname     python-openstackclient
-checksums           md5     9c4db008494d1da9c06e6b97013aa827 \
-                    rmd160  cd6c5587661b10f8c6ecf98fb70b237e13f5520d \
-                    sha256  7c53abe1b73b453f59da7b73679c3b759b48e51b8b054864b5fdea2ea82727d6 \
-                    size    886194
+distname            python_openstackclient-${version}
+checksums           md5     206372f2e4b8e15da33bb2b90636a9eb \
+                    rmd160  f03d783c16d7bf2754e85e2b39b55de16bec184c \
+                    sha256  5b7a5e06893f833b5d296d019c50d42c7368e37748ee6be8e9b15655b999424e \
+                    size    914450
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
                     port:py${python.version}-pbr
 
     depends_run-append \
-                    port:py${python.version}-six \
                     port:py${python.version}-cliff \
+                    port:py${python.version}-cryptography \
+                    port:py${python.version}-iso8601 \
                     port:py${python.version}-openstacksdk \
                     port:py${python.version}-osc-lib \
                     port:py${python.version}-oslo-i18n \
-                    port:py${python.version}-oslo-utils \
                     port:py${python.version}-keystoneclient \
-                    port:py${python.version}-novaclient \
                     port:py${python.version}-cinderclient \
+                    port:py${python.version}-requests \
                     port:py${python.version}-stevedore
 }

--- a/python/py-openstacksdk/Portfile
+++ b/python/py-openstacksdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-openstacksdk
-version             1.4.0
+version             4.5.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -13,29 +13,28 @@ platforms           {darwin any}
 description         Client library for building applications to work with OpenStack clouds
 long_description    {*}${description}
 homepage            https://docs.openstack.org/openstacksdk/
-checksums           rmd160  3b5edf80fe3d2e667dccacf85d0de85020ae43db \
-                    sha256  3615129edb67c82afbd1a1706e915ffa68e0eebfc99c903c343aac6517dd5858 \
-                    size    1173316
+checksums           rmd160  e0bcd6fd0673060ee97b09bbfeab7ade35b0c817 \
+                    sha256  ab7a1240207a6969ba09ceee8f16653805730677b4497a806cd956733651fe68 \
+                    size    1284921
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
                     port:py${python.version}-pbr
 
     depends_run-append \
-                    port:py${python.version}-yaml \
-                    port:py${python.version}-appdirs \
-                    port:py${python.version}-requestsexceptions \
-                    port:py${python.version}-jsonpatch \
-                    port:py${python.version}-os-service-types \
-                    port:py${python.version}-keystoneauth1 \
-                    port:py${python.version}-munch \
-                    port:py${python.version}-decorator \
-                    port:py${python.version}-jmespath \
-                    port:py${python.version}-iso8601 \
-                    port:py${python.version}-netifaces \
-                    port:py${python.version}-dogpile-cache \
                     port:py${python.version}-cryptography \
-                    port:py${python.version}-importlib-metadata
+                    port:py${python.version}-decorator \
+                    port:py${python.version}-dogpile-cache \
+                    port:py${python.version}-iso8601 \
+                    port:py${python.version}-jmespath \
+                    port:py${python.version}-jsonpatch \
+                    port:py${python.version}-keystoneauth1 \
+                    port:py${python.version}-os-service-types \
+                    port:py${python.version}-platformdirs \
+                    port:py${python.version}-psutil \
+                    port:py${python.version}-requestsexceptions \
+                    port:py${python.version}-typing_extensions \
+                    port:py${python.version}-yaml
 }

--- a/python/py-os-service-types/Portfile
+++ b/python/py-os-service-types/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  7f8b29835237773138d4902eba57d02422bdca11 \
                     sha256  31800299a82239363995b91f1ebf9106ac7758542a1e4ef6dc737a5932878c6c \
                     size    24474
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-osc-lib/Portfile
+++ b/python/py-osc-lib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-osc-lib
-version             2.8.0
+version             4.0.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -13,11 +13,12 @@ platforms           {darwin any}
 description         Common support modules for writing OpenStackClient plugins
 long_description    {*}${description}
 homepage            https://docs.openstack.org/osc-lib/latest/
-checksums           rmd160  a253a41441b877be98853f2d3246abb5fcff34b3 \
-                    sha256  67e0d413911e8d49cb9601e80eb28dc4b391b3d7dbd70adc9a69a204516d9452 \
-                    size    98870
+distname            osc_lib-${version}
+checksums           rmd160  d717bcded2424a42d4a029ee20d9585b6212e9aa \
+                    sha256  1dd15dd64c2b62101487a0f774821839df6b2baa5abc1a572c8e6c53314ee3e7 \
+                    size    101874
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
@@ -29,6 +30,6 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-openstacksdk \
                     port:py${python.version}-oslo-i18n \
                     port:py${python.version}-oslo-utils \
-                    port:py${python.version}-simplejson \
+                    port:py${python.version}-requests \
                     port:py${python.version}-stevedore
 }

--- a/python/py-oslo-config/Portfile
+++ b/python/py-oslo-config/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-oslo-config
-version             9.1.1
+version             9.7.1
 platforms           {darwin any}
 maintainers         nomaintainer
 license             Apache-2
@@ -14,14 +14,18 @@ description         Oslo Configuration Library
 long_description    {*}${description}
 homepage            https://docs.openstack.org/oslo.config/latest/
 python.rootname     oslo.config
-checksums           md5     769016a71e3074fb32d9f2171092360b \
-                    rmd160  d59bd8418db05788e59e7b17261c9c7fddf56bfa \
-                    sha256  b07654b53d87792ae8e739962ad729c529c9938a118d891ece9ee31d59716bc9 \
-                    size    160964
+distname            oslo_config-${version}
+checksums           md5     5ff5ce394addc9cf84885c48aba03aca \
+                    rmd160  0812d883f1c1817b464e0801adb9eabef46300c8 \
+                    sha256  5558b34bcc2b52f2208e80fcad955a4f7b2c41bb245b6451d43a621ad1263bbd \
+                    size    164787
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
+    depends_build-append \
+                    port:py${python.version}-pbr
+
     depends_run-append \
                     port:py${python.version}-debtcollector \
                     port:py${python.version}-netaddr \
@@ -29,6 +33,5 @@ if {${subport} ne ${name}} {
                     port:py${python.version}-oslo-i18n \
                     port:py${python.version}-rfc3986 \
                     port:py${python.version}-yaml \
-                    port:py${python.version}-requests \
-                    port:py${python.version}-importlib-metadata
+                    port:py${python.version}-requests
 }

--- a/python/py-oslo-i18n/Portfile
+++ b/python/py-oslo-i18n/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oslo-i18n
 python.rootname     oslo.i18n
-version             6.0.0
+version             6.5.1
 
 maintainers         nomaintainer
 license             Apache-2
@@ -17,17 +17,15 @@ long_description    The oslo.utils library provides support for common \
                     utility type functions, such as encoding, exception \
                     handling, string manipulation, and time handling.
 homepage            https://docs.openstack.org/oslo.i18n/latest/
+distname            oslo_i18n-${version}
 
-checksums           rmd160  8ab90a815bc11184f78599d2f972d7c74242a0a2 \
-                    sha256  ed10686b75f7c607825177a669155f4e259ce39f6143a375f6359bbcaa4a35cd \
-                    size    47479
+checksums           rmd160  d6eda675a8d44ac873875e5bdb06d2197fd66b3d \
+                    sha256  ea856a70c5af7c76efb6590994231289deabe23be8477159d37901cef33b109d \
+                    size    48000
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
                     port:py${python.version}-pbr
-
-    depends_run-append \
-                    port:py${python.version}-six
 }

--- a/python/py-oslo-serialization/Portfile
+++ b/python/py-oslo-serialization/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oslo-serialization
 python.rootname     oslo.serialization
-version             5.1.1
+version             5.7.0
 revision            0
 
 maintainers         nomaintainer
@@ -18,11 +18,12 @@ long_description    The oslo.utils library provides support for common \
                     utility type functions, such as encoding, exception \
                     handling, string manipulation, and time handling.
 homepage            https://docs.openstack.org/oslo.serialization/latest/
-checksums           rmd160  38b001a483b2c37d9ea2ee249ef28b46d4b12dc3 \
-                    sha256  8abbda8b1763a06071fc28c5d8a9be547ba285f4830e68a70ff88fe11f16bf43 \
-                    size    34306
+distname            oslo_serialization-${version}
+checksums           rmd160  d433ccda8dfbadf7a6221e228144860c8d5588c8 \
+                    sha256  bdc4d3dd97b80639b3505e46d9aa439fc95028814177f30b91743e81366c3be7 \
+                    size    35067
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-oslo-utils/Portfile
+++ b/python/py-oslo-utils/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oslo-utils
 python.rootname     oslo.utils
-version             6.2.0
+version             8.2.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -16,25 +16,26 @@ long_description    The oslo.utils library provides support for common \
                     utility type functions, such as encoding, exception \
                     handling, string manipulation, and time handling.
 homepage            https://docs.openstack.org/oslo.utils/latest/
+distname            oslo_utils-${version}
 
-checksums           rmd160  2a37c08aec67c9866f8b0bf9fed1d9681a7853a7 \
-                    sha256  fe1d166f4cb004fbd6b6bc9adfbc32aedeaf3eb54eeaf70d91a224a87543c6a5 \
-                    size    103944
+checksums           rmd160  7da4870cbe971c0802dafb89ec15b0b5ed69036a \
+                    sha256  dcf78d14b968fb7b14263c77278b2b930a7861d3caa887d3a58b2890f6659835 \
+                    size    137934
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \
                     port:py${python.version}-pbr
 
     depends_run-append \
-                    port:py${python.version}-six \
-                    port:py${python.version}-iso8601 \
-                    port:py${python.version}-oslo-i18n \
-                    port:py${python.version}-tz \
-                    port:py${python.version}-netaddr \
-                    port:py${python.version}-netifaces \
                     port:py${python.version}-debtcollector \
+                    port:py${python.version}-iso8601 \
+                    port:py${python.version}-netaddr \
+                    port:py${python.version}-oslo-i18n \
                     port:py${python.version}-parsing \
-                    port:py${python.version}-packaging
+                    port:py${python.version}-packaging \
+                    port:py${python.version}-psutil \
+                    port:py${python.version}-tz \
+                    port:py${python.version}-yaml
 }

--- a/python/py-requestsexceptions/Portfile
+++ b/python/py-requestsexceptions/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  1d0b0a38362767f9b033a90f1ad14769dfad50a1 \
                     sha256  b095cbc77618f066d459a02b137b020c37da9f46d9b057704019c9f77dba3065 \
                     size    6880
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-stevedore/Portfile
+++ b/python/py-stevedore/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-stevedore
-version             5.2.0
+version             5.4.1
 revision            0
 
 categories-append   devel
@@ -18,16 +18,14 @@ long_description    {*}${description}
 
 homepage            https://docs.openstack.org/stevedore
 
-checksums           rmd160  dd44226a3a309b7e4bec8d44286d334acfe029fd \
-                    sha256  46b93ca40e1114cea93d738a6c1e365396981bb6bb78c27045b7587c9473544d \
-                    size    513817
+checksums           rmd160  535a2f83e6d57baadd60fe00421f4af109563be1 \
+                    sha256  3135b5ae50fe12816ef291baff420acb727fcd356106e3e9cbfa9e5985cd6f4b \
+                    size    513858
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools \
-                        port:py${python.version}-pbr \
-                        port:py${python.version}-six
+    depends_build-append port:py${python.version}-pbr
 
     post-destroot {
         set dest_doc ${destroot}${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description

Update py-openstackclient to 8.0.0 and its dependencies to up-to-date versions (incl. non-OpenStack packages py-cmd2, py-dogpile-cache, py-iso8601) and enable them to build under Python <= 3.13.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 9.1 9B55

macOS 15.4 24E248 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
