### PR TITLE
openjdk24-temurin: update to 24.0.1

### DIFF
--- a/java/openjdk24-temurin/Portfile
+++ b/java/openjdk24-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}
-set build    36
+version      ${feature}.0.1
+set build    9
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Short Term Support until September 2025)
@@ -28,14 +28,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  39d7158e24c57ea2e70a51f956d74230cf2f2928 \
-                 sha256  07a99d4a81c4d5e0c4936bf4b9f901565213781c67e865f304a8d8eb75e880d8 \
-                 size    120238929
+    checksums    rmd160  e74adf5247f1a291310544bfc4423bba85984834 \
+                 sha256  181593f79dd278e0f44712cd87fd9874fd191e211810a0712450963370badb0a \
+                 size    120245031
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  8f8fe6a77861f3bd5a599e2d977fbb72e3c23544 \
-                 sha256  8e343d2aaa1d00fdee351d392a4a3f537d81fa4a36f5fdf05e2e2c26d5c50af9 \
-                 size    135758891
+    checksums    rmd160  f2cb000ff7942f6bcb52ee0c237df9961588267a \
+                 sha256  e3b1fe4cd3da335d07d62f335ae958f5a43c594be1ba333a06a03a49d2212cd4 \
+                 size    135757102
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 24.0.1.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?