### PR TITLE
openjdk11-coretto: update to 11.0.27.6.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      ${feature}.0.26.4.1
+version      ${feature}.0.27.6.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  42ccede61365ef9cb6ec7a632638e996e4af8e09 \
-                 sha256  0855810233e5075917b316fb153a5119ebccca0983293f62f0fff077cee82064 \
-                 size    187876762
+    checksums    rmd160  0154ebb4c535c1b7c339215f6552d7ff51cf3128 \
+                 sha256  fdc87869eb29309d3bff60cd32848e5d2a85d52bda78ced5dabdd2e9872bdce1 \
+                 size    187879484
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  baf31812b80cce46990346646f4431184fbc8a79 \
-                 sha256  e722d9389ff488ec52b64e6d36913c47502f2b5e428c1feb4876566faa075dfb \
-                 size    185451618
+    checksums    rmd160  20430703498b69ae0e64b2a9994d7a1801f61f65 \
+                 sha256  da6e1b54afb4f15e949a1e51562e3488afd64218decc063b19cad588602fa9d2 \
+                 size    185492180
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Coretto 11.0.27.6.1.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?