### PR TITLE
ruby-build: Update to 20250507

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250430 v
+github.setup        rbenv ruby-build 20250507 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  da35e1a554c894abf69204b0aa66c85f8e67aaf1 \
-                    sha256  06e2a934f84102ed6aff430d73c76f2051c70d8aecd4d3b3dfb94f71e790f986 \
-                    size    96521
+checksums           rmd160  d2525218c298c3abdf42254f920a653966be7860 \
+                    sha256  59992f934dccb48d2547969efd3075a5338617e02a5bff8c566ca1e51b6d349d \
+                    size    96694
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250507

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
