### PR TITLE
openjdk11-zulu: update to 11.80.21

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -15,10 +15,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.78.15
+version      ${feature}.80.21
 revision     0
 
-set openjdk_version ${feature}.0.26
+set openjdk_version ${feature}.0.27
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -30,14 +30,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  1a2dbe33bd5f5f43d541e6ec5aab7e86873d1c6f \
-                 sha256  bb3884619c6f09ec5ca3ce43810c61ade647bb896f4120a6cf076ec993b5a1a0 \
-                 size    195096639
+    checksums    rmd160  2bd1c85ce3bfbe243207113d3add408a8f1cd486 \
+                 sha256  5b2cbab1cede1290a0cd30dfdac3687a1443ef08157f9a393671ca51e78c43aa \
+                 size    195072241
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  d5317f917c80169cec233e4cc31567ccc25d0bc8 \
-                 sha256  3708badcc0c79fc1791e74b62478188a1f43c4f9a1e7d3e1bd4173da995479a3 \
-                 size    193064136
+    checksums    rmd160  822c0ee6e96648b7041103264fd1b1c66dcf596f \
+                 sha256  f24b8c06b586efbde158200e764e89d7437f2916f934616ca8bb14c307603624 \
+                 size    193066941
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.80.21.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?