### PR TITLE
py-fido2, yubikey-manager(4): Backport upstream fixes for py-scard API change

### DIFF
--- a/python/py-fido2/Portfile
+++ b/python/py-fido2/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-fido2
 version             1.2.0
+revision            1
 categories          python security crypto
 license             BSD
 platforms           {darwin any}
@@ -22,6 +23,8 @@ long_description    Provides library functionality for communicating with a \
 checksums           rmd160  2cf72565783670b9a53e246311527272f47d0b64 \
                     sha256  e39f95920122d64283fda5e5581d95a206e704fa42846bfa4662f86aa0d3333b \
                     size    266369
+
+patchfiles          e2eb7d4a52a762795c1a8aa9804f184b11b5e64d.patch
 
 python.versions     39 310 311 312
 

--- a/python/py-fido2/files/e2eb7d4a52a762795c1a8aa9804f184b11b5e64d.patch
+++ b/python/py-fido2/files/e2eb7d4a52a762795c1a8aa9804f184b11b5e64d.patch
@@ -1,0 +1,41 @@
+From e2eb7d4a52a762795c1a8aa9804f184b11b5e64d Mon Sep 17 00:00:00 2001
+From: Dain Nilsson <dain@yubico.com>
+Date: Mon, 14 Apr 2025 13:20:17 +0200
+Subject: [PATCH] Support pyscard >=2.2.2
+
+Upstream-Status: Backport [https://github.com/Yubico/python-fido2/commit/e2eb7d4a52a762795c1a8aa9804f184b11b5e64d]
+---
+ fido2/pcsc.py | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/fido2/pcsc.py b/fido2/pcsc.py
+index 894c56b..4ce1f64 100644
+--- ./fido2/pcsc.py
++++ ./fido2/pcsc.py
+@@ -34,7 +34,6 @@
+ from smartcard import System
+ from smartcard.CardConnection import CardConnection
+ from smartcard.pcsc.PCSCExceptions import ListReadersException
+-from smartcard.pcsc.PCSCContext import PCSCContext
+ 
+ from threading import Event
+ from typing import Callable, Iterator
+@@ -243,9 +242,15 @@ def list_devices(cls, name: str = "") -> Iterator[CtapPcscDevice]:
+ def _list_readers():
+     try:
+         return System.readers()
+-    except ListReadersException:
++    except ListReadersException as e:
+         # If the PCSC system has restarted the context might be stale, try
+         # forcing a new context (This happens on Windows if the last reader is
+         # removed):
+-        PCSCContext.instance = None
+-        return System.readers()
++        try:
++            from smartcard.pcsc.PCSCContext import PCSCContext
++
++            PCSCContext.instance = None
++            return System.readers()
++        except ImportError:
++            # As of pyscard 2.2.2 the PCSCContext singleton has been removed
++            raise e

--- a/security/yubikey-manager/Portfile
+++ b/security/yubikey-manager/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                yubikey-manager
 version             5.6.1
-revision            0
+revision            1
 categories-prepend  security
 platforms           {darwin any}
 supported_archs     noarch
@@ -24,6 +24,8 @@ homepage            https://developers.yubico.com/yubikey-manager/
 checksums           rmd160  f2bc89e54bb36f0a121b806d5b54e8bd5cd615d8 \
                     sha256  730da1358504de6616f1868bf48ddb788ada4b39137fb3ada435efbf39070160 \
                     size    220053
+
+patchfiles          b951fcd0c6e916a5ccf751307b8dcdf71149b38a.patch
 
 python.default_version 312
 

--- a/security/yubikey-manager/files/b951fcd0c6e916a5ccf751307b8dcdf71149b38a.patch
+++ b/security/yubikey-manager/files/b951fcd0c6e916a5ccf751307b8dcdf71149b38a.patch
@@ -1,0 +1,45 @@
+From b951fcd0c6e916a5ccf751307b8dcdf71149b38a Mon Sep 17 00:00:00 2001
+From: Dain Nilsson <dain@yubico.com>
+Date: Mon, 14 Apr 2025 10:41:46 +0200
+Subject: [PATCH] Lock pyscard to <2.2.2 until PCSCContext removal is handled
+
+Upstream-Stauts: Backport [https://github.com/Yubico/yubikey-manager/commit/b951fcd0c6e916a5ccf751307b8dcdf71149b38a]
+
+---
+ ykman/pcsc/__init__.py | 13 +++++++++----
+ 3 files changed, 21 insertions(+), 16 deletions(-)
+
+diff --git a/ykman/pcsc/__init__.py b/ykman/pcsc/__init__.py
+index e5bbf962f..617f2edee 100644
+--- ./ykman/pcsc/__init__.py
++++ ./ykman/pcsc/__init__.py
+@@ -34,7 +34,6 @@
+ from smartcard import System
+ from smartcard.Exceptions import CardConnectionException, NoCardException
+ from smartcard.pcsc.PCSCExceptions import ListReadersException
+-from smartcard.pcsc.PCSCContext import PCSCContext
+ from smartcard.ExclusiveConnectCardConnection import ExclusiveConnectCardConnection
+ 
+ from fido2.pcsc import CtapPcscDevice
+@@ -198,12 +197,18 @@ def kill_yubikey_agent():
+ def list_readers():
+     try:
+         return System.readers()
+-    except ListReadersException:
++    except ListReadersException as e:
+         # If the PCSC system has restarted the context might be stale, try
+         # forcing a new context (This happens on Windows if the last reader is
+         # removed):
+-        PCSCContext.instance = None
+-        return System.readers()
++        try:
++            from smartcard.pcsc.PCSCContext import PCSCContext
++
++            PCSCContext.instance = None
++            return System.readers()
++        except ImportError:
++            # As of pyscard 2.2.2 the PCSCContext singleton has been removed
++            raise e
+ 
+ 
+ def list_devices(name_filter=None):

--- a/security/yubikey-manager4/Portfile
+++ b/security/yubikey-manager4/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                yubikey-manager4
 version             4.0.9
-revision            1
+revision            2
 categories-prepend  security
 platforms           {darwin any}
 supported_archs     noarch
@@ -24,6 +24,8 @@ checksums           rmd160  91110d9dc284c53e1c43a1d8bba73b9536d13ea9 \
 conflicts           yubikey-manager
 
 python.rootname     yubikey-manager
+
+patchfiles          0001-Avoid-using-PCSCContext-if-it-is-unavailable.patch
 
 # This must be bumped in step with the yubico-authenticator port's Python
 # version. The full, built app must be tested: Python 3.8 previously failed at

--- a/security/yubikey-manager4/files/0001-Avoid-using-PCSCContext-if-it-is-unavailable.patch
+++ b/security/yubikey-manager4/files/0001-Avoid-using-PCSCContext-if-it-is-unavailable.patch
@@ -1,0 +1,49 @@
+From 946093be61e668dd371978a1715519a0db2137ee Mon Sep 17 00:00:00 2001
+From: Dain Nilsson <dain@yubico.com>
+Date: Mon, 14 Apr 2025 10:41:46 +0200
+Subject: [PATCH] Avoid using PCSCContext if it is unavailable
+
+(cherry picked from commit b951fcd0c6e916a5ccf751307b8dcdf71149b38a)
+
+Upstream-Staus: Backport [https://github.com/Yubico/yubikey-manager/commit/b951fcd0c6e916a5ccf751307b8dcdf71149b38a]
+---
+ ykman/pcsc/__init__.py | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/ykman/pcsc/__init__.py b/ykman/pcsc/__init__.py
+index 39aaf3aa..bb11a66c 100644
+--- ./ykman/pcsc/__init__.py
++++ ./ykman/pcsc/__init__.py
+@@ -33,7 +33,6 @@ from ..base import YUBIKEY, YkmanDevice
+ from smartcard import System
+ from smartcard.Exceptions import CardConnectionException
+ from smartcard.pcsc.PCSCExceptions import ListReadersException
+-from smartcard.pcsc.PCSCContext import PCSCContext
+ 
+ from fido2.pcsc import CtapPcscDevice
+ from time import sleep
+@@ -150,12 +149,18 @@ def kill_scdaemon():
+ def list_readers():
+     try:
+         return System.readers()
+-    except ListReadersException:
++    except ListReadersException as e:
+         # If the PCSC system has restarted the context might be stale, try
+         # forcing a new context (This happens on Windows if the last reader is
+         # removed):
+-        PCSCContext.instance = None
+-        return System.readers()
++        try:
++            from smartcard.pcsc.PCSCContext import PCSCContext
++
++            PCSCContext.instance = None
++            return System.readers()
++        except ImportError:
++            # As of pyscard 2.2.2 the PCSCContext singleton has been removed
++            raise e
+ 
+ 
+ def list_devices(name_filter=None):
+-- 
+2.49.0
+


### PR DESCRIPTION
#### Description
This fixes Yubico Authenticator.

See
  https://github.com/Yubico/python-fido2/commit/e2eb7d4a52a762795c1a8aa9804f184b11b5e64d
and
  https://github.com/Yubico/yubikey-manager/commit/b951fcd0c6e916a5ccf751307b8dcdf71149b38a

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? One tests in yubikey-manager4 fails, but due to use of removed OpenSSL API, not because of this change.
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
