### PR TITLE
jdk24: update to 24.0.1

### DIFF
--- a/java/jdk24/Portfile
+++ b/java/jdk24/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk24-mac
-version      ${feature}
+version      ${feature}.0.1
 revision     0
 
 description  Oracle Java SE Development Kit ${feature} (Short Term Support until September 2025)
@@ -29,14 +29,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  1d217604f8c12463e0169cbd7edcf37aa7b89fc5 \
-                 sha256  1867374b8ffafdfeafa31a4da8c1785544df96007d7ef3694bb0a394fccc65cd \
-                 size    239146249
+    checksums    rmd160  aef9f2ccf17cf594caa403681628741a183e20f4 \
+                 sha256  cf77c1d143c94b8e0594822da608594c15f88749db808eaa36ebd6bd8b71a835 \
+                 size    239198871
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  73304ef21c8ec627c204a5a16332488e1e92c706 \
-                 sha256  e266b39c505d976985eb7823e9ee6613b46a98f115dd0b4cd7cb580fbc8d850e \
-                 size    235966417
+    checksums    rmd160  e95cb3a692d063bf2083f7063a19a6c0768694e8 \
+                 sha256  692b4f8e7655a87a0a9c8f217c11d4d56995dfb114851fea8451759a5788a9fa \
+                 size    236087227
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to JDK 24.0.1.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?