### PR TITLE
ntpsec: update to 1.2.4

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -4,9 +4,17 @@ PortSystem          1.0
 PortGroup           waf 1.0
 PortGroup           python 1.0
 PortGroup           openssl 1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime(), clock_settime()
+legacysupport.newest_darwin_requires_legacy 15
+
+# Note:  Due to a bug in the ntpsec build procedure, the legacy-support library
+# is linked *after* libSystem.  This is undesirable in the general case, but
+# isn't believed to cause trouble with the specific functions used here.
 
 name                ntpsec
-version             1.2.3
+version             1.2.4
 revision            0
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
@@ -19,12 +27,12 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  f6ee175289710afd8c053dd39a5a825d995c7a15 \
-                    sha256  750b7337b3b42b5573700a8d5a483e1bf556e447549177a670c7c00fb9049375 \
-                    size    2725081
+checksums           rmd160  455ed30dc803e83dd19a0ab28d8361459ce45eb1 \
+                    sha256  443e54a6149d1b0bf08677d17b18fced9028b101fc2ffd2c81e0834f87eebc7d \
+                    size    2736913
 
-# ntpsec requires Python 2.6, 2.7, or 3.3+.
-# We skip 2.6 and 3.3, but keep 2.7 and 3.4+.
+# ntpsec requires Python 2.7 or 3.3+.
+# We skip 3.3, but keep 2.7 and 3.4+.
 # Some variants may force a more restricted list.
 #
 set pythons_suffixes {27 34 35 36 37 38 39 310 311 312 313}
@@ -42,15 +50,14 @@ foreach s ${pythons_suffixes} {
     variant ${p} description "Build ${name} to use Python ${v}" conflicts {*}${c} ""
 }
 
-# Default to +python27
+# Default to +python312
 #
-# Since this port provides Python modules that may be used by users, changing
-# the Python version may break existing user code.  Since earlier versions of
-# this port had no pythonXX variant, there is no established default variant
-# to avoid such a switch on an upgrade.  Hence, the default should remain at
-# +python27 for a while.
+# This is an "almost latest" version of Python, without the "bleeding edge"
+# issues of python313, including its current inability to build on all
+# platforms.  It can be requested explicitly, however.  Upgrades to existing
+# installs will preserve the current selection.
 #
-set pyver_no_dot "27"
+set pyver_no_dot "312"
 
 foreach s ${pythons_suffixes} {
     if {[variant_isset python${s}]} {
@@ -74,7 +81,6 @@ pre-fetch {
 }
 
 python.version          ${pyver_no_dot}
-waf.python_branch       ${python.branch}
 
 # Avoid treating python311+ differently from earlier versions.
 # In particular, avoid clobbering destroot.target and adding superfluous
@@ -88,16 +94,29 @@ openssl.branch      3
 # NOTE: doesn't work with libressl
 
 depends_build-append port:bison port:pkgconfig
-#depends_lib-append  port:python${pyver_no_dot}
+depends_lib-append  port:python${pyver_no_dot}
 
-# Consolidated patchfile, based on GitHub/fhgwright/macports-releases
+# Consolidated patchfile, based on GitLab/fhgwright/ntpsec
+#
+# This diff is from NTPsec_1_2_4 vs. macports-1_2_4
+#
+# The patches are reduced from earlier versions, based on using legacy-support
+# to provide some missing features.  Some patches are still needed, though,
+# to accommodate OS versions <10.13 (plus a Python 2 fix in ntpq).
+#
 patchfiles          patch-allfixes.diff
+
+# Some PGs used here bring in the unnecessary compiler_wrapper PG.
+# Disable it to reduce logfile clutter and obfuscation.
+#
+compwrap.compilers_to_wrap
 
 use_configure       yes
 configure.post_args-delete --nocache
 configure.args      --alltests \
                     --define=CONFIG_FILE=${prefix}/etc/ntp.conf \
                     --disable-manpage \
+                    --disable-mdns-registration \
                     --python=${python.bin} \
                     --enable-pylib=ext \
                     --pyshebang=${python.bin} \
@@ -132,6 +151,10 @@ variant doc description {Build manpages and HTML documentation} {
     configure.args-append   --enable-doc --htmldir=${prefix}/share/doc/${name}
     configure.args-delete   --disable-manpage
 }
+variant mdns description {Enable mDNS service discovery} {
+    depends_lib-append      port:avahi
+    configure.args-delete   --disable-mdns-registration
+}
 variant refclock description {Enable all reference clocks} {
     configure.args-append   --refclock=all
 }
@@ -149,10 +172,6 @@ post-destroot {
     destroot.keepdirs \
         ${destroot}${prefix}/var/db \
         ${destroot}${prefix}/var/run
-
-    # The install script inappropriately installs the runtests program
-    # See https://gitlab.com/NTPsec/ntpsec/-/issues/786
-    delete "${destroot}${prefix}/bin/runtests"
 }
 post-activate {
     if {![file exists ${prefix}/etc/ntp.conf]} {

--- a/sysutils/ntpsec/files/patch-allfixes.diff
+++ b/sysutils/ntpsec/files/patch-allfixes.diff
@@ -1,214 +1,5 @@
---- attic/backwards.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ attic/backwards.c	2023-12-30 22:12:39.000000000 -0800
-@@ -7,6 +7,8 @@
- #include <stdlib.h>
- #include <time.h>
- 
-+#include "ntp_machine.h"	/* For clock_gettime fallback */
-+
- #define UNUSED_ARG(arg)         ((void)(arg))
- 
- static void ts_print(struct timespec *ts0, struct timespec *ts1);
---- attic/clocks.c.orig	2023-12-28 20:53:56.000000000 -0800
-+++ attic/clocks.c	2023-12-30 22:12:39.000000000 -0800
-@@ -9,6 +9,8 @@
- #include <unistd.h>
- 
- 
-+#include "ntp_machine.h"	/* For clock_gettime fallback */
-+
- struct table {
-   const int type;
-   const char* name;
---- attic/cmac-timing.c.orig	2023-12-28 20:53:53.000000000 -0800
-+++ attic/cmac-timing.c	2023-12-30 22:12:39.000000000 -0800
-@@ -36,6 +36,8 @@
- #include <openssl/params.h> 
- #endif
- 
-+#include "ntp_machine.h"	/* For clock_gettime fallback */
-+
- #define UNUSED_ARG(arg)         ((void)(arg))
- 
- 
---- attic/digest-timing.c.orig	2023-12-28 20:53:56.000000000 -0800
-+++ attic/digest-timing.c	2023-12-30 22:12:39.000000000 -0800
-@@ -32,6 +32,8 @@
- #include <openssl/objects.h>
- #include <openssl/ssl.h>
- 
-+#include "ntp_machine.h"	/* For clock_gettime fallback */
-+
- #define UNUSED_ARG(arg)         ((void)(arg))
- 
- #ifndef EVP_MD_CTX_new
---- attic/random.c.orig	2023-12-28 20:53:56.000000000 -0800
-+++ attic/random.c	2023-12-30 22:12:39.000000000 -0800
-@@ -10,6 +10,8 @@
- #include <openssl/opensslv.h>    /* for OPENSSL_VERSION_NUMBER */
- #include <openssl/rand.h>
- 
-+#include "ntp_machine.h"	/* For clock_gettime fallback */
-+
- #define BATCHSIZE 1000000
- #define BILLION 1000000000
- #define HISTSIZE 2500
---- include/ntp_machine.h.orig	2022-12-22 22:08:52.000000000 -0800
-+++ include/ntp_machine.h	2023-12-30 22:12:39.000000000 -0800
-@@ -13,14 +13,145 @@
- 
- #ifndef CLOCK_REALTIME
- /*
-- * Pacify platforms that don't have a real clock_gettime(2),
-- * notably Mac OS X.
-+ * Handle platforms that don't have a real clock_gettime(2),
-+ * notably some versions of Mac OS X.
-  */
--#define CLOCK_REALTIME	0
--#define CLOCK_MONOTONIC	1
-+
-+#include <errno.h>
-+
- typedef int clockid_t;
--int clock_gettime(clockid_t clock_id, struct timespec *tp);
--#endif
-+
-+#define CLOCK_REALTIME	0
-+
-+#ifdef __APPLE__
-+
-+#define CLOCK_MONOTONIC 1
-+#define CLOCK_MONOTONIC_RAW 2
-+
-+#include <mach/clock.h>
-+#include <mach/mach.h>
-+#include <mach/mach_time.h>
-+
-+#endif /* __APPLE__ */
-+
-+static inline int clock_gettime(clockid_t clk_id, struct timespec *tp)
-+{
-+    switch (clk_id) {
-+
-+    case CLOCK_REALTIME:
-+	{
-+	    /*
-+	     * On OSX, it's tempting to use clock_get_time() for its apparent
-+	     * nanosecond resolution, but it really only has microsecond
-+	     * resolution, and is substantially slower than gettimeofday().
-+	     */
-+	    struct timeval tv;
-+
-+	    if (gettimeofday(&tv, NULL))
-+		return -1;
-+	    tp->tv_sec = tv.tv_sec;
-+	    tp->tv_nsec = tv.tv_usec * 1000;
-+	    return 0;
-+	}
-+
-+#ifdef __APPLE__
-+    case CLOCK_MONOTONIC:
-+	{
-+	    mach_timespec_t mts;
-+	    static clock_serv_t sclock = 0;
-+
-+	    /*
-+	     * Obtain clock port on first call, then reuse it.
-+	     * Rely on exit cleanup to free it.
-+	     */
-+	    if (!sclock) {
-+		mach_port_t mach_host = mach_host_self();
-+		host_get_clock_service(mach_host,
-+		    SYSTEM_CLOCK, &sclock);
-+		mach_port_deallocate(mach_task_self(), mach_host);
-+	    }
-+	    clock_get_time(sclock, &mts);
-+	    tp->tv_sec = mts.tv_sec;
-+	    tp->tv_nsec = mts.tv_nsec;
-+	    return 0;
-+	}
-+
-+    case CLOCK_MONOTONIC_RAW:
-+	{
-+	    static mach_timebase_info_data_t sTimebaseInfo = {0, 0};
-+	    unsigned long long nanos;
-+
-+	    /* Obtain scale factors on first call, then reuse them. */
-+	    if ( sTimebaseInfo.denom == 0 ) {
-+		    (void) mach_timebase_info(&sTimebaseInfo);
-+	    }
-+	    nanos = mach_absolute_time()
-+		    * sTimebaseInfo.numer / sTimebaseInfo.denom;
-+	    tp->tv_sec = nanos / 1000000000U;
-+	    tp->tv_nsec = nanos - tp->tv_sec * 1000000000U;
-+	    return 0;
-+	}
-+#endif /* __APPLE__ */
-+
-+    default:
-+	errno = EINVAL;
-+	return -1;
-+    }
-+}
-+
-+static inline int clock_getres(clockid_t clk_id, struct timespec *res)
-+{
-+    switch (clk_id) {
-+
-+    case CLOCK_REALTIME:
-+	res->tv_sec = 0;
-+	res->tv_nsec = 1000;
-+	return 0;
-+
-+#ifdef __APPLE__
-+    case CLOCK_MONOTONIC:
-+    case CLOCK_MONOTONIC_RAW:
-+	res->tv_sec = 0;
-+	res->tv_nsec = 1;
-+	return 0;
-+#endif /* __APPLE__ */
-+
-+    default:
-+	errno = EINVAL;
-+	return -1;
-+    }
-+}
-+
-+/*
-+ * Prototype for settimeofday() may suppressed by feature-test flags.
-+ * Provide it here just in case, and get an error if it mismatches.
-+ * Similarly, "struct timezone" definition may be suppressed, but the
-+ * incomplete definition provided here is adequate given that the
-+ * timezone argument is unused.
-+ */
-+struct timezone;
-+int settimeofday(const struct timeval *, const struct timezone *);
-+
-+static inline int clock_settime(clockid_t clk_id, const struct timespec *tp)
-+{
-+    switch (clk_id) {
-+
-+    case CLOCK_REALTIME:
-+	{
-+	    struct timeval tv;
-+
-+	    tv.tv_sec = tp->tv_sec;
-+	    tv.tv_usec = (tp->tv_nsec + 500) / 1000;
-+	    return settimeofday(&tv, NULL);
-+	}
-+
-+    default:
-+	errno = EINVAL;
-+	return -1;
-+    }
-+}
-+
-+#endif /* !CLOCK_REALTIME */
- 
- int ntp_set_tod (struct timespec *tvs);
- 
---- include/ntp_stdlib.h.orig	2023-12-28 20:53:56.000000000 -0800
-+++ include/ntp_stdlib.h	2023-12-30 22:12:39.000000000 -0800
+--- include/ntp_stdlib.h.orig	2025-04-18 12:54:14.000000000 -0700
++++ include/ntp_stdlib.h	2025-04-20 16:24:35.000000000 -0700
 @@ -103,7 +103,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -220,7 +11,7 @@
  extern	const char * socktoa	(const sockaddr_u *);
  extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
 --- include/ntp_syscall.h.orig	2022-12-22 22:08:52.000000000 -0800
-+++ include/ntp_syscall.h	2023-12-30 22:12:39.000000000 -0800
++++ include/ntp_syscall.h	2025-04-20 16:24:35.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -234,7 +25,7 @@
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
 --- libntp/clockwork.c.orig	2023-12-28 20:53:56.000000000 -0800
-+++ libntp/clockwork.c	2023-12-30 22:12:39.000000000 -0800
++++ libntp/clockwork.c	2025-04-20 16:24:35.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -248,8 +39,8 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
---- libntp/statestr.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ libntp/statestr.c	2023-12-30 22:12:39.000000000 -0800
+--- libntp/statestr.c.orig	2025-04-18 12:54:14.000000000 -0700
++++ libntp/statestr.c	2025-04-20 16:24:35.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -350,9 +141,26 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ntpd/ntp_control.c.orig	2023-12-28 20:53:56.000000000 -0800
-+++ ntpd/ntp_control.c	2023-12-30 22:12:39.000000000 -0800
-@@ -35,7 +35,9 @@ struct utsname utsnamebuf;
+--- ntpclients/ntpq.py.orig	2025-04-18 12:54:14.000000000 -0700
++++ ntpclients/ntpq.py	2025-04-20 16:24:35.000000000 -0700
+@@ -25,6 +25,14 @@ import socket
+ import sys
+ import time
+ 
++# The BrokenPipeError doesn't exist in Python 2, but the problem that requires
++# catching it also doesn't seem to exist in Python 2, so just make it a dummy
++# in Python 2.
++try:
++    BrokenPipeError
++except NameError:
++    BrokenPipeError = None
++
+ try:
+     import ntp.control
+     import ntp.ntpc
+--- ntpd/ntp_control.c.orig	2025-04-18 12:54:14.000000000 -0700
++++ ntpd/ntp_control.c	2025-04-20 16:24:35.000000000 -0700
+@@ -37,7 +37,9 @@ struct utsname utsnamebuf;
  
  /* Variables that need updating each time. */
  static leap_signature_t lsig;
@@ -360,9 +168,9 @@
  static struct timex ntx;
 +#endif	/* HAVE_KERNEL_PLL */
  
- /*
-  * Statistic counters to keep track of requests and responses.
-@@ -364,6 +366,7 @@ static const struct var sys_var[] = {
+ /* Ugh.  timex slots are tough.  The man page says "long"
+  * But the actual implementation on Linux uses something else.
+@@ -382,6 +384,7 @@ static const struct var sys_var[] = {
    Var_uli("authcmacdecrypts", RO, authcmacdecrypt),
    Var_uli("authcmacfails", RO, authcmacfail),
  
@@ -370,15 +178,15 @@
  /* kerninfo: Kernel timekeeping info */
    Var_kli("koffset", RO|N_CLOCK|KNUToMS, ntx.offset),
    Var_kli("kfreq", RO|N_CLOCK|K_16, ntx.freq),
-@@ -381,6 +384,7 @@ static const struct var sys_var[] = {
-   Var_li("kppscaliberrs", RO|N_CLOCK, ntx.errcnt),
-   Var_li("kppsjitexc", RO|N_CLOCK, ntx.jitcnt),
-   Var_li("kppsstbexc", RO|N_CLOCK, ntx.stbcnt),
+@@ -399,6 +402,7 @@ static const struct var sys_var[] = {
+   Var_kli("kppscalibs", RO|N_CLOCK, ntx.calcnt),
+   Var_kli("kppscaliberrs", RO|N_CLOCK, ntx.errcnt),
+   Var_kli("kppsstbexc", RO|N_CLOCK, ntx.stbcnt),
 +#endif	/* HAVE_KERNEL_PLL */
  
  
  /* refclock stuff in ntp_io */
-@@ -1395,7 +1399,9 @@ ctl_putarray(
+@@ -1402,7 +1406,9 @@ ctl_putarray(
   */
  static void
  ctl_putsys(const struct var * v) {
@@ -388,7 +196,7 @@
  	static unsigned long ntp_leap_time;
  
  /* older compilers don't allow declarations on each case without {} */
-@@ -1407,6 +1413,7 @@ ctl_putsys(const struct var * v) {
+@@ -1414,6 +1420,7 @@ ctl_putsys(const struct var * v) {
   * This should get pushed up a layer: flag, once per request
   * This could get data from 2 samples if the clock ticks while we are working..
   */
@@ -396,7 +204,7 @@
  	/* The Kernel clock variables need up-to-date output of ntp_adjtime() */
  	if (v->flags&N_CLOCK && current_time != ntp_adjtime_time) {
  		ZERO(ntx);
-@@ -1415,6 +1422,7 @@ ctl_putsys(const struct var * v) {
+@@ -1422,6 +1429,7 @@ ctl_putsys(const struct var * v) {
                              "MODE6: ntp_adjtime() for mode 6 query failed: %s", strerror(errno));
                  ntp_adjtime_time = current_time;
  	}
@@ -404,8 +212,8 @@
  
  	/* The leap second variables need up-to-date info */
          if (v->flags&N_LEAP && current_time != ntp_leap_time) {
---- ntpd/ntp_loopfilter.c.orig	2023-12-28 20:53:56.000000000 -0800
-+++ ntpd/ntp_loopfilter.c	2023-12-30 22:12:39.000000000 -0800
+--- ntpd/ntp_loopfilter.c.orig	2025-04-18 12:54:14.000000000 -0700
++++ ntpd/ntp_loopfilter.c	2025-04-20 16:24:35.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -599,7 +407,7 @@
  
  		/*
  		 * Initialize frequency if given; otherwise, begin frequency
-@@ -1178,11 +1210,14 @@ loop_config(
+@@ -1178,7 +1210,9 @@ loop_config(
  			rstclock(EVNT_FSET, 0);
  		else
  			rstclock(EVNT_NSET, 0);
@@ -608,151 +416,14 @@
 +#endif /* HAVE_KERNEL_PLL */
  		break;
  
- 	case LOOP_KERN_CLEAR:
- #if 0		/* XXX: needs more review, and how can we get here? */
-+# ifdef HAVE_KERNEL_PLL
- 		if (!loop_data.lockclock && (clock_ctl.pll_control && clock_ctl.kern_enable)) {
- 			memset((char *)&ntv, 0, sizeof(ntv));
- 			ntv.modes = MOD_STATUS;
-@@ -1192,6 +1227,7 @@ loop_config(
- 				pll_status,
- 				ntv.status);
- 		   }
-+# endif /* HAVE_KERNEL_PLL */
- #endif
- 		break;
- 
-@@ -1272,4 +1308,3 @@ loop_config(
+ 	/*
+@@ -1252,4 +1286,3 @@ loop_config(
  		    "CONFIG: loop_config: unsupported option %d", item);
  	}
  }
 -
---- ntpd/ntp_packetstamp.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpd/ntp_packetstamp.c	2023-12-30 22:12:39.000000000 -0800
-@@ -6,6 +6,7 @@
-  */
- #include "config.h"
- 
-+#include <stdint.h>
- #ifdef HAVE_SYS_IOCTL_H
- # include <sys/ioctl.h>
- #endif
-@@ -33,6 +34,44 @@
-  *
-  */
- 
-+/*
-+ * OSX prior to 10.6 defines CMSG_DATA incorrectly in 64-bit builds, due to
-+ * bad alignment assumptions.
-+ *
-+ * In those OS versions we substitute a version of the definition from >=10.6.
-+ */
-+
-+#if defined(__APPLE__) \
-+  && (!defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) \
-+      || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1060)
-+
-+#define	__DARWIN_ALIGNBYTES32 (sizeof(__uint32_t) - 1)
-+#define	__DARWIN_ALIGN32(p) \
-+	((size_t)((char *)(size_t)(p) \
-+	 + __DARWIN_ALIGNBYTES32) &~ __DARWIN_ALIGNBYTES32)
-+
-+/* given pointer to struct cmsghdr, return pointer to data */
-+#undef CMSG_DATA
-+#define	CMSG_DATA(cmsg) ((unsigned char *)(cmsg) + \
-+	__DARWIN_ALIGN32(sizeof(struct cmsghdr)))
-+
-+#endif /* OSX < 10.6 */
-+
-+/*
-+ * Packet timestamps use the kernel's notion of time_t, which may not match
-+ * the userspace version.  We need to accomodate both 32- and 64-bit
-+ * versions.
-+ */
-+
-+struct timeval_32 {
-+	uint32_t	tv_sec;  /* Unsigned to get past 2038 */
-+	int32_t		tv_usec;
-+};
-+
-+struct timeval_64 {
-+	int64_t		tv_sec;
-+	int32_t		tv_usec;
-+};
- 
- void
- enable_packetstamps(
-@@ -104,10 +143,11 @@ fetch_packetstamp(
- 	)
- {
- 	struct cmsghdr *	cmsghdr;
-+	int			datalen;
- #if defined(SO_TIMESTAMPNS) || defined(SO_TS_CLOCK)
- 	struct timespec *	tsp;
- #elif defined(SO_TIMESTAMP)
--	struct timeval *	tvp;
-+	struct timeval		tv;
- #endif
- #ifdef ENABLE_FUZZ
- 	unsigned long		ticks;
-@@ -124,6 +164,7 @@ fetch_packetstamp(
- 		exit(2);
- 		/* return ts;	** Kludge to use time from select. */
- 	}
-+	datalen = cmsghdr->cmsg_len - sizeof(*cmsghdr);
- #if defined(SO_TIMESTAMPNS)
- 	/* Linux and ?? */
- 	if (SCM_TIMESTAMPNS != cmsghdr->cmsg_type) {
-@@ -160,16 +201,42 @@ fetch_packetstamp(
- 		(long)tsp->tv_sec, tsp->tv_nsec));
- 	nts = tspec_stamp_to_lfp(*tsp);
- #elif defined(SO_TIMESTAMP)
--	tvp = (struct timeval *)CMSG_DATA(cmsghdr);
-+	switch (datalen) {
-+
-+	case sizeof(struct timeval_32):
-+		{
-+		struct timeval_32 *tvp = (struct timeval_32 *)
-+						CMSG_DATA(cmsghdr);
-+		tv.tv_sec = tvp->tv_sec; tv.tv_usec = tvp->tv_usec;
-+		}
-+		break;
-+
-+	case sizeof(struct timeval_64):
-+		{
-+		struct timeval_64 *tvp = (struct timeval_64 *)
-+						CMSG_DATA(cmsghdr);
-+		tv.tv_sec = tvp->tv_sec; tv.tv_usec = tvp->tv_usec;
-+		}
-+		break;
-+
-+	default:
-+		DPRINT(4,
-+			("fetch_timestamp: bad timestamp length %d",
-+			datalen));
-+		msyslog(LOG_ERR,
-+			"ERR: fetch_timestamp: bad timestamp length %d",
-+			datalen);
-+		exit(2);
-+	}
- #ifdef ENABLE_FUZZ
- 	if (sys_tick > measured_tick && sys_tick > S_PER_NS) {
--	    ticks = (unsigned long) ((tvp->tv_usec * S_PER_NS) / sys_tick);
--	    tvp->tv_usec = (long)(ticks * US_PER_S * sys_tick);
-+	    ticks = (unsigned long) ((tv.tv_usec * S_PER_NS) / sys_tick);
-+	    tv.tv_usec = (long)(ticks * US_PER_S * sys_tick);
- 	}
- #endif
- 	DPRINT(4, ("fetch_timestamp: system usec network time stamp: %jd.%06ld\n",
--		(intmax_t)tvp->tv_sec, (long)tvp->tv_usec));
--	nts = tspec_stamp_to_lfp(tval_to_tspec(*tvp));
-+		(intmax_t)tv.tv_sec, (long)tv.tv_usec));
-+	nts = tspec_stamp_to_lfp(tval_to_tspec(tv));
- #else
- # error "Can't get packet timestamp"
- #endif
---- ntpd/ntp_timer.c.orig	2023-12-28 20:53:56.000000000 -0800
-+++ ntpd/ntp_timer.c	2023-12-30 22:12:39.000000000 -0800
+--- ntpd/ntp_timer.c.orig	2025-04-18 12:54:14.000000000 -0700
++++ ntpd/ntp_timer.c	2025-04-20 16:24:35.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -775,17 +446,17 @@
  #ifdef ENABLE_LEAP_SMEAR
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
---- ntpd/refclock_local.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpd/refclock_local.c	2023-12-30 22:12:39.000000000 -0800
-@@ -158,6 +158,7 @@ local_poll(
+--- ntpd/refclock_local.c.orig	2025-04-18 12:54:14.000000000 -0700
++++ ntpd/refclock_local.c	2025-04-20 16:24:35.000000000 -0700
+@@ -164,6 +164,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
  	 */
 +#ifdef HAVE_KERNEL_PLL
  	if (loop_data.lockclock) {
- 		struct timex ntv;
- 		memset(&ntv,  0, sizeof ntv);
-@@ -188,6 +189,13 @@ local_poll(
+ /* Both ntp_adjtime() and ntp_gettime() return the clock status
+  * which includes leap pending info.  See man ntp_adjtime
+@@ -210,6 +211,13 @@ local_poll(
  		pp->disp = DISPERSION;
  		pp->jitter = 0;
  	}
@@ -799,18 +470,8 @@
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ntpfrob/precision.c.orig	2023-12-28 20:53:56.000000000 -0800
-+++ ntpfrob/precision.c	2023-12-30 22:12:39.000000000 -0800
-@@ -11,6 +11,7 @@
- #include "ntp_types.h"
- #include "ntp_calendar.h"
- #include "ntpfrob.h"
-+#include "ntp_machine.h"
- 
- #define	DEFAULT_SYS_PRECISION	-99
- 
---- tests/libntp/statestr.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ tests/libntp/statestr.c	2023-12-30 22:12:39.000000000 -0800
+--- tests/libntp/statestr.c.orig	2025-04-18 12:54:14.000000000 -0700
++++ tests/libntp/statestr.c	2025-04-20 16:24:35.000000000 -0700
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -821,7 +482,7 @@
  
  TEST_GROUP(statestr);
  
-@@ -29,7 +31,9 @@ TEST(statestr, ResAccessFlags) {
+@@ -32,7 +34,9 @@ TEST(statestr, ResAccessFlags2) {
  
  // k_st_flags()
  TEST(statestr, KSTFlags) {
@@ -831,24 +492,24 @@
  }
  
  // statustoa
---- wafhelpers/bin_test.py.orig	2022-12-22 22:08:52.000000000 -0800
-+++ wafhelpers/bin_test.py	2023-12-30 22:12:39.000000000 -0800
-@@ -103,6 +103,12 @@ def cmd_bin_test(ctx):
-     if ctx.env['PYTHON_CURSES']:
-         cmd_map_python.update(cmd_map_python_curses)
- 
-+    # Kludge to remove ntptime if it didn't get built
-+    if not ctx.env.HEADER_SYS_TIMEX_H:
-+        for cmd in list(cmd_map.keys()):
-+            if 'ntptime' in cmd[0]:
-+                del cmd_map[cmd]
+--- wafhelpers/bin_test.py.orig	2025-04-18 12:54:14.000000000 -0700
++++ wafhelpers/bin_test.py	2025-04-20 16:24:35.000000000 -0700
+@@ -88,8 +88,11 @@ def cmd_bin_test(ctx):
+         (BIN, NTPCLIENTS, "ntpleapfetch", "--version"),
+         (SBIN, NTPD, "ntpd", "--version"),
+         (BIN, NTPFROB, "ntpfrob", "-V"),
+-        (BIN, NTPTIME, "ntptime", "-V"),
+     ]
++    # Only include ntptime if it was built
++    if ctx.env.HEADER_SYS_TIMEX_H:
++        cmd_list.append((BIN, NTPTIME, "ntptime", "-V"))
 +
-     for cmd in sorted(cmd_map):
-         if not run(cmd, cmd_map[cmd] % version):
-             fails += 1
---- wafhelpers/options.py.orig	2023-12-28 20:53:56.000000000 -0800
-+++ wafhelpers/options.py	2023-12-30 22:12:39.000000000 -0800
-@@ -23,6 +23,8 @@ def options_cmd(ctx, config):
+     cmd_list_python = [
+         (BIN, NTPCLIENTS, "ntpdig", "--version"),
+         (BIN, NTPCLIENTS, "ntpkeygen", "--version"),
+--- wafhelpers/options.py.orig	2025-04-18 12:54:14.000000000 -0700
++++ wafhelpers/options.py	2025-04-20 16:24:35.000000000 -0700
+@@ -24,6 +24,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
                     default=False, help="Enable seccomp (restricts syscalls).")
@@ -857,9 +518,9 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- wscript.orig	2023-12-28 20:53:56.000000000 -0800
-+++ wscript	2023-12-30 22:12:39.000000000 -0800
-@@ -587,7 +587,7 @@ int main(int argc, char **argv) {
+--- wscript.orig	2025-04-18 12:54:14.000000000 -0700
++++ wscript	2025-04-20 16:24:35.000000000 -0700
+@@ -578,7 +578,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
          ("struct if_laddrreq", ["sys/types.h", "net/if6.h"], False),
@@ -868,9 +529,9 @@
          ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
      for (s, h, r) in structures:
-@@ -812,6 +812,21 @@ int main(int argc, char **argv) {
-         ctx.define("ENABLE_FUZZ", 1,
-                    comment="Enable fuzzing low bits of time")
+@@ -809,6 +809,21 @@ int main(int argc, char **argv) {
+     if ctx.options.disable_fuzz:
+         pprint("YELLOW", "--disable-fuzz is now standard.  Clock fuzzing is gone.")
  
 +    # Does the kernel implement a phase-locked loop for timing?
 +    # All modern Unixes (in particular Linux and *BSD) have this.


### PR DESCRIPTION
As of this version, legacy-support is used to provide clock_gettime() and clock_settime(), though patches are still needed to accommodate other missing features prior to 10.13.  As usual (and as documented in the Portfile), the patches can be viewed more readably on the GitLab fork.

The default Python variant is now python312.

Former versions opportunistically included mDNS support, relying on an undeclared dependency on the avahi port.  This is now a variant, with an appropriate dependency.  Since this is a fairly low-utility feature, and avahi is a somewhat heavyweight port (that doesn't build on all platforms), and that feature was never guaranteed to be available, this variant defaults off.

TESTED:
Built (including running tests) on 10.4-10.5 ppc, 10.4-10.6 i386, 10.4-10.15 x86_64, and 11.x-15.x arm64.
Ran operationally on a representative subset.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.5 22H527, arm64, Xcode 15.2 15C500b
macOS 14.7.5 23H527, arm64, Xcode 16.2 16C5032a
macOS 15.3.2 24D81, arm64, Xcode 16.3 16E140
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
