### PR TITLE
esmf-devel: New port

### DIFF
--- a/science/esmf-devel/Portfile
+++ b/science/esmf-devel/Portfile
@@ -1,0 +1,202 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           mpi 1.0
+PortGroup           active_variants 1.1
+PortGroup           github 1.0
+
+compilers.choose    f90 cxx
+compilers.setup     require_fortran -clang
+compiler.cxx_standard \
+                    2011
+compiler.thread_local_storage \
+                    yes
+
+mpi.setup
+mpi.enforce_variant netcdf-fortran
+
+github.setup        esmf-org esmf 7dc5cea4a7152457e6bb2ca01da23e119dca6086
+name                esmf-devel
+version             20250430
+revision            0
+
+# Branch = origin/fix/32-bit-abi
+
+checksums           rmd160  2e2efb237741dd314a09bef752e68929de200104 \
+                    sha256  5ec22aae34593ae9d29bb0c95c6fee494af6bc8a716c165b37390c726602b788 \
+                    size    14271228
+
+categories          science devel
+license             NCSA
+maintainers         {@Dave-Allured noaa.gov:dave.allured} \
+                    openmaintainer
+
+description         Test port for ESMF development versions
+long_description    {*}${description}
+
+homepage            https://earthsystemmodeling.org
+##github.tarball_from archive
+
+depends_build       bin:ranlib:cctools
+
+depends_lib         port:netcdf \
+                    port:netcdf-fortran \
+                    port:xercesc3 \
+                    port:yaml-cpp
+
+# Avoid duplicate LC_RPATH.
+# Discussion in https://github.com/macports/macports-ports/pull/21765
+compilers.add_gcc_rpath_support no
+
+post-patch {
+    if {[variant_isset openmpi]} {
+        foreach c {g95 gfortran gfortranclang} {
+            reinplace "s| -lmpi_f77||" ${worksrcpath}/build_config/Darwin.${c}.default/build_rules.mk
+        }
+    }
+}
+
+pre-configure {
+    if {${configure.cxx_stdlib} eq "libc++" && ![mpi_variant_isset]} {
+        reinplace "s|stdc++|c++|" ${worksrcpath}/build_config/Darwin.g95.default/build_rules.mk
+    }
+}
+
+if {![variant_isset atlas]} {
+    default_variants    +accelerate
+}
+
+use_configure       no
+if {[variant_isset gcc47] || [variant_isset gcc48] || [variant_isset gcc49] || [variant_isset gcc5]} {
+    configure.cxxflags-append   -std=c++11
+} elseif {[variant_isset gcc44] || [variant_isset gcc45] || [variant_isset gcc46]} {
+    configure.cxxflags-append   -std=c++0x
+}
+
+build.target        lib
+pre-build {
+    build.env       ESMF_DIR=${worksrcpath} \
+                    ESMF_F90=${configure.f90} \
+                    ESMF_F90COMPILEOPTS=${configure.f90flags} \
+                    ESMF_CXX=${configure.cxx} \
+                    ESMF_CXXCOMPILEOPTS=${configure.cxxflags} \
+                    ESMF_NETCDF=split \
+                    ESMF_NETCDF_INCLUDE=${prefix}/include \
+                    ESMF_NETCDF_LIBPATH=${prefix}/lib \
+                    ESMF_XERCES=standard \
+                    ESMF_XERCES_INCLUDE=${prefix}/include \
+                    ESMF_XERCES_LIBPATH=${prefix}/lib \
+                    ESMF_YAMLCPP=standard \
+                    ESMF_YAMLCPP_INCLUDE=${prefix}/include \
+                    ESMF_YAMLCPP_LIBPATH=${prefix}/lib \
+                    ESMF_INSTALL_LIBDIR=${prefix}/lib
+
+    # ESMF 8.8.0: Multiple issues with PIO.  Temporarily disable.
+    # -- Internal (default) PIO requires new cmake dependency.
+    # -- Internal PIO configure fails: "Check size of size_t - failed"
+    # -- * (Probably a library path issue, not PIO specific.)
+    # -- Internal PIO is out of date, requires patching.
+    # -- * Maybe future fix in 8.9.0.  See upstream issues.
+    # -- More work needed for PIO.
+    build.env-append    ESMF_PIO=OFF
+
+    if {[variant_isset accelerate]} {
+        build.env-append    ESMF_LAPACK=system \
+                            ESMF_LAPACK_LIBS=-lvecLibFort
+    } elseif {[variant_isset atlas]} {
+        build.env-append    ESMF_LAPACK=system \
+                            ESMF_LAPACK_LIBS=-lsatlas
+    }
+    if {[variant_isset g95]} {
+        build.env-append    ESMF_COMPILER=g95
+    } else {
+        if {[string match *clang* ${configure.cxx}]} {
+            build.env-append ESMF_COMPILER=gfortranclang
+        } else {
+            build.env-append ESMF_COMPILER=gfortran
+        }
+    }
+    if {[variant_isset mpich] || [variant_isset mpich_devel]} {
+        build.env-append    ESMF_COMM=mpich2
+    } elseif {[variant_isset openmpi] || [variant_isset openmpi_devel]} {
+        build.env-append    ESMF_COMM=openmpi
+    } else {
+        build.env-append    ESMF_COMM=mpiuni
+    }
+}
+pre-destroot {
+    destroot.env    ESMF_DIR=${worksrcpath} \
+                    ESMF_F90=${configure.f90} \
+                    ESMF_F90COMPILEOPTS=${configure.f90flags} \
+                    "ESMF_F90LINKOPTS=-L${worksrcpath}/lib ${configure.ldflags}" \
+                    ESMF_CXX=${configure.cxx} \
+                    ESMF_CXXCOMPILEOPTS=${configure.cxxflags} \
+                    "ESMF_CXXLINKOPTS=-L${worksrcpath}/lib ${configure.ldflags}" \
+                    ESMF_NETCDF=split \
+                    ESMF_NETCDF_INCLUDE=${prefix}/include \
+                    ESMF_NETCDF_LIBPATH=${prefix}/lib \
+                    ESMF_XERCES=standard \
+                    ESMF_XERCES_INCLUDE=${prefix}/include \
+                    ESMF_XERCES_LIBPATH=${prefix}/lib \
+                    ESMF_YAMLCPP=standard \
+                    ESMF_YAMLCPP_INCLUDE=${prefix}/include \
+                    ESMF_YAMLCPP_LIBPATH=${prefix}/lib \
+                    ESMF_INSTALL_PREFIX=${destroot}${prefix} \
+                    ESMF_INSTALL_HEADERDIR=${destroot}${prefix}/include/${name} \
+                    ESMF_INSTALL_CMAKEDIR=${destroot}${prefix}/share/cmake/Modules \
+                    ESMF_INSTALL_MODDIR=${destroot}${prefix}/include/${name} \
+                    ESMF_INSTALL_LIBDIR=${destroot}${prefix}/lib \
+                    ESMF_INSTALL_BINDIR=${destroot}${prefix}/bin \
+                    ESMF_INSTALL_DOCDIR=${destroot}${prefix}/share/doc/${name}
+
+    # See note under build.env above, for ESMF_PIO=OFF.
+    # Remove this when the other one is removed.
+    destroot.env-append ESMF_PIO=OFF
+
+    if {[variant_isset accelerate]} {
+        destroot.env-append ESMF_LAPACK=system \
+                            ESMF_LAPACK_LIBS=-lvecLibFort
+    } elseif {[variant_isset atlas]} {
+        destroot.env-append ESMF_LAPACK=system \
+                            ESMF_LAPACK_LIBS=-lsatlas
+    }
+    if {[variant_isset g95]} {
+        destroot.env-append ESMF_COMPILER=g95
+    } else {
+        if {[string match *clang* ${configure.cxx}]} {
+            destroot.env-append ESMF_COMPILER=gfortranclang
+        } else {
+            destroot.env-append ESMF_COMPILER=gfortran
+        }
+    }
+    if {[variant_isset mpich] || [variant_isset mpich_devel]} {
+        destroot.env-append ESMF_COMM=mpich2
+    } elseif {[variant_isset openmpi] || [variant_isset openmpi_devel]} {
+        destroot.env-append ESMF_COMM=openmpi
+    } else {
+        destroot.env-append ESMF_COMM=mpiuni
+    }
+}
+
+variant accelerate conflicts atlas description {use Accelerate framework for LAPACK} {
+    depends_lib-append  port:vecLibFort
+}
+
+variant atlas conflicts accelerate description {use Atlas for LAPACK} {
+    depends_lib-append  port:atlas
+}
+
+post-destroot {
+    reinplace "s|${destroot}||g" ${destroot}${prefix}/lib/esmf.mk
+    reinplace "s|-L${worksrcpath}/lib||g" ${destroot}${prefix}/lib/esmf.mk
+    reinplace "s|-I${worksrcpath}/src/Infrastructure/stubs|-I${prefix}/share/esmf/src/Infrastructure/stubs|g" ${destroot}${prefix}/lib/esmf.mk
+    reinplace "s|${worksrcpath}|${prefix}/share/esmf|g" ${destroot}${prefix}/lib/esmf.mk
+    xinstall -d ${destroot}${prefix}/share/${name}
+    file copy ${worksrcpath}/src ${destroot}${prefix}/share/${name}
+    system -W ${destroot}${prefix}/lib "ranlib libesmf.a"
+    system -W ${destroot}${prefix}/lib "ranlib libesmftrace_static.a"
+    file delete ${destroot}${prefix}/lib/preload.sh
+}
+
+# Exclude pre-release candidates
+github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

* Test port for ESMF development versions.

###### Type(s)

- [x] enhancement

###### Tested on

* CI only.  OS 13, 14, 15 only.
* Need merge to test new development branch on i386 builder.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?