### PR TITLE
jdk21-graalvm: update to 21.0.7

### DIFF
--- a/java/jdk21-graalvm/Portfile
+++ b/java/jdk21-graalvm/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava21-mac
 supported_archs  x86_64 arm64
 
-version     ${feature}.0.6
+version     ${feature}.0.7
 set build 8
 revision    0
 
@@ -40,14 +40,14 @@ long_description Oracle GraalVM for JDK ${feature} compiles your Java applicatio
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  5ec242d980f733265c6041598a64c167a3553793 \
-                 sha256  a4e5ce59a63e8325c3eba2d2a7091fd99927b08e04eb8a90f35e0b358bc9dee7 \
-                 size    315781872
+    checksums    rmd160  fc7502e289c33ff1abd4ea88a43bcb5fde0cb201 \
+                 sha256  24094515078a83158bc7b76f73497d52127fdfe32a96665803a52285edd2c08c \
+                 size    315691454
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  a66d9ed4019e3d3e65d9309cec3b3a33a5f0ef0c \
-                 sha256  3ee94ee274cef7d0fb79fb79a35c4bc11df0854434f88b18507da722f5962464 \
-                 size    328365882
+    checksums    rmd160  cdbb4202dcea71b908da25616fe69951f32b59de \
+                 sha256  5c665f8c4a9c10352023fdbee367784cd8dfc22ffda0e625cd8c823c83b4345d \
+                 size    328232365
 }
 
 worksrcdir   graalvm-jdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 21.0.7.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?