### PR TITLE
openjdk21-jetbrains: update to 21.0.7-b982.16

### DIFF
--- a/java/openjdk21-jetbrains/Portfile
+++ b/java/openjdk21-jetbrains/Portfile
@@ -3,12 +3,12 @@
 PortSystem       1.0
 PortGroup        github 1.0
 
-set openjdk_version 21.0.6
-set jbr_version b895.91
+set feature 21
+set openjdk_version ${feature}.0.7
+set jbr_version b982.16
 github.setup     JetBrains JetBrainsRuntime ${openjdk_version}${jbr_version} jbr-release-
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-name             openjdk21-jetbrains
+github.tarball_from archive
+name             openjdk${feature}-jetbrains
 categories       java devel
 maintainers      {danchr @danchr} openmaintainer
 
@@ -25,7 +25,7 @@ universal_variant no
 # https://github.com/JetBrains/JetBrainsRuntime/releases
 supported_archs  x86_64 arm64
 
-description      JetBrains Runtime on OpenJDK 21
+description      JetBrains Runtime on OpenJDK ${feature}
 long_description JetBrains Runtime is a fork of OpenJDK available for \
                  Windows, Mac OS X, and Linux. It supports enhanced \
                  class redefinition (DCEVM), features optional JCEF, a \
@@ -41,14 +41,14 @@ use_bzip2        no
 
 if {${configure.build_arch} eq "x86_64"} {
     set jbr_arch x64
-    checksums    rmd160  8ffb1dc048376433e3b32d3d307fc0af84079658 \
-                 sha256  5102b756229869fe115b2016dbf25cc652ea6a99a72b1757eac774a8a5809997 \
-                 size    86574740
+    checksums    rmd160  588cf91628a8d058ca7931e992ade8df3089f50e \
+                 sha256  4b53fc37039a6ca0c67a4b5cb9cb4cfdea5efcfcbeb85d76853cead464f847d9 \
+                 size    86606463
 } else {
     set jbr_arch aarch64
-    checksums    rmd160  bad985bf2298df2152b8762851b4024921160f35 \
-                 sha256  52f1c30698528ceaa8eb3e25c20478c6305eee3e279bff518a989097f56138eb \
-                 size    85466158
+    checksums    rmd160  54008e782e2edb8cdbaa7bdd788b354fe7e8d9fb \
+                 sha256  5eee11e32591c76a4d6e55cc62713a96f3418f3e657b900177e6bfcc21a039d7 \
+                 size    85503301
 }
 
 distname         jbr-${openjdk_version}-osx-${jbr_arch}-${jbr_version}


### PR DESCRIPTION
#### Description

Update to JetBrains Runtime 21.0.7-b982.16.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?