### PR TITLE
openjdk11-microsoft: update to 11.0.27

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.26
-set build    4
+version      ${feature}.0.27
+set build    6
 revision     0
 
 description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  38e0cf382c47d6ca5aee9c6794ea3fcf4c38f4c3 \
-                 sha256  9411b7efa62aa7c222489c18353d2031ebd6a04296cd5f77f6c4803cdedf5c8a \
-                 size    191532609
+    checksums    rmd160  4a6ee09a7abfaddc53e4b16e5f494046a9c031cb \
+                 sha256  d5547c30f914d60be45db0ea9807da30931e82855b805e8d49b5d6d08923c4c0 \
+                 size    191555664
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  3b9ed83d09fae20fe750486627eab19f6870143d \
-                 sha256  093d6c306dfc219b0a7937cb7544607536adc54ed34da7acbd169c37dd179a81 \
-                 size    185632300
+    checksums    rmd160  dd623250b3c48102fd527d77cfbc8c63b5dc82ed \
+                 sha256  f6cbe6d6f3602dcc04828f96a8baad165c572633e727fa7ccd4ec326cf1804cd \
+                 size    185642575
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft Build of OpenJDK 11.0.27.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?