### PR TITLE
jc: update to 1.25.5

### DIFF
--- a/sysutils/jc/Portfile
+++ b/sysutils/jc/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    jc
-version                 1.25.4
+version                 1.25.5
 revision                0
 
 homepage                https://pypi.org/project/jc
@@ -23,9 +23,9 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
 supported_archs         noarch
 platforms               {darwin any}
 
-checksums               rmd160  d909270f559f5e07c6820022463f86de561a78e7 \
-                        sha256  a32eaf029c56b582dadae48895f20784d0f84f2fa28a8e2b32f377a8bffa8b39 \
-                        size    587475
+checksums               rmd160  fdfd300c3a93da9fe3d05790d03b601c8b786efd \
+                        sha256  f8ac0e4bc427b0ee8a3bdb07a254cc9df6b6036cd440f6c425e2e519cdbda78a \
+                        size    594042
 
 python.default_version  312
 


### PR DESCRIPTION
#### Description
https://github.com/kellyjonbrazil/jc/releases/tag/v1.25.5

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
