### PR TITLE
py-gnupg: Update to 0.5.4, enable support for Python 3.13, fix tests

### DIFF
--- a/python/py-gnupg/Portfile
+++ b/python/py-gnupg/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-gnupg
 python.rootname     python-gnupg
-version             0.5.1
+version             0.5.4
 revision            0
 
 description         A Python wrapper for GnuPG
@@ -27,9 +27,9 @@ maintainers         {@F30 f30.me:f30} openmaintainer
 
 python.versions     38 39 310 311 312
 
-checksums           rmd160  1bb779e2243cccc8f4d8ed0770c93e84866fc88b \
-                    sha256  5674bad4e93876c0b0d3197e314d7f942d39018bf31e2b833f6788a6813c3fb8 \
-                    size    64377
+checksums           rmd160  d18d05a9fc76e2ae32fa2dbb0785c821d110f32c \
+                    sha256  f2fdb5fb29615c77c2743e1cb3d9314353a6e87b10c37d238d91ae1c6feae086 \
+                    size    65705
 
 if {${subport} ne ${name}} {
     depends_run-append \

--- a/python/py-gnupg/Portfile
+++ b/python/py-gnupg/Portfile
@@ -25,7 +25,7 @@ homepage            https://pythonhosted.org/python-gnupg/
 categories-append   crypto security
 maintainers         {@F30 f30.me:f30} openmaintainer
 
-python.versions     38 39 310 311 312
+python.versions     38 39 310 311 312 313
 
 checksums           rmd160  d18d05a9fc76e2ae32fa2dbb0785c821d110f32c \
                     sha256  f2fdb5fb29615c77c2743e1cb3d9314353a6e87b10c37d238d91ae1c6feae086 \

--- a/python/py-gnupg/Portfile
+++ b/python/py-gnupg/Portfile
@@ -37,7 +37,7 @@ if {${subport} ne ${name}} {
 
     test.run        yes
     python.test_framework
-    test.cmd        ${python.bin} test_gnupg.py
+    test.cmd        NO_EXTERNAL_TESTS=1 ${python.bin} test_gnupg.py
     # `TMPDIR` being set to a path within `${workpath}` can easily result in a "socket name '...' is
     # too long" error from gpg-agent
     test.env        TMPDIR=/tmp


### PR DESCRIPTION
#### Description

* Update py-gnupg to the latest release
* Enable support for Python 3.13
* Disable test that relies on external keyservers

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`? → No `-t` due to https://trac.macports.org/ticket/66358
- [x] tested basic functionality of all binary files?