### PR TITLE
devel/libnewt: Add support for python 3.13

### DIFF
--- a/devel/libnewt/Portfile
+++ b/devel/libnewt/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                libnewt
 version             0.52.24
+revision            0
 checksums           rmd160  ae2b10238f3f9499f281076d97614074bc540d53 \
                     sha256  5ded7e221f85f642521c49b1826c8de19845aa372baf5d630a51774b544fbdbb \
                     size    176693
@@ -82,7 +83,7 @@ subport whiptcl {
     destroot.target         install-tcl
 }
 
-set python_versions [list 3.8 3.9 3.10 3.11 3.12]
+set python_versions [list 3.9 3.10 3.11 3.12 3.13]
 
 foreach pv ${python_versions} {
     set pv_no_dot [string map {. {}} ${pv}]


### PR DESCRIPTION
#### Description

- Add support for python 3.13 with new subport `py313-libnewt`
- Drop support for EOL python 3.8 in subport `py38-libnewt`

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

- macOS 14.7.5 23H527 arm64
  Xcode 16.2 16C5032a
- macOS 10.15.7 19H2026 x86_64
  Command Line Tools 12.4.0.0.1.1610135815

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
       => Not applicable
