### PR TITLE
google-cloud-sdk: update to 521.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             520.0.0
+version             521.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3599b9ecd369b0f751e8cfae8520be3ab3c4a44a \
-                    sha256  4bd6839fea1ff521e48069a9ecd859cbd8b7c18b24acce3f5d1b893184c22ab3 \
-                    size    53816761
+    checksums       rmd160  e9b56ce60f89e45928249db3a90820b86f6d13ce \
+                    sha256  947d9bdb51a7980a12d8b40b7a3f4e42e9abe0b16e5a69471f09674276b7ddff \
+                    size    53848919
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  25a8ce625f80e2f5497183da4d47ae769fbb0dec \
-                    sha256  fce9d1d2b4d45136b6ed32985f44fc8101426dcf043b7d27af8527160314b8ea \
-                    size    55286749
+    checksums       rmd160  db6c522a3fbbc8a6aecf992a3bab0a04a5b71b16 \
+                    sha256  9e0838c41c98052c0e15c03697f1c3a8b03faac1722dff3e9188eba76310e7e2 \
+                    size    55317632
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  21a184b3a3543cc0657781aebad96030f1631c8f \
-                    sha256  5c1b793c7938e84185d9abc61a68508f6b74396d26a34426368b7c6254bd2481 \
-                    size    55225375
+    checksums       rmd160  41ca172436e2187e6b03a1f2514af92c397ee963 \
+                    sha256  765c5a2cf2bcb91cbd6180fedec715fad9d53c461057727b74abb646fe0d2760 \
+                    size    55256856
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 521.0.0.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?