### PR TITLE
esmf: Fix builds for 10.6

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -42,6 +42,14 @@ github.tarball_from archive
 # Patch copied from upstream patch by @barracuda156.
 patchfiles-append   patch-task_vm_info_missing.diff
 
+# Fix builds for 10.6.
+# Upstream fix after ESMF version 8.8.1 is pending.
+# Remove this patch on next release after 8.8.1.
+# Fixes "error: missing terminating ' character".
+# This is actually a preprocessor bug that breaks only in
+# Clang 11 and other early Clang versions.
+patchfiles-append   patch.FieldEmpty_cppF90.diff
+
 depends_build       bin:ranlib:cctools
 
 depends_lib         port:netcdf \

--- a/science/esmf/files/patch.FieldEmpty_cppF90.diff
+++ b/science/esmf/files/patch.FieldEmpty_cppF90.diff
@@ -1,0 +1,65 @@
+--- src/Infrastructure/Field/src/ESMF_FieldEmpty.cppF90.orig	2025-04-17 15:58:54
++++ src/Infrastructure/Field/src/ESMF_FieldEmpty.cppF90	2025-05-06 15:34:33
+@@ -4403,14 +4403,14 @@
+   ! Get pointer to internal Field
+   ftypep => field%ftypep
+ 
+-  ! Get field's current status
++  ! Get current status of field
+   currStatus=ftypep%status
+ 
+   ! Change Field based on current status and new status
+   if (currStatus == ESMF_FIELDSTATUS_EMPTY) then
+ 
+      if (setStatus == ESMF_FIELDSTATUS_EMPTY) then
+-         ! Don't do anything, since no change in status
++         ! Do not do anything, since no change in status
+      else if (setStatus == ESMF_FIELDSTATUS_GRIDSET) then
+         call ESMF_LogSetError(rcToCheck=ESMF_RC_ARG_WRONG, &
+              msg="a Field can't be reset to be more complete than its current status.", &
+@@ -4437,11 +4437,11 @@
+         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+              ESMF_CONTEXT, rcToReturn=rc)) return
+ 
+-        ! Set flag back to it's inital setting
++        ! Set flag back to its inital setting
+         ftypep%geomb_internal = .false.
+ 
+      else if (setStatus == ESMF_FIELDSTATUS_GRIDSET) then
+-         ! Don't do anything, since no change in status
++         ! Do not do anything, since no change in status
+      else if (setStatus == ESMF_FIELDSTATUS_COMPLETE) then
+         call ESMF_LogSetError(rcToCheck=ESMF_RC_ARG_WRONG, &
+              msg="a Field can't be reset to be more complete than its current status.", &
+@@ -4463,7 +4463,7 @@
+         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+              ESMF_CONTEXT, rcToReturn=rc)) return
+ 
+-        ! Set Array internal flag back to it's inital setting
++        ! Set Array internal flag back to its inital setting
+         ftypep%array_internal = .false.
+ 
+         ! Destroy Geometry
+@@ -4471,7 +4471,7 @@
+         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+              ESMF_CONTEXT, rcToReturn=rc)) return
+ 
+-        ! Set geom internal flag back to it's inital setting
++        ! Set geom internal flag back to its inital setting
+         ftypep%geomb_internal = .false.
+ 
+      else if (setStatus == ESMF_FIELDSTATUS_GRIDSET) then
+@@ -4481,11 +4481,11 @@
+         if (ESMF_LogFoundError(localrc, ESMF_ERR_PASSTHRU, &
+              ESMF_CONTEXT, rcToReturn=rc)) return
+ 
+-        ! Set Array internal flag back to it's inital setting
++        ! Set Array internal flag back to its inital setting
+         ftypep%array_internal = .false.
+ 
+      else if (setStatus == ESMF_FIELDSTATUS_COMPLETE) then
+-         ! Don't do anything, since no change in status
++         ! Do not do anything, since no change in status
+      else
+         call ESMF_LogSetError(rcToCheck=ESMF_RC_ARG_WRONG, &
+              msg="unknown status type", &


### PR DESCRIPTION
#### Description

* Fixes "error: missing terminating ' character".
* This is actually a preprocessor bug that breaks only in Clang 11 and other early Clang versions.
* Clang CPP does not correctly handle fortran comment lines containing unbalanced quote characters such as ('), ("), etc.
* Upstream fix after ESMF version 8.8.1 is pending.
* Upstream details: https://github.com/orgs/esmf-org/discussions/400
* Build fixes only, no rev bump is needed.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  MacOS 13, 14, 15 only.

* Waiting on merge to retest 10.6 builds.
* Only comment lines in fortran code were changed, so testing is minimal.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

CC:  @barracuda156