### PR TITLE
gitleaks: Update to 8.25.0

### DIFF
--- a/security/gitleaks/Portfile
+++ b/security/gitleaks/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/zricethezav/gitleaks 8.24.3 v
+go.setup            github.com/zricethezav/gitleaks 8.25.0 v
 go.package          github.com/zricethezav/gitleaks/v8
 go.offline_build    no
 revision            0
@@ -24,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  62d2b713cfbe0f11fb3a8c559caa8856844edeb9 \
-                    sha256  1cf78443355066cb056d6fb5fc0ea695d2cd06dcd8e33a3c92999fb340c67cc7 \
-                    size    238360
+checksums           rmd160  33cf4f1c4a23f5f0403403dd4777c91b2f27ab80 \
+                    sha256  c186ca129f2315625bf5db4fc3f60c65557c51a4811586fd1b50a619be945935 \
+                    size    243290
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

gitleaks: Update to 8.25.0

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
