### PR TITLE
openjdk24-zulu: update to 24.30.11

### DIFF
--- a/java/openjdk24-zulu/Portfile
+++ b/java/openjdk24-zulu/Portfile
@@ -15,10 +15,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-24&os=macos&package=jdk#zulu
-version      ${feature}.28.83
+version      ${feature}.30.11
 revision     0
 
-set openjdk_version ${feature}.0.0
+set openjdk_version ${feature}.0.1
 
 description  Azul Zulu Community OpenJDK ${feature} (Short Term Support until September 2025)
 long_description {*}${description}\
@@ -33,14 +33,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  af30b2b5438fcfbfdc3082dbc7e8a8921e4fd7b2 \
-                 sha256  7bb289b49f7e98515274a0a3ebcb617d35e0b961f9cd769249bf698735dffe54 \
-                 size    225379276
+    checksums    rmd160  d8d38ccefd02424776c98a47711331ff1c8e22f2 \
+                 sha256  56118e8996aca5779554b129d0c2595f18fffa8bc6826cbe8116f6059f4eba16 \
+                 size    225389420
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  130a3fe7c543dea810b9ad1b9edd1fd7261299e7 \
-                 sha256  ef25cb38908ad1167c575bec7b1386c4647d340c22fe90a5f790653bc13c9c65 \
-                 size    222903791
+    checksums    rmd160  48b4990db9db7a5231fa02dc956c5dba33934be0 \
+                 sha256  a49b2ada029c4f2e38cdb15b4808fa29de55662d3de63286919a9df1c788cfb1 \
+                 size    222919508
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 24.30.11.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?