### PR TITLE
mise: Update to 2025.4.12

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.4.9 v
+github.setup        jdx mise 2025.4.12 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  375a66b766f9caf95c7d531034dbcdd41b667b3f \
-                    sha256  8ccc2ab67280826529ed1aaad563c1846ddbdde787f0c88ccf19b1fc19ffcdaf \
-                    size    4156370
+                    rmd160  3d304a6eda0c9069256bf12e5e4d631bf89c246a \
+                    sha256  bd50c240355fa2d975af0069ee8b270812ebc39267c542c63f13a5877729688c \
+                    size    4159060
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -132,7 +132,6 @@ cargo.crates \
     bytecount                        0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                           1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
-    bytesize                         1.3.3  2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659 \
     bytesize                         2.0.1  a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba \
     bzip2                            0.5.2  49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47 \
     bzip2-sys                 0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
@@ -200,7 +199,7 @@ cargo.crates \
     deranged                         0.4.0  9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e \
     derive_arbitrary                 1.4.1  30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800 \
     derive_more                    0.99.20  6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f \
-    deunicode                        1.6.1  dc55fe0d1f6c107595572ec8b107c0999bb1a2e0b75e37429a4fb0d6474a0e7d \
+    deunicode                        1.6.2  abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04 \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     directories                      5.0.1  9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35 \
@@ -229,7 +228,7 @@ cargo.crates \
     exec                             0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
     expr-lang                        0.3.0  8ecf48d3d55edfb3a2960f8cd3d13412af146b912446a9e04812af69761e3b56 \
     eyre                            0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
-    faster-hex                       0.9.0  a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183 \
+    faster-hex                      0.10.0  7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73 \
     fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
@@ -263,67 +262,69 @@ cargo.crates \
     getrandom                        0.3.2  73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0 \
     ghash                            0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
-    gix                             0.71.0  a61e71ec6817fc3c9f12f812682cfe51ee6ea0d2e27e02fc3849c35524617435 \
-    gix-actor                       0.34.0  f438c87d4028aca4b82f82ba8d8ab1569823cfb3e5bc5fa8456a71678b2a20e7 \
-    gix-archive                     0.20.0  9bc3a718dab8958d67a20d6d464daeea46a69b05d3cf0d369cb5c871dcd51a6e \
-    gix-attributes                  0.25.0  e4e25825e0430aa11096f8b65ced6780d4a96a133f81904edceebb5344c8dd7f \
+    gix                             0.72.1  01237e8d3d78581f71642be8b0c2ae8c0b2b5c251c9c5d9ebbea3c1ea280dce8 \
+    gix-actor                       0.35.1  6b300e6e4f31f3f6bd2de5e2b0caab192ced00dc0fcd0f7cc56e28c575c8e1ff \
+    gix-archive                     0.21.1  85e59cc5867c40065122324265d99416ca0ddeb51d007870868b5f835423fb6c \
+    gix-attributes                  0.26.0  e7e26b3ac280ddb25bb6980d34f4a82ee326f78bf2c6d4ea45eef2d940048b8e \
     gix-bitmap                      0.2.14  b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540 \
     gix-chunk                       0.4.11  0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f \
-    gix-command                      0.5.0  c0378995847773a697f8e157fe2963ecf3462fe64be05b7b3da000b3b472def8 \
-    gix-commitgraph                 0.27.0  043cbe49b7a7505150db975f3cb7c15833335ac1e26781f615454d9d640a28fe \
-    gix-config                      0.44.0  9c6f830bf746604940261b49abf7f655d2c19cadc9f4142ae9379e3a316e8cfa \
-    gix-config-value               0.14.12  8dc2c844c4cf141884678cabef736fd91dd73068b9146e6f004ba1a0457944b6 \
-    gix-credentials                 0.28.0  25322308aaf65789536b860d21137c3f7b69004ac4971c15c1abb08d3951c062 \
-    gix-date                         0.9.4  daa30058ec7d3511fbc229e4f9e696a35abd07ec5b82e635eff864a2726217e4 \
-    gix-diff                        0.51.0  a2c975dad2afc85e4e233f444d1efbe436c3cdcf3a07173984509c436d00a3f8 \
-    gix-dir                         0.13.0  5879497bd3815d8277ed864ec8975290a70de5b62bb92d2d666a4cefc5d4793b \
-    gix-discover                    0.39.0  f7fb8a4349b854506a3915de18d3341e5f1daa6b489c8affc9ca0d69efe86781 \
-    gix-features                    0.41.1  016d6050219458d14520fe22bdfdeb9cb71631dec9bc2724767c983f60109634 \
-    gix-filter                      0.18.0  cb2b2bbffdc5cc9b2b82fc82da1b98163c9b423ac2b45348baa83a947ac9ab89 \
-    gix-fs                          0.14.0  951e886120dc5fa8cac053e5e5c89443f12368ca36811b2e43d1539081f9c111 \
-    gix-glob                        0.19.0  20972499c03473e773a2099e5fd0c695b9b72465837797a51a43391a1635a030 \
-    gix-hash                        0.17.0  834e79722063958b03342edaa1e17595cd2939bb2b3306b3225d0815566dcb49 \
-    gix-hashtable                    0.8.0  f06066d8702a9186dc1fdc1ed751ff2d7e924ceca21cb5d51b8f990c9c2e014a \
-    gix-ignore                      0.14.0  9a27c8380f493a10d1457f756a3f81924d578fc08d6535e304dfcafbf0261d18 \
-    gix-index                       0.39.0  855bece2d4153453aa5d0a80d51deea1ce8cd6a3b4cf213da85ac344ccb908a7 \
-    gix-lock                        17.0.0  df47b8f11c34520db5541bc5fc9fbc8e4b0bdfcec3736af89ccb1a5728a0126f \
-    gix-mailmap                     0.26.0  ff80d086d2684d30c5785cc37eba9d2cf817cfb33797ed999db9a359d16ab393 \
-    gix-negotiate                   0.19.0  dad912acf5a68a7defa4836014337ff4381af8c3c098f41f818a8c524285e57b \
-    gix-object                      0.48.0  4943fcdae6ffc135920c9ea71e0362ed539182924ab7a85dd9dac8d89b0dd69a \
-    gix-odb                         0.68.0  50306d40dcc982eb6b7593103f066ea6289c7b094cb9db14f3cd2be0b9f5e610 \
-    gix-pack                        0.58.0  9b65fffb09393c26624ca408d32cfe8776fb94cd0a5cdf984905e1d2f39779cb \
-    gix-packetline                  0.18.4  123844a70cf4d5352441dc06bab0da8aef61be94ec239cb631e0ba01dc6d3a04 \
-    gix-packetline-blocking         0.18.3  1ecf3ea2e105c7e45587bac04099824301262a6c43357fad5205da36dbb233b3 \
-    gix-path                       0.10.15  f910668e2f6b2a55ff35a1f04df88a1a049f7b868507f4cbeeaa220eaba7be87 \
-    gix-pathspec                    0.10.0  fef8422c3c9066d649074b24025125963f85232bfad32d6d16aea9453b82ec14 \
-    gix-prompt                      0.10.0  fbf9cbf6239fd32f2c2c9c57eeb4e9b28fa1c9b779fa0e3b7c455eb1ca49d5f0 \
-    gix-protocol                    0.49.0  5678ddae1d62880bc30e2200be1b9387af3372e0e88e21f81b4e7f8367355b5a \
-    gix-quote                        0.5.0  1b005c550bf84de3b24aa5e540a23e6146a1c01c7d30470e35d75a12f827f969 \
-    gix-ref                         0.51.0  b2e1f7eb6b7ce82d2d19961f74bd637bab3ea79b1bc7bfb23dbefc67b0415d8b \
-    gix-refspec                     0.29.0  1d8587b21e2264a6e8938d940c5c99662779c13a10741a5737b15fc85c252ffc \
-    gix-revision                    0.33.0  342caa4e158df3020cadf62f656307c3948fe4eacfdf67171d7212811860c3e9 \
-    gix-revwalk                     0.19.0  2dc7c3d7e5cdc1ab8d35130106e4af0a4f9f9eca0c81f4312b690780e92bde0d \
-    gix-sec                        0.10.12  47aeb0f13de9ef2f3033f5ff218de30f44db827ac9f1286f9ef050aacddd5888 \
-    gix-shallow                      0.3.0  cc0598aacfe1d52575a21c9492fee086edbb21e228ec36c819c42ab923f434c3 \
-    gix-status                      0.18.0  605a6d0eb5891680c46e24b2ee7a63ef7bd39cb136dc7c7e55172960cf68b2f5 \
-    gix-submodule                   0.18.0  78c7390c2059505c365e9548016d4edc9f35749c6a9112b7b1214400bbc68da2 \
-    gix-tempfile                    17.0.0  3d6de439bbb9a5d3550c9c7fab0e16d2d637d120fcbe0dfbc538772a187f099b \
+    gix-command                      0.6.0  d2f47f3fb4ba33644061e8e0e1030ef2a937d42dc969553118c320a205a9fb28 \
+    gix-commitgraph                 0.28.0  e05050fd6caa6c731fe3bd7f9485b3b520be062d3d139cb2626e052d6c127951 \
+    gix-config                      0.45.1  48f3c8f357ae049bfb77493c2ec9010f58cfc924ae485e1116c3718fc0f0d881 \
+    gix-config-value                0.15.0  439d62e241dae2dffd55bfeeabe551275cf9d9f084c5ebc6b48bad49d03285b7 \
+    gix-credentials                 0.29.0  ce1c7307e36026b6088e5b12014ffe6d4f509c911ee453e22a7be4003a159c9b \
+    gix-date                        0.10.1  3a98593f1f1e14b9fa15c5b921b2c465e904d698b9463e21bb377be8376c3c1a \
+    gix-diff                        0.52.1  5e9b43e95fe352da82a969f0c84ff860c2de3e724d93f6681fedbcd6c917f252 \
+    gix-dir                         0.14.1  01e6e2dc5b8917142d0ffe272209d1671e45b771e433f90186bc71c016792e87 \
+    gix-discover                    0.40.1  dccfe3e25b4ea46083916c56db3ba9d1e6ef6dce54da485f0463f9fc0fe1837c \
+    gix-features                    0.42.1  56f4399af6ec4fd9db84dd4cf9656c5c785ab492ab40a7c27ea92b4241923fed \
+    gix-filter                      0.19.1  f90c21f0d61778f518bbb7c431b00247bf4534b2153c3e85bcf383876c55ca6c \
+    gix-fs                          0.15.0  67a0637149b4ef24d3ea55f81f77231401c8463fae6da27331c987957eb597c7 \
+    gix-glob                        0.20.0  2926b03666e83b8d01c10cf06e5733521aacbd2d97179a4c9b1fdddabb9e937d \
+    gix-hash                        0.18.0  8d4900562c662852a6b42e2ef03442eccebf24f047d8eab4f23bc12ef0d785d8 \
+    gix-hashtable                    0.8.1  b5b5cb3c308b4144f2612ff64e32130e641279fcf1a84d8d40dad843b4f64904 \
+    gix-ignore                      0.15.0  ae358c3c96660b10abc7da63c06788dfded603e717edbd19e38c6477911b71c8 \
+    gix-index                       0.40.0  e6d505aea7d7c4267a3153cb90c712a89970b4dd02a2cb3205be322891f530b5 \
+    gix-lock                        17.1.0  570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796 \
+    gix-mailmap                     0.27.1  5e7c52eb13d84ad26030d07a2c2975ba639dd1400a7996e6966c5aef617ed829 \
+    gix-negotiate                   0.20.1  2e1ea901acc4d5b44553132a29e8697210cb0e739b2d9752d713072e9391e3c9 \
+    gix-object                      0.49.1  d957ca3640c555d48bb27f8278c67169fa1380ed94f6452c5590742524c40fbb \
+    gix-odb                         0.69.1  868f703905fdbcfc1bd750942f82419903ecb7039f5288adb5206d6de405e0c9 \
+    gix-pack                        0.59.1  9d49c55d69c8449f2a0a5a77eb9cbacfebb6b0e2f1215f0fc23a4cb60528a450 \
+    gix-packetline                  0.19.0  8ddc034bc67c848e4ef7596ab5528cd8fd439d310858dbe1ce8b324f25deb91c \
+    gix-packetline-blocking         0.19.0  c44880f028ba46d6cf37a66d27a300310c6b51b8ed0e44918f93df061168e2f3 \
+    gix-path                       0.10.17  c091d2e887e02c3462f52252c5ea61150270c0f2657b642e8d0d6df56c16e642 \
+    gix-pathspec                    0.11.0  ce061c50e5f8f7c830cacb3da3e999ae935e283ce8522249f0ce2256d110979d \
+    gix-prompt                      0.11.0  d024a3fe3993bbc17733396d2cefb169c7a9d14b5b71dafb7f96e3962b7c3128 \
+    gix-protocol                    0.50.1  f5c17d78bb0414f8d60b5f952196dc2e47ec320dca885de9128ecdb4a0e38401 \
+    gix-quote                        0.6.0  4a375a75b4d663e8bafe3bf4940a18a23755644c13582fa326e99f8f987d83fd \
+    gix-ref                         0.52.1  d1b7985657029684d759f656b09abc3e2c73085596d5cdb494428823970a7762 \
+    gix-refspec                     0.30.1  445ed14e3db78e8e79980085e3723df94e1c8163b3ae5bc8ed6a8fe6cf983b42 \
+    gix-revision                    0.34.1  78d0b8e5cbd1c329e25383e088cb8f17439414021a643b30afa5146b71e3c65d \
+    gix-revwalk                     0.20.1  1bc756b73225bf005ddeb871d1ca7b3c33e2417d0d53e56effa5a36765b52b28 \
+    gix-sec                         0.11.0  d0dabbc78c759ecc006b970339394951b2c8e1e38a37b072c105b80b84c308fd \
+    gix-shallow                      0.4.0  6b9a6f6e34d6ede08f522d89e5c7990b4f60524b8ae6ebf8e850963828119ad4 \
+    gix-status                      0.19.1  072099c2415cfa5397df7d47eacbcb6016d2cd17e0d674c74965e6ad1b17289f \
+    gix-submodule                   0.19.1  5f51472f05a450cc61bc91ed2f62fb06e31e2bbb31c420bc4be8793f26c8b0c1 \
+    gix-tempfile                    17.1.0  c750e8c008453a2dba67a2b0d928b7716e05da31173a3f5e351d5457ad4470aa \
     gix-trace                       0.1.12  7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7 \
-    gix-transport                   0.46.0  b3f68c2870bfca8278389d2484a7f2215b67d0b0cc5277d3c72ad72acf41787e \
-    gix-traverse                    0.45.0  36c0b049f8bdb61b20016694102f7b507f2e1727e83e9c5e6dad4f7d84ff7384 \
-    gix-url                         0.30.0  48dfe23f93f1ddb84977d80bb0dd7aa09d1bf5d5afc0c9b6820cccacc25ae860 \
-    gix-utils                        0.2.0  189f8724cf903e7fd57cfe0b7bc209db255cacdcb22c781a022f52c3a774f8d0 \
-    gix-validate                     0.9.4  34b5f1253109da6c79ed7cf6e1e38437080bb6d704c76af14c93e2f255234084 \
-    gix-worktree                    0.40.0  f7760dbc4b79aa274fed30adc0d41dca6b917641f26e7867c4071b1fb4dc727b \
-    gix-worktree-state              0.18.0  490eb4d38ec2735b3466840aa3881b44ec1a4c180d6a658abfab03910380e18b \
-    gix-worktree-stream             0.20.0  0062d69b23f136ace0e6f8e5372a98bde89b9092a52d0996d89a75085489ea63 \
+    gix-transport                   0.47.0  edfe22ba26d4b65c17879f12b9882eafe65d3c8611c933b272fce2c10f546f59 \
+    gix-traverse                    0.46.1  39094185f6d9a4d81101130fbbf7f598a06441d774ae3b3ae7930a613bbe1157 \
+    gix-url                         0.31.0  42a1ad0b04a5718b5cb233e6888e52a9b627846296161d81dcc5eb9203ec84b8 \
+    gix-utils                        0.3.0  5351af2b172caf41a3728eb4455326d84e0d70fe26fc4de74ab0bd37df4191c5 \
+    gix-validate                    0.10.0  77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d \
+    gix-worktree                    0.41.0  54f1916f8d928268300c977d773dd70a8746b646873b77add0a34876a8c847e9 \
+    gix-worktree-state              0.19.0  f81e31496d034dbdac87535b0b9d4659dbbeabaae1045a0dce7c69b5d16ea7d6 \
+    gix-worktree-stream             0.21.1  9c7731f9e7ffc45f1f79d6601a37169be0697d4e2bd015495b4f53dffd80b42e \
     glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
     globset                         0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     h2                               0.4.9  75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633 \
+    hash32                           0.3.1  47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
+    heapless                         0.8.0  0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
@@ -371,7 +372,7 @@ cargo.crates \
     indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
     indoc                            2.0.6  f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
     inout                            0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
-    insta                           1.42.2  50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084 \
+    insta                           1.43.0  ab2d11b2f17a45095b8c3603928ba29d7d918d7129d0d0641a36ba73cf07daa6 \
     intl-memoizer                    0.5.2  fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda \
     intl_pluralrules                 7.0.2  078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972 \
     io-close                         0.3.7  9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc \
@@ -397,7 +398,7 @@ cargo.crates \
     libc                           0.2.172  d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa \
     libm                            0.2.13  c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
+    libz-rs-sys                      0.5.0  6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                    0.9.4  cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
     litemap                          0.7.5  23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856 \
@@ -416,8 +417,8 @@ cargo.crates \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     memmap2                          0.9.5  fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f \
-    miette                           7.5.0  1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484 \
-    miette-derive                    7.5.0  bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147 \
+    miette                           7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
+    miette-derive                    7.6.0  db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     minisign-verify                  0.2.3  6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3 \
@@ -495,7 +496,7 @@ cargo.crates \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro2                     1.0.95  02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778 \
     prodash                         29.0.2  f04bb108f648884c23b98a0e940ebc2c93c0c3b89f04dbaf7eb8256ce617d1bc \
-    quick-xml                       0.37.4  a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369 \
+    quick-xml                       0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
     quinn                           0.11.7  c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012 \
     quinn-proto                    0.11.11  bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b \
     quinn-udp                       0.5.11  541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5 \
@@ -598,7 +599,7 @@ cargo.crates \
     strum_macros                    0.27.1  c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8 \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                            2.0.100  b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0 \
+    syn                            2.0.101  8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
@@ -633,9 +634,10 @@ cargo.crates \
     tokio-rustls                    0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
     tokio-util                      0.7.15  66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df \
     toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
-    toml                            0.8.20  cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148 \
-    toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
-    toml_edit                      0.22.24  17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474 \
+    toml                            0.8.22  05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae \
+    toml_datetime                    0.6.9  3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3 \
+    toml_edit                      0.22.26  310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e \
+    toml_write                       0.1.1  bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076 \
     tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
@@ -671,7 +673,7 @@ cargo.crates \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                        2.0.7  1706435caf04e58ce1020a4fe18db7354fba447cdffc26273d1a39dc0cf543af \
+    usage-lib                        2.1.1  f5fa05e330e8533a1b7899b89fc7096f48378c49e7cdfdc3472ce32bb38860b3 \
     utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -694,7 +696,7 @@ cargo.crates \
     wasm-bindgen-shared            0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
     web-sys                         0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-roots                    0.26.8  2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9 \
+    webpki-roots                    0.26.9  29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b \
     which                            7.0.3  24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762 \
     widestring                       1.2.0  dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
@@ -757,9 +759,9 @@ cargo.crates \
     yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
-    zerocopy                        0.8.24  2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879 \
+    zerocopy                        0.8.25  a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb \
     zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
-    zerocopy-derive                 0.8.24  a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be \
+    zerocopy-derive                 0.8.25  28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef \
     zerofrom                         0.1.6  50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5 \
     zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
@@ -768,6 +770,7 @@ cargo.crates \
     zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
     zip                              2.5.0  27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88 \
     zipsign-api                      0.1.3  8e7c724c3a8e5833aad6b7028f4f0989fa3a640ce799bf8c352f417b8ef9db3e \
+    zlib-rs                          0.5.0  868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8 \
     zopfli                           0.8.2  edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7 \
     zstd                            0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \
     zstd-safe                        7.2.4  8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d \


### PR DESCRIPTION
#### Description

mise: Update to 2025.4.12

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
