### PR TITLE
openjdk17-zulu: update to 17.58.21

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -15,10 +15,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.56.15
+version      ${feature}.58.21
 revision     0
 
-set openjdk_version ${feature}.0.14
+set openjdk_version ${feature}.0.15
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -30,14 +30,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  8b21cf7dda9d6d056f2527c5d7346d5fbab1843e \
-                 sha256  ee1a55b6b63d62d1a24d420b1550ef1736fda36db0e612893d9d26eb1d7f1611 \
-                 size    194233163
+    checksums    rmd160  54b5423d131ea6af8e6f0e8721081acdd1ed505c \
+                 sha256  ebaa3d4c1eefd3d612320a5caf3e2b190d1a2524449f02afb0e5374eaadae628 \
+                 size    194285628
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  89d8186b9af1df410a6eb55034403991df97aa22 \
-                 sha256  c3b9bfb0a6dbe4c5d9efce6c46d3a89c92d7b07ba1bd0afc944612298ac284ec \
-                 size    192183605
+    checksums    rmd160  8cd696044691cef10a71e9ebc8615b97748334fa \
+                 sha256  e63a2fc063d40945bb849912c38b70f7b18a3bf0c04e3e05b5dbe26938a6f356 \
+                 size    192224762
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.58.21.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?