### PR TITLE
postgresql: fix strchrnul on 15.4

### DIFF
--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -8,7 +8,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql14
 version             14.17
-revision            0
+revision            1
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -42,6 +42,9 @@ patchfiles-append   patch-no_doc.diff
 platform darwin powerpc {
     patchfiles-append  patch-icu.diff
 }
+
+# https://www.postgresql.org/message-id/flat/E1tziZ6-002AW9-2C%40gemulon.postgresql.org
+patchfiles-append   patch-strchrnul.diff
 
 depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib port:libxml2 port:libxslt path:lib/pkgconfig/icu-uc.pc:icu path:lib/libgssapi_krb5.dylib:kerberos5
 depends_build       port:bison port:pkgconfig

--- a/databases/postgresql14/files/patch-strchrnul.diff
+++ b/databases/postgresql14/files/patch-strchrnul.diff
@@ -1,0 +1,187 @@
+From 71790aef1a6eea6f9662a1edcd669d89d5486b03 Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 1 Apr 2025 16:49:51 -0400
+Subject: [PATCH] Fix detection and handling of strchrnul() for macOS 15.4.
+
+As of 15.4, macOS has strchrnul(), but access to it is blocked behind
+a check for MACOSX_DEPLOYMENT_TARGET >= 15.4.  But our does-it-link
+configure check finds it, so we try to use it, and fail with the
+present default deployment target (namely 15.0).  This accounts for
+today's buildfarm failures on indri and sifaka.
+
+This is the identical problem that we faced some years ago when Apple
+introduced preadv and pwritev in the same way.  We solved that in
+commit f014b1b9b by using AC_CHECK_DECLS instead of AC_CHECK_FUNCS
+to check the functions' availability.  So do the same now for
+strchrnul().  Interestingly, we already had a workaround for
+"the link check doesn't agree with <string.h>" cases with glibc,
+which we no longer need since only the header declaration is being
+checked.
+
+Testing this revealed that the meson version of this check has never
+worked, because it failed to use "-Werror=unguarded-availability-new".
+(Apparently nobody's tried to build with meson on macOS versions that
+lack preadv/pwritev as standard.)  Adjust that while at it.  Also,
+we had never put support for "-Werror=unguarded-availability-new"
+into v13, but we need that now.
+
+Co-authored-by: Tom Lane <tgl@sss.pgh.pa.us>
+Co-authored-by: Peter Eisentraut <peter@eisentraut.org>
+Discussion: https://postgr.es/m/385134.1743523038@sss.pgh.pa.us
+Backpatch-through: 13
+---
+ configure                  | 14 +++++++++++++-
+ configure.ac               |  2 +-
+ src/include/pg_config.h.in |  7 ++++---
+ src/port/snprintf.c        | 29 +++++++++++++----------------
+ src/tools/msvc/Solution.pm |  2 +-
+ 5 files changed, 32 insertions(+), 22 deletions(-)
+
+diff --git configure configure
+index fa9085b1c0dde..33bc3203b36b0 100755
+--- configure
++++ configure
+@@ -16037,7 +16037,7 @@ fi
+ LIBS_including_readline="$LIBS"
+ LIBS=`echo "$LIBS" | sed -e 's/-ledit//g' -e 's/-lreadline//g'`
+ 
+-for ac_func in backtrace_symbols clock_gettime copyfile fdatasync getifaddrs getpeerucred getrlimit kqueue mbstowcs_l memset_s poll posix_fallocate ppoll pstat pthread_is_threaded_np readlink readv setproctitle setproctitle_fast setsid shm_open strchrnul strsignal symlink syncfs sync_file_range uselocale wcstombs_l writev
++for ac_func in backtrace_symbols clock_gettime copyfile fdatasync getifaddrs getpeerucred getrlimit kqueue mbstowcs_l memset_s poll posix_fallocate ppoll pstat pthread_is_threaded_np readlink readv setproctitle setproctitle_fast setsid shm_open strsignal symlink syncfs sync_file_range uselocale wcstombs_l writev
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+@@ -16601,6 +16601,18 @@ esac
+ 
+ fi
+ 
++ac_fn_c_check_decl "$LINENO" "strchrnul" "ac_cv_have_decl_strchrnul" "#include <string.h>
++"
++if test "x$ac_cv_have_decl_strchrnul" = xyes; then :
++  ac_have_decl=1
++else
++  ac_have_decl=0
++fi
++
++cat >>confdefs.h <<_ACEOF
++#define HAVE_DECL_STRCHRNUL $ac_have_decl
++_ACEOF
++
+ 
+ # This is probably only present on macOS, but may as well check always
+ ac_fn_c_check_decl "$LINENO" "F_FULLFSYNC" "ac_cv_have_decl_F_FULLFSYNC" "#include <fcntl.h>
+diff --git configure.ac configure.ac
+index 35dc9f74b7369..53d341c175125 100644
+--- configure.ac
++++ configure.ac
+@@ -1807,7 +1807,6 @@ AC_CHECK_FUNCS(m4_normalize([
+ 	setproctitle_fast
+ 	setsid
+ 	shm_open
+-	strchrnul
+ 	strsignal
+ 	symlink
+ 	syncfs
+@@ -1849,6 +1848,7 @@ AC_CHECK_DECLS([strlcat, strlcpy, strnlen])
+ # won't handle deployment target restrictions on macOS
+ AC_CHECK_DECLS([preadv], [], [AC_LIBOBJ(preadv)], [#include <sys/uio.h>])
+ AC_CHECK_DECLS([pwritev], [], [AC_LIBOBJ(pwritev)], [#include <sys/uio.h>])
++AC_CHECK_DECLS([strchrnul], [], [], [#include <string.h>])
+ 
+ # This is probably only present on macOS, but may as well check always
+ AC_CHECK_DECLS(F_FULLFSYNC, [], [], [#include <fcntl.h>])
+diff --git src/include/pg_config.h.in src/include/pg_config.h.in
+index d9ef9a41bf298..605c830a1b284 100644
+--- src/include/pg_config.h.in
++++ src/include/pg_config.h.in
+@@ -155,6 +155,10 @@
+    don't. */
+ #undef HAVE_DECL_RTLD_NOW
+ 
++/* Define to 1 if you have the declaration of `strchrnul', and to 0 if you
++   don't. */
++#undef HAVE_DECL_STRCHRNUL
++
+ /* Define to 1 if you have the declaration of `strlcat', and to 0 if you
+    don't. */
+ #undef HAVE_DECL_STRLCAT
+@@ -523,9 +527,6 @@
+ /* Define to 1 if you have the <stdlib.h> header file. */
+ #undef HAVE_STDLIB_H
+ 
+-/* Define to 1 if you have the `strchrnul' function. */
+-#undef HAVE_STRCHRNUL
+-
+ /* Define to 1 if you have the `strerror_r' function. */
+ #undef HAVE_STRERROR_R
+ 
+diff --git src/port/snprintf.c src/port/snprintf.c
+index 8306ab4f2b8dc..79c5f523bf16d 100644
+--- src/port/snprintf.c
++++ src/port/snprintf.c
+@@ -348,13 +348,22 @@ static void leading_pad(int zpad, int signvalue, int *padlen,
+ static void trailing_pad(int padlen, PrintfTarget *target);
+ 
+ /*
+- * If strchrnul exists (it's a glibc-ism), it's a good bit faster than the
+- * equivalent manual loop.  If it doesn't exist, provide a replacement.
++ * If strchrnul exists (it's a glibc-ism, but since adopted by some other
++ * platforms), it's a good bit faster than the equivalent manual loop.
++ * Use it if possible, and if it doesn't exist, use this replacement.
+  *
+  * Note: glibc declares this as returning "char *", but that would require
+  * casting away const internally, so we don't follow that detail.
++ *
++ * Note: macOS has this too as of Sequoia 15.4, but it's hidden behind
++ * a deployment-target check that causes compile errors if the deployment
++ * target isn't high enough.  So !HAVE_DECL_STRCHRNUL may mean "yes it's
++ * declared, but it doesn't compile".  To avoid failing in that scenario,
++ * use a macro to avoid matching <string.h>'s name.
+  */
+-#ifndef HAVE_STRCHRNUL
++#if !HAVE_DECL_STRCHRNUL
++
++#define strchrnul pg_strchrnul
+ 
+ static inline const char *
+ strchrnul(const char *s, int c)
+@@ -364,19 +373,7 @@ strchrnul(const char *s, int c)
+ 	return s;
+ }
+ 
+-#else
+-
+-/*
+- * glibc's <string.h> declares strchrnul only if _GNU_SOURCE is defined.
+- * While we typically use that on glibc platforms, configure will set
+- * HAVE_STRCHRNUL whether it's used or not.  Fill in the missing declaration
+- * so that this file will compile cleanly with or without _GNU_SOURCE.
+- */
+-#ifndef _GNU_SOURCE
+-extern char *strchrnul(const char *s, int c);
+-#endif
+-
+-#endif							/* HAVE_STRCHRNUL */
++#endif							/* !HAVE_DECL_STRCHRNUL */
+ 
+ 
+ /*
+diff --git src/tools/msvc/Solution.pm src/tools/msvc/Solution.pm
+index f0ce2ac80403b..040e9d98b1fef 100644
+--- src/tools/msvc/Solution.pm
++++ src/tools/msvc/Solution.pm
+@@ -248,6 +248,7 @@ sub GenerateFiles
+ 		HAVE_DECL_PWRITEV                           => 0,
+ 		HAVE_DECL_RTLD_GLOBAL                       => 0,
+ 		HAVE_DECL_RTLD_NOW                          => 0,
++		HAVE_DECL_STRCHRNUL                         => 0,
+ 		HAVE_DECL_STRLCAT                           => 0,
+ 		HAVE_DECL_STRLCPY                           => 0,
+ 		HAVE_DECL_STRNLEN                           => 1,
+@@ -367,7 +368,6 @@ sub GenerateFiles
+ 		HAVE_SRANDOM                             => undef,
+ 		HAVE_STDINT_H                            => 1,
+ 		HAVE_STDLIB_H                            => 1,
+-		HAVE_STRCHRNUL                           => undef,
+ 		HAVE_STRERROR_R                          => undef,
+ 		HAVE_STRINGS_H                           => undef,
+ 		HAVE_STRING_H                            => 1,

--- a/databases/postgresql15/Portfile
+++ b/databases/postgresql15/Portfile
@@ -8,7 +8,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql15
 version             15.12
-revision            0
+revision            1
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -35,6 +35,9 @@ use_bzip2           yes
 
 # do not build man or html files (use postgresqlXY-doc instead)
 patchfiles-append   patch-no_doc.diff
+
+# https://www.postgresql.org/message-id/flat/E1tziZ6-002AW9-2C%40gemulon.postgresql.org
+patchfiles-append   patch-strchrnul.diff
 
 # https://trac.macports.org/ticket/66060
 # https://trac.macports.org/ticket/67365

--- a/databases/postgresql15/files/patch-strchrnul.diff
+++ b/databases/postgresql15/files/patch-strchrnul.diff
@@ -1,0 +1,187 @@
+From 0de9560ba9b8fc4f0de8c5784303db82156279a6 Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 1 Apr 2025 16:49:51 -0400
+Subject: [PATCH] Fix detection and handling of strchrnul() for macOS 15.4.
+
+As of 15.4, macOS has strchrnul(), but access to it is blocked behind
+a check for MACOSX_DEPLOYMENT_TARGET >= 15.4.  But our does-it-link
+configure check finds it, so we try to use it, and fail with the
+present default deployment target (namely 15.0).  This accounts for
+today's buildfarm failures on indri and sifaka.
+
+This is the identical problem that we faced some years ago when Apple
+introduced preadv and pwritev in the same way.  We solved that in
+commit f014b1b9b by using AC_CHECK_DECLS instead of AC_CHECK_FUNCS
+to check the functions' availability.  So do the same now for
+strchrnul().  Interestingly, we already had a workaround for
+"the link check doesn't agree with <string.h>" cases with glibc,
+which we no longer need since only the header declaration is being
+checked.
+
+Testing this revealed that the meson version of this check has never
+worked, because it failed to use "-Werror=unguarded-availability-new".
+(Apparently nobody's tried to build with meson on macOS versions that
+lack preadv/pwritev as standard.)  Adjust that while at it.  Also,
+we had never put support for "-Werror=unguarded-availability-new"
+into v13, but we need that now.
+
+Co-authored-by: Tom Lane <tgl@sss.pgh.pa.us>
+Co-authored-by: Peter Eisentraut <peter@eisentraut.org>
+Discussion: https://postgr.es/m/385134.1743523038@sss.pgh.pa.us
+Backpatch-through: 13
+---
+ configure                  | 14 +++++++++++++-
+ configure.ac               |  2 +-
+ src/include/pg_config.h.in |  7 ++++---
+ src/port/snprintf.c        | 29 +++++++++++++----------------
+ src/tools/msvc/Solution.pm |  2 +-
+ 5 files changed, 32 insertions(+), 22 deletions(-)
+
+diff --git configure configure
+index 1df55250ed60b..a52cef20f39ff 100755
+--- configure
++++ configure
+@@ -16308,7 +16308,7 @@ fi
+ LIBS_including_readline="$LIBS"
+ LIBS=`echo "$LIBS" | sed -e 's/-ledit//g' -e 's/-lreadline//g'`
+ 
+-for ac_func in backtrace_symbols clock_gettime copyfile fdatasync getifaddrs getpeerucred getrlimit inet_pton kqueue mbstowcs_l memset_s poll posix_fallocate ppoll pstat pthread_is_threaded_np readlink readv setproctitle setproctitle_fast setsid shm_open strchrnul strsignal symlink syncfs sync_file_range uselocale wcstombs_l writev
++for ac_func in backtrace_symbols clock_gettime copyfile fdatasync getifaddrs getpeerucred getrlimit inet_pton kqueue mbstowcs_l memset_s poll posix_fallocate ppoll pstat pthread_is_threaded_np readlink readv setproctitle setproctitle_fast setsid shm_open strsignal symlink syncfs sync_file_range uselocale wcstombs_l writev
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+@@ -16930,6 +16930,18 @@ esac
+ 
+ fi
+ 
++ac_fn_c_check_decl "$LINENO" "strchrnul" "ac_cv_have_decl_strchrnul" "#include <string.h>
++"
++if test "x$ac_cv_have_decl_strchrnul" = xyes; then :
++  ac_have_decl=1
++else
++  ac_have_decl=0
++fi
++
++cat >>confdefs.h <<_ACEOF
++#define HAVE_DECL_STRCHRNUL $ac_have_decl
++_ACEOF
++
+ 
+ # This is probably only present on macOS, but may as well check always
+ ac_fn_c_check_decl "$LINENO" "F_FULLFSYNC" "ac_cv_have_decl_F_FULLFSYNC" "#include <fcntl.h>
+diff --git configure.ac configure.ac
+index 0488b4bdd80a7..93dd05ddeba81 100644
+--- configure.ac
++++ configure.ac
+@@ -1854,7 +1854,6 @@ AC_CHECK_FUNCS(m4_normalize([
+ 	setproctitle_fast
+ 	setsid
+ 	shm_open
+-	strchrnul
+ 	strsignal
+ 	symlink
+ 	syncfs
+@@ -1923,6 +1922,7 @@ AC_CHECK_DECLS([strlcat, strlcpy, strnlen])
+ # won't handle deployment target restrictions on macOS
+ AC_CHECK_DECLS([preadv], [], [AC_LIBOBJ(preadv)], [#include <sys/uio.h>])
+ AC_CHECK_DECLS([pwritev], [], [AC_LIBOBJ(pwritev)], [#include <sys/uio.h>])
++AC_CHECK_DECLS([strchrnul], [], [], [#include <string.h>])
+ 
+ # This is probably only present on macOS, but may as well check always
+ AC_CHECK_DECLS(F_FULLFSYNC, [], [], [#include <fcntl.h>])
+diff --git src/include/pg_config.h.in src/include/pg_config.h.in
+index 1a0d9eee4f748..5ec240d59a53e 100644
+--- src/include/pg_config.h.in
++++ src/include/pg_config.h.in
+@@ -150,6 +150,10 @@
+    don't. */
+ #undef HAVE_DECL_SIGWAIT
+ 
++/* Define to 1 if you have the declaration of `strchrnul', and to 0 if you
++   don't. */
++#undef HAVE_DECL_STRCHRNUL
++
+ /* Define to 1 if you have the declaration of `strlcat', and to 0 if you
+    don't. */
+ #undef HAVE_DECL_STRLCAT
+@@ -520,9 +524,6 @@
+ /* Define to 1 if you have the <stdlib.h> header file. */
+ #undef HAVE_STDLIB_H
+ 
+-/* Define to 1 if you have the `strchrnul' function. */
+-#undef HAVE_STRCHRNUL
+-
+ /* Define to 1 if you have the `strerror_r' function. */
+ #undef HAVE_STRERROR_R
+ 
+diff --git src/port/snprintf.c src/port/snprintf.c
+index b8e2b0e7f8660..a821a297f48b0 100644
+--- src/port/snprintf.c
++++ src/port/snprintf.c
+@@ -348,13 +348,22 @@ static void leading_pad(int zpad, int signvalue, int *padlen,
+ static void trailing_pad(int padlen, PrintfTarget *target);
+ 
+ /*
+- * If strchrnul exists (it's a glibc-ism), it's a good bit faster than the
+- * equivalent manual loop.  If it doesn't exist, provide a replacement.
++ * If strchrnul exists (it's a glibc-ism, but since adopted by some other
++ * platforms), it's a good bit faster than the equivalent manual loop.
++ * Use it if possible, and if it doesn't exist, use this replacement.
+  *
+  * Note: glibc declares this as returning "char *", but that would require
+  * casting away const internally, so we don't follow that detail.
++ *
++ * Note: macOS has this too as of Sequoia 15.4, but it's hidden behind
++ * a deployment-target check that causes compile errors if the deployment
++ * target isn't high enough.  So !HAVE_DECL_STRCHRNUL may mean "yes it's
++ * declared, but it doesn't compile".  To avoid failing in that scenario,
++ * use a macro to avoid matching <string.h>'s name.
+  */
+-#ifndef HAVE_STRCHRNUL
++#if !HAVE_DECL_STRCHRNUL
++
++#define strchrnul pg_strchrnul
+ 
+ static inline const char *
+ strchrnul(const char *s, int c)
+@@ -364,19 +373,7 @@ strchrnul(const char *s, int c)
+ 	return s;
+ }
+ 
+-#else
+-
+-/*
+- * glibc's <string.h> declares strchrnul only if _GNU_SOURCE is defined.
+- * While we typically use that on glibc platforms, configure will set
+- * HAVE_STRCHRNUL whether it's used or not.  Fill in the missing declaration
+- * so that this file will compile cleanly with or without _GNU_SOURCE.
+- */
+-#ifndef _GNU_SOURCE
+-extern char *strchrnul(const char *s, int c);
+-#endif
+-
+-#endif							/* HAVE_STRCHRNUL */
++#endif							/* !HAVE_DECL_STRCHRNUL */
+ 
+ 
+ /*
+diff --git src/tools/msvc/Solution.pm src/tools/msvc/Solution.pm
+index 8c8dd4996fe09..d92bbbaf7dbac 100644
+--- src/tools/msvc/Solution.pm
++++ src/tools/msvc/Solution.pm
+@@ -246,6 +246,7 @@ sub GenerateFiles
+ 		HAVE_DECL_RTLD_GLOBAL                       => 0,
+ 		HAVE_DECL_RTLD_NOW                          => 0,
+ 		HAVE_DECL_SIGWAIT                           => 0,
++		HAVE_DECL_STRCHRNUL                         => 0,
+ 		HAVE_DECL_STRLCAT                           => 0,
+ 		HAVE_DECL_STRLCPY                           => 0,
+ 		HAVE_DECL_STRNLEN                           => 1,
+@@ -366,7 +367,6 @@ sub GenerateFiles
+ 		HAVE_SSL_CTX_SET_NUM_TICKETS             => undef,
+ 		HAVE_STDINT_H                            => 1,
+ 		HAVE_STDLIB_H                            => 1,
+-		HAVE_STRCHRNUL                           => undef,
+ 		HAVE_STRERROR_R                          => undef,
+ 		HAVE_STRINGS_H                           => undef,
+ 		HAVE_STRING_H                            => 1,

--- a/databases/postgresql16/Portfile
+++ b/databases/postgresql16/Portfile
@@ -8,7 +8,7 @@ PortGroup legacysupport 1.1
 
 name                postgresql16
 version             16.8
-revision            0
+revision            1
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -55,6 +55,9 @@ platform darwin powerpc {
     depends_build-append \
                         path:bin/perl:perl5
 }
+
+# https://www.postgresql.org/message-id/flat/E1tziZ6-002AW9-2C%40gemulon.postgresql.org
+patchfiles-append   patch-strchrnul.diff
 
 legacysupport.newest_darwin_requires_legacy \
                     15

--- a/databases/postgresql16/files/patch-strchrnul.diff
+++ b/databases/postgresql16/files/patch-strchrnul.diff
@@ -1,0 +1,234 @@
+From a39eb9c77faaf51f8d02da718546e77e00a7622a Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 1 Apr 2025 16:49:51 -0400
+Subject: [PATCH] Fix detection and handling of strchrnul() for macOS 15.4.
+
+As of 15.4, macOS has strchrnul(), but access to it is blocked behind
+a check for MACOSX_DEPLOYMENT_TARGET >= 15.4.  But our does-it-link
+configure check finds it, so we try to use it, and fail with the
+present default deployment target (namely 15.0).  This accounts for
+today's buildfarm failures on indri and sifaka.
+
+This is the identical problem that we faced some years ago when Apple
+introduced preadv and pwritev in the same way.  We solved that in
+commit f014b1b9b by using AC_CHECK_DECLS instead of AC_CHECK_FUNCS
+to check the functions' availability.  So do the same now for
+strchrnul().  Interestingly, we already had a workaround for
+"the link check doesn't agree with <string.h>" cases with glibc,
+which we no longer need since only the header declaration is being
+checked.
+
+Testing this revealed that the meson version of this check has never
+worked, because it failed to use "-Werror=unguarded-availability-new".
+(Apparently nobody's tried to build with meson on macOS versions that
+lack preadv/pwritev as standard.)  Adjust that while at it.  Also,
+we had never put support for "-Werror=unguarded-availability-new"
+into v13, but we need that now.
+
+Co-authored-by: Tom Lane <tgl@sss.pgh.pa.us>
+Co-authored-by: Peter Eisentraut <peter@eisentraut.org>
+Discussion: https://postgr.es/m/385134.1743523038@sss.pgh.pa.us
+Backpatch-through: 13
+---
+ configure                  | 14 +++++++++++++-
+ configure.ac               |  2 +-
+ meson.build                | 21 ++++++++++++++++++---
+ src/include/pg_config.h.in |  7 ++++---
+ src/port/snprintf.c        | 29 +++++++++++++----------------
+ src/tools/msvc/Solution.pm |  2 +-
+ 6 files changed, 50 insertions(+), 25 deletions(-)
+
+diff --git configure configure
+index 8c8df505f7014..c8b217e0132bf 100755
+--- configure
++++ configure
+@@ -15715,7 +15715,7 @@ fi
+ LIBS_including_readline="$LIBS"
+ LIBS=`echo "$LIBS" | sed -e 's/-ledit//g' -e 's/-lreadline//g'`
+ 
+-for ac_func in backtrace_symbols copyfile getifaddrs getpeerucred inet_pton kqueue mbstowcs_l memset_s posix_fallocate ppoll pthread_is_threaded_np setproctitle setproctitle_fast strchrnul strsignal syncfs sync_file_range uselocale wcstombs_l
++for ac_func in backtrace_symbols copyfile getifaddrs getpeerucred inet_pton kqueue mbstowcs_l memset_s posix_fallocate ppoll pthread_is_threaded_np setproctitle setproctitle_fast strsignal syncfs sync_file_range uselocale wcstombs_l
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+@@ -16279,6 +16279,18 @@ esac
+ 
+ fi
+ 
++ac_fn_c_check_decl "$LINENO" "strchrnul" "ac_cv_have_decl_strchrnul" "#include <string.h>
++"
++if test "x$ac_cv_have_decl_strchrnul" = xyes; then :
++  ac_have_decl=1
++else
++  ac_have_decl=0
++fi
++
++cat >>confdefs.h <<_ACEOF
++#define HAVE_DECL_STRCHRNUL $ac_have_decl
++_ACEOF
++
+ 
+ # This is probably only present on macOS, but may as well check always
+ ac_fn_c_check_decl "$LINENO" "F_FULLFSYNC" "ac_cv_have_decl_F_FULLFSYNC" "#include <fcntl.h>
+diff --git configure.ac configure.ac
+index e2d8ca9f1a0d8..e7cd4de01639d 100644
+--- configure.ac
++++ configure.ac
+@@ -1809,7 +1809,6 @@ AC_CHECK_FUNCS(m4_normalize([
+ 	pthread_is_threaded_np
+ 	setproctitle
+ 	setproctitle_fast
+-	strchrnul
+ 	strsignal
+ 	syncfs
+ 	sync_file_range
+@@ -1849,6 +1848,7 @@ AC_CHECK_DECLS([strlcat, strlcpy, strnlen])
+ # won't handle deployment target restrictions on macOS
+ AC_CHECK_DECLS([preadv], [], [AC_LIBOBJ(preadv)], [#include <sys/uio.h>])
+ AC_CHECK_DECLS([pwritev], [], [AC_LIBOBJ(pwritev)], [#include <sys/uio.h>])
++AC_CHECK_DECLS([strchrnul], [], [], [#include <string.h>])
+ 
+ # This is probably only present on macOS, but may as well check always
+ AC_CHECK_DECLS(F_FULLFSYNC, [], [], [#include <fcntl.h>])
+diff --git meson.build meson.build
+index 2a6e45b79a7ee..ce184c6dfb328 100644
+--- meson.build
++++ meson.build
+@@ -2323,6 +2323,7 @@ decl_checks = [
+ decl_checks += [
+   ['preadv', 'sys/uio.h'],
+   ['pwritev', 'sys/uio.h'],
++  ['strchrnul', 'string.h'],
+ ]
+ 
+ foreach c : decl_checks
+@@ -2331,8 +2332,23 @@ foreach c : decl_checks
+   args = c.get(2, {})
+   varname = 'HAVE_DECL_' + func.underscorify().to_upper()
+ 
+-  found = cc.has_header_symbol(header, func,
+-    args: test_c_args, include_directories: postgres_inc,
++  found = cc.compiles('''
++#include <@0@>
++
++int main()
++{
++#ifndef @1@
++    (void) @1@;
++#endif
++
++return 0;
++}
++'''.format(header, func),
++    name: 'test whether @0@ is declared'.format(func),
++    # need to add cflags_warn to get at least
++    # -Werror=unguarded-availability-new if applicable
++    args: test_c_args + cflags_warn,
++    include_directories: postgres_inc,
+     kwargs: args)
+   cdata.set10(varname, found, description:
+ '''Define to 1 if you have the declaration of `@0@', and to 0 if you
+@@ -2579,7 +2595,6 @@ func_checks = [
+   ['shm_unlink', {'dependencies': [rt_dep], 'define': false}],
+   ['shmget', {'dependencies': [cygipc_dep], 'define': false}],
+   ['socket', {'dependencies': [socket_dep], 'define': false}],
+-  ['strchrnul'],
+   ['strerror_r', {'dependencies': [thread_dep]}],
+   ['strlcat'],
+   ['strlcpy'],
+diff --git src/include/pg_config.h.in src/include/pg_config.h.in
+index ce3063b2b223d..a27cb325aa384 100644
+--- src/include/pg_config.h.in
++++ src/include/pg_config.h.in
+@@ -128,6 +128,10 @@
+    don't. */
+ #undef HAVE_DECL_PWRITEV
+ 
++/* Define to 1 if you have the declaration of `strchrnul', and to 0 if you
++   don't. */
++#undef HAVE_DECL_STRCHRNUL
++
+ /* Define to 1 if you have the declaration of `strlcat', and to 0 if you
+    don't. */
+ #undef HAVE_DECL_STRLCAT
+@@ -409,9 +413,6 @@
+ /* Define to 1 if you have the <stdlib.h> header file. */
+ #undef HAVE_STDLIB_H
+ 
+-/* Define to 1 if you have the `strchrnul' function. */
+-#undef HAVE_STRCHRNUL
+-
+ /* Define to 1 if you have the `strerror_r' function. */
+ #undef HAVE_STRERROR_R
+ 
+diff --git src/port/snprintf.c src/port/snprintf.c
+index e3e316e04981e..bd5ec7dfad4e2 100644
+--- src/port/snprintf.c
++++ src/port/snprintf.c
+@@ -338,13 +338,22 @@ static void leading_pad(int zpad, int signvalue, int *padlen,
+ static void trailing_pad(int padlen, PrintfTarget *target);
+ 
+ /*
+- * If strchrnul exists (it's a glibc-ism), it's a good bit faster than the
+- * equivalent manual loop.  If it doesn't exist, provide a replacement.
++ * If strchrnul exists (it's a glibc-ism, but since adopted by some other
++ * platforms), it's a good bit faster than the equivalent manual loop.
++ * Use it if possible, and if it doesn't exist, use this replacement.
+  *
+  * Note: glibc declares this as returning "char *", but that would require
+  * casting away const internally, so we don't follow that detail.
++ *
++ * Note: macOS has this too as of Sequoia 15.4, but it's hidden behind
++ * a deployment-target check that causes compile errors if the deployment
++ * target isn't high enough.  So !HAVE_DECL_STRCHRNUL may mean "yes it's
++ * declared, but it doesn't compile".  To avoid failing in that scenario,
++ * use a macro to avoid matching <string.h>'s name.
+  */
+-#ifndef HAVE_STRCHRNUL
++#if !HAVE_DECL_STRCHRNUL
++
++#define strchrnul pg_strchrnul
+ 
+ static inline const char *
+ strchrnul(const char *s, int c)
+@@ -354,19 +363,7 @@ strchrnul(const char *s, int c)
+ 	return s;
+ }
+ 
+-#else
+-
+-/*
+- * glibc's <string.h> declares strchrnul only if _GNU_SOURCE is defined.
+- * While we typically use that on glibc platforms, configure will set
+- * HAVE_STRCHRNUL whether it's used or not.  Fill in the missing declaration
+- * so that this file will compile cleanly with or without _GNU_SOURCE.
+- */
+-#ifndef _GNU_SOURCE
+-extern char *strchrnul(const char *s, int c);
+-#endif
+-
+-#endif							/* HAVE_STRCHRNUL */
++#endif							/* !HAVE_DECL_STRCHRNUL */
+ 
+ 
+ /*
+diff --git src/tools/msvc/Solution.pm src/tools/msvc/Solution.pm
+index 557feb00866cd..8f92b3c5c901c 100644
+--- src/tools/msvc/Solution.pm
++++ src/tools/msvc/Solution.pm
+@@ -241,6 +241,7 @@ sub GenerateFiles
+ 		HAVE_DECL_POSIX_FADVISE => 0,
+ 		HAVE_DECL_PREADV => 0,
+ 		HAVE_DECL_PWRITEV => 0,
++		HAVE_DECL_STRCHRNUL => 0,
+ 		HAVE_DECL_STRLCAT => 0,
+ 		HAVE_DECL_STRLCPY => 0,
+ 		HAVE_DECL_STRNLEN => 1,
+@@ -332,7 +333,6 @@ sub GenerateFiles
+ 		HAVE_SSL_CTX_SET_NUM_TICKETS => undef,
+ 		HAVE_STDINT_H => 1,
+ 		HAVE_STDLIB_H => 1,
+-		HAVE_STRCHRNUL => undef,
+ 		HAVE_STRERROR_R => undef,
+ 		HAVE_STRINGS_H => undef,
+ 		HAVE_STRING_H => 1,

--- a/databases/postgresql17/Portfile
+++ b/databases/postgresql17/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 
 name                postgresql17
 version             17.4
-revision            0
+revision            1
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -42,6 +42,9 @@ platform darwin powerpc {
     patchfiles-append  patch-icu.diff \
                        patch-fix-ppc-asm.diff
 }
+
+# https://www.postgresql.org/message-id/flat/E1tziZ6-002AW9-2C%40gemulon.postgresql.org
+patchfiles-append   patch-strchrnul.diff
 
 depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib \
                     port:libxml2 port:libxslt \

--- a/databases/postgresql17/files/patch-strchrnul.diff
+++ b/databases/postgresql17/files/patch-strchrnul.diff
@@ -1,0 +1,213 @@
+From 915e88968034a7422679b74c3002f5c150c33e35 Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 1 Apr 2025 16:49:51 -0400
+Subject: [PATCH] Fix detection and handling of strchrnul() for macOS 15.4.
+
+As of 15.4, macOS has strchrnul(), but access to it is blocked behind
+a check for MACOSX_DEPLOYMENT_TARGET >= 15.4.  But our does-it-link
+configure check finds it, so we try to use it, and fail with the
+present default deployment target (namely 15.0).  This accounts for
+today's buildfarm failures on indri and sifaka.
+
+This is the identical problem that we faced some years ago when Apple
+introduced preadv and pwritev in the same way.  We solved that in
+commit f014b1b9b by using AC_CHECK_DECLS instead of AC_CHECK_FUNCS
+to check the functions' availability.  So do the same now for
+strchrnul().  Interestingly, we already had a workaround for
+"the link check doesn't agree with <string.h>" cases with glibc,
+which we no longer need since only the header declaration is being
+checked.
+
+Testing this revealed that the meson version of this check has never
+worked, because it failed to use "-Werror=unguarded-availability-new".
+(Apparently nobody's tried to build with meson on macOS versions that
+lack preadv/pwritev as standard.)  Adjust that while at it.  Also,
+we had never put support for "-Werror=unguarded-availability-new"
+into v13, but we need that now.
+
+Co-authored-by: Tom Lane <tgl@sss.pgh.pa.us>
+Co-authored-by: Peter Eisentraut <peter@eisentraut.org>
+Discussion: https://postgr.es/m/385134.1743523038@sss.pgh.pa.us
+Backpatch-through: 13
+---
+ configure                  | 14 +++++++++++++-
+ configure.ac               |  2 +-
+ meson.build                | 21 ++++++++++++++++++---
+ src/include/pg_config.h.in |  7 ++++---
+ src/port/snprintf.c        | 29 +++++++++++++----------------
+ 5 files changed, 49 insertions(+), 24 deletions(-)
+
+diff --git configure configure
+index 055fd1b825bc7..b1442afe4c192 100755
+--- configure
++++ configure
+@@ -15272,7 +15272,7 @@ fi
+ LIBS_including_readline="$LIBS"
+ LIBS=`echo "$LIBS" | sed -e 's/-ledit//g' -e 's/-lreadline//g'`
+ 
+-for ac_func in backtrace_symbols copyfile copy_file_range getifaddrs getpeerucred inet_pton kqueue mbstowcs_l memset_s posix_fallocate ppoll pthread_is_threaded_np setproctitle setproctitle_fast strchrnul strsignal syncfs sync_file_range uselocale wcstombs_l
++for ac_func in backtrace_symbols copyfile copy_file_range getifaddrs getpeerucred inet_pton kqueue mbstowcs_l memset_s posix_fallocate ppoll pthread_is_threaded_np setproctitle setproctitle_fast strsignal syncfs sync_file_range uselocale wcstombs_l
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+@@ -15816,6 +15816,18 @@ cat >>confdefs.h <<_ACEOF
+ #define HAVE_DECL_PWRITEV $ac_have_decl
+ _ACEOF
+ 
++ac_fn_c_check_decl "$LINENO" "strchrnul" "ac_cv_have_decl_strchrnul" "#include <string.h>
++"
++if test "x$ac_cv_have_decl_strchrnul" = xyes; then :
++  ac_have_decl=1
++else
++  ac_have_decl=0
++fi
++
++cat >>confdefs.h <<_ACEOF
++#define HAVE_DECL_STRCHRNUL $ac_have_decl
++_ACEOF
++
+ 
+ # This is probably only present on macOS, but may as well check always
+ ac_fn_c_check_decl "$LINENO" "F_FULLFSYNC" "ac_cv_have_decl_F_FULLFSYNC" "#include <fcntl.h>
+diff --git configure.ac configure.ac
+index 82b4640193179..6f0230b0bf501 100644
+--- configure.ac
++++ configure.ac
+@@ -1763,7 +1763,6 @@ AC_CHECK_FUNCS(m4_normalize([
+ 	pthread_is_threaded_np
+ 	setproctitle
+ 	setproctitle_fast
+-	strchrnul
+ 	strsignal
+ 	syncfs
+ 	sync_file_range
+@@ -1803,6 +1802,7 @@ AC_CHECK_DECLS([strlcat, strlcpy, strnlen])
+ # won't handle deployment target restrictions on macOS
+ AC_CHECK_DECLS([preadv], [], [], [#include <sys/uio.h>])
+ AC_CHECK_DECLS([pwritev], [], [], [#include <sys/uio.h>])
++AC_CHECK_DECLS([strchrnul], [], [], [#include <string.h>])
+ 
+ # This is probably only present on macOS, but may as well check always
+ AC_CHECK_DECLS(F_FULLFSYNC, [], [], [#include <fcntl.h>])
+diff --git meson.build meson.build
+index 842d4f745a2b3..78b0542b1462f 100644
+--- meson.build
++++ meson.build
+@@ -2469,6 +2469,7 @@ decl_checks = [
+ decl_checks += [
+   ['preadv', 'sys/uio.h'],
+   ['pwritev', 'sys/uio.h'],
++  ['strchrnul', 'string.h'],
+ ]
+ 
+ # Check presence of some optional LLVM functions.
+@@ -2485,8 +2486,23 @@ foreach c : decl_checks
+   args = c.get(2, {})
+   varname = 'HAVE_DECL_' + func.underscorify().to_upper()
+ 
+-  found = cc.has_header_symbol(header, func,
+-    args: test_c_args, include_directories: postgres_inc,
++  found = cc.compiles('''
++#include <@0@>
++
++int main()
++{
++#ifndef @1@
++    (void) @1@;
++#endif
++
++return 0;
++}
++'''.format(header, func),
++    name: 'test whether @0@ is declared'.format(func),
++    # need to add cflags_warn to get at least
++    # -Werror=unguarded-availability-new if applicable
++    args: test_c_args + cflags_warn,
++    include_directories: postgres_inc,
+     kwargs: args)
+   cdata.set10(varname, found, description:
+ '''Define to 1 if you have the declaration of `@0@', and to 0 if you
+@@ -2724,7 +2740,6 @@ func_checks = [
+   ['shm_unlink', {'dependencies': [rt_dep], 'define': false}],
+   ['shmget', {'dependencies': [cygipc_dep], 'define': false}],
+   ['socket', {'dependencies': [socket_dep], 'define': false}],
+-  ['strchrnul'],
+   ['strerror_r', {'dependencies': [thread_dep]}],
+   ['strlcat'],
+   ['strlcpy'],
+diff --git src/include/pg_config.h.in src/include/pg_config.h.in
+index 2397d90b465cf..0ee4a63eaa63d 100644
+--- src/include/pg_config.h.in
++++ src/include/pg_config.h.in
+@@ -115,6 +115,10 @@
+    don't. */
+ #undef HAVE_DECL_PWRITEV
+ 
++/* Define to 1 if you have the declaration of `strchrnul', and to 0 if you
++   don't. */
++#undef HAVE_DECL_STRCHRNUL
++
+ /* Define to 1 if you have the declaration of `strlcat', and to 0 if you
+    don't. */
+ #undef HAVE_DECL_STRLCAT
+@@ -393,9 +397,6 @@
+ /* Define to 1 if you have the <stdlib.h> header file. */
+ #undef HAVE_STDLIB_H
+ 
+-/* Define to 1 if you have the `strchrnul' function. */
+-#undef HAVE_STRCHRNUL
+-
+ /* Define to 1 if you have the `strerror_r' function. */
+ #undef HAVE_STRERROR_R
+ 
+diff --git src/port/snprintf.c src/port/snprintf.c
+index 884f0262dd15c..14fb1783866c5 100644
+--- src/port/snprintf.c
++++ src/port/snprintf.c
+@@ -338,13 +338,22 @@ static void leading_pad(int zpad, int signvalue, int *padlen,
+ static void trailing_pad(int padlen, PrintfTarget *target);
+ 
+ /*
+- * If strchrnul exists (it's a glibc-ism), it's a good bit faster than the
+- * equivalent manual loop.  If it doesn't exist, provide a replacement.
++ * If strchrnul exists (it's a glibc-ism, but since adopted by some other
++ * platforms), it's a good bit faster than the equivalent manual loop.
++ * Use it if possible, and if it doesn't exist, use this replacement.
+  *
+  * Note: glibc declares this as returning "char *", but that would require
+  * casting away const internally, so we don't follow that detail.
++ *
++ * Note: macOS has this too as of Sequoia 15.4, but it's hidden behind
++ * a deployment-target check that causes compile errors if the deployment
++ * target isn't high enough.  So !HAVE_DECL_STRCHRNUL may mean "yes it's
++ * declared, but it doesn't compile".  To avoid failing in that scenario,
++ * use a macro to avoid matching <string.h>'s name.
+  */
+-#ifndef HAVE_STRCHRNUL
++#if !HAVE_DECL_STRCHRNUL
++
++#define strchrnul pg_strchrnul
+ 
+ static inline const char *
+ strchrnul(const char *s, int c)
+@@ -354,19 +363,7 @@ strchrnul(const char *s, int c)
+ 	return s;
+ }
+ 
+-#else
+-
+-/*
+- * glibc's <string.h> declares strchrnul only if _GNU_SOURCE is defined.
+- * While we typically use that on glibc platforms, configure will set
+- * HAVE_STRCHRNUL whether it's used or not.  Fill in the missing declaration
+- * so that this file will compile cleanly with or without _GNU_SOURCE.
+- */
+-#ifndef _GNU_SOURCE
+-extern char *strchrnul(const char *s, int c);
+-#endif
+-
+-#endif							/* HAVE_STRCHRNUL */
++#endif							/* !HAVE_DECL_STRCHRNUL */
+ 
+ 
+ /*


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4 24E248 x86_64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
