### PR TITLE
jdk21: update to 21.0.7

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      ${feature}.0.6
+version      ${feature}.0.7
 revision     0
 
 description  Oracle Java SE Development Kit ${feature}
@@ -27,14 +27,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  9fcd44e14b065b4bf5ccdb30f5bb64c3de158d61 \
-                 sha256  2b06509c933817a6194b3f36f39148f576d76721b0767eb63b825ce2f673d719 \
-                 size    193200583
+    checksums    rmd160  c4f4e1b94df111f29563e9c4395e13d20f921370 \
+                 sha256  d876db943926408075f18372240d8b08b4540b10fe3fe602a7a488b91541b886 \
+                 size    193271275
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  2d71574b8c0d07f67dc131891424ab1c3e9f1196 \
-                 sha256  816196c571a537f0d07b4f6a15eb16c2f9521bbd21f3b731ac36b15885f8a413 \
-                 size    190854257
+    checksums    rmd160  d397b8e99b1e00f90bceed6b76f5bf92034d6405 \
+                 sha256  d29e6bf91bd7ebd14c289c2daa112a0d613ee568ee5c1a8c5f9e4bb31b09173e \
+                 size    190915097
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to JDK 21.0.7.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?