### PR TITLE
pascal-p5: reenable ppc build

### DIFF
--- a/lang/pascal-p5/Portfile
+++ b/lang/pascal-p5/Portfile
@@ -21,7 +21,7 @@ git.branch          f730c1
 
 depends_build       port:fpc
 
-supported_archs     x86_64 arm64
+supported_archs     x86_64 arm64 ppc
 
 installs_libs       no
 use_configure       no


### PR DESCRIPTION
#### Description

pascal-p5: reenable ppc build
(According to barracuda156 it builds on ppc)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
