### PR TITLE
postgresql16/17: Remove conflict, fix dependant builds

### DIFF
--- a/databases/postgresql16/Portfile
+++ b/databases/postgresql16/Portfile
@@ -43,7 +43,7 @@ depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib \
 depends_build       port:bison port:pkgconfig \
                     port:docbook-xml-4.5 port:docbook-xsl-nons
 depends_run         port:postgresql_select-16 \
-                    path:share/curl/curl-ca-bundle.crt:certsync
+                    path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 
 # https://trac.macports.org/ticket/66060
 # https://trac.macports.org/ticket/67365

--- a/databases/postgresql17/Portfile
+++ b/databases/postgresql17/Portfile
@@ -56,7 +56,7 @@ depends_build       port:bison port:pkgconfig \
                     port:docbook-xml-4.5 port:docbook-xsl-nons \
                     path:bin/perl:perl5
 depends_run         port:postgresql_select-17 \
-                    path:share/curl/curl-ca-bundle.crt:certsync
+                    path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 
 legacysupport.newest_darwin_requires_legacy \
                     15


### PR DESCRIPTION
#### Description

Switch to the same path dependency used by other ports.
Closes: https://trac.macports.org/ticket/72215

This problem is breaking ports that depend on both cmake and postgresql16 or 17, because of unexpected conflict between curl-ca-bundle and certsync.
A current example is gdal following its recent update.
See https://trac.macports.org/ticket/72215 for details.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  Macos 13, 14, 15.

Early CI failure on Macos 15, due to recent SDK update to 15.4, is now solved by PR #28208.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?