### PR TITLE
openjdk25-zulu: update to 25.0.33

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.31
-set build    15
+version      ${feature}.0.33
+set build    19
 revision     0
 
 set openjdk_version ${feature}.0.0
@@ -37,14 +37,14 @@ use_zip yes
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_x64
-    checksums    rmd160  fa5e9cb5029e7c189719bda9cfa900eafa19d990 \
-                 sha256  1430844cf3bc63e0aa0e7b860d1eb5c20b2b90a32b6e245ee973250285a59e3a \
-                 size    227746627
+    checksums    rmd160  4c2f59e869717f8c0c4d0d5d6d97826f51e12527 \
+                 sha256  39002b14953f1c090461adcb1064e0278a1347b1668e955235e520b16dfd644c \
+                 size    227762850
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_aarch64
-    checksums    rmd160  85dbd5d8ca624e0278a592f039c4bbd337a3b626 \
-                 sha256  2b459cf4c9d504e4f6dbaec5811d37a03da71ed9082c052fc4e53f8f05e91e09 \
-                 size    225286637
+    checksums    rmd160  79877f50c4a4e328362b11df1d9c224d5674c2d0 \
+                 sha256  a14e18def8c3f12381dab9ad32e046223a8db49972abb3a217be5f6faf5d7699 \
+                 size    225272117
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.0.33.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?