### PR TITLE
Bear: update to 3.1.6, update dependencies

### DIFF
--- a/devel/Bear/Portfile
+++ b/devel/Bear/Portfile
@@ -9,14 +9,13 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 19
 legacysupport.use_mp_libcxx                 yes
 
-github.setup        rizsotto Bear 3.1.5
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        rizsotto Bear 3.1.6
+github.tarball_from archive
 revision            0
 
-checksums           rmd160  15a2c3369693c1ec3b14f82cf483fbc0a214c100 \
-                    sha256  2b3ac2fe04f76999083db604fbe25743c95548ce73e3148036e50e80d3d1026b \
-                    size    152222
+checksums           rmd160  41ff322cdbc0c5f15adf17193b586c3dad441230 \
+                    sha256  99cd891eec6e89b734d7cafe0e623dd8c2f27d8cbf3ee9bc4807e69e5c8fb55c \
+                    size    170892
 
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-3+

--- a/devel/Bear/Portfile
+++ b/devel/Bear/Portfile
@@ -31,7 +31,7 @@ long_description    {*}${description} \
 
 patchfiles          patch-spdlog-header-only.diff
 
-set port_libfmt     libfmt9
+set port_libfmt     libfmt10
 cmake.module_path-append \
                     ${prefix}/lib/${port_libfmt}/cmake
 
@@ -40,14 +40,13 @@ compiler.cxx_standard 2017
 
 depends_build-append \
                     port:pkgconfig \
-                    port:spdlog \
                     port:nlohmann-json \
+                    port:spdlog
 
 depends_lib-append  port:abseil \
                     port:grpc \
                     port:${port_libfmt} \
-                    port:protobuf3-cpp \
-                    port:re2
+                    port:protobuf3-cpp
 
 configure.args-append \
                     -DENABLE_UNIT_TESTS=Off \


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
