### PR TITLE
openjdk11-temurin: update to 11.0.27

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?os=mac&version=11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.26
-set build    4
+version      ${feature}.0.27
+set build    6
 revision     0
 
 # See https://adoptium.net/support/ for end of support date
@@ -32,14 +32,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  dff7ba0f169ecd42cfe7bd70e744052f00146766 \
-                 sha256  b0142c2c85da43bb3565321164e8129b1166de5d6a43c88e567a92c39128c003 \
-                 size    187768613
+    checksums    rmd160  306d2fad65baf21067a6fae1b7a4f7d3a0c7f811 \
+                 sha256  805d225d46eab5702bf2f654856d846f426bebf6f143e5f06c8b1397855252e5 \
+                 size    187806165
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  215de772cb718ddb36b876b5faff2ab97224fd18 \
-                 sha256  c970e5917964da1b50c0029ba88a6fbe962783def4de6a8a2835af6a6859002c \
-                 size    185055401
+    checksums    rmd160  e25d8872549d7f3e331f741f474db550d805cab2 \
+                 sha256  780ae402dcd93fea0fee10d02dcd0a0b72cb7298f2ef4dddbad4d54c31a40a4d \
+                 size    185102522
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.27.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?