### PR TITLE
cosign: remove sget variant

### DIFF
--- a/security/cosign/Portfile
+++ b/security/cosign/Portfile
@@ -36,14 +36,4 @@ destroot {
         ${destroot}${prefix}/share/doc/${name}
 }
 
-variant sget description {sget command for safer, automatic verification of signatures and integration with transparency log Rekor} {
-    post-build {
-        system -W ${worksrcpath} "${build.env} ${go.bin} build ./cmd/sget"
-    }
-    post-destroot {
-        xinstall -m 0755 ${worksrcpath}/sget \
-            ${destroot}${prefix}/bin/
-    }
-}
-
 github.livecheck.regex  "(\\d+(?:\\.\\d+)+)"


### PR DESCRIPTION
#### Description

`sget` has been removed from cosign as of  sigstore/cosign#2885. It is no longer possible to install this port with the `sget` command, as its source code is no longer present in upstream.

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?