### PR TITLE
rtl_433: Update to 25.02

### DIFF
--- a/science/rtl_433/Portfile
+++ b/science/rtl_433/Portfile
@@ -5,26 +5,33 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 epoch               1
-github.setup        merbanan rtl_433 21.12
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        merbanan rtl_433 25.02
+github.tarball_from archive
 revision            0
 
 categories          science comms
 license             GPL-2
-maintainers         {@ducksauz duksta.org:john} openmaintainer
+maintainers         nomaintainer
 
 description         RTL-SDR 433.92 MHz generic data receiver
-long_description    rtl_433 turns your Realtek RTL2832 based DVB dongle into a 433.92 MHz generic data receiver
+long_description    rtl_433 turns your Realtek RTL2832 based DVB dongle \
+                    into a 433.92 MHz generic data receiver
 
-checksums           rmd160  2610e3882d83877c291f9a2cef421e03470135b1 \
-                    sha256  8bc1866f61f8c2b4f6140c7b9ce159187e5ab821ecfba1ae2e35cde34423b8b9 \
-                    size    954737
+checksums           rmd160  255a8154784c2c46aafa2a500e0ceb560ed9c7b1 \
+                    sha256  5a409ea10e6d3d7d4aa5ea91d2d6cc92ebb2d730eb229c7b37ade65458223432 \
+                    size    1125144
 
-depends_build-append \
-                    port:pkgconfig
+cmake.out_of_source yes
+cmake.generator     Ninja
 
-depends_lib-append  path:lib/pkgconfig/libusb-1.0.pc:libusb \
+# Settings recommended for MacOS, in docs/BUILDING.md:
+
+depends_lib-append  port:openssl \
                     port:rtl-sdr \
                     port:SoapySDR
 
+configure.args-append \
+                    -DENABLE_RTLSDR=ON \
+                    -DENABLE_SOAPYSDR=ON \
+                    -DENABLE_OPENSSL=ON \
+                    -DBUILD_DOCUMENTATION=OFF


### PR DESCRIPTION
#### Description

* Update 21.12 --> 25.02.
* Add OpenSSL option and dependency.
* Update dependencies.
* Update cmake controls.
* Remove retired maintainer.  Switch to nomaintainer.

Closes: https://trac.macports.org/ticket/69940

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants]