### PR TITLE
lf: Update to 35

### DIFF
--- a/sysutils/lf/Portfile
+++ b/sysutils/lf/Portfile
@@ -3,9 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gokcehan/lf 33 r
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+go.setup            github.com/gokcehan/lf 35 r
 revision            0
 categories          sysutils
 maintainers         {judaew @judaew} openmaintainer
@@ -20,32 +18,32 @@ long_description    ${name} (as in \"list files\") is a terminal file manager \
                     external tools.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  0f54ae796714f0e53163967a3dbcde4ee7938e09 \
-                        sha256  bb22c16c30200142704e48eb044a8811db7d0f51edeed1662824ceb110da2060 \
-                        size    146119
+                        rmd160  d002923f290de4676dcd42a542f41cf467103be1 \
+                        sha256  bf2ecd63eb75ceeb88f42977d49515bbd755b7f3d4db651a097c6ba47fd2d989 \
+                        size    150705
 
 build.pre_args      -ldflags \"-s -w -X main.gVersion=${version}\"
 
 go.vendors          golang.org/x/text \
-                        lock    v0.14.0 \
-                        rmd160  e26a72d542901d19f6dde4e07746f72206fb8701 \
-                        sha256  ef54709caaafdd8b27ce3d5f7c53408f11bc5fd1688c1c4f328de8ed268b3188 \
-                        size    8972503 \
+                        lock    v0.24.0 \
+                        rmd160  b181709ec4248be6a143e2448942748f081b2f50 \
+                        sha256  329c3d21dc0465c090733bdb87cc596776a8492901411be9024028af808903ac \
+                        size    8974645 \
                     golang.org/x/term \
-                        lock    v0.25.0 \
-                        rmd160  ca833ac737fee5ec966abbb66a96939a99bb0cc4 \
-                        sha256  b7e1430c8d62c201eeb85b4dabd2801c0bbe7e83cdeb71c35f3e4fa44faed0ad \
-                        size    14759 \
+                        lock    v0.31.0 \
+                        rmd160  9955bd92d2cc8266fab627e129f4f17cbf1ec66a \
+                        sha256  62582c2da67b0726f8a32170383edc9ca3bc63bf67e72a4508a76f7cfd072f9e \
+                        size    14905 \
                     golang.org/x/sys \
-                        lock    v0.26.0 \
-                        rmd160  19987e0da1912ad52b2b04531f53e61b342592e6 \
-                        sha256  4f47aa2c6f4fede87b4ff8bfb3da47c6b1ddc10bfdb2a5d85a97131f6a459313 \
-                        size    1509195 \
+                        lock    v0.32.0 \
+                        rmd160  be748f58461f9537913e1ce3b69815e4a7e4c8c6 \
+                        sha256  82c933346569d1a26b3ca51991dc2dd805f6ae4e55b5a1da8bc19ca0c204da34 \
+                        size    1526498 \
                     github.com/rivo/uniseg \
-                        lock    v0.4.3 \
-                        rmd160  8549c36ce2cf42213bec9682642a6711ef4041f3 \
-                        sha256  7578a5eac90d671db12e8ffd6c808ec285af8751bdeaa6a59bddd4341698758a \
-                        size    452761 \
+                        lock    v0.4.7 \
+                        rmd160  a9056dc9a2a80aa9c46d0ff9e54f9e2e5a498c41 \
+                        sha256  abc6a2f17b64b34b8a0c56eb9d0b53886ebbe0c88d467755c09c7fa696a16677 \
+                        size    458166 \
                     github.com/mattn/go-runewidth \
                         lock    v0.0.16 \
                         rmd160  297825c4365b5f723ae485e726259ebb620ecd66 \
@@ -57,25 +55,30 @@ go.vendors          golang.org/x/text \
                         sha256  fbad1aade4444bf51409f5b6a008cc14c7a7cdd1af856841fc1170605fae3914 \
                         size    970841 \
                     github.com/gdamore/tcell \
-                        lock    v2.7.4 \
-                        rmd160  9c47c3776ddce4497bdf09b2045541aa28eacb2b \
-                        sha256  d0278f45afc50b1067a8ea8f581289514d73275f11e6c866ca6f7cc34fa18f23 \
-                        size    179213 \
+                        lock    v2.8.1 \
+                        rmd160  0fbf5bc67e01706b0fca0930090d9e0fab35eec6 \
+                        sha256  088141739e49263b0e44b18b768a11b092281c4b54c443bdeaa122232b259d94 \
+                        size    187858 \
                     github.com/gdamore/encoding \
-                        lock    v1.0.0 \
-                        rmd160  3ed8916f763a5b51db1bcc8bd3ad06cf3d12ec07 \
-                        sha256  4f470c7308790bea8a526ea26cecbaa22345aad8dc566821cda6175b3d241ee1 \
-                        size    10900 \
+                        lock    v1.0.1 \
+                        rmd160  7e73cab014fe3647552b67678a397ba5ce2475e9 \
+                        sha256  dc7a586abe34b2d9562ca2aed225a1db734cc8b548a89bb238e75251d9aa0344 \
+                        size    14814 \
                     github.com/fsnotify/fsnotify \
-                        lock    v1.7.0 \
-                        rmd160  9198dec094f5008a8b24a2e51542ce4ec3453162 \
-                        sha256  d7cd46fbc8e25bfd37edb1b86851dcccc18c5180f09e533c6a35e4dcf2693d22 \
-                        size    57508 \
+                        lock    v1.9.0 \
+                        rmd160  24b514b003e8a613b938e13f7df3ba60dc755499 \
+                        sha256  46aaaf931594e32ce1e087da58dc8d3e27f0e34eaca38a9280f6c10a198d4166 \
+                        size    73949 \
                     github.com/djherbis/times \
                         lock    v1.6.0 \
                         rmd160  74bbca79275e2c9a5c240f77e906b640b69543a7 \
                         sha256  2b1e000f0c9408eb4d7735547a95e65860d6c2d7411ef70558db6b2b5d526f1f \
-                        size    8891
+                        size    8891 \
+                    github.com/Xuanwo/go-locale \
+                        lock    v1.1.3 \
+                        rmd160  63a2d6daeb4ca03e908ceaa1725209a418721f10 \
+                        sha256  31cfdd7f485d9f72062215a3c6491bc7a4061e512999ee30bd3eadf558ed8047 \
+                        size    15444
 
 patchfiles          patch-config-file-in-prefix.diff
 


### PR DESCRIPTION
#### Description

Update `lf` to its latest released version, 35

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
