### PR TITLE
gitlab-runner: update version to 17.11.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 17.5.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 17.11.0 v
 revision            0
 
 homepage            https://docs.gitlab.com/runner/
@@ -22,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  f220b828fb31bede2ab761543efc945858569935 \
-                    sha256  caf8c9295242cb41be526f07daa9939651a190fdf5b8e96bb083d84afc7031f6 \
-                    size    1727140
+checksums           rmd160  5ad1daee4ba3dac7ac013cd0d510fa756d919c8a \
+                    sha256  8717f66a220a107acf6c7734cb95f2554cdbfa90961590aa2dc1454e9b5c97b2 \
+                    size    1873665
 
 # Allow Go to fetch deps at build time
 go.offline_build no


### PR DESCRIPTION
#### Description

- Simple bump to latest release 17.11.0

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
- macOS 14.7.5 23H527 arm64
  Xcode 16.2 16C5032a
- macOS 13.7.5 22H527 x86_64
  Command Line Tools 15.1.0.0.1.1700200546

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
