### PR TITLE
git-crypt: update to 0.7.0, use local manpage xsl

### DIFF
--- a/devel/git-crypt/Portfile
+++ b/devel/git-crypt/Portfile
@@ -5,16 +5,15 @@ PortGroup               github 1.0
 PortGroup               openssl 1.0
 
 github.setup            AGWA git-crypt 0.7.0
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.tarball_from     archive
 revision                0
 homepage                https://www.agwa.name/projects/git-crypt/
 categories              devel
 maintainers             @nareshov openmaintainer
 license                 {GPL-3+ OpenSSLException}
-checksums               rmd160  c6db08fe5d107b372fc456b4bd0b21fb9cae6fdc \
-                        sha256  e3b396243b7b777d33f38000e09ea23cbbfc6c4237272216613f9d1b5021bae6 \
-                        size    57944
+checksums               rmd160  eb1f91c49813239801a6960fb5b086ebdea3bf78 \
+                        sha256  2210a89588169ae9a54988c7fdd9717333f0c6053ff704d335631a387bd3bcff \
+                        size    57921
 description             Transparent file encryption in git.
 long_description        git-crypt enables transparent encryption and \
                         decryption of files in a git repository. Files which \
@@ -53,4 +52,4 @@ build.env               CXX=${configure.cxx} \
 
 destroot.args           ENABLE_MAN=yes \
                         PREFIX=${prefix} \
-                        DOCBOOK_XSL=${prefix}/share/xsl/docbook-xsl-nons/manpages/docbook.xsl
+                        XML_CATALOG_FILES=${prefix}/etc/xml/catalog

--- a/devel/git-crypt/Portfile
+++ b/devel/git-crypt/Portfile
@@ -4,17 +4,17 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               openssl 1.0
 
-github.setup            AGWA git-crypt 0.6.0
+github.setup            AGWA git-crypt 0.7.0
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision                4
+revision                0
 homepage                https://www.agwa.name/projects/git-crypt/
 categories              devel
 maintainers             @nareshov openmaintainer
 license                 {GPL-3+ OpenSSLException}
-checksums               rmd160  b151b4426cdf2c317f9ac15125ffbcb265511ba2 \
-                        sha256  d033017252a0bbec86dd67c2489eb59159b9c61856afc0502304fc32ded7bb80
-
+checksums               rmd160  c6db08fe5d107b372fc456b4bd0b21fb9cae6fdc \
+                        sha256  e3b396243b7b777d33f38000e09ea23cbbfc6c4237272216613f9d1b5021bae6 \
+                        size    57944
 description             Transparent file encryption in git.
 long_description        git-crypt enables transparent encryption and \
                         decryption of files in a git repository. Files which \
@@ -51,4 +51,6 @@ build.env               CXX=${configure.cxx} \
                         "LDFLAGS=${configure.ldflags}  [get_canonical_archflags ld]" \
                         PREFIX=${prefix}
 
-destroot.args           ENABLE_MAN=yes PREFIX=${prefix}
+destroot.args           ENABLE_MAN=yes \
+                        PREFIX=${prefix} \
+                        DOCBOOK_XSL=${prefix}/share/xsl/docbook-xsl-nons/manpages/docbook.xsl


### PR DESCRIPTION
fixes: https://trac.macports.org/ticket/66262

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
