### PR TITLE
libpng: update to 1.6.48

### DIFF
--- a/graphics/libpng/Portfile
+++ b/graphics/libpng/Portfile
@@ -4,11 +4,11 @@ PortSystem              1.0
 PortGroup               muniversal 1.0
 
 name                    libpng
-version                 1.6.47
+version                 1.6.48
 revision                0
-checksums               rmd160  571eca398708c705e6cbbd228b5ff73472dca778 \
-                        sha256  b213cb381fbb1175327bd708a77aab708a05adde7b471bc267bd15ac99893631 \
-                        size    1054664
+checksums               rmd160  c5b898a1fa5b575654d0a4368a32f4d2c11309a2 \
+                        sha256  46fd06ff37db1db64c0dc288d78a3f5efd23ad9ac41561193f983e20937ece03 \
+                        size    1054968
 
 set branch              [join [lrange [split ${version} .] 0 1] ""]
 categories              graphics
@@ -31,8 +31,7 @@ long_description        Libpng was written as a companion to the PNG \
                         understand. Currently, this library only supports C. \
                         Support for other languages is being considered.
 
-master_sites            sourceforge:project/${name}/${name}${branch}/${version} \
-                        ftp://ftp.simplesystems.org/pub/libpng/png/src/${name}${branch}/
+master_sites            sourceforge:project/${name}/${name}${branch}/${version}
 
 depends_lib             port:zlib
 


### PR DESCRIPTION
* remove the abandoned mirror from master_sites (no updates since 2019)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
