### PR TITLE
astroid: update to 0.17

### DIFF
--- a/mail/astroid/Portfile
+++ b/mail/astroid/Portfile
@@ -6,10 +6,9 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           boost 1.0
 
-github.setup        astroidmail astroid 0.15 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-revision            6
+github.setup        astroidmail astroid 0.17 v
+github.tarball_from archive
+revision            0
 
 description         Astroid Mail
 long_description    A graphical threads-with-tags style, lightweight and fast, e-mail client for Notmuch
@@ -19,9 +18,9 @@ categories          mail
 homepage            https://astroidmail.github.io/
 license             GPL-3+ LGPL-2.1+
 
-checksums           rmd160  a7babb6609724a7b8fe950bc1321ee61b2af7609 \
-                    sha256  0eb8a5d9d6f48eb79a64a35e7dc0919ee0d20c3104c0f7b2c2d185c6ec24df34 \
-                    size    3365848
+checksums           rmd160  da08c298ba82fc96d6007d3784e49d6403d4922a \
+                    sha256  dd419d4e11d1efa95979472e17cca5066799a5c64a595d5cea2b9e8d9f60f9c8 \
+                    size    3371728
 
 compiler.cxx_standard 2014
 compiler.blacklist-append {clang < 800}


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
