### PR TITLE
boost18{1,7}: add and default to python313

### DIFF
--- a/devel/boost181/Portfile
+++ b/devel/boost181/Portfile
@@ -275,7 +275,7 @@ post-destroot {
     }
 }
 
-set pythons_versions {2.7 3.9 3.10 3.11 3.12}
+set pythons_versions {2.7 3.9 3.10 3.11 3.12 3.13}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {
@@ -320,7 +320,7 @@ foreach v ${pythons_versions} {
 }
 
 if {![variant_isset debug]} {
-    set selected_python python312
+    set selected_python python313
     foreach v ${pythons_versions} {
         set s [string map {. {}} ${v}]
         if {[variant_isset python${s}]} {
@@ -357,7 +357,7 @@ variant no_single description {Disable building single-threaded libraries} {
 }
 
 subport ${name}-numpy {
-    revision 6
+    revision 7
     description Boost.Numpy library
     long_description {*}${description}
     depends_lib port:boost${tag}
@@ -382,7 +382,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 12
+    revision 13
 
     patchfiles-append patch-disable-numpy-extension.diff
 

--- a/devel/boost187/Portfile
+++ b/devel/boost187/Portfile
@@ -248,7 +248,7 @@ post-destroot {
     }
 }
 
-set pythons_versions {2.7 3.9 3.10 3.11 3.12}
+set pythons_versions {2.7 3.9 3.10 3.11 3.12 3.13}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {
@@ -293,7 +293,7 @@ foreach v ${pythons_versions} {
 }
 
 if {![variant_isset debug]} {
-    set selected_python python312
+    set selected_python python313
     foreach v ${pythons_versions} {
         set s [string map {. {}} ${v}]
         if {[variant_isset python${s}]} {
@@ -330,7 +330,7 @@ variant no_single description {Disable building single-threaded libraries} {
 }
 
 subport ${name}-numpy {
-    revision 0
+    revision 1
     description Boost.Numpy library
     long_description {*}${description}
 
@@ -355,7 +355,7 @@ subport ${name}-numpy {
 }
 
 if {$subport eq $name} {
-    revision 0
+    revision 1
 
     patchfiles-append patch-disable-numpy-extension.diff
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
