### PR TITLE
openjdk8-zulu: update to 8.86.0.25

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      ${feature}.84.0.15
+version      ${feature}.86.0.25
 revision     0
 
-set openjdk_version ${feature}.0.442
+set openjdk_version ${feature}.0.452
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -35,14 +35,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  4ea10c09257a46b6f69d769e4261903fda68c466 \
-                 sha256  52131294512042dd6356426202e6a4116536477281fe76cfc0a3a15fe0d6ff44 \
-                 size    106931505
+    checksums    rmd160  32bb7f4a0d582cfaca0c9f0d191ac7cf5289a0e1 \
+                 sha256  0cb3d9b8c4285cd7e518e047975ec8eded90f61cd6ea0dea2d499ed4402e2ca0 \
+                 size    106917218
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  10a414d91ccdf10cd6ab7396040db909e5ce75ab \
-                 sha256  effa6d1bd4b6bce68328df66e063a97c2c4afeb0aa36fda4f85c434dd8246572 \
-                 size    104734182
+    checksums    rmd160  75a96cd46062164fb0e4175498ef9c7c6d02e21e \
+                 sha256  796dbb0d13ac1bea1198e53e52ac576df25a1c5c43449a563fc0b7d7759935fc \
+                 size    104723196
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.86.0.25.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?