### PR TITLE
openjdk11-openj9: update to 11.0.27

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -15,11 +15,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.26
+version      ${feature}.0.27
 revision     0
 
-set build    4
-set openj9_version 0.49.0
+set build    6
+set openj9_version 0.51.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -29,14 +29,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  7d41306d7c13efc20263c77de4ba3406be0811bd \
-                 sha256  2afb6848775d18bd9591f19e169f8071bdc63d19d9695f3cdff6cc5b690801e0 \
-                 size    208227426
+    checksums    rmd160  4900ffb79525e8de7d4004bf3fb8d968a012f40a \
+                 sha256  bfb748db4246d0b78554f461f6e4fe7909c0a4c595ec7a7535a287dc3ab3feaa \
+                 size    207960615
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  dda54239733767f3e26fce1270b90d1df402e540 \
-                 sha256  69c393fb7a9b916309198b94f8d60741b8224b718bba72d662cb1932830aafa8 \
-                 size    202442196
+    checksums    rmd160  927df8fa8035542e68bb165a28037ef1f6e2709c \
+                 sha256  93bda5ae950cc2fba34803b059ad13db567f50ea2d8b7a635d39c3bc330a4890 \
+                 size    201938561
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.27.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?