### PR TITLE
scalapack: fix duplicate rpaths warning/error

### DIFF
--- a/math/scalapack/Portfile
+++ b/math/scalapack/Portfile
@@ -9,7 +9,7 @@ PortGroup           mpi 1.0
 PortGroup           muniversal 1.0
 
 github.setup        Reference-ScaLAPACK scalapack 2.2.2 v
-revision            0
+revision            1
 categories          math
 maintainers         nomaintainer
 license             BSD
@@ -24,25 +24,28 @@ homepage            https://www.netlib.org/scalapack
 checksums           rmd160  91015da6f02b4185c644c4567b2679852966e824 \
                     sha256  a2f0c9180a210bf7ffe126c9cb81099cf337da1a7120ddb4cbe4894eb7b7d022 \
                     size    4769347
+
 github.tarball_from archive
 
 mpi.setup           require require_fortran
 
-compiler.blacklist-append   {clang < 500}
+# fix wrong version, which results in wrong versioned name of
+# libscalapack.${version}.dylib
+# see https://github.com/Reference-ScaLAPACK/scalapack/issues/108
+post-patch {
+    reinplace "s|2.2.1|${version}|g" ${worksrcpath}/CMakeLists.txt
+}
+
+compiler.blacklist-append \
+                    {clang < 500}
 
 # remove when issue https://trac.macports.org/ticket/62567 is closed
-configure.cflags-append -Wno-implicit-function-declaration
+configure.cflags-append \
+                    -Wno-implicit-function-declaration
+
 configure.args      -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
                     -DBUILD_SHARED_LIBS=ON \
                     -DBUILD_TESTING=ON
-# BUILD_TESTING only affects BLACS directory anyway
-
-test.run            yes
-
-pre-test {
-    # test infrastructure uses /bin/ps (I think for checking on job timeout), which is forbidden by sandboxing
-    append portsandbox_profile " (allow process-exec (literal \"/bin/ps\") (with no-profile))"
-}
 
 pre-configure {
     configure.args-append \
@@ -55,3 +58,26 @@ pre-configure {
 # see https://github.com/Reference-ScaLAPACK/scalapack/issues/21
 compilers.allow_arguments_mismatch \
                     yes
+
+# remove duplicate rpath ${prefix}/lib/libgcc
+compilers.add_gcc_rpath_support \
+                    no
+
+# remove duplicate rpath ${prefix}/lib
+if {${os.platform} eq "darwin" && ${os.major} >= 10} { # 10.6, Snow Leopard
+    post-build {
+        system -W ${workpath}/build/lib/ "install_name_tool -delete_rpath \
+            ${prefix}/lib libscalapack.${version}.dylib"
+    }
+}
+
+# BUILD_TESTING only affects BLACS directory anyway
+
+test.run            yes
+
+pre-test {
+    # test infrastructure uses /bin/ps (I think for checking on job
+    # timeout), which is forbidden by sandboxing
+    append portsandbox_profile \
+        " (allow process-exec (literal \"/bin/ps\") (with no-profile))"
+}


### PR DESCRIPTION
#### Description

scalapack: fix duplicate rpaths warning/error
Fixes trac issue [#72299](https://trac.macports.org/ticket/72299)

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
