### PR TITLE
mosh: minor enhancements

### DIFF
--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -5,7 +5,7 @@ PortGroup               perl5 1.0
 
 name                    mosh
 version                 1.4.0
-revision                2
+revision                3
 categories              net
 license                 {GPL-3+ OpenSSLException}
 maintainers             {mit.edu:quentin @quentinmit} \
@@ -44,8 +44,14 @@ post-patch {
         ${worksrcpath}/scripts/mosh.pl
 }
 
-#protobuf3-cpp requires c++11 now
-configure.cxxflags-append -std=c++11
+# https://github.com/protocolbuffers/protobuf/issues/9947
+configure.cflags-append   -DNDEBUG
+
+# avoid overlinking abseil
+configure.ldflags-append  -Wl,-dead_strip_dylibs
+
+# abseil uses C++17; use `gnu++17` as Mosh allows use of GNU extensions
+configure.cxxflags-append -std=gnu++17
 
 # force protobuf3-cpp into the no_threadlocal mode on older systems
 if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
@@ -62,11 +68,9 @@ if {${os.platform} eq "darwin" && ${os.major} > 11} {
                         --with-crypto-library=openssl
 }
 
-post-destroot {
-    xinstall -d ${destroot}${prefix}/etc/bash_completion.d
-    copy ${worksrcpath}/conf/bash-completion/completions/mosh \
-         ${destroot}${prefix}/etc/bash_completion.d/mosh
-}
+configure.args-append \
+                    --enable-completion \
+                    --disable-silent-rules
 
 livecheck.type          regex
 livecheck.url           ${homepage}


### PR DESCRIPTION
#### Description
Adds compilation flags to:

- Avoid overlinking against abseil
- Use C++17 (`gnu++17`)
- Install bash completions without the need for a `post-destroot` block

The only critical change is the second one mentioned above. This is necessary for the port to build successfully after `protobuf3-cpp` gets updated (#28321).

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
