### PR TITLE
openjdk17-coretto: update to 17.0.15.6.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.14.7.1
+version      ${feature}.0.15.6.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  1c13170637b07811863d9c88b826d16ca4c6eeac \
-                 sha256  7b67fe48ada326153257acce0c96a62b0c5a551012ba511a1675c7ca3c2c66d8 \
-                 size    188076599
+    checksums    rmd160  3dcbf66f5cdbab6502caf392a854ed30ddb7f486 \
+                 sha256  b840d10c3b51b4ba3829f7a7bfc230fe366fa1ed9218f46ecac4590be2fb04a7 \
+                 size    188139726
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  07e382c40b4b813cb1729b1c65a05aabcfc03773 \
-                 sha256  34986a2c682a12404ae2fb1ea409400ef74f4d1c8da8cc7e6a285180cfd8d351 \
-                 size    186222574
+    checksums    rmd160  b0e1c9dcf627dbd264bc310e181b3e2f5dd57c68 \
+                 sha256  0102047bbcf897fd66af96c0859d6a552973038a142f36ca64344d1b68f90d68 \
+                 size    186305356
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Coretto 17.0.15.6.1.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?