### PR TITLE
dagger: update to 0.18.6

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.5 v
+github.setup        dagger dagger 0.18.6 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  634dcec471900f5d196af6f672ff3b00cdc26aed \
-                            sha256  7f837852e7a737b7e327c458c60957401ab4b7287a4a6ed1ba56f6f2419e8040 \
-                            size    18746924
+        checksums           rmd160  50817194d57b7ab62f28fbd13d97bb498d8512f6 \
+                            sha256  96f74fe60e909c35134fb5c4aa7db020ac2cd5d6538af607ec10c72a58eae00e \
+                            size    18753539
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  a364d9c5c078cdeeecf31483ff23c4d9d04631a6 \
-                            sha256  846d9ede28b34fae044a0e9d686ceafdb76e1ca1b2a27afb14b3ea7903cd2c19 \
-                            size    17918966
+        checksums           rmd160  fa67c5e3f5aca300be7a896160107f55e6e5750b \
+                            sha256  cc64126ea4555285a812fa826ad15feaa4e8c578ec2f6c8531875c47013fd51e \
+                            size    17927121
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Update to the current version.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
