### PR TITLE
isync: update to 1.5.1

### DIFF
--- a/mail/isync/Portfile
+++ b/mail/isync/Portfile
@@ -3,8 +3,8 @@
 PortSystem              1.0
 
 name                    isync
-version                 1.5.0
-revision                1
+version                 1.5.1
+revision                0
 categories              mail
 license                 GPL-2
 maintainers             {gmail.com:emanuele.giaquinta @exg} openmaintainer
@@ -17,9 +17,9 @@ long_description        isync is a command line utility for synchronizing IMAP4 
 homepage                http://isync.sourceforge.net/
 master_sites            sourceforge:project/isync/isync/${version}/
 
-checksums               rmd160  5012373dae07a2113d9ae652c65d36ff1b97c06a \
-                        sha256  a0c81e109387bf279da161453103399e77946afecf5c51f9413c5e773557f78d \
-                        size    412925
+checksums               rmd160  0fd0d1119ab4fed4e96ffd3062318f33c63a64df \
+                        sha256  28cc90288036aa5b6f5307bfc7178a397799003b96f7fd6e4bd2478265bb22fa \
+                        size    324364
 
 compiler.c_standard     2011
 
@@ -37,8 +37,7 @@ startupitem.name        mbsync
 # Patch the sample configuration to use MacPorts certificates and
 # drv_proxy_gen.pl to use MacPorts perl for building on OS X 10.8 and
 # earlier: https://sourceforge.net/p/isync/bugs/37/
-patchfiles          patch-paths.diff \
-                    0001-accept-zero-sized-messages-from-IMAP.patch
+patchfiles          patch-paths.diff
 
 post-extract {
     xinstall -m 644 -W ${filespath} mbsync.plist ${worksrcpath}


### PR DESCRIPTION
* Upstream now accepts zero-sized messages from IMAP Stores, so previous patch has been removed.

See: https://sourceforge.net/projects/isync/files/isync/1.5.1/

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.2 24C101 arm64
Xcode 16.1 16B40

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
