### PR TITLE
xyce, trilinos16: new ports for Trilinos 16 and Xyce

### DIFF
--- a/science/trilinos16/Portfile
+++ b/science/trilinos16/Portfile
@@ -1,0 +1,76 @@
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+name                trilinos16
+version             16.1.0
+categories          science
+maintainers         {gmail.com:degnan.68k @bpdegnan} \
+                    openmaintainer
+license             BSD
+description         Scientific computing libraries including solvers and preconditioners
+long_description    \
+    Trilinos is a collection of packages for scientific computing, including \
+    solvers, preconditioners, nonlinear and optimization libraries, and interfaces \
+    to third-party libraries. It is designed for flexibility and high performance.
+
+#homepage            https://trilinos.github.io/
+##note, the project used - instead of . for archive files
+#distname            trilinos-release-16-1-0
+#master_sites        https://github.com/trilinos/Trilinos/archive/refs/tags/
+#extract.suffix      .tar.gz
+##note, the mixed capitalization is causing fits with the default build system
+#worksrcdir  Trilinos-trilinos-release-16-1-0
+
+github.setup        trilinos Trilinos trilinos-release-16-1-0
+github.tarball_from archive
+
+
+checksums           rmd160 0464487926704ba40cc6f1b20fa631aec7512333 \
+					sha256 e9651c88f581049457036cfc01b527a9d3903c257338eeeab942befd7452f23a \
+                    size 197260161
+
+depends_build-append port:pkgconfig
+
+depends_lib-append  port:gcc13 \
+                    port:OpenBLAS \
+                    port:SuiteSparse \
+                    port:netcdf
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_Fortran_COMPILER=${prefix}/bin/gfortran-mp-13 \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=ON \
+    -DTrilinos_ALLOW_DEPRECATED_PACKAGES=ON \
+    -DTrilinos_ENABLE_ALL_PACKAGES=OFF \
+    -DTrilinos_ENABLE_Epetra=ON \
+    -DTrilinos_ENABLE_EpetraExt=ON \
+    -DTrilinos_ENABLE_Teuchos=ON \
+    -DTrilinos_ENABLE_AztecOO=ON \
+    -DTrilinos_ENABLE_Ifpack=ON \
+    -DTrilinos_ENABLE_Belos=ON \
+    -DTrilinos_ENABLE_Amesos=ON \
+    -DAmesos_ENABLE_KLU=ON \
+    -DEpetraExt_BUILD_BTF=ON \
+    -DEpetraExt_BUILD_EXPERIMENTAL=ON \
+    -DEpetraExt_BUILD_GRAPH_REORDERINGS=ON \
+    -DTrilinos_ENABLE_COMPLEX_DOUBLE=ON \
+    -DTrilinos_ENABLE_Sacado=ON \
+    -DTrilinos_ENABLE_NOX=ON \
+    -DTrilinos_ENABLE_TrilinosCouplings=ON \
+    -DNOX_ENABLE_LOCA=ON \
+    -DTPL_ENABLE_BLAS=ON \
+    -DTPL_ENABLE_LAPACK=ON \
+    -DTPL_ENABLE_SuiteSparse=ON \
+    -DTPL_ENABLE_Netcdf=ON \
+    -DTPL_Netcdf_INCLUDE_DIRS=${prefix}/include \
+    -DTPL_Netcdf_LIBRARIES=${prefix}/lib/libnetcdf.dylib \
+    -DTrilinos_INSTALL_CMAKE_DIR=lib/cmake/Trilinos \
+    -DTPL_ENABLE_AMD=ON \
+    -DAMD_INCLUDE_DIRS=${prefix}/include/suitesparse \
+    -DAMD_LIBRARY_NAMES=amd \
+    -DAMD_LIBRARY_DIRS=${prefix}/lib \
+    -DBUILD_SHARED_LIBS=ON
+

--- a/science/trilinos16/Portfile
+++ b/science/trilinos16/Portfile
@@ -14,13 +14,6 @@ long_description    \
     solvers, preconditioners, nonlinear and optimization libraries, and interfaces \
     to third-party libraries. It is designed for flexibility and high performance.
 
-#homepage            https://trilinos.github.io/
-##note, the project used - instead of . for archive files
-#distname            trilinos-release-16-1-0
-#master_sites        https://github.com/trilinos/Trilinos/archive/refs/tags/
-#extract.suffix      .tar.gz
-##note, the mixed capitalization is causing fits with the default build system
-#worksrcdir  Trilinos-trilinos-release-16-1-0
 
 github.setup        trilinos Trilinos trilinos-release-16-1-0
 github.tarball_from archive
@@ -30,17 +23,19 @@ checksums           rmd160 0464487926704ba40cc6f1b20fa631aec7512333 \
 					sha256 e9651c88f581049457036cfc01b527a9d3903c257338eeeab942befd7452f23a \
                     size 197260161
 
-depends_build-append port:pkgconfig
-
 depends_lib-append  port:gcc13 \
                     port:OpenBLAS \
                     port:SuiteSparse \
                     port:netcdf
 
+
 configure.args-append \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_C_COMPILER=${configure.cc} \
+    -DCMAKE_CXX_COMPILER=${configure.cxx} \
     -DCMAKE_Fortran_COMPILER=${prefix}/bin/gfortran-mp-13 \
+    -DCMAKE_INSTALL_RPATH=${prefix}/lib/gcc13 \
     -DCMAKE_CXX_STANDARD=17 \
     -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=ON \
     -DTrilinos_ALLOW_DEPRECATED_PACKAGES=ON \
@@ -73,4 +68,6 @@ configure.args-append \
     -DAMD_LIBRARY_NAMES=amd \
     -DAMD_LIBRARY_DIRS=${prefix}/lib \
     -DBUILD_SHARED_LIBS=ON
+
+
 

--- a/science/xyce/Portfile
+++ b/science/xyce/Portfile
@@ -30,6 +30,7 @@ depends_lib-append  port:fftw-3 \
                     port:SuiteSparse \
                     port:OpenBLAS \
                     port:bison \
+                    port:flex \
                     port:lapack 
 
 

--- a/science/xyce/Portfile
+++ b/science/xyce/Portfile
@@ -28,11 +28,8 @@ checksums           rmd160 298d502e49427e39a96ebcbb1f193833c9c905ec \
 depends_lib-append  port:fftw-3 \
                     port:trilinos16 \
                     port:SuiteSparse \
-                    port:bison \
-                    port:flex \
                     port:OpenBLAS \
                     port:lapack 
-
 
 
 set trilinos_component_paths [list \
@@ -47,7 +44,6 @@ set trilinos_component_paths [list \
     ${prefix}/lib/cmake/Belos \
     ${prefix}/lib/cmake/Amesos \
 ]
-
 
 configure.args-append \
     -DCMAKE_BUILD_TYPE=Release \

--- a/science/xyce/Portfile
+++ b/science/xyce/Portfile
@@ -1,0 +1,82 @@
+PortSystem          1.0
+PortGroup           cmake 1.1
+
+
+name                xyce
+version             7.9
+categories          science
+
+maintainers     {gmail.com:degnan.68k @bpdegnan} \
+                openmaintainer
+                
+license             GPL-2
+description         Parallel SPICE-compatible analog circuit simulator
+long_description    \
+    Xyce is a SPICE-compatible, high-performance analog circuit simulator \
+    capable of solving extremely large circuit problems using massively \
+    parallel computing platforms.
+
+homepage            https://xyce.sandia.gov
+master_sites        https://xyce.sandia.gov/files/xyce/
+distname            Xyce-${version}
+extract.suffix      .tar.gz
+
+checksums           rmd160 298d502e49427e39a96ebcbb1f193833c9c905ec \
+                    sha256 de2a7227b09a83d5abad36ea9b27a834e2bd2d6547417f27e6576418c80d4f8b
+
+
+depends_lib-append  port:fftw-3 \
+                    port:trilinos16 \
+                    port:SuiteSparse \
+                    port:bison \
+                    port:flex \
+                    port:OpenBLAS \
+                    port:lapack 
+
+
+
+set trilinos_component_paths [list \
+    ${prefix}/lib/cmake/Epetra \
+    ${prefix}/lib/cmake/EpetraExt \
+    ${prefix}/lib/cmake/TrilinosCouplings \
+    ${prefix}/lib/cmake/AztecOO \
+    ${prefix}/lib/cmake/Ifpack \
+    ${prefix}/lib/cmake/Teuchos \
+    ${prefix}/lib/cmake/Sacado \
+    ${prefix}/lib/cmake/NOX \
+    ${prefix}/lib/cmake/Belos \
+    ${prefix}/lib/cmake/Amesos \
+]
+
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${prefix} \
+    -DCMAKE_C_COMPILER=${configure.cc} \
+    -DCMAKE_CXX_COMPILER=${configure.cxx} \
+    -DCMAKE_INSTALL_DOCDIR=${prefix}/share/doc/${name} \
+    -DCMAKE_Fortran_COMPILER=${prefix}/bin/gfortran-mp-13 \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DTrilinos_DIR=${prefix} \
+    -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake" \
+    -DTrilinos_DIR=${prefix}/lib/cmake/Trilinos \
+    -DCMAKE_PREFIX_PATH="[join $trilinos_component_paths {;}]"    
+
+
+#there's something weird in cmake that is making things to ${prefix}/doc
+post-destroot {
+    set bad_doc_path ${destroot}${prefix}/doc
+    if {[file exists ${bad_doc_path}]} {
+        set good_doc_path ${destroot}${prefix}/share/doc/${name}
+        xinstall -m 755 -d ${good_doc_path}
+
+        # Move known files to correct place
+        foreach f [glob -nocomplain ${bad_doc_path}/*] {
+            file rename $f $good_doc_path/
+        }
+
+        # Remove empty /opt/local/doc
+        file delete -force ${bad_doc_path}
+    }
+}
+

--- a/science/xyce/Portfile
+++ b/science/xyce/Portfile
@@ -29,6 +29,7 @@ depends_lib-append  port:fftw-3 \
                     port:trilinos16 \
                     port:SuiteSparse \
                     port:OpenBLAS \
+                    port:bison \
                     port:lapack 
 
 


### PR DESCRIPTION

xyce: Sandia's parallel SPICE-compatible circuit simulator, which depends on trilinos16.
trilinos16: a versioned port for Trilinos 16.1.0 needed by newer scientific packages.  
trilinos16 had to be versioned because the 17+ version deprecates some packages needed by xyce.  For this reason, these ports are not mutually exclusive.

   

###### Type(s)


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.7.5 22H527 x86_64
Xcode 14.3.1 14E300c


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
