### PR TITLE
openjdk17-microsoft: update to 17.0.15

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.14
-set build    7
+version      ${feature}.0.15
+set build    6
 revision     0
 
 description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  f8f5c18e99c9bf5f81fc68bac979ba796d6260de \
-                 sha256  c0d677165073b08f765982d8bb20c08db03933c79ab269103150f88805c93e6e \
-                 size    187664597
+    checksums    rmd160  72bb1e5f125b8782867de4322a9e0ee2a1e342ef \
+                 sha256  72ffaaf9efdb1cbcaa4d0033674f8f589f4d71c67a79396c09960c0e0ecdb509 \
+                 size    187749568
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  6fa553461daa9ecfbf27bb184d168e2f712f0b57 \
-                 sha256  1c00394d83edb32275d98463d64184c33a4ee3ddd89aa5b0762289a9ab3277ec \
-                 size    185525741
+    checksums    rmd160  7f6d87eb0c23fc54d89f1d94c308b8c284e6b853 \
+                 sha256  08f338f2c73a4f19bc43bd2a76e8a5eb7262defc8aa127f8bfc422b95e372a28 \
+                 size    185614487
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft Build of OpenJDK 17.0.15.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?