### PR TITLE
archivemount: fix building against new fuse3

### DIFF
--- a/fuse/archivemount/Portfile
+++ b/fuse/archivemount/Portfile
@@ -25,5 +25,27 @@ checksums               rmd160  5cfc50492f53074c902663d7b2d3cfbffeee31dd \
 
 depends_lib-append      port:libarchive
 
+post-patch {
+    reinplace "s|-std=c++2b|-std=gnu++2b|" ${worksrcpath}/Makefile
+}
+
+configure.cppflags-append \
+                        -DFUSE_DARWIN_ENABLE_EXTENSIONS=0
+
 compiler.cxx_standard   2020
 build.args-append       VERSION=${version}
+
+variant fs_link description "Link ${name} to a .fs bundle in /Library/Filesystems" {
+    post-destroot {
+        set dir /Library/Filesystems/${name}.fs/Contents/Resources
+        xinstall -d ${destroot}${dir}
+        ln -s ${prefix}/bin/${name} ${destroot}${dir}/mount_${name}
+    }
+
+    destroot.violate_mtree \
+                        yes
+
+    notes-append "
+        With +fs_link, you may use \'mount -t ${name}\' and use ${name} in /etc/fstab.
+    "
+}


### PR DESCRIPTION
add fs_link variant

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
