### PR TITLE
crossgcc: add build dep texinfo

### DIFF
--- a/_resources/port1.0/group/crossgcc-1.0.tcl
+++ b/_resources/port1.0/group/crossgcc-1.0.tcl
@@ -207,6 +207,9 @@ proc crossgcc.setup {target version} {
 
         worksrcdir      gcc-${version}
 
+        depends_build   port:gettext \
+                        bin:makeinfo:texinfo
+
         depends_lib     port:${crossgcc.target}-binutils \
                         port:gmp \
                         port:mpfr \
@@ -214,8 +217,6 @@ proc crossgcc.setup {target version} {
                         port:libiconv \
                         port:libmpc \
                         port:zlib
-
-        depends_build   port:gettext
 
         # Extract gcc distfiles only. libc tarball might be available as gzip only;
         # handled below in post-extract in the variant.


### PR DESCRIPTION
#### Description

A required build dep for gcc, yet somehow it managed to build until recently?

The missing dep is the reason for https://github.com/macports/macports-ports/commit/6db39daae92b9e442aba7649b9ef8811cfda6e43 failing to on most versions of macOS

Once merged I'd like to request the buildbots try to build `i686-w64-mingw32-gcc `& `x86_64-w64-mingw32-gcc` again for affected macOS versions.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->