### PR TITLE
pdfjam: update to 4.2

### DIFF
--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            rrthomas pdfjam 3.12 v
+github.setup            rrthomas pdfjam 4.2 v
 categories              textproc pdf
 maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 license                 GPL-2
@@ -22,9 +22,9 @@ long_description \
 
 github.tarball_from     releases
 
-checksums               rmd160  2422c5a576a5dbcf38745213d85b6a281672847f \
-                        sha256  c8c227d10abd0e787c1c2da290bb5ddb77c19eebfd434649e8cbb2c5152feb31 \
-                        size    162802
+checksums               rmd160  7db7ff4d8e5910bfa816d68951bbea0234cb2398 \
+                        sha256  528d7b2eec8461b9ee9cea1d06a117c7ecfa306cf1191d09d64419122464dd89 \
+                        size    34419
 
 depends_run \
     bin:pdflatex:texlive-latex \
@@ -33,7 +33,7 @@ depends_run \
 post-patch {
     reinplace "s|/usr/local|${prefix}|g" \
         ${worksrcpath}/bin/pdfjam \
-        ${worksrcpath}/man1/pdfjam.1 \
+        ${worksrcpath}/man/pdfjam.1 \
         ${worksrcpath}/README.md
 }
 
@@ -46,10 +46,10 @@ test.args   --version
 
 destroot {
     xinstall -m 755 ${worksrcpath}/bin/pdfjam ${destroot}${prefix}/bin/pdfjam
-    xinstall -m 644 ${worksrcpath}/man1/pdfjam.1 ${destroot}${prefix}/share/man/man1/pdfjam.1
+    xinstall -m 644 ${worksrcpath}/man/pdfjam.1 ${destroot}${prefix}/share/man/man1/pdfjam.1
     xinstall -m 644 ${worksrcpath}/pdfjam.conf ${destroot}${prefix}/etc/pdfjam.conf.sample
 
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 -W ${worksrcpath} COPYING README.md VERSION \
+    xinstall -m 644 -W ${worksrcpath} COPYING README.md VERSION-${version} \
        ${destroot}${prefix}/share/doc/${name}
 }


### PR DESCRIPTION
#### Description

Update to pdfjam 4.2.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?