### PR TITLE
chezmoi: Update to 2.62.2

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 2.62.1 v
+go.setup            github.com/twpayne/chezmoi 2.62.2 v
 go.offline_build    no
 revision            0
 
@@ -20,9 +20,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  62909f3b7dc4106f6dff898dd2c33c1d61cc4821 \
-                    sha256  de9710bcbde845824b863ee75cec6c6affb2cc7e680ec2bb53b41c418492eecd \
-                    size    2538642
+checksums           rmd160  9b24251bd004791cd14f1453b5d64ce8f61f23a5 \
+                    sha256  623220e410898cd98028a65d2f5d1e6a6d46c5cca74b3b3f2ff65ab270c8171c \
+                    size    2539514
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

chezmoi: Update to 2.62.2

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
