### PR TITLE
mesa: fix build on Tiger

### DIFF
--- a/x11/mesa/Portfile
+++ b/x11/mesa/Portfile
@@ -61,6 +61,9 @@ patchfiles              patch-meson-spec-python.diff \
 # https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32658
 patchfiles-append       patch-fix-32-bit.diff
 
+# https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34718
+patchfiles-append       patch-missing-mach-init-include.patch
+
 # MP ticket 66269
 # the sizes of int and GLint are different on 10.4 PPC, at least
 # not sure how many systems this might affect, but all systems on buildbot were OK

--- a/x11/mesa/files/patch-missing-mach-init-include.patch
+++ b/x11/mesa/files/patch-missing-mach-init-include.patch
@@ -1,0 +1,12 @@
+diff --git src/util/os_misc.c src/util/os_misc.c
+index 4b7916634b3..c88898ee34b 100644
+--- src/util/os_misc.c
++++ src/util/os_misc.c
+@@ -66,6 +66,7 @@
+ #  include <sys/sysctl.h>
+ #  if DETECT_OS_APPLE
+ #    include <mach/mach_host.h>
++#    include <mach/mach_init.h>
+ #    include <mach/vm_param.h>
+ #    include <mach/vm_statistics.h>
+ #   endif


### PR DESCRIPTION
The build failed on Tiger due to a missing include, see upstream MR for details:

https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34718

Fixes https://trac.macports.org/ticket/72409

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
