### PR TITLE
gperf: update to 3.3

### DIFF
--- a/devel/gperf/Portfile
+++ b/devel/gperf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           clang_dependency 1.0
 
 name                gperf
-version             3.2
+version             3.3
 revision            0
 
 categories          devel
@@ -18,13 +18,14 @@ long_description    Generates a perfect hash function for various input.
 homepage            https://www.gnu.org/software/gperf/gperf.html
 master_sites        gnu
 
-checksums           rmd160  c6b492ee7098e59099677934c113b43e32063915 \
-                    sha256  e0ddadebb396906a3e3e4cac2f697c8d6ab92dffa5d365a5bc23c7d41d30ef62 \
-                    size    1268603
+checksums           rmd160  1465cc9a714cf3c55913f4fc5277790d33058b30 \
+                    sha256  fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8 \
+                    size    1831294
 
 installs_libs       no
 
-configure.args      --infodir=${prefix}/share/info
+configure.args      --docdir=${prefix}/share/doc/${name} \
+                    --infodir=${prefix}/share/info
 
 # Also needed by later clangs.
 if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {


### PR DESCRIPTION
https://lists.gnu.org/archive/html/info-gnu/2025-04/msg00013.html

Closes: https://trac.macports.org/ticket/71950

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
