### PR TITLE
ruff: Update to 0.11.6

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.11.5
+github.setup        astral-sh ruff 0.11.6
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  161a47928069f84ee6bd5e6c802a7d73f949fc8f \
-                    sha256  f4562ee021e2100ae4d54392ddd8af986254bf5d9e0351b2dd91947b2adc956b \
-                    size    6262729
+                    rmd160  be5b46ead28deb85ad609b02c9e8dc121c01c1bd \
+                    sha256  cfb7b1fa9891c6d3c3c3e6b6d0a178384f3bf437d81a06d7d91592bd47846123 \
+                    size    6304747
 
 cargo.offline_cmd
 
@@ -79,7 +79,7 @@ cargo.crates \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-svg                      0.1.7  d3607949e9f6de49ea4bafe12f5e4fd73613ebf24795e48587302a8cc0e4bb35 \
     anstyle-wincon                   3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
-    anyhow                          1.0.97  dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f \
+    anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
     argfile                          0.2.1  0a1cc0ba69de57db40674c66f7cf2caee3981ddef084388482c95c0e2133e5e8 \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert_fs                        1.1.2  7efdb1fdb47602827a342857666feb372712cbc64b414172bd6b167a02927674 \
@@ -90,7 +90,7 @@ cargo.crates \
     bitflags                         2.9.0  5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     boxcar                          0.2.11  6740c6e2fc6360fa57c35214c7493826aee95993926092606f27c983b40837be \
-    bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
+    bstr                            1.12.0  234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4 \
     bumpalo                         3.17.0  1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
@@ -104,8 +104,8 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.35  d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944 \
-    clap_builder                    4.5.35  2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9 \
+    clap                            4.5.36  2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04 \
+    clap_builder                    4.5.36  132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5 \
     clap_complete                   4.5.46  f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.5  c6a8b1593457dfc2fe539002b795710d022dc62a65bf15023f039f9760c7b18a \
@@ -227,6 +227,8 @@ cargo.crates \
     itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
     jiff                             0.2.4  d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e \
     jiff-static                      0.2.4  8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9 \
+    jiff-tzdb                        0.1.4  c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524 \
+    jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
     jod-thread                       0.1.2  8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae \
     js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
@@ -236,7 +238,7 @@ cargo.crates \
     libc                           0.2.171  c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6 \
     libcst                           1.7.0  ad9e315e3f679e61b9095ffd5e509de78b8a4ea3bba9d772f6fb243209f808d4 \
     libcst_derive                    1.7.0  bfa96ed35d0dccc67cf7ba49350cb86de3dcb1d072a7ab28f99117f19d874953 \
-    libmimalloc-sys                 0.1.41  6b20daca3a4ac14dbdc753c5e90fc7b490a48a9131daed3c9a9ced7b2defd37b \
+    libmimalloc-sys                 0.1.42  ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     libtest-mimic                    0.7.3  cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58 \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
@@ -251,7 +253,7 @@ cargo.crates \
     matches                         0.1.10  2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5 \
     matchit                          0.8.6  2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9 \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
-    mimalloc                        0.1.45  03cb1f88093fe50061ca1195d336ffec131347c7b833db31f9ab62a2d1b7925f \
+    mimalloc                        0.1.46  995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af \
     minicov                          0.3.7  f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.8.5  8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5 \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.11.6

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
