### PR TITLE
python313: fix build on Tiger and Leopard

### DIFF
--- a/lang/python313/Portfile
+++ b/lang/python313/Portfile
@@ -36,7 +36,11 @@ patchfiles          patch-configure.diff \
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     # work around no copyfile and/or pthread_threadid_np on older systems
     patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+                       patch-threadid-older-systems.diff \
+                       patch-testexternalinspection-tiger.patch
+    if {${os.major} < 9} {
+        patchfiles-append patch-largefile-tiger.patch
+    }
 }
 
 depends_build       path:bin/pkg-config:pkgconfig
@@ -122,6 +126,8 @@ if {$subport ne "${name}-freethreading"} {
 platform darwin {
     if {${os.major} < 11} {
         configure.args-append   --without-mimalloc
+        # Use 64 bit inodes on 10.5 and 10.6 ppc
+        configure.cppflags-append -D_DARWIN_USE_64_BIT_INODE
     }
     if {${os.major} < 9} {
         # Fixes the return type of `ttyname_r`

--- a/lang/python313/files/patch-largefile-tiger.patch
+++ b/lang/python313/files/patch-largefile-tiger.patch
@@ -1,0 +1,11 @@
+--- Modules/posixmodule.c
++++ Modules/posixmodule.c
+@@ -13238,7 +13238,7 @@ _pystatvfs_fromstructstatfs(PyObject *module, struct statfs st) {
+         flags |= ST_NOSUID;
+     }
+ 
+-    _Static_assert(sizeof(st.f_blocks) == sizeof(long long), "assuming large file");
++   /* _Static_assert(sizeof(st.f_blocks) == sizeof(long long), "assuming large file"); */
+ 
+ #define SET_ITEM(SEQ, INDEX, EXPR)                       \
+     do {                                                 \

--- a/lang/python313/files/patch-testexternalinspection-tiger.patch
+++ b/lang/python313/files/patch-testexternalinspection-tiger.patch
@@ -1,0 +1,21 @@
+--- Modules/_testexternalinspection.c
++++ Modules/_testexternalinspection.c
+@@ -17,10 +17,18 @@
+ 
+ #if defined(__APPLE__)
+ #  include <TargetConditionals.h>
++#  include <AvailabilityMacros.h>
+ // Older macOS SDKs do not define TARGET_OS_OSX
+ #  if !defined(TARGET_OS_OSX)
+ #     define TARGET_OS_OSX 1
+ #  endif
++
++// Tiger does not have libproc, so use the non-osx fallback
++#  if MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++#    undef    TARGET_OS_OSX
++#    define   TARGET_OS_OSX 0
++#  endif
++
+ #  if TARGET_OS_OSX
+ #    include <libproc.h>
+ #    include <mach-o/fat.h>


### PR DESCRIPTION
#### Description

This adds the 2 patches from @kencu, originally posted in https://trac.macports.org/ticket/71206#comment:13, to fix the build on Tiger.

To fix the build on Leopard, we simply add `-D_DARWIN_USE_64_BIT_INODE`.

Tiger does not have 64-bit inode support. Disabling the assert completely is not ideal but for now is better than not being able to build it at all. Looking at the code, the relevant function (vstatfs) should still work regardless.

/cc @barracuda156 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
