### PR TITLE
pkgconf: Update to 2.4.3

### DIFF
--- a/devel/pkgconf/Portfile
+++ b/devel/pkgconf/Portfile
@@ -1,9 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
+PortGroup                   legacysupport 1.1
+
+# readlinkat
+legacysupport.newest_darwin_requires_legacy 13
 
 name                        pkgconf
-version                     2.2.0
+version                     2.4.3
 revision                    0
 categories                  devel
 license                     ISC
@@ -15,9 +19,9 @@ long_description            pkgconf is ${description}. \
 homepage                    https://github.com/pkgconf/pkgconf
 master_sites                https://distfiles.ariadne.space/pkgconf/
 
-checksums                   rmd160  3bad459c012b072b43bf92f6007e821c0d8df41f \
-                            sha256  28f8dfc279a10ef66148befa3f6eb266e5f3570316600208ed50e9781c7269d8 \
-                            size    451551
+checksums                   rmd160  64ef5d57908267686c1946ab786d63d833c0877a \
+                            sha256  cf6be37c79265802f2cb1dfc412e18de23a35b5204fc5868bc09fcfd092ac225 \
+                            size    468948
 
 # both ports install ${prefix}/share/aclocal/pkg.m4
 conflicts                   pkgconfig
@@ -28,4 +32,5 @@ configure.checks.implicit_function_declaration.whitelist-append strchr
 post-destroot {
     # since ports already conflict, follow https://github.com/pkgconf/pkgconf/#pkg-config-symlink
     ln -s pkgconf ${destroot}${prefix}/bin/pkg-config
+    ln -s pkgconf.1 ${destroot}${prefix}/share/man/man1/pkg-config.1
 }


### PR DESCRIPTION
#### Description

Update `pkgconf` to its latest released version, 2.4.3. The `legacysupport` PortGroup is now needed to fix building `libpkgconf` on older systems (e.g OSX 10.7)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
