### PR TITLE
openjdk21-coretto: update to 21.0.7.6.1

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      ${feature}.0.6.7.1
+version      ${feature}.0.7.6.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  8bc78b3ff91ab35a2062afd0c3a44a782e317093 \
-                 sha256  d444621a84ce91a314ac54525a2efa410b660e03c26b9895e83da2f76e0c5db5 \
-                 size    202366538
+    checksums    rmd160  b80c261eb2fa6f61ebc2860c99b8b616e8712fc1 \
+                 sha256  162c8d39c77c15e1b522ab640951e691ea0951d7aaa48c7efec690cc0bdd6c31 \
+                 size    202443249
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  bc0e369a1ab4e7e689f0c747926974bb700fa407 \
-                 sha256  49a051e6e6940b29dd093b4bd317a06d2145d8340ef953821022e517f89d2bea \
-                 size    200248007
+    checksums    rmd160  f0263122cb37987447f3c55e15124082e7d34b9b \
+                 sha256  911f8dc963a23a9ab417b5270662c7152ab99bb1634f75893a863c6eca91958c \
+                 size    200308124
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Coretto 21.0.7.6.1.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?