### PR TITLE
openjdk24: update to 24.0.1

### DIFF
--- a/java/openjdk24/Portfile
+++ b/java/openjdk24/Portfile
@@ -9,8 +9,8 @@ set boot_feature 23
 
 name                openjdk${feature}
 # See https://github.com/openjdk/jdk24u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             ${feature}
-set build 36
+version             ${feature}.0.1
+set build 9
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -25,9 +25,9 @@ master_sites        https://github.com/openjdk/jdk${feature}u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk${feature}u-${distname}
 
-checksums           rmd160  de461bb8ca8bf3f7c852f7ad1ca8bdd5fc111fa5 \
-                    sha256  62cfe6846267a31edb1a4f451b1b1c6fddd25b7ec8522d32387f5450963b9996 \
-                    size    120680620
+checksums           rmd160  e4d431355090cdb11fe445cb8839541d89bb83ab \
+                    sha256  2ccaaf7c5f03b6f689347df99e6e34cd6d3b30bc56af815c8c152a6eeb6a6c25 \
+                    size    120717798
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 
@@ -44,6 +44,12 @@ license_noconflict  ${bootjdk_port}
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4
     reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
+
+    # Temporary workaround for 'illegal byte sequence' issue on macOS 15+: https://bugs.openjdk.org/browse/JDK-8353948
+    # Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+    if {${os.platform} eq "darwin" && ${os.major} >= 24} {
+        delete ${worksrcpath}/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/resource/xmlsecurity_de.properties
+    }
 }
 
 # Temporary workaround for clang 16.0-16.1: https://trac.macports.org/ticket/70819


### PR DESCRIPTION
#### Description

Update to OpenJDK 24.0.1.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?