### PR TITLE
dagger: update to 0.18.5

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.4 v
+github.setup        dagger dagger 0.18.5 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  72f45ef4e15dabb75e741f5646c0b91420608759 \
-                            sha256  77f1dd080d0b412da0ccf218e59303f34c8a19c9d6e3b9e5269c78fa543a7f6f \
-                            size    18740203
+        checksums           rmd160  634dcec471900f5d196af6f672ff3b00cdc26aed \
+                            sha256  7f837852e7a737b7e327c458c60957401ab4b7287a4a6ed1ba56f6f2419e8040 \
+                            size    18746924
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  a71cbc6ef6ad3a3aa536df441b84e5bb817a40f3 \
-                            sha256  b73dd04d2e441aec47eedb0e2aeb9c5d9eb07b2c708f4e0b80b7f4088ebac6b6 \
-                            size    17912330
+        checksums           rmd160  a364d9c5c078cdeeecf31483ff23c4d9d04631a6 \
+                            sha256  846d9ede28b34fae044a0e9d686ceafdb76e1ca1b2a27afb14b3ea7903cd2c19 \
+                            size    17918966
     }
     default {
         known_fail  yes

--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.17.1 v
+github.setup        dagger dagger 0.18.4 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  b0a67cb7015adb5c2b89ca8ca7e345219465c9b6 \
-                            sha256  af941590fc982b7ad53eacd1813571763ffb4767954a7ac77837b74dbc178cb5 \
-                            size    18503591
+        checksums           rmd160  72f45ef4e15dabb75e741f5646c0b91420608759 \
+                            sha256  77f1dd080d0b412da0ccf218e59303f34c8a19c9d6e3b9e5269c78fa543a7f6f \
+                            size    18740203
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  5fc9ded165061ddef225ed76fd03bce07bf6b10d \
-                            sha256  90ff1d9fa5403c6cd10f15268d49c01a349eb00635102440e9c7588409396200 \
-                            size    17683827
+        checksums           rmd160  a71cbc6ef6ad3a3aa536df441b84e5bb817a40f3 \
+                            sha256  b73dd04d2e441aec47eedb0e2aeb9c5d9eb07b2c708f4e0b80b7f4088ebac6b6 \
+                            size    17912330
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Update to the latest version

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?