### PR TITLE
py-awscli2: update to 2.27.7

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.25.1
+github.setup        aws aws-cli 2.27.7
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  6e21d889f6eb49cad0e1e15a5a3e8328a4fd337b \
-                    sha256  a4a920714ce5e97a9aa7721295342fd9eba448c8da6cf3b22f4a2d2e8cb136c1 \
-                    size    16169434
+checksums           rmd160  70df4d850c8fdcc1c99014d07610d3dc6052b74c \
+                    sha256  4d707565a94ec1add9cd4d824d2143cadbdb6ccb025a488ea1153aee247798f1 \
+                    size    16297977
 
 python.versions     39 310 311 312 313
 python.pep517       yes

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,9 +1,9 @@
 Keep awscrt pinned. This is the only user, and presumably
 Amazon has a good reason for not bumping the version yet.
 
-diff -ru aws-cli-2.22.16-orig/pyproject.toml aws-cli-2.22.16/pyproject.toml
---- aws-cli-2.22.16-orig/pyproject.toml	2024-12-12 20:43:54.480484769 -0500
-+++ aws-cli-2.22.16/pyproject.toml	2024-12-12 20:52:57.202110859 -0500
+diff -ru aws-cli-2.26.5-orig/pyproject.toml aws-cli-2.26.5/pyproject.toml
+--- aws-cli-2.26.5-orig/pyproject.toml	2025-04-19 19:07:31.783354675 -0400
++++ aws-cli-2.26.5/pyproject.toml	2025-04-19 19:08:43.051611599 -0400
 @@ -1,6 +1,6 @@
  [build-system]
  requires = [
@@ -12,8 +12,8 @@ diff -ru aws-cli-2.22.16-orig/pyproject.toml aws-cli-2.22.16/pyproject.toml
  ]
  build-backend = "pep517"
  backend-path = ["backends"]
-@@ -30,25 +30,23 @@
-     'Programming Language :: Python :: 3.12',
+@@ -30,21 +30,21 @@
+     "Programming Language :: Python :: 3.13",
  ]
  dependencies = [
 -    "colorama>=0.2.5,<0.4.7",
@@ -28,17 +28,13 @@ diff -ru aws-cli-2.22.16-orig/pyproject.toml aws-cli-2.22.16/pyproject.toml
      # less than or equal to Python 3.10. In order to ensure we have
      # a consistent dependency closure across all Python versions,
      # we explicitly include ruamel.yaml.clib as a dependency.
--    "ruamel.yaml.clib>=0.2.0,<=0.2.8",
+-    "ruamel.yaml.clib>=0.2.0,<=0.2.12",
 -    "prompt-toolkit>=3.0.24,<3.0.39",
 -    "distro>=1.5.0,<1.9.0",
--    "awscrt==0.23.8",
+-    "awscrt==0.26.1",
 -    "python-dateutil>=2.1,<=2.9.0",
 -    "jmespath>=0.7.1,<1.1.0",
 -    "urllib3>=1.25.4,<1.27",
--    # zipp>=3.21.0 dropped support for Python 3.8. In order to ensure
--    # we have a consistent dependency closure across all Python
--    # versions, we explicitly include zipp as a dependency.
--    "zipp<3.21.0",
 +    "ruamel.yaml.clib",
 +    "prompt-toolkit",
 +    "distro",
@@ -46,8 +42,6 @@ diff -ru aws-cli-2.22.16-orig/pyproject.toml aws-cli-2.22.16/pyproject.toml
 +    "python-dateutil",
 +    "jmespath",
 +    "urllib3",
-+    # MacPorts py-import-lib-metadata has the zipp dependency that
-+    # was specified in here.
  ]
  dynamic = ["version"]
 

--- a/python/py-awscrt/Portfile
+++ b/python/py-awscrt/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-awscrt
 # This is only used by awscli2. Bump when Amazon bumps
 # their pinned version in awscli2's setup.cfg.
-version             0.23.8
+version             0.26.1
 revision            0
 
 categories-append   devel
@@ -18,9 +18,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  475537bce85d14c773cad867a6109048ba24577d \
-                    sha256  cba55f3ee80ea3192a0a24e84caad778570250800a59d29ef9efbcd4d1612f2f \
-                    size    77078798
+checksums           rmd160  79eaf6221328d060e699f4b3eb3d795bef53eb1f \
+                    sha256  a8d63a7dcc6484c5c1675b31a8d1b6726c3dc85b13796fb143dfb0072260935e \
+                    size    77265756
 
 python.versions     39 310 311 312 313
 

--- a/python/py-prompt_toolkit/Portfile
+++ b/python/py-prompt_toolkit/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-prompt_toolkit
 version             3.0.51
-revision            0
+revision            1
 
 license             BSD
 platforms           {darwin any}
@@ -25,6 +25,13 @@ checksums           rmd160  11647715062e9aedbdaa985e8366052b181b5242 \
 if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-wcwidth
+
+    patchfiles      patch-importlib-metadata.diff
+
+    post-patch {
+        reinplace -W ${worksrcpath} "s|@@MP_VERSION@@|${version}|g" \
+            src/prompt_toolkit/__init__.py
+    }
 
     test.run        yes
 

--- a/python/py-prompt_toolkit/files/patch-importlib-metadata.diff
+++ b/python/py-prompt_toolkit/files/patch-importlib-metadata.diff
@@ -1,0 +1,11 @@
+--- src/prompt_toolkit/__init__.py	2025-05-04 16:24:22.796628843 -0400
++++ src/prompt_toolkit/__init__.py	2025-05-04 16:24:50.914891133 -0400
+@@ -29,7 +29,7 @@
+ from .shortcuts import PromptSession, print_formatted_text, prompt
+
+ # Don't forget to update in `docs/conf.py`!
+-__version__ = metadata.version("prompt_toolkit")
++__version__ = '@@MP_VERSION@@'
+
+ assert pep440.match(__version__)
+


### PR DESCRIPTION
#### Description

Patching prompt_toolkit in this way gets awscli2 working for now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4 24E248 x86_64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
