### PR TITLE
nlohmann-json: Update to 3.12.0

### DIFF
--- a/devel/nlohmann-json/Portfile
+++ b/devel/nlohmann-json/Portfile
@@ -5,7 +5,7 @@ PortSystem                      1.0
 PortGroup                       github  1.0
 PortGroup                       cmake   1.1
 
-github.setup                    nlohmann json 3.11.3 v
+github.setup                    nlohmann json 3.12.0 v
 github.tarball_from             archive
 revision                        0
 name                            nlohmann-json
@@ -18,9 +18,9 @@ description                     Nlohmann JSON for modern C++.
 long_description                Nlohmann is a header-only (and optionally single-header) JSON library \
                                 written in vanilla C++11. Has Unicode support\; DOM and SAX parsers, among other features.
 
-checksums                       rmd160  f4ccb4fffcc2f0226250977ee688bdf640ea2c64 \
-                                sha256  0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406 \
-                                size    8053705
+checksums                       rmd160  60aaa23d50680673a0999513b515f883ee414008 \
+                                sha256  4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187 \
+                                size    9678593
 
 compiler.cxx_standard           2011
 


### PR DESCRIPTION
#### Description

* Update 3.11.3 --> 3.12.0.
* Obtain bug fixes.

###### Tested on

macOS 14.6.1
Xcode 16.2
Command Line Tools 16.2.0
SDK 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -s install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?