### PR TITLE
xschem: new port of xschem schematic editor for EDA

### DIFF
--- a/science/xschem/Portfile
+++ b/science/xschem/Portfile
@@ -1,0 +1,93 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            xschem
+version         3.4.6
+revision        0
+license         GPL-2
+categories      science cad
+
+maintainers     {gmail.com:degnan.68k @bpdegnan} \
+                openmaintainer
+
+description     schematic capture and netlisting EDA tool
+long_description \
+    Xschem is a schematic capture program that supports digital, analog, behavioral \
+    circuit design and simulation. It is designed to interface well with ngspice \
+    and other simulation tools.
+
+homepage        https://xschem.sourceforge.io/stefan/index.html
+
+distname        ${name}-${version}
+master_sites    master_sites    sourceforge:xschem
+
+
+checksums       rmd160  bf5f75f9e0838293515796bdead483ff2b667049 \
+                sha256  a46bd296b2b9f8436370892eb81264599c2e3ae84b298d7a4e3b89c4126185e7 \
+                size    14990039
+
+set docdir      ${prefix}/share/doc/${name}
+
+depends_build       port:pkgconfig
+depends_lib         port:cairo \
+                    port:xorg-libxcb \
+                    port:xrender \
+                    port:freetype \
+                    port:Xft2 \
+                    port:xpm \
+                    port:readline \
+                    port:tcl \
+                    port:tk \
+                    port:xorg-libX11
+                    
+use_configure   yes
+configure.args      --prefix=${prefix}
+
+destroot {
+    set bindir      ${destroot}${prefix}/bin
+    set sharedir    ${destroot}${prefix}/share/xschem
+    set docdir      ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d ${bindir} ${sharedir} ${docdir}
+
+    # Install the main binary
+    xinstall -m 755 ${worksrcpath}/src/xschem ${bindir}
+
+    # Install all .tcl, .awk, and xschemrc from src/
+    foreach f [glob -nocomplain -directory ${worksrcpath}/src *.tcl *.awk xschemrc] {
+        if {[file exists $f]} {
+            xinstall -m 644 $f ${sharedir}
+        }
+    }
+
+    # Install example schematics and library files
+     foreach dir {xschem_library} {
+        set srcdir "${worksrcpath}/${dir}"
+        if {[file exists $srcdir]} {
+            copy $srcdir ${sharedir}
+        }
+    }
+
+    # Now explicitly copy systemlib from src/
+    if {[file exists ${worksrcpath}/src/systemlib]} {
+        copy ${worksrcpath}/src/systemlib ${sharedir}
+    }
+    # Install documentation if present
+    foreach docfile {README.md README LICENSE AUTHORS INSTALL} {
+        set srcfile "${worksrcpath}/${docfile}"
+        if {[file exists $srcfile]} {
+            xinstall -m 644 $srcfile ${docdir}
+        }
+    }
+}
+
+livecheck.type      regex
+livecheck.url       https://sourceforge.net/projects/xschem/files/
+livecheck.regex     {xschem-([0-9.]+)\.tar\.gz}  
+
+notes "
+Xschem has been installed to ${prefix}/bin/xschem.
+Libraries and examples are in ${prefix}/share/xschem.
+You may wish to create ~/.xschem/xschemrc for custom settings.
+"


### PR DESCRIPTION
#### Description

xschem: new port for Xschem schematic editor

###### Type(s)
new Portfile

###### Tested on
macOS 13.7.5 22H527 x86_64
Xcode 14.3.1 14E300c


###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [X ] tried existing tests with `sudo port test`?
- [ X] tried a full install with `sudo port -vst install`?
- [X ] tested basic functionality of all binary files?
- [ X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?


