### PR TITLE
esmf: Fix builds for 10.8-10.10

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -7,6 +7,11 @@ PortGroup           github 1.0
 
 compilers.choose    f90 cxx
 compilers.setup     require_fortran -clang
+compiler.cxx_standard \
+                    2011
+compiler.thread_local_storage \
+                    yes
+
 mpi.setup
 mpi.enforce_variant netcdf-fortran
 
@@ -40,14 +45,6 @@ depends_lib         port:netcdf \
 # Avoid duplicate LC_RPATH.
 # Discussion in https://github.com/macports/macports-ports/pull/21765
 compilers.add_gcc_rpath_support no
-
-if {${os.platform} eq "darwin" && ${os.major} < 12} {
-    known_fail      yes
-    pre-fetch {
-        ui_error "${name} @{version} requires OS X Mountain Lion or later."
-        return -code error "unsupported Mac OS X version"
-    }
-}
 
 post-patch {
     if {[variant_isset openmpi]} {


### PR DESCRIPTION
#### Description

* Add compiler.cxx_standard and thread_local_storage to fix builds for 10.8-10.10.  Tentative fix, not tested yet.
* Remove known_fail for older OS versions <= 10.7, re-test and enable new work.
* Build fixes only.  No rev bump needed.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 13, 14, 15 only.
Needs testing for 10.8-10.0, and older.  Waiting for buildbots on this, after merge.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
