### PR TITLE
openjdk8-openj9: update to 8u452

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -20,11 +20,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
-version      ${feature}u442
+version      ${feature}u452
 revision     0
 
-set build    06
-set openj9_version 0.49.0
+set build    09
+set openj9_version 0.51.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -35,9 +35,9 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  9f2f003bf628952319805dfca9117a865d7f9c60 \
-             sha256  1ba4cf33aacdde9e08a805099d107d994dd3fbb1fd87a468f74ca71337593bae \
-             size    130740309
+checksums    rmd160  1bc27eada9d15e1d287156345379539e35496aa3 \
+             sha256  04ce03f6b8f914821425a1c118bd20d4d9f014346efe1592f78fd91ff4345de4 \
+             size    129528649
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8u452.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?