### PR TITLE
jsoncons: update to 1.3.2

### DIFF
--- a/devel/jsoncons/Portfile
+++ b/devel/jsoncons/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            danielaparker jsoncons 1.3.0 v
+github.setup            danielaparker jsoncons 1.3.2 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -15,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             A C++, header-only library for constructing JSON and JSON-like data formats
 long_description        {*}${description}
 
-checksums               rmd160  a4bf22e43c7018bc755fa84602fb13f1784bf560 \
-                        sha256  7a485c2af0ff214b62bb00f5a1487e5a0c4997eadc6ee9155ce3e8c9d05b9d7a \
-                        size    1500434
+checksums               rmd160  3ea3cda1fecf0d123d46d50b6313b7c3cb2c103b \
+                        sha256  f22fb163df1a12c2f9ee5f95cad9fc37c6cfbefe0ae6f30aba7440832ef70fbe \
+                        size    1504068
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description
https://github.com/danielaparker/jsoncons/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
