### PR TITLE
google-cloud-sdk: update to 520.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             519.0.0
+version             520.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  72eb504d99f7ca6b313955c52a7b0aa6681b8067 \
-                    sha256  e9ebf8a8a73703fb2643351a61e1f91fafea86661661807b1d549aa32728e330 \
-                    size    53713791
+    checksums       rmd160  3599b9ecd369b0f751e8cfae8520be3ab3c4a44a \
+                    sha256  4bd6839fea1ff521e48069a9ecd859cbd8b7c18b24acce3f5d1b893184c22ab3 \
+                    size    53816761
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a4da6e01043d7ab5a7d263870d47837b6c92645b \
-                    sha256  240845749c3e1313d69e7391e4e957d068342c0ce7fcda9291a6098a2219f1ed \
-                    size    55181893
+    checksums       rmd160  25a8ce625f80e2f5497183da4d47ae769fbb0dec \
+                    sha256  fce9d1d2b4d45136b6ed32985f44fc8101426dcf043b7d27af8527160314b8ea \
+                    size    55286749
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  d56fb6f4e85afea4c5af49f9fa813c0a913acb72 \
-                    sha256  75247a7cb0700b5b3590b9114848602a6975ba277c720fd0784cf9d433eb618d \
-                    size    55119301
+    checksums       rmd160  21a184b3a3543cc0657781aebad96030f1631c8f \
+                    sha256  5c1b793c7938e84185d9abc61a68508f6b74396d26a34426368b7c6254bd2481 \
+                    size    55225375
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 520.0.0.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?