### PR TITLE
openjdk21: update to 21.0.7

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 set feature 21
 name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk21/ for the version and build number that matches the latest '-ga' version
-version             ${feature}.0.6
-set build 7
+version             ${feature}.0.7
+set build 6
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -26,9 +26,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  2987f9e3ae3542b1913c65c4e0385564c963270a \
-                    sha256  586bf34a4ce41d6a02f81315ef6cac7d2395a6d47d293af94a6a8fa7c7014ead \
-                    size    70317744
+checksums           rmd160  29b2690fb3f49dd19810de98ca609c6c5a1317c2 \
+                    sha256  18809fec2b348bd28ce7bdb4de27112431fdfef8e224f31e0beb0b79ce1ab5b1 \
+                    size    70334524
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.7.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?