### PR TITLE
openjdk21-temurin: update to 21.0.7

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.6
-set build    7
+version      ${feature}.0.7
+set build    6
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least December 2029)
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  b7a11f6421fff6e31852141c134595e423e45053 \
-                 sha256  7aacfc400078ad65b7c7de3ec75ff74bf5c2077d6740b350f85ae10be4f71e76 \
-                 size    193844017
+    checksums    rmd160  c7ff61ad5d41492782fcabba33a627a26abb4ec3 \
+                 sha256  8e6d876f60bc8b7866e91222ba9f27a78e5102d7a4ce4a6e915f95fe539b66ed \
+                 size    193920354
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  43b7b102d42446de0b783c1ed643961f5337e004 \
-                 sha256  4ef4083919126a3d93e603284b405c7493905497485a92b375f5d6c3e8f7e8f2 \
-                 size    199608953
+    checksums    rmd160  9ee05daa3e193dc9db80c7e8942be824d268a53f \
+                 sha256  6fcb25f3f71a5ff245dec4ebe8bd5c643f179a5cd0a61c08e58a8c65914d2f97 \
+                 size    199692905
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 21.0.7.

###### Tested on

macOS 15.4 24E248 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?