### PR TITLE
openjdk21-sap: update to 21.0.7

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/21
-version      ${feature}.0.6
+version      ${feature}.0.7
 revision     0
 
 description  SAP Machine ${feature}
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  4a6b76ffa4c593a0ec6057fae683c397ce69bdfa \
-                 sha256  7f550106bf0bcf926b9637c70c3ce3a40e7b311c01f2a81a0dc7d95064c5054d \
-                 size    202583192
+    checksums    rmd160  05441ce18b0836fcc7c88dddbc3b07bfc687854b \
+                 sha256  853cc0bc3242645326c47dc46117e8c3c5117202ea1fc711b502ab08bf9829e4 \
+                 size    202669047
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  e2f729a097ed99d1f36a2d02ddb197543f00ea25 \
-                 sha256  5b5acc052a823f6861bf43aacbecf0b0c3c93204a3bced36d7426591c4792a8f \
-                 size    200322931
+    checksums    rmd160  b557b2918bbf2b85e6c30bd26a3357a19fcf6344 \
+                 sha256  0c287f26b22f720addd3535de5852934112cbe2a01dfef5d36f0bca33b292d23 \
+                 size    200403831
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 21.0.7.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?