### PR TITLE
qemu: Fix compilation when macfuse is installed

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
 version                 10.0.0
-revision                0
+revision                1
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -145,7 +145,8 @@ configure.args-append   --disable-cocoa \
                         --enable-vdi \
                         --enable-virtfs \
                         --enable-vvfat \
-                        --enable-fdt=system
+                        --enable-fdt=system \
+                        --disable-fuse
 
 # Use 'smbd' installed by samba port, rather than macOS; latter does not work with qemu.
 configure.args-append   --smbd=${prefix}/sbin/smbd
@@ -274,6 +275,11 @@ variant ssh description {Support remote block devices over SSH} {
 variant dbus description {Export the VM display through D-Bus} {
     configure.args-replace  --disable-dbus-display --enable-dbus-display
     configure.args-append   --enable-modules
+}
+
+variant fuse description {Support exporting block devices via FUSE} {
+    configure.args-replace  --disable-fuse --enable-fuse
+    depends_lib-append      port:macfuse
 }
 
 # Default universal variant does not work


### PR DESCRIPTION
#### Description

- Since [macfuse was bumped from 4.8.3 to 4.9.1](https://github.com/macports/macports-ports/commit/fc4bb96dd6ef5bb8b056391a9997db3f7e84ea87) building `qemu` with fuse support (enabled by auto-detection of fuse headers) fails compilation (some header mismatch). The fuse support only enables relative less used functionality to 'export block device using fuse loopback driver'.
- Add new variant `fuse`, disabled by default
  - Workaround only, compilation bug still exists.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.7.5 23H527 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? 
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
