### PR TITLE
py-nclib: Enable support for Python 3.13

### DIFF
--- a/python/py-nclib/Portfile
+++ b/python/py-nclib/Portfile
@@ -22,7 +22,7 @@ platforms            {darwin any}
 supported_archs      noarch
 maintainers          {@F30 f30.me:f30} openmaintainer
 
-python.versions      39 310 311 312
+python.versions      39 310 311 312 313
 
 checksums            rmd160  3d78346ef327a3827d7194114abdd748da32f727 \
                      sha256  b0a6c84a52f984e06ed63eb359289bd878c90af12832ba9dc33806da478ca831 \


### PR DESCRIPTION
#### Description

Enable Python 3.13 support for py-nclib.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`? → No `-t` due to https://trac.macports.org/ticket/66358
- [x] tested basic functionality of all binary files?