### PR TITLE
zizmor: Update to 1.6.0

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        woodruffw zizmor 1.5.2 v
+github.setup        woodruffw zizmor 1.6.0 v
 github.tarball_from archive
 revision            0
 
@@ -20,9 +20,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fd78bc3b8937115d407d1e1cb6aae5d10ae53f94 \
-                    sha256  9789dca47e36ac8c124be5856c38acfac6169839c7fb3a0ce492776e47f1d880 \
-                    size    291839
+                    rmd160  3bf4f4e07388db085fdb833a3dcece736fac1296 \
+                    sha256  17a244ff5a4d5ea58b323e421da2c061bb661c2e533c3827988a83cc1ed79f78 \
+                    size    309349
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -41,7 +41,7 @@ cargo.crates \
     anstyle-parse                       0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                       1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                      3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
-    anyhow                             1.0.97  dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f \
+    anyhow                             1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
     arrayvec                            0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert_cmd                         2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
     async-trait                        0.1.86  644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d \
@@ -60,9 +60,9 @@ cargo.crates \
     camino                              1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
     cc                                 1.2.16  be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c \
     cfg-if                              1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    clap                               4.5.32  6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83 \
+    clap                               4.5.36  2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04 \
     clap-verbosity-flag                 3.0.2  2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84 \
-    clap_builder                       4.5.32  22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8 \
+    clap_builder                       4.5.36  132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5 \
     clap_derive                        4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     colorchoice                         1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
@@ -86,7 +86,7 @@ cargo.crates \
     etcetera                           0.10.0  26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6 \
     fastrand                            2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     filetime                           0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
-    flate2                              1.1.0  11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc \
+    flate2                              1.1.1  7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece \
     fnv                                 1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     form_urlencoded                     1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     futures                            0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
@@ -101,7 +101,7 @@ cargo.crates \
     generic-array                      0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                          0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
     gimli                              0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
-    github-actions-models              0.26.0  63a17952a0374993a4c7f8df12bd75b3d1ed8fb9c78e8dbaa32cf451143faaaa \
+    github-actions-models              0.28.1  90f4e09b721ac4c2c4af87cbdeac88fff82284dbcf71702066eecc17c3717dff \
     globset                            0.4.15  15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19 \
     hashbrown                          0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                                0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
@@ -134,10 +134,10 @@ cargo.crates \
     idna                                1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                        1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                             0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
-    indexmap                            2.8.0  3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058 \
+    indexmap                            2.9.0  cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e \
     indicatif                         0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
     insta                              1.42.2  50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084 \
-    inventory                          0.3.15  f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767 \
+    inventory                          0.3.20  ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83 \
     ipnet                              2.10.1  ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708 \
     is_terminal_polyfill               1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                          0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
@@ -171,10 +171,10 @@ cargo.crates \
     overload                            0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     owo-colors                          4.2.0  1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564 \
     percent-encoding                    2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    pest                               2.7.15  8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc \
-    pest_derive                        2.7.15  816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e \
-    pest_generator                     2.7.15  7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b \
-    pest_meta                          2.7.15  e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea \
+    pest                                2.8.0  198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6 \
+    pest_derive                         2.8.0  d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5 \
+    pest_generator                      2.8.0  db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841 \
+    pest_meta                           2.8.0  7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0 \
     pin-project                         1.1.8  1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916 \
     pin-project-internal                1.1.8  d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb \
     pin-project-lite                   0.2.15  915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff \
@@ -202,8 +202,8 @@ cargo.crates \
     regex-automata                      0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                       0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    reqwest                           0.12.14  989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254 \
-    reqwest-middleware                  0.4.1  64e8975513bd9a7a43aad01030e79b3498e05db14e9d945df6483e8cf9b8c4c4 \
+    reqwest                           0.12.15  d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb \
+    reqwest-middleware                  0.4.2  57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e \
     ring                              0.17.13  70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee \
     rustc-demangle                     0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                          2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
@@ -221,9 +221,9 @@ cargo.crates \
     serde-sarif                         0.7.0  b39432f20e354de863582451c54bac03ffa63f7dd77f8b1e0ddee211950ab2a2 \
     serde_derive                      1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
     serde_json                        1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
-    serde_json_path                     0.7.1  e176fbf9bd62f75c2d8be33207fa13af2f800a506635e89759e46f934c520f4d \
-    serde_json_path_core                0.2.1  ea3bfd54a421bec8328aefede43ac9f18c8c7ded3b2afc8addd44b4813d99fd0 \
-    serde_json_path_macros              0.1.5  ee05bac728cc5232af5c23896b34fbdd17cf0bb0c113440588aeeb1b57c6ba1f \
+    serde_json_path                     0.7.2  b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33 \
+    serde_json_path_core                0.2.2  dde67d8dfe7d4967b5a95e247d4148368ddd1e753e500adb34b3ffe40c6bc1bc \
+    serde_json_path_macros              0.1.6  517acfa7f77ddaf5c43d5f119c44a683774e130b4247b7d3210f8924506cfac8 \
     serde_json_path_macros_internal     0.1.2  aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90 \
     serde_spanned                       0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                    0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
@@ -254,9 +254,9 @@ cargo.crates \
     termtree                            0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
     text-size                           1.1.1  f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233 \
     thiserror                          1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                           2.0.9  f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc \
+    thiserror                          2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
     thiserror-impl                     1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                      2.0.9  7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4 \
+    thiserror-impl                     2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
     thread_local                        1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     time                               0.3.37  35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21 \
     time-core                           0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
@@ -264,7 +264,7 @@ cargo.crates \
     tinystr                             0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                             1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
     tinyvec_macros                      0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                              1.44.1  f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a \
+    tokio                              1.44.2  e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48 \
     tokio-macros                        2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-rustls                       0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
     tokio-stream                       0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
@@ -357,7 +357,7 @@ cargo.crates \
     writeable                           0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     xattr                               1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
     xxhash-rust                        0.8.12  6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984 \
-    yamlpath                           0.15.0  796a3f441fd5a8d00a2dac6ca0ce0f0b07b7e1997e014a32d4f17a9d39fbdc9f \
+    yamlpath                           0.16.0  87c585ad15cb2a723978a39719af264133486ee68bd980e214ff43402e7b674a \
     yansi                               1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                         0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.6.0

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
