### PR TITLE
openjdk21-microsoft: update to 21.0.7

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.6
-set build    7
+version      ${feature}.0.7
+set build    6
 revision     0
 
 description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  846b3e53f7a0856861f0dc2de0a9183058bea323 \
-                 sha256  72a4be9114ff8fb1830aeccd9dc2cde5eaad685aef9b3869f5d8a1dc9ce40eee \
-                 size    202004724
+    checksums    rmd160  e3e04f9382a4e66a91bfecc32ec69ce5187bf249 \
+                 sha256  862435de8c6ecd10ddce544ff2cbc7f6d95f41476b5536757554c806568b7522 \
+                 size    202080910
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  4e6a72e4d74ffd315707cbb8c20e169e314a2433 \
-                 sha256  c277969b6b9021179e1e356d03e91f59333699e776ede58b66c99fb39fec6c43 \
-                 size    199599557
+    checksums    rmd160  27e6df7dfa6fcae887c17b6fae62ad8a06653da2 \
+                 sha256  dfc5ed1e8ef5042bba8aaa780fafa835da88f40bb7f9b9192b4bfeb22efc363d \
+                 size    199691887
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft Build of OpenJDK 21.0.7.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?