### PR TITLE
pinact: Update to 3.0.5

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.0.3 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.0.5 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,9 +16,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  c46018fd687291ae9a9a1af4be4205762c1bf2e0 \
-                    sha256  199149e6b379786d7786948ccaae62b72453f83e9de9ccabf30d2c6a743f8b9c \
-                    size    32493
+                    rmd160  d449b6e92951d2ab8515b6d408ce3b40daeb9018 \
+                    sha256  557a82924dabad35faec3c649a18ec09130220f58610e9a925f5e33da6a9f2b1 \
+                    size    32718
 
 build.args-append   -ldflags \"-X main.version=${version} -X main.commit=MacPorts \" \
                     ./cmd/pinact
@@ -34,6 +34,7 @@ notes {
   If you have an existing .pinact.yaml file, you will need to use pinact 2.2 and run
   'pinact migrate' to fix the pinact configuration file for pinact 3.0.
 }
+
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
@@ -56,10 +57,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  ec9757aa9994bbc9a94472b49e3258eb2384d5c0c1c5e70c0bb945643fcba0f8 \
                         size    1520458 \
                     golang.org/x/oauth2 \
-                        lock    v0.28.0 \
-                        rmd160  784167167d978ec8e104f9cc638911d2488e52d4 \
-                        sha256  4ab29fbe50a6ab7bf9b12c85ab220b686187cdc643cbc21ed7096d0365955962 \
-                        size    98950 \
+                        lock    v0.29.0 \
+                        rmd160  3aa27d6d9a21c67a223a71829fc181750274f912 \
+                        sha256  8b466b5b749df3a959b2d9c386b16dc6a846ecf837c4be6d34963b5277c7df62 \
+                        size    99266 \
                     github.com/wk8/go-ordered-map \
                         lock    v2.1.8 \
                         rmd160  3b679491f631b4900bfe3169517517b2731ebc35 \
@@ -71,10 +72,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  bafc806faca3ad2f5b314a3405382ca690ecd691cfc9dd4bbbccb3abc62222f4 \
                         size    6788461 \
                     github.com/suzuki-shunsuke/urfave-cli-v3-util \
-                        lock    v0.0.1 \
-                        rmd160  b3a7f9ccfdf98d9810c1a6194191b67a75e7a6db \
-                        sha256  c5350681a8dfffed4e430d68e0a972fd138094c74102b8bf0df6b6eec004a7ed \
-                        size    7780 \
+                        lock    v0.0.2 \
+                        rmd160  b77048cea055451ce1cb0646ebd318056c967b4c \
+                        sha256  033e202202ab1d25a741025d7d6f2f512f24d34d60499c06a378cddbd1b9d4f7 \
+                        size    7760 \
                     github.com/suzuki-shunsuke/logrus-error \
                         lock    v0.1.4 \
                         rmd160  d52b0d1f07e0dde083a4deaea70d508880b724ba \
@@ -136,10 +137,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
                         size    10418 \
                     github.com/google/go-github \
-                        lock    v70.0.0 \
-                        rmd160  d45ed31d1e506a35db5fec7b5b93cd988baa251f \
-                        sha256  1198d39a659059bddb72c0f682ec2ec4bd552c5eb7e369547b142dd378543bef \
-                        size    813286 \
+                        lock    v71.0.0 \
+                        rmd160  29ff4ca0039b79c675f3b02a88fb14883baf1b6c \
+                        sha256  0824925a59c1c602872fb2c43f26147eba7971bc4de5067cf6d301e307ed3cad \
+                        size    815939 \
                     github.com/google/go-cmp \
                         lock    v0.7.0 \
                         rmd160  3f04a79c291d786f9c69c2944bdd521402052a5c \
@@ -165,3 +166,4 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  da4b9f58b6734da97644fb565c81d1bc01ccd7f7 \
                         sha256  aaa6a0719258985eddfa488155edd6a749c070a998d91c48182138115f5de069 \
                         size    5054
+


### PR DESCRIPTION
#### Description

pinact: Update to 3.0.5

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
