### PR TITLE
google-cloud-sdk: update to 519.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             518.0.0
+version             519.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  09b824bef6d8d6b90ff5355c2e21da68ee1a9423 \
-                    sha256  40aa5a057a2d27c1f70e91d068a9a58f0ee93e86b9af147950c27d1fbae88f93 \
-                    size    53679264
+    checksums       rmd160  72eb504d99f7ca6b313955c52a7b0aa6681b8067 \
+                    sha256  e9ebf8a8a73703fb2643351a61e1f91fafea86661661807b1d549aa32728e330 \
+                    size    53713791
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a354316a42791f9b4a3e2c991cb32c4bbfc6c916 \
-                    sha256  dc98c14df8aa1f313cb65c426469783b863516298d8a5f0f68cacfbb6e75e95c \
-                    size    55150051
+    checksums       rmd160  a4da6e01043d7ab5a7d263870d47837b6c92645b \
+                    sha256  240845749c3e1313d69e7391e4e957d068342c0ce7fcda9291a6098a2219f1ed \
+                    size    55181893
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  9213309be0819953d1292e7d25a4c5eee39ce60a \
-                    sha256  e61e021cba3bb6f08c1acfa375feead67292086bce72991e8f20fda20b5c6d21 \
-                    size    55085420
+    checksums       rmd160  d56fb6f4e85afea4c5af49f9fa813c0a913acb72 \
+                    sha256  75247a7cb0700b5b3590b9114848602a6975ba277c720fd0784cf9d433eb618d \
+                    size    55119301
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 519.0.0.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?