### PR TITLE
openjdk17: update to 17.0.15

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 set feature 17
 name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk17/ for the version and build number that matches the latest '-ga' version
-version             ${feature}.0.14
-set build 7
+version             ${feature}.0.15
+set build 6
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -21,13 +21,13 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  d44423fb510e75d0516423573190959d7e9a284d \
-                    sha256  39a984e49a4216013e7a418fb91d46263165e5762e4ad9bd4ef95f9545e96fd6 \
-                    size    66483076
+checksums           rmd160  815a4bf32aa6f4113f71eff5ae976ab871ed385a \
+                    sha256  0ead550ff5abe15df9c2c8b3656198e6e6679186b544e1fa329436e90eb46b31 \
+                    size    66554460
 
 depends_lib         port:freetype \
                     port:libiconv
-depends_build       port:openjdk${feature}-bootstrap \
+depends_build       port:openjdk${feature}-zulu \
                     port:autoconf \
                     port:gmake \
                     port:bash
@@ -56,7 +56,7 @@ configure.args      --with-debug-level=release \
                     --with-extra-cflags="${configure.cflags}" \
                     --with-extra-cxxflags="${configure.cxxflags}" \
                     --with-extra-ldflags="${configure.ldflags}" \
-                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk${feature}-bootstrap/Contents/Home \
+                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk${feature}-zulu/Contents/Home \
                     --with-freetype=system \
                     --with-freetype-include=${prefix}/include/freetype2 \
                     --with-freetype-lib=${prefix}/lib \


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.15.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?