### PR TITLE
openjdk24-coretto: update to 24.0.1.9.1

### DIFF
--- a/java/openjdk24-corretto/Portfile
+++ b/java/openjdk24-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-24/releases
-version      ${feature}.0.0.36.2
+version      ${feature}.0.1.9.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Short Term Support until September 2025)
@@ -32,14 +32,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  e1c27a0db7d23c888709beb97b7d1342120dd944 \
-                 sha256  dcbca9aaf60dee9356d28268305e9de5a288cdd9ee2c37741d0503d9082139ff \
-                 size    220047642
+    checksums    rmd160  fa98b3e93e903a60178f9c9ceb34e66042cfb92b \
+                 sha256  be0dcec5e8a67d17d34206f31b31a3da5c2c757318660b8a221a6f5593b45e9a \
+                 size    220044690
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  01f3291763a9bc5bf07449c8c1602163d43743aa \
-                 sha256  b93e74ff5107a5602c5b8c9ba2482da2b1c05b4ac82f2bc325ede5a4d768ad59 \
-                 size    217665215
+    checksums    rmd160  25f01ebe1fbb90ffbe335f1cbbde5844cc49dc58 \
+                 sha256  cdbf70570a0a9bfbee3524021e4b61ee3b1a8615162dfbb7edf80c1b6da5ff3b \
+                 size    217651724
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Coretto 24.0.1.9.1.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?