### PR TITLE
cutter-rizin: use qt6, enable python support

### DIFF
--- a/devel/cutter-rizin/Portfile
+++ b/devel/cutter-rizin/Portfile
@@ -2,13 +2,13 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           qt5 1.0
+PortGroup           qt6 1.0
 PortGroup           cmake 1.1
 PortGroup           app 1.1
 
 github.setup        rizinorg cutter 2.3.4 v
 name                cutter-rizin
-revision            2
+revision            3
 github.tarball_from releases
 distname            Cutter-v${version}-src
 
@@ -26,28 +26,32 @@ checksums           rmd160  d74bbc32f6f319117deb40627396f2960492cb83 \
                     sha256  edc266a5f7a1f1c7f71cf5c6c9727e05008b728eae3bb42beb7d0b24ce07c5c3 \
                     size    11608176
 
-extract.rename      yes
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:rizin \
+                    port:graphviz
 
-depends_lib-append  port:rizin
-depends_run-append  path:bin/dot:graphviz
-qt5.depends_build_component \
-                    qttools
-#qt6.depends_build   qttools
-qt5.depends_component \
-                    qtsvg
-#qt6.depends_lib     qtsvg
+qt6.depends_build   qttools
+
+qt6.depends_lib     qtsvg \
+                    qt5compat
+
+extract.rename      yes
 
 compiler.cxx_standard \
                     2017
+
+patch.args          -p1
+patchfiles-append   patch-3395_PySide_6.8.diff
+
 configure.args-append \
                     -DCUTTER_USE_BUNDLED_RIZIN=NO \
                     -DCUTTER_ENABLE_GRAPHVIZ=YES \
                     -DCUTTER_ENABLE_DEPENDENCY_DOWNLOADS=NO \
-                    -DCUTTER_EXTRA_PLUGIN_DIRS=${prefix}/lib/rizin/plugins
-                    #-DCUTTER_QT6=ON
+                    -DCUTTER_EXTRA_PLUGIN_DIRS=${prefix}/lib/rizin/plugins \
+                    -DCUTTER_QT6=ON
 
-#cmake.module_path   ${qt6.dir}/lib/cmake/Qt6LinguistTools
-# Cannot build with Qt6 for now because we don't have pyside6 port
+cmake.module_path   ${qt6.dir}/lib/cmake/Qt6LinguistTools
 
 app.name            Cutter
 app.identifier      re.[string trimright ${github.author} "org"].${github.project}
@@ -61,41 +65,58 @@ destroot.keepdirs   ${destroot}${prefix}/lib/rizin/plugins
 
 proc python-depends {python_branch} {
         global frameworks_dir prefix
-        set python_version [string map {. ""} ${python_branch}]
-        set ::python_framework ${frameworks_dir}/Python.framework
-        global python_framework
+        set python_version  [string map {. ""} ${python_branch}]
+        set ::python_prefix ${frameworks_dir}/Python.framework/Versions/${python_branch}
+        global python_prefix
+        set ::python_pkgd   ${python_prefix}/lib/python${python_branch}/site-packages
+        global python_pkgd
         # same here, and creating an alias of the variable in proc namespace so we can use it here
 
         depends_lib-append  port:python${python_version} \
-                            port:py${python_version}-pyside2
-        
+                            port:py${python_version}-pyside6
+
         configure.args-append \
                             -DCUTTER_ENABLE_PYTHON=ON \
                             -DCUTTER_ENABLE_PYTHON_BINDINGS=ON \
-                            -DPYTHON_LIBRARY="${python_framework}/Versions/${python_branch}/lib/libpython${python_branch}.dylib" \
-                            -DPYTHON_INCLUDE_DIR="${python_framework}/Versions/${python_branch}/include/python${python_branch}" \
+                            -DPYTHON_LIBRARY="${python_prefix}/lib/libpython${python_branch}.dylib" \
+                            -DPYTHON_INCLUDE_DIR="${python_prefix}/include/python${python_branch}" \
                             -DPYTHON_EXECUTABLE="${prefix}/bin/python${python_branch}"
+
+        cmake.install_rpath-append \
+                            ${python_pkgd}/PySide6 \
+                            ${python_pkgd}/shiboken6
 }
 
-# Python variants are currently broken due to https://trac.macports.org/ticket/65411
-variant python39 conflicts python310 python311 description {Enable Python support and bindings using Python 3.9} {
+variant python39 conflicts python310 python311 python312 python313 description {Enable Python support and bindings using Python 3.9} {
     set ::python_branch 3.9
     # :: refers to global namespace, so the variable is created in global ns and is usable in pre-destroot
     python-depends ${::python_branch}
 }
 
-variant python310 conflicts python39 python311 description {Enable Python support and bindings using Python 3.10} {
+variant python310 conflicts python39 python311 python31 python3132 description {Enable Python support and bindings using Python 3.10} {
     set ::python_branch 3.10
     # :: refers to global namespace, so the variable is created in global ns and is usable in pre-destroot
     python-depends ${::python_branch}
 }
 
-variant python311 conflicts python39 python311 description {Enable Python support and bindings using Python 3.11} {
+variant python311 conflicts python39 python310 python312 python313 description {Enable Python support and bindings using Python 3.11} {
     set ::python_branch 3.11
     # :: refers to global namespace, so the variable is created in global ns and is usable in pre-destroot
     python-depends ${::python_branch}
 }
 
-#if {![variant_isset python39] && ![variant_isset python310]} {
-#    default_variants +python311
-#}
+variant python312 conflicts python39 python310 python311 python313 description {Enable Python support and bindings using Python 3.11} {
+    set ::python_branch 3.12
+    # :: refers to global namespace, so the variable is created in global ns and is usable in pre-destroot
+    python-depends ${::python_branch}
+}
+
+variant python313 conflicts python39 python310 python311 python312 description {Enable Python support and bindings using Python 3.11} {
+    set ::python_branch 3.13
+    # :: refers to global namespace, so the variable is created in global ns and is usable in pre-destroot
+    python-depends ${::python_branch}
+}
+
+if {![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312]} {
+    default_variants +python313
+}

--- a/devel/cutter-rizin/files/patch-3395_PySide_6.8.diff
+++ b/devel/cutter-rizin/files/patch-3395_PySide_6.8.diff
@@ -1,0 +1,14 @@
+diff --git a/src/common/PythonManager.cpp b/src/common/PythonManager.cpp
+index eb43b018e..dca8fcba9 100644
+--- a/src/common/PythonManager.cpp
++++ b/src/common/PythonManager.cpp
+@@ -133,7 +133,9 @@ void PythonManager::shutdown()
+     Core()->setProperty("_PySideInvalidatePtr", QVariant());
+ 
+     // see PySide::destroyQCoreApplication()
++#    if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+     PySide::SignalManager::instance().clear();
++#    endif
+     Shiboken::BindingManager &bm = Shiboken::BindingManager::instance();
+     SbkObject *pyQApp = bm.retrieveWrapper(QCoreApplication::instance());
+     PyTypeObject *pyQObjectType = Shiboken::Conversions::getPythonTypeObject("QObject*");


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
