### PR TITLE
mbtileserver: update to 0.11.0

### DIFF
--- a/gis/mbtileserver/Portfile
+++ b/gis/mbtileserver/Portfile
@@ -3,9 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/consbio/mbtileserver 0.10.0 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+go.setup            github.com/consbio/mbtileserver 0.11.0 v
 revision            0
 categories          gis
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -15,9 +13,9 @@ description         A simple Go-based server for map tiles stored in mbtiles for
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  cf00a2e47794b3457a3d3ef808d95acb5409328f \
-                        sha256  a4f38c0bdd8da27c74406fd9d85bdc61eb35312a0ec0d0aa983f4f9f7eaf91b6 \
-                        size    1509505
+                        rmd160  1fb37b88f1080475b098bf1f2476cb43ebc9307b \
+                        sha256  6ad18d67a8f46421f332eb7ee9b3ce1f9410a24cd3563e1eeb863b64d0db69c3 \
+                        size    1519146
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
@@ -25,30 +23,30 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
                         size    91208 \
                     golang.org/x/time \
-                        lock    v0.3.0 \
-                        rmd160  1db54fc6608ef07cc574d51db48fabe595579ade \
-                        sha256  2cc1d4590e17f17f5198c1b5a9f2830104bbd0427fb54a5374f6f7d3c6b35096 \
-                        size    12217 \
+                        lock    v0.6.0 \
+                        rmd160  a8649c7469cbb459e8241757c6a614fdcb1ccdeb \
+                        sha256  603182a18e9d5e0522081e6b783b72b7f819ecfb6773d9e1ea91b3e791202fa3 \
+                        size    12222 \
                     golang.org/x/text \
-                        lock    v0.13.0 \
-                        rmd160  41adfd8809cec3b7d0d885c1d698bc2a0d73ab1c \
-                        sha256  b499b39462b190a30882184132b47afb02c2c76ee9fee315c0aebe477c4b8354 \
-                        size    8964803 \
+                        lock    v0.18.0 \
+                        rmd160  3e5a1cb8e141cf12ec79d1eab772321e81b07a60 \
+                        sha256  6e7c97372c202ad9843ff3c45d8e945b2dfecb31ada4d3271e8022e54f833bb9 \
+                        size    8972482 \
                     golang.org/x/sys \
-                        lock    v0.13.0 \
-                        rmd160  6105681bf18684d55835bd5ba9b20f599488c623 \
-                        sha256  f35bdc78f45a0bab73411b3c117b134ae68eed96eb301f719f873fbbcd8abf33 \
-                        size    1442708 \
+                        lock    v0.25.0 \
+                        rmd160  55d28e9a063084b6785b7f62b304ec1d1a20a0a5 \
+                        sha256  b73bf6a693f6ead22a333323731ab80d829685cab4e98e3e9c0bc1e3eb9e5d58 \
+                        size    1507013 \
                     golang.org/x/net \
-                        lock    v0.17.0 \
-                        rmd160  3e1d150fbede0be1af1b248e536930de2446ef0e \
-                        sha256  6bb73c8f9eef753cab2b18d4af7893ff955b4427c6d34c8f4d7c9127d09abcc0 \
-                        size    1456371 \
+                        lock    v0.29.0 \
+                        rmd160  4ada27f7775af13a883cbc920781c6d38cf9af91 \
+                        sha256  9f52b3e3bb6aca1f9d43c767f9b9c5ede7074e2bfa2fde783ecc5e0acb342354 \
+                        size    1454733 \
                     golang.org/x/crypto \
-                        lock    v0.14.0 \
-                        rmd160  e47babd382d1c75f56ec60a945361dc7b7dc2c5a \
-                        sha256  673dbcc180bdbf773569fbff655915b5040200bb9b5f919e1cc3521b387b5ed2 \
-                        size    1797771 \
+                        lock    v0.27.0 \
+                        rmd160  225a4defa0e0ed4e5125bbb5eebf3181126bdea6 \
+                        sha256  8d2bf88cb3dd9064daebeb93dfa4d051c40bd218bf6bc12b78e972540a574e41 \
+                        size    1845066 \
                     github.com/valyala/fasttemplate \
                         lock    v1.2.2 \
                         rmd160  c341ee599972d95a7f9235fc4886ac9d7466d600 \
@@ -70,10 +68,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
                         size    50815 \
                     github.com/spf13/cobra \
-                        lock    v1.7.0 \
-                        rmd160  2d0592a4c5aca1ba5daa45cd1d4e662adadd0703 \
-                        sha256  913afd358ab699baf7773e7a5661c9f6436c6f825da2a1d61623e69d2c0b4b2d \
-                        size    187188 \
+                        lock    v1.8.1 \
+                        rmd160  a735ec73fa26b66076a971e066513fff3eb7e367 \
+                        sha256  49ca05093e0452e1b56be8a0765e23fd74be819228f0e1870c759b2e2e8178da \
+                        size    192387 \
                     github.com/sirupsen/logrus \
                         lock    v1.9.3 \
                         rmd160  db211aeb52d4a85a7dc8acf83f7475b5f4fa9092 \
@@ -100,15 +98,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
                         size    9778 \
                     github.com/labstack/gommon \
-                        lock    v0.4.0 \
-                        rmd160  82475913c42536c4bc63fbe34115179c473e1dfc \
-                        sha256  18193f7f4461c6e5c182785fc7975f75822aac8612f6efa68183f875ba1d3be0 \
-                        size    13205 \
+                        lock    v0.4.2 \
+                        rmd160  8a70dd4ea78c19450ac9d05db2c30528d2559e0f \
+                        sha256  ed7cd57a20028e1c40a88138590570bceb339d69550ce02be01a7a8b2c43eb17 \
+                        size    14095 \
                     github.com/labstack/echo \
-                        lock    v4.11.2 \
-                        rmd160  ef3e040f7eae559312e9dd50a7b7b38f0a1c4b1a \
-                        sha256  b10c0f0f7be3c24d3e931ce3a693f614835bac3e415549c4f2db5e55f09fbb4b \
-                        size    398846 \
+                        lock    v4.12.0 \
+                        rmd160  5a166e01bc9e767f6bfcc16d6e51287f9b350ea7 \
+                        sha256  ee0bac7112beec5bcc9b6af5bc56e26383f4df61031f01de54bf8522f53cfa63 \
+                        size    404124 \
                     github.com/inconshreveable/mousetrap \
                         lock    v1.1.0 \
                         rmd160  88f9577df93ac0f8801d8960adc7f28e38867f3e \
@@ -125,10 +123,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  690d7813db5510d0dc739335dc950519c6664cc47ce49029e9c817f4a0c896c1 \
                         size    19245 \
                     github.com/fsnotify/fsnotify \
-                        lock    v1.6.0 \
-                        rmd160  2d5150222f41b06715da40ebdceafb183979bd07 \
-                        sha256  af0e2b174dd969ee214e5899eb499fec5a75f5319ab4c810256f6018649b2a2c \
-                        size    46049 \
+                        lock    v1.7.0 \
+                        rmd160  9198dec094f5008a8b24a2e51542ce4ec3453162 \
+                        sha256  d7cd46fbc8e25bfd37edb1b86851dcccc18c5180f09e533c6a35e4dcf2693d22 \
+                        size    57508 \
                     github.com/evalphobia/logrus_sentry \
                         lock    v0.8.2 \
                         rmd160  d51b09200a328f2f66ee9f12c7973b9c9abcfb70 \
@@ -145,10 +143,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  a06bb1869b1ef9fa2253eaaffc738deed98535e65c04b5fea6e03cbfb5879ec0 \
                         size    121737 \
                     github.com/brendan-ward/mbtiles-go \
-                        lock    6c48cea51706 \
-                        rmd160  4691fe3bdaffcd2b6099218eab137c1f38315f0c \
-                        sha256  d250995718af6d9425a74b83264bf65c2f85ee2b736667c9e05394f6b8419f7f \
-                        size    1235647 \
+                        lock    v0.2.0 \
+                        rmd160  dc723a2ab0379b7c534cc066c24e2b88618561ce \
+                        sha256  3042936b50f058b17910fe4f5a03df7ad518bcd98db0189af0a8f57dbff77823 \
+                        size    1235773 \
                     crawshaw.io/sqlite \
                         repo    github.com/crawshaw/sqlite \
                         lock    d1964889ea3c \


### PR DESCRIPTION
#### Description
https://github.com/consbio/mbtileserver/releases/tag/v0.11.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
