### PR TITLE
GPXSee: update to 13.39

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.37
+github.setup        tumic0 GPXSee 13.39
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  37ee6e1b7e9c74272a233006d3a256a73677bb54 \
-                    sha256  3c60f9ab693fc2aae0e1958f7ae3aa079a7fdb319135dcfa5dffdc603d5188ae \
-                    size    5561051
+checksums           rmd160  0f13429e8676ee7d6c704b699d6029a3986c9362 \
+                    sha256  e7eb8c6d487f7f7705cb0276bfd3c3aadf77a1fe1cd2a28ea547bbeb1c73a152 \
+                    size    5877816
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
