### PR TITLE
new port: samba420 4.20.8

### DIFF
--- a/net/samba420/Portfile
+++ b/net/samba420/Portfile
@@ -1,0 +1,108 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           perl5 1.0
+
+# O_CLOEXEC, AT_FDCWD
+PortGroup           legacysupport 1.1
+
+legacysupport.newest_darwin_requires_legacy 13
+
+name                samba420
+conflicts           samba3 samba4
+version             4.20.8
+revision            0
+checksums           rmd160  5900b477747cd4cb1bc1279b376f10e8bf218efa \
+                    sha256  75be0e8d31f45013e9b260fe7cf304a36d2d8128391914772577215ec173a807 \
+                    size    42531989
+
+categories          net
+maintainers         nomaintainer
+license             GPL-3+
+description         SMB/CIFS server and client
+long_description    Samba is an software suite that provides seamless file \
+                    and print services to SMB/CIFS clients.
+
+homepage            https://www.samba.org
+master_sites        https://download.samba.org/pub/samba/stable
+distname            samba-${version}
+
+perl5.major         5.34
+
+depends_build       port:pkgconfig \
+                    port:gettext \
+                    port:bison
+
+depends_lib         port:cctools \
+                    port:gettext-runtime \
+                    path:lib/pkgconfig/gnutls.pc:gnutls \
+                    port:gpgme \
+                    path:lib/pkgconfig/icu-uc.pc:icu \
+                    port:jansson \
+                    port:libarchive \
+                    port:libiconv \
+                    path:lib/libldap.dylib:openldap \
+                    port:p${perl5.major}-parse-yapp \
+                    port:popt \
+                    port:python313 \
+                    port:readline \
+                    port:zlib
+
+platform darwin {
+    # patch "get_user_groups: failed to get the unix group list" on
+    # macOS
+    #
+    # Samba fails on macOS when current user belongs to more than 16
+    # groups.
+    #
+    # The 16 group limit is returned by sysconf when asked for
+    # _SC_NGROUPS_MAX; this is apparently due to OS X's nested groups;
+    # while the call to getgrouplist returns a flat (not nested) group
+    # list. getgrouplist will happily return the first 16 groups but
+    # still return a -1 return code, indicating failure. Hence the
+    # strange maximum of 16 groups on OS X.
+    #
+    # https://github.com/Homebrew/legacy-homebrew/issues/5954
+    patchfiles-append \
+                    patch-macos-grouplimit.diff
+}
+
+# patch to disable building documentation on MacOS
+# this enables us to have a working samba4 port without docs,
+# rather than not having samba4 at all. Can be removed when
+# doc build issues are resolved.
+patchfiles-append patch-no-xsltproc.diff
+patchfiles-append patch-bug-15030.diff
+patchfiles-append patch-samba-install.diff
+patchfiles-append patch-link-icui18n.diff
+
+configure.perl      ${perl5.bin}
+configure.python    ${prefix}/bin/python3.13
+configure.env-append \
+                    YAPP=${prefix}/bin/yapp-${perl5.major}
+# configure script provided by samba forwards to waf, but also sets environment.
+# bypassing it breaks build on ppc: https://trac.macports.org/ticket/65622
+# configure.cmd       ${configure.python} ./buildtools/bin/waf configure
+configure.args      -C \
+                    --enable-fhs \
+                    --mandir=${prefix}/share/man \
+                    --with-libiconv=${prefix} \
+                    --without-acl-support \
+                    --without-ad-dc \
+                    --disable-avahi \
+                    --with-gpgme \
+                    --disable-spotlight
+
+build.pre_args
+build.env-append    PYTHON=${configure.python} DESTDIR=${destroot}
+
+destroot.env-append PYTHON=${configure.python} DESTDIR=${destroot}
+destroot.destdir
+
+# error: redefinition of typedef ‘SMB_STRUCT_STAT’
+compiler.blacklist-append *gcc-4.* {clang < 400}
+
+livecheck.type  regex
+livecheck.url   https://download.samba.org/pub/samba/
+livecheck.regex samba-(\[0-9a-z.\]+)\\.tar\\.gz

--- a/net/samba420/files/patch-bug-15030.diff
+++ b/net/samba420/files/patch-bug-15030.diff
@@ -1,0 +1,26 @@
+Upstream-Status: Submitted [https://bugzilla.samba.org/show_bug.cgi?id=15030]
+--- ./lib/replace/wscript
++++ ./lib/replace/wscript
+@@ -961,7 +961,10 @@ def build(bld):
+                         target='stdbool.h',
+                         enabled = not bld.CONFIG_SET('HAVE_STDBOOL_H'))
+ 
+-    bld.SAMBA_SUBSYSTEM('samba_intl', source='', use_global_deps=False,deps=bld.env.intl_libs)
++    bld.SAMBA_SUBSYSTEM('samba_intl', source='',
++                        provide_builtin_linking=True,
++                        use_global_deps=False,
++                        deps=bld.env.intl_libs)
+ 
+ def testonly(ctx):
+     '''run talloc testsuite'''
+--- ./third_party/heimdal_build/wscript_build.orig	2023-09-18 00:12:49.000000000 +0200
++++ ./third_party/heimdal_build/wscript_build	2023-09-18 00:13:03.000000000 +0200
+@@ -1104,7 +1104,7 @@
+         includes='../heimdal/lib/asn1',
+         group='hostcc_build_main',
+         deps='ROKEN_HOSTCC HEIMBASE_HOSTCC LIBREPLACE_HOSTCC HEIMDAL_VERS_HOSTCC '
+-             'HEIMDAL_ASN1_GEN_HOSTCC',
++             'HEIMDAL_ASN1_GEN_HOSTCC intl',
+         install=False
+     )
+     bld.env['ASN1_COMPILE'] = os.path.join(bld.bldnode.parent.abspath(), 'asn1_compile')

--- a/net/samba420/files/patch-link-icui18n.diff
+++ b/net/samba420/files/patch-link-icui18n.diff
@@ -1,0 +1,10 @@
+--- ./lib/util/charset/wscript_configure
++++ ./lib/util/charset/wscript_configure
+@@ -41,6 +41,7 @@
+                args='--cflags --libs',
+                msg='Checking for icu-i18n',
+                uselib_store='ICU_I18N'):
++    conf.env['LIB_ICU_I18N'].append('icuuc')
+     for lib in conf.env['LIB_ICU_I18N']:
+         conf.CHECK_LIB(lib, shlib=True, mandatory=True)
+     conf.env['icu-libs'] = ' '.join(conf.env['LIB_ICU_I18N'])

--- a/net/samba420/files/patch-macos-grouplimit.diff
+++ b/net/samba420/files/patch-macos-grouplimit.diff
@@ -1,0 +1,59 @@
+--- source3/lib/system.c.orig	2021-09-13 08:42:07.000000000 -0500
++++ source3/lib/system.c	2022-01-11 20:30:07.000000000 -0600
+@@ -758,7 +758,25 @@
+ 
+ int setgroups_max(void)
+ {
+-#if defined(SYSCONF_SC_NGROUPS_MAX)
++#if defined(DARWINOS)
++	/*
++   * Fixes the Grouplimit of 16 users os OS X
++   *
++   * Bug has been raised upstream: https://bugzilla.samba.org/show_bug.cgi?id=8773
++   * "https://raw.github.com/gist/1892831/af9ac310b5bd2ffafc79a6ae04d6f9e23e3593ee/samba.3.6.3.osx-getgrouplist.patch"
++   *
++   * On OS X, sysconf(_SC_NGROUPS_MAX) returns 16 due to OS X's group nesting
++	 * and getgrouplist will return a flat list; users do almost always exceed the
++	 * maximum of 16 groups.
++   *
++   * https://bugzilla.samba.org/show_bug.cgi?id=8773
++   * https://github.com/mxcl/homebrew/issues/5954
++   * https://serverfault.com/questions/414908/osx-10-7-4-samba3-6-6-get-user-groups-failed-to-get-the-unix-group-list
++   * https://gist.github.com/lasombra/1888778
++   * https://github.com/Homebrew/legacy-homebrew/pull/10311
++	 */
++	return 128;
++#elif defined(SYSCONF_SC_NGROUPS_MAX)
+ 	int ret = sysconf(_SC_NGROUPS_MAX);
+ 	return (ret == -1) ? NGROUPS_MAX : ret;
+ #else
+--- source3/lib/system_smbd.c.orig	2021-09-13 08:42:07.000000000 -0500
++++ source3/lib/system_smbd.c	2022-01-11 20:32:02.000000000 -0600
+@@ -205,7 +205,27 @@
+ 			 gid_t primary_gid,
+ 			 gid_t **ret_groups, uint32_t *p_ngroups)
+ {
++#if defined(DARWINOS)
++	/*
++   * Fixes the Grouplimit of 16 users os OS X
++   *
++   * Bug has been raised upstream: https://bugzilla.samba.org/show_bug.cgi?id=8773
++   * "https://raw.github.com/gist/1892831/af9ac310b5bd2ffafc79a6ae04d6f9e23e3593ee/samba.3.6.3.osx-getgrouplist.patch"
++   *
++   * On OS X, sysconf(_SC_NGROUPS_MAX) returns 16 due to OS X's group nesting
++	 * and getgrouplist will return a flat list; users do almost always exceed the
++	 * maximum of 16 groups.
++   *
++   * https://bugzilla.samba.org/show_bug.cgi?id=8773
++   * https://github.com/mxcl/homebrew/issues/5954
++   * https://serverfault.com/questions/414908/osx-10-7-4-samba3-6-6-get-user-groups-failed-to-get-the-unix-group-list
++   * https://gist.github.com/lasombra/1888778
++   * https://github.com/Homebrew/legacy-homebrew/pull/10311
++	 */
++	int max_grp = 128;
++#else
+ 	int max_grp = MIN(128, getgroups_max());
++#endif
+ 	gid_t stack_groups[max_grp];
+ 	uint32_t ngrp;
+ 	gid_t *temp_groups = stack_groups;

--- a/net/samba420/files/patch-no-xsltproc.diff
+++ b/net/samba420/files/patch-no-xsltproc.diff
@@ -1,0 +1,44 @@
+--- buildtools/wafsamba/samba_conftests.py.orig	2021-08-09 08:38:35.000000000 -0500
++++ buildtools/wafsamba/samba_conftests.py	2022-01-11 20:36:04.000000000 -0600
+@@ -484,7 +484,7 @@
+ 
+ 
+     if not conf.CONFIG_SET('XSLTPROC'):
+-        conf.find_program('xsltproc', var='XSLTPROC')
++        conf.find_program('NOTxsltproc', var='XSLTPROC')
+     if not conf.CONFIG_SET('XSLTPROC'):
+         return False
+ 
+--- ctdb/wscript.orig	2021-08-09 08:38:36.000000000 -0500
++++ ctdb/wscript	2022-01-11 20:36:04.000000000 -0600
+@@ -1183,7 +1183,7 @@
+     BASE_URL = 'http://docbook.sourceforge.net/release/xsl/current'
+     MAN_XSL = '%s/manpages/docbook.xsl' % BASE_URL
+     HTML_XSL = '%s/html/docbook.xsl' % BASE_URL
+-    CMD_TEMPLATE = 'xsltproc --xinclude -o %s --nonet %s %s'
++    CMD_TEMPLATE = 'NOTxsltproc --xinclude -o %s --nonet %s %s'
+     manpages = manpages_binary + manpages_misc + manpages_etcd + manpages_ceph
+     for t in manpages:
+         cmd = CMD_TEMPLATE % ('doc/%s' % t, MAN_XSL, 'doc/%s.xml' % t)
+--- lib/ldb/wscript.orig	2021-10-27 07:53:55.000000000 -0500
++++ lib/ldb/wscript	2022-01-11 20:36:04.000000000 -0600
+@@ -60,7 +60,7 @@
+             conf.define('USING_SYSTEM_CMOCKA', 1)
+ 
+     conf.RECURSE('lib/replace')
+-    conf.find_program('xsltproc', var='XSLTPROC')
++    conf.find_program('NOTxsltproc', var='XSLTPROC')
+     conf.SAMBA_CHECK_PYTHON()
+     conf.SAMBA_CHECK_PYTHON_HEADERS()
+ 
+--- wscript.orig	2021-08-26 04:01:35.000000000 -0500
++++ wscript	2022-01-11 20:36:04.000000000 -0600
+@@ -166,7 +166,7 @@
+     conf.RECURSE('examples/winexe')
+ 
+     conf.SAMBA_CHECK_PERL(mandatory=True)
+-    conf.find_program('xsltproc', var='XSLTPROC')
++    conf.find_program('NOTxsltproc', var='XSLTPROC')
+ 
+     if conf.env.disable_python:
+         if not (Options.options.without_ad_dc):

--- a/net/samba420/files/patch-samba-install.diff
+++ b/net/samba420/files/patch-samba-install.diff
@@ -1,0 +1,27 @@
+diff --git buildtools/wafsamba/samba_install.py buildtools/wafsamba/samba_install.py
+index a43d103..eb2ee57 100644
+--- buildtools/wafsamba/samba_install.py
++++ buildtools/wafsamba/samba_install.py
+@@ -81,7 +81,7 @@ def install_library(self):
+ 
+         target_name = self.target
+ 
+-        if install_ldflags != build_ldflags:
++        if False:
+             # we will be creating a new target name, and using that for the
+             # install link. That stops us from overwriting the existing build
+             # target, which has different ldflags
+@@ -138,6 +138,13 @@ def install_library(self):
+                 t.env.append_value('LINKFLAGS', t.env.SONAME_ST % install_name)
+             t.env.SONAME_ST = ''
+ 
++        if '-dynamiclib' in t.env.LINKFLAGS_cshlib:
++            t.env.append_value('LINKFLAGS_cshlib', '-install_name')
++            if install_link:
++                t.env.append_value('LINKFLAGS_cshlib', os.path.join(install_path, install_link))
++            else:
++                t.env.append_value('LINKFLAGS_cshlib', os.path.join(install_path, install_name))
++
+         # tell waf to install the library
+         bld.install_as(os.path.join(install_path, install_name),
+                        self.path.find_or_declare(inst_name),


### PR DESCRIPTION
#### Description

This submission addresses the fact that samba4 is broken (core dumps) every time on all my tested environments (tested: 10.15, 13) ever since it has been upgraded to 4.21.x. The latest effort there assured that the binaries are build and runs, but once there is even a minimal share defined in `smb.conf`, `smbd` inevitably crashes.

Since I do not have the experience, I did not attempt to dig into debugging the cause of this, nor did I submit a ticket on the bug tracker (I should have), but have been daily driving the last maintenance releases of 4.20.x branch and it works great. I'm submitting this as my proposed solution, so the software remains usable while somebody could work on porting 4.22.0 to MacPorts. Since this branch is supported for about another 5 months (cf. https://wiki.samba.org/index.php/Samba_Release_Planning), I believe it's worth it.

As a side effect, `samba3` and `samba4` should add `samba420` as a conflicting port, but I'm unfamiliar with the workflow in this case, so I'm leaving this out for now. Should I squash the commit when I later include these changes?

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Command Line Tools 12.4.0.0.1.1610135815

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
