### PR TITLE
jdk24-graalvm: update to 24.0.1

### DIFF
--- a/java/jdk24-graalvm/Portfile
+++ b/java/jdk24-graalvm/Portfile
@@ -16,8 +16,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava24-mac
 supported_archs  x86_64 arm64
 
-version     ${feature}
-set build 36
+version     ${feature}.0.1
+set build 9
 revision    0
 
 master_sites https://download.oracle.com/graalvm/${feature}/archive/
@@ -37,14 +37,14 @@ long_description {*}${description} \
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  14dde3236445fdf0b22a338c73c0c6047e1f2860 \
-                 sha256  4c820eb9554f37344dd960be9efeef98765ce41e1f958a6d789ae38e25eb6d19 \
-                 size    344248946
+    checksums    rmd160  cfdd199e9e006f4e7b8d728ccd238446a22fef65 \
+                 sha256  35852ef7040be5e73d4b8f23481c4f70e4dcb088d302e28f6a88e6a4d47de2b9 \
+                 size    344433795
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  d2be2ab6b08f879b0069197285143ed7e783ce17 \
-                 sha256  acfe2188f93d44dc0fe9c0dee6765ed8c5cc789ce3f1d6625c68e886a6ac83ab \
-                 size    358616328
+    checksums    rmd160  d7d624c2937f6ef05faafb28ef030547efde88c7 \
+                 sha256  875555f6063b4847b617504e8f8a36290a6726770be72388261f6118bcf28f81 \
+                 size    358863647
 }
 
 worksrcdir   graalvm-jdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 24.0.1.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?