### PR TITLE
pinact: Update to 3.1.0-0

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.0.5 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.1.0-0 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,9 +16,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d449b6e92951d2ab8515b6d408ce3b40daeb9018 \
-                    sha256  557a82924dabad35faec3c649a18ec09130220f58610e9a925f5e33da6a9f2b1 \
-                    size    32718
+                    rmd160  b0d087fb6221b4f7534cba6cc99380b1d0d77851 \
+                    sha256  f6a8faf155b85e18be29fe1b6bfd39b35cd8bda8d7adbefd2727787e27a5fec2 \
+                    size    36343
 
 build.args-append   -ldflags \"-X main.version=${version} -X main.commit=MacPorts \" \
                     ./cmd/pinact
@@ -36,6 +36,7 @@ notes {
 }
 
 
+
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
                         rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
@@ -51,31 +52,41 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  febd99ac1a9d727290c467b44d1e4b6b90cf7c7d \
                         sha256  fe8e1d49b2c470afa75311e5336594399227ddbb272cb0fb3dbef77efea30d63 \
                         size    8974449 \
+                    golang.org/x/term \
+                        lock    v0.31.0 \
+                        rmd160  9955bd92d2cc8266fab627e129f4f17cbf1ec66a \
+                        sha256  62582c2da67b0726f8a32170383edc9ca3bc63bf67e72a4508a76f7cfd072f9e \
+                        size    14905 \
                     golang.org/x/sys \
-                        lock    v0.29.0 \
-                        rmd160  0e6e5b718d234eea0fe889a67ce06d5ecd1be27d \
-                        sha256  ec9757aa9994bbc9a94472b49e3258eb2384d5c0c1c5e70c0bb945643fcba0f8 \
-                        size    1520458 \
+                        lock    v0.32.0 \
+                        rmd160  be748f58461f9537913e1ce3b69815e4a7e4c8c6 \
+                        sha256  82c933346569d1a26b3ca51991dc2dd805f6ae4e55b5a1da8bc19ca0c204da34 \
+                        size    1526498 \
                     golang.org/x/oauth2 \
-                        lock    v0.29.0 \
-                        rmd160  3aa27d6d9a21c67a223a71829fc181750274f912 \
-                        sha256  8b466b5b749df3a959b2d9c386b16dc6a846ecf837c4be6d34963b5277c7df62 \
-                        size    99266 \
+                        lock    v0.30.0 \
+                        rmd160  63353a82f136c21da2c2613e3393b724d52b6f92 \
+                        sha256  259d504972689aef6ba45f2ca479d462524e0803a0104735262c94a5ad3b1da2 \
+                        size    100393 \
+                    github.com/zalando/go-keyring \
+                        lock    v0.2.6 \
+                        rmd160  4ba7f2321fbcb2c4cb00917dc7f25129b91a0278 \
+                        sha256  fb0173e112a8eb22835b740fdce707e27e7938adceaa2cb0a063a078a0169c25 \
+                        size    11944 \
                     github.com/wk8/go-ordered-map \
                         lock    v2.1.8 \
                         rmd160  3b679491f631b4900bfe3169517517b2731ebc35 \
                         sha256  c7caff4ba164feeebdcc568d6598931a20719827e05dfa18ac7d7c495d36b883 \
                         size    20797 \
                     github.com/urfave/cli \
-                        lock    v3.1.1 \
-                        rmd160  cdb8c38c49211c80fe9b3479e3e6570ca4b3db2a \
-                        sha256  bafc806faca3ad2f5b314a3405382ca690ecd691cfc9dd4bbbccb3abc62222f4 \
-                        size    6788461 \
+                        lock    v3.3.2 \
+                        rmd160  e94bc7b255d5cea87598ffa74b9d270de0fb9bdb \
+                        sha256  e2a1cae8a67ea295dfcc9293726eb1c55025b4d01897cdedeca890c0e27337d5 \
+                        size    6801176 \
                     github.com/suzuki-shunsuke/urfave-cli-v3-util \
-                        lock    v0.0.2 \
-                        rmd160  b77048cea055451ce1cb0646ebd318056c967b4c \
-                        sha256  033e202202ab1d25a741025d7d6f2f512f24d34d60499c06a378cddbd1b9d4f7 \
-                        size    7760 \
+                        lock    v0.0.4 \
+                        rmd160  79a3caab2c0f86d15f21cf81ef041bd3c190e3bd \
+                        sha256  9303b5a5238c8c8c84dcc89ea1ddb43057398905cc7e5ffb5725602b93d997a8 \
+                        size    9238 \
                     github.com/suzuki-shunsuke/logrus-error \
                         lock    v0.1.4 \
                         rmd160  d52b0d1f07e0dde083a4deaea70d508880b724ba \
@@ -91,6 +102,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  43f142561513d8f10ce4971bf91cabbad9a021cc \
                         sha256  be33d85711f2b92b7269a39574af64701ed5b2c4e4446547ea75ea046ec97629 \
                         size    112769 \
+                    github.com/stretchr/objx \
+                        lock    v0.5.2 \
+                        rmd160  96ffcde8897243df89c8da1084cb84c90eb72676 \
+                        sha256  39661f2a3eb998c52776126d166556a804fa18bf7e2d7e4dc73e20cd25d3145c \
+                        size    33242 \
                     github.com/spf13/afero \
                         lock    v1.14.0 \
                         rmd160  95180c509220d8ffdd6cfd9f9ca708ae3be7b1a5 \
@@ -131,6 +147,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  f17baae769838015801830335bfd94a0849cd21f \
                         sha256  70f6404c7d3d3dc84133e1e9870af211c526934cc49cabe1965ddd8982554cb7 \
                         size    17088 \
+                    github.com/google/shlex \
+                        lock    e7afc7fbc510 \
+                        rmd160  4e505c7f96adfae0b23fe7f4d7d3d12cd39beb52 \
+                        sha256  d72b457eb90c286cca39c51f2d60ba241351cbad49f9980e30c43a15b2f09b34 \
+                        size    7342 \
                     github.com/google/go-querystring \
                         lock    v1.1.0 \
                         rmd160  d74c139ec42fee88039b05bd10924f560467fac7 \
@@ -146,6 +167,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  3f04a79c291d786f9c69c2944bdd521402052a5c \
                         sha256  b621b304b529134076c9ebe09343aea7add039cd98e68be7e5a616245b0c3d03 \
                         size    105180 \
+                    github.com/godbus/dbus \
+                        lock    v5.1.0 \
+                        rmd160  c9b400a865c27debfcc741f2f2c18f088125c91d \
+                        sha256  870c356aa2ab1d1ea7f18afef3cfc4f5a4795c66c3d542e309f5dfa0e21a1be1 \
+                        size    74088 \
                     github.com/goccy/go-yaml \
                         lock    v1.17.1 \
                         rmd160  7f85a843b0f541b5d327d7f882a53ee345f60e6f \
@@ -156,6 +182,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
+                    github.com/danieljoos/wincred \
+                        lock    v1.2.2 \
+                        rmd160  d2adcbee01a5b95a6f9283b466b9c5bce0db2aa4 \
+                        sha256  b0fa81e39529e855316fd9c97a4234fcd09abec8a3ca422d6154806ee9d7d81a \
+                        size    10040 \
                     github.com/buger/jsonparser \
                         lock    v1.1.1 \
                         rmd160  35ad9d7a60f9fec3b2eb38c0b2f0268e421a0a5e \
@@ -165,5 +196,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         lock    v0.2.0 \
                         rmd160  da4b9f58b6734da97644fb565c81d1bc01ccd7f7 \
                         sha256  aaa6a0719258985eddfa488155edd6a749c070a998d91c48182138115f5de069 \
-                        size    5054
+                        size    5054 \
+                    al.essio.dev/pkg/shellescape \
+                        repo    github.com/alessio/shellescape \
+                        lock    v1.5.1 \
+                        rmd160  3c6b1f0ae382d2bc2cdcc548259249af862a3966 \
+                        sha256  4270818b93dbc43ffbfecd02806fb850634f474b0704e14a39b12a2dde896106 \
+                        size    9969
 


### PR DESCRIPTION
#### Description

pinact: Update to 3.1.0-0

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
