### PR TITLE
iverilog: fix implicit declaration error

### DIFF
--- a/science/iverilog/Portfile
+++ b/science/iverilog/Portfile
@@ -2,11 +2,15 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
+
+# strndup
+legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        steveicarus iverilog 20250103 s
 github.tarball_from archive
 
-revision            0
+revision            1
 set major           12
 set minor           0
 
@@ -46,6 +50,9 @@ configure.args-append --enable-libvvp
 configure.ldflags-append -Wl,-rpath,${prefix}/lib
 
 patchfiles-append patch-vvp-Makefile.in.diff
+
+# main.c:1065:17: error: implicit declaration of function '_NSGetExecutablePath' [-Wimplicit-function-declaration]
+patchfiles-append patch-fix-headers.diff
 
 platform darwin {
     #under MacOS, this is needed, the library references were incorrect as-is

--- a/science/iverilog/files/patch-fix-headers.diff
+++ b/science/iverilog/files/patch-fix-headers.diff
@@ -1,0 +1,13 @@
+--- driver/main.c.orig
++++ driver/main.c
+@@ -81,6 +81,10 @@
+ extern const char*optarg;
+ #endif
+ 
++#if defined(__APPLE__)
++#include <mach-o/dyld.h>
++#endif
++
+ #if !defined(WIFEXITED)
+ # define WIFEXITED(rc) ((rc&0x7f) == 0)
+ #endif


### PR DESCRIPTION
* fix build on macOS <10.7

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
