### PR TITLE
rizin: update to 0.8.0

### DIFF
--- a/devel/rizin/Portfile
+++ b/devel/rizin/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson   1.0
 PortGroup           openssl 1.0
 
 epoch               1
-github.setup        rizinorg rizin 0.7.4 v
+github.setup        rizinorg rizin 0.8.0 v
 github.tarball_from releases
 revision            0
 # Please revbump cutter-rizin whenever this is updated to a new version
@@ -30,9 +30,9 @@ distname            ${github.project}-src-v${github.version}
 worksrcdir          ${github.project}-v${github.version}
 use_xz              yes
 
-checksums           rmd160  9d81976b1432b4535cddf7a10d0fe13c9dfd711e \
-                    sha256  f7118910e5dc843c38baa3e00b30ec019a1cdd5c132ba2bc16cf0c7497631201 \
-                    size    18613012
+checksums           rmd160  d59f17b0a6fac966a5582214664efa27611a42ad \
+                    sha256  da9ac726109719289f908007d1802c6494a23c43cb9950ca42821d42aa5c7e37 \
+                    size    21332740
 
 depends_build-append \
                     port:pkgconfig
@@ -42,7 +42,7 @@ depends_lib-append  port:capstone \
                     port:zlib \
                     port:lz4 \
                     port:zstd \
-                    port:tree-sitter
+                    port:xxhash
 
 configure.args-append \
                     -Duse_sys_capstone=enabled \
@@ -50,7 +50,6 @@ configure.args-append \
                     -Duse_sys_libzip=enabled \
                     -Duse_sys_zlib=enabled \
                     -Duse_sys_lz4=enabled \
-                    -Duse_sys_xxhash=disabled \
+                    -Duse_sys_xxhash=enabled \
                     -Duse_sys_openssl=enabled \
-                    -Duse_sys_libzstd=enabled \
-                    -Duse_sys_tree_sitter=enabled
+                    -Duse_sys_libzstd=enabled


### PR DESCRIPTION
Use MP xxhash, drop usage of MP tree-sitter

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
