### PR TITLE
whisper: fix wrong # args: should be "sha256 action ?file?"

### DIFF
--- a/audio/whisper/Portfile
+++ b/audio/whisper/Portfile
@@ -26,7 +26,7 @@ output.wav` to convert the file first.
 checksums           whisper.cpp-${version}.tar.gz \
                     rmd160  211e55a336132a878471382d8002425f069db683 \
                     sha256  2fda42b57b7b8427d724551bd041616d85401fb9382e42b0349132a28920a34f \
-                    size    6216643 
+                    size    6216643
 
 patchfiles          whisper-add-models.diff \
                     whisper-add-depends.diff \
@@ -50,7 +50,7 @@ post-destroot {
     xinstall ${workpath}/build/bin/ggml-metal.metal ${destroot}${prefix}/share/whisper/ggml
     xinstall ${workpath}/build/bin/ggml-common.h ${destroot}${prefix}/share/whisper/ggml
     xinstall -d ${destroot}${prefix}/lib
-    xinstall ${workpath}/build/src/libwhisper.1.7.5.dylib ${destroot}${prefix}/lib/libwhisper.1.dylib
+    xinstall ${workpath}/build/src/libwhisper.${version}.dylib ${destroot}${prefix}/lib/libwhisper.1.dylib
     xinstall ${workpath}/build/ggml/src/libggml.dylib ${destroot}${prefix}/lib/libggml.dylib
     xinstall ${workpath}/build/ggml/src/libggml-cpu.dylib ${destroot}${prefix}/lib/libggml-cpu.dylib
     xinstall ${workpath}/build/ggml/src/libggml-base.dylib ${destroot}${prefix}/lib/libggml-base.dylib
@@ -112,7 +112,7 @@ variant medium description {Install medium model} {
 variant large description {Install large model} {
     distfiles-append        ggml-large-v3.bin:large
     master_sites-append     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/
-    checksums-append        ggml-large.bin
+    checksums-append        ggml-large-v3.bin \
                             sha256  64d182b440b98d5203c4f9bd541544d84c605196c4f7b845dfa11fb23594d1e2 \
                             size    3095033483
     post-destroot {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? N/A
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
