### PR TITLE
mise: Update to 2025.5.2

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.5.1 v
+github.setup        jdx mise 2025.5.2 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  35a98079685322f15a3ceaeed01015a8a98e3c71 \
-                    sha256  b6584c19918e1fc821f7cce10f0d58ccfe55fe4f525050ac5f249565e7b25bad \
-                    size    4161262
+                    rmd160  3a84db652d29d287e49f7b9588c428dcb63615f7 \
+                    sha256  7f25802b23c229a1bc0c5d63723fb8acd7a3781c888cbd81e04e0ea3d3476f9c \
+                    size    4161252
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -113,7 +113,7 @@ cargo.crates \
     async-trait                     0.1.88  e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
-    backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
+    backtrace                       0.3.75  6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002 \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     base64ct                         1.7.3  89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3 \
@@ -164,7 +164,7 @@ cargo.crates \
     console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     constant_time_eq                 0.3.1  7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6 \
-    contracts                        0.6.5  f096aae9f0af6a1f5801c5b4142c9381d0f3d5ba548fe0f7ce798299e736fd31 \
+    contracts                        0.6.6  dc486fc59d4d0e52ea0b4461a12720c8617338c9ee955cc4013fb7319d264abd \
     cookie-factory                   0.3.3  9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2 \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
     core-foundation                 0.10.0  b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63 \
@@ -381,8 +381,8 @@ cargo.crates \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
-    jiff                            0.2.12  d07d8d955d798e7a4d6f9c58cd1f1916e790b42b092758a9ef6e16fef9f1b3fd \
-    jiff-static                     0.2.12  f244cfe006d98d26f859c7abd1318d85327e1882dc9cef80f62daeeb0adcf300 \
+    jiff                            0.2.13  f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806 \
+    jiff-static                     0.2.13  f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48 \
     jiff-tzdb                        0.1.4  c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524 \
     jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jobserver                       0.1.33  38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a \
@@ -394,7 +394,7 @@ cargo.crates \
     lazy-regex-proc_macros           3.4.1  4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     libc                           0.2.172  d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa \
-    libm                            0.2.14  a25169bd5913a4b437588a7e3d127cd6e90127b60e0ffbd834a38f1599e016b8 \
+    libm                            0.2.15  f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     libz-rs-sys                      0.5.0  6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
@@ -519,7 +519,7 @@ cargo.crates \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     rops                             0.1.5  5c830d8ae5c50ef149e290235ef564ac84d97181dce248ae30706cfaf1d3e7cc \
     rowan                          0.15.16  0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d \
-    rust-embed                       8.7.0  e5fbc0ee50fcb99af7cebb442e5df7b5b45e9460ffa3f8f549cd26b862bec49d \
+    rust-embed                       8.7.1  60e425e204264b144d4c929d126d0de524b40a961686414bab5040f7465c71be \
     rust-embed-impl                  8.7.0  6bf418c9a2e3f6663ca38b8a7134cc2c2167c9d69688860e8961e3faa731702e \
     rust-embed-utils                 8.7.0  08d55b95147fe01265d06b3955db798bdaed52e60e2211c41137701b3aba8e21 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
@@ -528,11 +528,11 @@ cargo.crates \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                           1.0.7  c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266 \
-    rustls                         0.23.26  df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0 \
+    rustls                         0.23.27  730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.11.0  917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c \
-    rustls-webpki                  0.103.1  fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03 \
+    rustls-webpki                  0.103.2  7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437 \
     rustversion                     1.0.20  eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2 \
     ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     salsa20                         0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
@@ -620,7 +620,7 @@ cargo.crates \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                          1.9.0  09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.44.2  e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48 \
+    tokio                           1.45.0  2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165 \
     tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                    0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
@@ -675,7 +675,7 @@ cargo.crates \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
     versions                         7.0.0  80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f \
-    vfox                             1.0.1  7a932a911ab6acdcb7d20c481cdbf7eea562ef209c6d1e13204c78a9549e58a3 \
+    vfox                             1.0.2  041f3a5f7c0b20a5e649a0e3719b7cbf86d6d07869e6e5bcafee6afd043fec5f \
     vte                             0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
@@ -689,7 +689,8 @@ cargo.crates \
     wasm-bindgen-shared            0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
     web-sys                         0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-roots                   0.26.10  37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93 \
+    webpki-roots                   0.26.11  521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9 \
+    webpki-roots                     1.0.0  2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb \
     which                            7.0.3  24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762 \
     widestring                       1.2.0  dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
@@ -730,7 +731,7 @@ cargo.crates \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
     winnow                          0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
-    winnow                           0.7.9  d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3 \
+    winnow                          0.7.10  c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.5.2

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
