### PR TITLE
ruby-build: Update to 20250430

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250424 v
+github.setup        rbenv ruby-build 20250430 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  4f74e375aa6c22f87611d9a0ca13ff710f610d9c \
-                    sha256  3610f8acdb750ab0be0bbc197cc722f8e1b4ea5e914ea0568d99d0a6c3ea76f6 \
-                    size    96055
+checksums           rmd160  da35e1a554c894abf69204b0aa66c85f8e67aaf1 \
+                    sha256  06e2a934f84102ed6aff430d73c76f2051c70d8aecd4d3b3dfb94f71e790f986 \
+                    size    96521
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250430

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
