### PR TITLE
openjdk17-sap: update to 17.0.15

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.14
+version      ${feature}.0.15
 revision     0
 
 description  OpenJDK ${feature} builds (Long Term Support) maintained and supported by SAP
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  f7801bece34a516bbe4cf9181d311874880ec49d \
-                 sha256  eca737bbc29de298da04856fdc9c856c2638df4151885050f710675a989cd31f \
-                 size    188308868
+    checksums    rmd160  de91b50ef3293cbbcf262d7b6281070836fe1ce2 \
+                 sha256  5dc0076b8c278080f9afb29b401c7736279a6722828ca822e1e70db941fa7052 \
+                 size    188400677
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  e7de341bae6d1ae8150ed797e7512567d61edcce \
-                 sha256  8dfd53f5cc6a00d85500fc637b68e256c0b8ed6770e9b9c9779297761a24f276 \
-                 size    186270285
+    checksums    rmd160  c62632f3a464d853f439c414acf758bd429f9219 \
+                 sha256  4262936d6e098551166ab7902c4cf8897201004a9728ef86ad2401ab6cf30321 \
+                 size    186355877
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.15.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?