### PR TITLE
py-json5: update to 0.12.0

### DIFF
--- a/python/py-json5/Portfile
+++ b/python/py-json5/Portfile
@@ -4,11 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dpranke pyjson5 0.9.28 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        dpranke pyjson5 0.12.0 v
 revision            0
 name                py-json5
+github.tarball_from archive
 
 python.versions     39 310 311 312 313
 categories-append   devel
@@ -20,9 +19,9 @@ description         A Python implementation of the JSON5 data format
 long_description    {*}${description}. JSON5 extends the JSON data interchange format to make it \
                     slightly more usable as a configuration language.
 
-checksums           rmd160  6e791a1d6060158b19b1a38b20daf2edb2b7c1e9 \
-                    sha256  96dad73e68f507667e4952bc0aba8c2075ba146d1908acd4b870b89b9f896d1e \
-                    size    366090
+checksums           rmd160  aa4c195f4a0d60c349ec875b73d1620ab583da43 \
+                    sha256  39b21785fc12c61716a3634b466e3faffc5c679148c2d9cbbef9cc0c15772b6f \
+                    size    424039
 
 if {${subport} ne ${name}} {
     depends_test-append \


### PR DESCRIPTION
### Description

Simple update to latest release.

Note that tests were run for the two latest Python versions (3.13 and 3.12), and both pass.