### PR TITLE
libffi: update to 3.4.8

### DIFF
--- a/devel/libffi/Portfile
+++ b/devel/libffi/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 PortGroup           github 1.0
 
-github.setup        libffi libffi 3.4.6 v
-revision            2
+github.setup        libffi libffi 3.4.8 v
+revision            0
 
-checksums           rmd160  8e927f6bc340564414a87cc5b6dffc9ce53eefd8 \
-                    sha256  b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e \
-                    size    1391684
+checksums           rmd160  ea8558bf3afdf92f470859807a31c6dc78921d0e \
+                    sha256  bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b \
+                    size    1397992
 
 github.tarball_from releases
 categories          devel
@@ -31,11 +31,7 @@ homepage            https://www.sourceware.org/libffi/
 
 # patch-sources.diff: fixes for various issues.
 #
-# This includes one upstream fix for a build problem on Sequoia.  Although
-# v3.4.7 includes this fix, it also has more test failures than v3.4.6,
-# so for now we just cherry-pick the needed change.
-#
-# This diff is from v3.4.6 vs. macports-3.4.6r2.
+# This diff is from v3.4.8 vs. macports-3.4.8.
 #
 patchfiles          patch-sources.diff
 
@@ -64,8 +60,6 @@ platform darwin {
 # compiler's default architecture.  We need to force this to match the
 # target architecture to get the correct build.  Merely providing the
 # correct architecture options in xxFLAGS is insufficient.
-#
-# This is a more general fix than the former fix for 10.6/ppc/Rosetta
 #
 if { [variant_isset universal] } {
     merger_arch_compiler yes

--- a/devel/libffi/files/patch-sources.diff
+++ b/devel/libffi/files/patch-sources.diff
@@ -1,37 +1,5 @@
---- src/aarch64/sysv.S.orig	2024-02-15 04:54:35.000000000 -0800
-+++ src/aarch64/sysv.S	2025-04-06 16:16:17.000000000 -0700
-@@ -89,8 +89,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    x5 closure
- */
- 
--	cfi_startproc
- CNAME(ffi_call_SYSV):
-+	cfi_startproc
- 	BTI_C
- 	/* Sign the lr with x1 since that is where it will be stored */
- 	SIGN_LR_WITH_REG(x1)
-@@ -347,8 +347,8 @@ CNAME(ffi_closure_SYSV_V):
- #endif
- 
- 	.align	4
--	cfi_startproc
- CNAME(ffi_closure_SYSV):
-+	cfi_startproc
- 	BTI_C
- 	SIGN_LR
- 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
-@@ -643,8 +643,8 @@ CNAME(ffi_go_closure_SYSV_V):
- #endif
- 
- 	.align	4
--	cfi_startproc
- CNAME(ffi_go_closure_SYSV):
-+	cfi_startproc
- 	BTI_C
- 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
- 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
---- src/powerpc/darwin.S.orig	2023-03-15 07:19:45.000000000 -0700
-+++ src/powerpc/darwin.S	2025-04-06 16:16:17.000000000 -0700
+--- src/powerpc/darwin.S.orig	2024-06-01 10:42:02.000000000 -0700
++++ src/powerpc/darwin.S	2025-04-17 11:40:54.000000000 -0700
 @@ -31,8 +31,6 @@
  #define MODE_CHOICE(x, y) x
  #endif
@@ -41,8 +9,8 @@
  ; Define some pseudo-opcodes for size-independent load & store of GPRs ...
  #define lgu		MODE_CHOICE(lwzu, ldu)
  #define lg		MODE_CHOICE(lwz,ld)
---- src/powerpc/darwin_closure.S.orig	2023-03-15 07:19:45.000000000 -0700
-+++ src/powerpc/darwin_closure.S	2025-04-06 16:16:17.000000000 -0700
+--- src/powerpc/darwin_closure.S.orig	2024-06-01 10:42:02.000000000 -0700
++++ src/powerpc/darwin_closure.S	2025-04-17 11:40:54.000000000 -0700
 @@ -34,7 +34,7 @@
  #define MODE_CHOICE(x, y) x
  #endif
@@ -52,8 +20,8 @@
  
  ; Define some pseudo-opcodes for size-independent load & store of GPRs ...
  #define lgu		MODE_CHOICE(lwzu, ldu)
---- testsuite/lib/libffi.exp.orig	2023-03-15 07:19:45.000000000 -0700
-+++ testsuite/lib/libffi.exp	2025-04-06 16:16:17.000000000 -0700
+--- testsuite/lib/libffi.exp.orig	2024-06-01 10:42:02.000000000 -0700
++++ testsuite/lib/libffi.exp	2025-04-17 11:40:54.000000000 -0700
 @@ -516,7 +516,10 @@ proc run-many-tests { testcases extra_fl
          }
        }
@@ -66,8 +34,8 @@
          if [info exists env(LIBFFI_TEST_OPTIMIZATION)] {
  	  set optimizations [ list $env(LIBFFI_TEST_OPTIMIZATION) ]
          } else {
---- testsuite/libffi.bhaible/bhaible.exp.orig	2023-03-15 07:19:45.000000000 -0700
-+++ testsuite/libffi.bhaible/bhaible.exp	2025-04-06 16:16:17.000000000 -0700
+--- testsuite/libffi.bhaible/bhaible.exp.orig	2024-06-01 10:42:02.000000000 -0700
++++ testsuite/libffi.bhaible/bhaible.exp	2025-04-17 11:40:54.000000000 -0700
 @@ -24,7 +24,10 @@ global compiler_vendor
  # was done in a pretty lazy fashion, and requires the use of compiler
  # flags to disable warnings for now.


### PR DESCRIPTION
As usual, the patchfile is derived from git differences, which no longer include the now-upstream fix for the build problem on Sequoia.

As usual, there are many test failures, but 3.4.8 is roughly comparable to 3.4.6 in this regard.

TESTED:
Tested -/+universal on 10.4-10.5 ppc, 10.5-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-15.x arm64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.5 22H527, arm64, Xcode 15.2 15C500b
macOS 14.7.5 23H527, arm64, Xcode 16.2 16C5032a
macOS 15.3.2 24D81, arm64, Xcode 16.3 16E140
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` Many test failures as usual and as noted.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
