### PR TITLE
luash: Disable upstream, fetch from MacPorts

### DIFF
--- a/shells/luash/Portfile
+++ b/shells/luash/Portfile
@@ -22,9 +22,10 @@ homepage                http://luaforge.net/projects/luash
 master_sites            macports_distfiles
 distname                ${name}
 dist_subdir             ${name}/${version}
-checksums               md5     67bbb8985166579686361fe840e016c0 \
-                        sha1    ef1d56843f19a29b96f6d5ce8f983b54074b955f \
-                        rmd160  165d88850e8d068d7586f1785b36dd20c9c8ce37
+
+checksums               rmd160  165d88850e8d068d7586f1785b36dd20c9c8ce37 \
+                        sha256  40ed9a86924fead319be3be966426f844a4ef7b5cb73425e5fe930daa6970634 \
+                        size    15927
 
 use_bzip2               yes
 


### PR DESCRIPTION
#### Description

* Fetch from macports_distfiles only.  Upstream site is broken.
* Remove unnecessary platforms line.
* Use modern checksums, fix lint.
* Minor whitespace fixes.
* Fetch fix only.  No rev bump needed.
* Fixes missing build for Sequoia.

Closes: https://trac.macports.org/ticket/72434

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?