### PR TITLE
openjdk21-openj9: update to 21.0.7

### DIFF
--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -20,11 +20,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.6
+version      ${feature}.0.7
 revision     0
 
-set build    7
-set openj9_version 0.49.0
+set build    6
+set openj9_version 0.51.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -34,14 +34,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  45ad9737a5cdcd2dbf079b6290d00bd453d15332 \
-                 sha256  4b28782f35a963845f8cb10f6b70ca803bfbefce0375a1aa77b24b7575a76c06 \
-                 size    225212007
+    checksums    rmd160  912d089ea87fee04e6273e86dcee6f70dcfac8af \
+                 sha256  e94f088eefdbe13275ea58797c0c013d382ede0eccddd5a04688c7c7641983cc \
+                 size    226481090
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  9b7d36c9c83f1b407727d556ca4dbf173646121c \
-                 sha256  7c8b65a0ecbdbde913f1096e839e5c5b48cd4175e33daa4a919ebabad82acb3b \
-                 size    218412220
+    checksums    rmd160  bfeb981db486c4e563260fd7823c5572d3d6e2d5 \
+                 sha256  ab206843f70ee1cf80a048bc651f445ea113b567ba0c440a70a1381e4681dc24 \
+                 size    220141326
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 21.0.7.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?