### PR TITLE
ddev: update to 1.24.4

### DIFF
--- a/devel/ddev/Portfile
+++ b/devel/ddev/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ddev/ddev 1.24.3 v
+go.setup            github.com/ddev/ddev 1.24.4 v
 go.offline_build    no
 
-checksums           rmd160  9f4e1e735149b2b4a0ba171a7e76eee8fecc4356 \
-                    sha256  222ba16d6465f947ac2f39268f0f937379e960e9e4f6fe1604380e0f7c87693c \
-                    size    19253633
+checksums           rmd160  2575cb97d8484b0fd125ae5695b60473ba1c16dd \
+                    sha256  728b97d1bd82f29b2941efe5ee79810a7d31dcd0ed9de3e5c225f9622119e6e5 \
+                    size    19466914
 
 categories          devel
 license             Apache-2


### PR DESCRIPTION
Update ddev port to version 1.24.4. Release notes: https://github.com/ddev/ddev/releases/tag/v1.24.4