### PR TITLE
ghostscript: update to 10.05.1

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                ghostscript
-version             10.05.0
+version             10.05.1
 revision            0
 
 categories          print
@@ -32,9 +32,9 @@ distfiles           ${distname}.tar.gz:source \
                     ${mappingresources_commit}.zip:misc
 
 checksums           ${distname}.tar.gz \
-                    rmd160  cff18f243131d666e127f4aee0801f6325a67f97 \
-                    sha256  1ee32af7183e6a1c7909f847c8045956b792c4c24bedfa2b9c0d0394241a7460 \
-                    size    98829869 \
+                    rmd160  d9dca9baac0c5b897f21eed1d39b66d9448f4d81 \
+                    sha256  c0be073366d19471320dce13e210b4c47e14b01070d6cf3d2d6d6e8415344615 \
+                    size    98843388 \
                     ghostscript-fonts-other-6.0.tar.gz \
                     rmd160  ab60dbf71e7d91283a106c3df381cadfe173082f \
                     sha256  4fa051e341167008d37fe34c19d241060cd17b13909932cd7ca7fe759243c2de \


### PR DESCRIPTION
#### Description

Simple upgrade to upstream version 10.05.1
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 x86_64
Command Line Tools 16.3.0.0.1.1742442376


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
