### PR TITLE
k9s: update to 0.50.4

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.50.3 v
+go.setup            github.com/derailed/k9s 0.50.4 v
 go.offline_build    no
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {breun.nl:nils @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  667ea96e492d0587e193662b0f113acacb947235 \
-                    sha256  cd0a46a9abbf190bcf081d8baab0c8a6bb499fd0ae035bc5c3d57eabae292413 \
-                    size    6821944
+checksums           rmd160  22761a37f29ca7d688fa43ca59411a140773945c \
+                    sha256  4f7f6702145b0eea2f42c684ff823aa261bc80b1a3b2a33b56fb6f87d7755c73 \
+                    size    6823825
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

Update to k9s 0.50.4.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?