### PR TITLE
auto-multiple-choice: update to version 1.7.0

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -26,26 +26,25 @@ subport auto-multiple-choice-devel {}
 
 if {${subport} eq ${name}} {
     # release
-    set amc.version.main        1.6.0
-    set amc.version.secondary   20230206142200
+    set amc.version.main        1.7.0
+    set amc.version.secondary   20250417073838
     set amc.version         ${amc.version.main}
     version                 ${amc.version.main}
-    revision                2
-    checksums               rmd160  00788859b8619b45ee1c19f702ea1295d7d3e445 \
-                            sha256  acd9d266ebb8104543702fae52f383ed6170e7e7e1c90bc9c6abc4e83e3734ba \
-                            size    13419428
+    checksums               rmd160  8886151969ace9a3693b840cd9fcb3aa3678ba28 \
+                            sha256  95c08477ae41f1b2a98881b677b0dce03f70c4a7ab5ac440311091175d9c98f6 \
+                            size    15449580
 
     conflicts               auto-multiple-choice-devel
 
 } else {
     # devel
-    set amc.version.main        1.6.0
-    set amc.version.secondary   20240805161640
-    set amc.version         ${amc.version.main}+git${amc.version.secondary}
-    version                 ${amc.version.main}-git${amc.version.secondary}
-    checksums               rmd160  1bcb05d689fa539ed88aeb1c9489fd56adb27450 \
-                            sha256  11c51f29ca4685f8ae7bade99656b1bb62689344e41b50f5386bb656763347a2 \
-                            size    15151070
+    set amc.version.main        1.7.0
+    set amc.version.secondary   20250417073838
+    set amc.version         ${amc.version.main}
+    version                 ${amc.version.main}
+    checksums               rmd160  8886151969ace9a3693b840cd9fcb3aa3678ba28 \
+                            sha256  95c08477ae41f1b2a98881b677b0dce03f70c4a7ab5ac440311091175d9c98f6 \
+                            size    15449580
 
     conflicts               auto-multiple-choice
 }


### PR DESCRIPTION
auto-multiple-choice: update to version 1.7.0
auto-multiple-choice-devel: update to version 1.7.0

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140 
MacPorts 2.10.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
