### PR TITLE
google-cloud-sdk: update to 518.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             517.0.0
+version             518.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  6ad23eb68b8c77d40f03be76bff1f05e7cbe6cbf \
-                    sha256  aed6bbb89a1ed713bd0da36011130c20e990aae78b44d1b3cf528770c121d84a \
-                    size    54312622
+    checksums       rmd160  09b824bef6d8d6b90ff5355c2e21da68ee1a9423 \
+                    sha256  40aa5a057a2d27c1f70e91d068a9a58f0ee93e86b9af147950c27d1fbae88f93 \
+                    size    53679264
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  4bd65600fec7ff6ccd9629fbad25f91c6560fae4 \
-                    sha256  ed5e74ecef3c4a7e1bb6d8857327fa0f5b564f980dd4d982f40fae4dbc4ff3b8 \
-                    size    55781755
+    checksums       rmd160  a354316a42791f9b4a3e2c991cb32c4bbfc6c916 \
+                    sha256  dc98c14df8aa1f313cb65c426469783b863516298d8a5f0f68cacfbb6e75e95c \
+                    size    55150051
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  f5af3ad49c83bf8b98f148eca172ce8fa9518e26 \
-                    sha256  1145bd806cac0954a6b5709b34c2da3d830f952129c12e4b68adfcd951313ffd \
-                    size    55723130
+    checksums       rmd160  9213309be0819953d1292e7d25a4c5eee39ce60a \
+                    sha256  e61e021cba3bb6f08c1acfa375feead67292086bce72991e8f20fda20b5c6d21 \
+                    size    55085420
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 518.0.0.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?