### PR TITLE
libayatana-indicator: Fix build with glib2 +quartz

### DIFF
--- a/devel/libayatana-indicator/Portfile
+++ b/devel/libayatana-indicator/Portfile
@@ -19,6 +19,10 @@ github.tarball_from archive
 # https://github.com/AyatanaIndicators/libayatana-indicator/pull/76
 patchfiles          0001-Fix-build-on-macOS.patch
 
+# Fix build with glib2 +quartz
+# https://github.com/AyatanaIndicators/libayatana-indicator/pull/77
+patchfiles-append   0001-Remove-unnecessary-gio-gdesktopappinfo.h-include.patch
+
 depends_build-append \
                     path:bin/pkg-config:pkgconfig \
                     path:bin/vala:vala

--- a/devel/libayatana-indicator/files/0001-Remove-unnecessary-gio-gdesktopappinfo.h-include.patch
+++ b/devel/libayatana-indicator/files/0001-Remove-unnecessary-gio-gdesktopappinfo.h-include.patch
@@ -1,0 +1,29 @@
+From cee3c3ab0817783e85f150ad5120d2ce9860a124 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Florian=20M=C3=A4rkl?= <info@florianmaerkl.de>
+Date: Fri, 9 May 2025 18:27:51 +0200
+Subject: [PATCH] Remove unnecessary gio/gdesktopappinfo.h include
+
+This was introduced in 5d7fbff4c97779922efe03268deaf669a5a4eaa8 but the
+code using it was removed in 0312ffa2d621b398462659429a7c2b778da93ca8 so
+it is not necessary anymore now. Moreover, this header is not
+available when glib is compiled with cocoa so it would break the build
+in such cases.
+---
+ src/indicator-desktop-shortcuts.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git src/indicator-desktop-shortcuts.c src/indicator-desktop-shortcuts.c
+index be1d632..99a687a 100644
+--- src/indicator-desktop-shortcuts.c
++++ src/indicator-desktop-shortcuts.c
+@@ -25,7 +25,6 @@ License along with this library. If not, see
+ #include "config.h"
+ #endif
+ 
+-#include <gio/gdesktopappinfo.h>
+ #include "indicator-desktop-shortcuts.h"
+ 
+ #define ACTIONS_KEY               "Actions"
+-- 
+2.49.0
+


### PR DESCRIPTION
#### Description

The `gdesktopappinfo.h` header does not exist in glib2 +quartz, but is also not needed by libayatana-indicator. See also https://github.com/AyatanaIndicators/libayatana-indicator/pull/77

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
