### PR TITLE
ortep3: fix errorneous lines in graphics output

### DIFF
--- a/science/ortep3/Portfile
+++ b/science/ortep3/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 
 name                ortep3
 version             1.0.3
-revision            1
+revision            2
 categories          science chemistry
 license             public-domain
 maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
@@ -61,10 +61,11 @@ post-patch {
 
 use_parallel_build  no
 
+# Note: Not setting -O0 leads to errorneous lines in the graphics
 build {
     system -W ${worksrcpath} "${configure.f90} \
         -fdiagnostics-color=auto -std=legacy  \
-        -O2 \
+        -O0 \
         -F${frameworks_dir} -framework AquaTerm \
         -L${prefix}/lib \
         -lpng -lpgplot -lX11 \


### PR DESCRIPTION
#### Description

-O2 optimization creates wrong overlap of lines calculations.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?  There is not test
- [x] tried a full install with `sudo port -vst install`?    only -vs works
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

