### PR TITLE
osxphotos: update to 0.70.0

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.69.2
+version                 0.70.0
 revision                0
 
 categories              graphics python
@@ -25,9 +25,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  93f49070fa4ff370101fcbb4da450acfcf431ee3 \
-                        sha256  ea6d431b9cea6ea4eede6079419e48a586149daca88937db121073e73306d47f \
-                        size    2234555
+checksums               rmd160  c54e0a6bc1d7f3a8191ced4cf8d503001e5a2b26 \
+                        sha256  9fc8b45667bdcc67452f9c05ea79ef3b1ba5035e6dec13178269e6b03799e4e4 \
+                        size    2238375
 
 python.default_version  313
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.70.0.

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?