### PR TITLE
qemu: update to 10.0.0

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -8,7 +8,7 @@ PortGroup               legacysupport               1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
-version                 9.2.2
+version                 10.0.0
 revision                0
 categories              emulators
 license                 GPL-2+
@@ -26,13 +26,12 @@ homepage                https://www.qemu.org
 master_sites            https://download.qemu.org/
 use_xz                  yes
 
-checksums               rmd160  79458545fadc4ec3bcf76919dd7ce55b2719329c \
-                        sha256  752eaeeb772923a73d536b231e05bcc09c9b1f51690a41ad9973d900e4ec9fbf \
-                        size    134756816
+checksums               rmd160  ec3d3294e2f8e8d84c5e9fcf5ee2ed3138753689 \
+                        sha256  22c075601fdcf8c7b2671a839ebdcef1d4f2973eb6735254fd2e1bd0f30b3896 \
+                        size    135618260
 
-set py_version          313
-set py_branch           \
-    [string index ${py_version} 0].[string range ${py_version} 1 end]
+set py_branch           3.13
+set py_version          [string replace ${py_branch} 1 1]
 
 depends_build-append    port:texinfo \
                         port:libtool \


### PR DESCRIPTION
#### Description

- Bump version to 10.0.0
  - Closes: https://trac.macports.org/ticket/72413
- Simplify definition of default `py_branch`  and `py_version`

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

- macOS 14.7.5 23H527 arm64
  Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
