### PR TITLE
protozero: update to 1.8.0

### DIFF
--- a/devel/protozero/Portfile
+++ b/devel/protozero/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        mapbox protozero 1.7.1 v
+github.setup        mapbox protozero 1.8.0 v
 github.tarball_from archive
-revision            2
+revision            0
 
 categories          devel
 platforms           any
@@ -26,9 +26,9 @@ long_description    Low-level: this is designed to be a building block \
                     generated with the Google Protobufs protoc \
                     program.
 
-checksums           rmd160  291b36bd4139c30caa08322abd084abaced6f518 \
-                    sha256  27e0017d5b3ba06d646a3ec6391d5ccc8500db821be480aefd2e4ddc3de5ff99 \
-                    size    1123468
+checksums           rmd160  edf02636352117603b6d2935e3ccc2ae2e4ce57f \
+                    sha256  d95ca543fc42bd22b8c4bce1e6d691ce1711eda4b4910f7863449e6517fade6b \
+                    size    1124292
 
 compiler.cxx_standard 2011
 


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
