### PR TITLE
imposm: update to 0.14.2

### DIFF
--- a/gis/imposm/Portfile
+++ b/gis/imposm/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/omniscale/imposm3 0.14.1 v
+go.setup            github.com/omniscale/imposm3 0.14.2 v
 go.offline_build    no
 name                imposm
 revision            0
@@ -15,9 +15,9 @@ description         Imposm imports OpenStreetMap data into PostGIS
 long_description    {*}${description}
 homepage            https://imposm.org/
 
-checksums           rmd160  bddcf43fbcbb14f0fae459d126ef0166d9a088b2 \
-                    sha256  aec2a5e95929891afa5cb68cfa9f6b1bf326c949a002d36f3171ed194f99fc0a \
-                    size    2351043
+checksums           rmd160  0ecc48fabdc81a9bc557235d3141e5b39cd64e34 \
+                    sha256  dc779a274a7ec7e86ffdb97c881b6410f82a6d21924d08b9ed0785d2cf266113 \
+                    size    2348921
 
 depends_lib-append  port:geos \
                     port:leveldb


### PR DESCRIPTION
#### Description
https://github.com/omniscale/imposm3/releases/tag/v0.14.2

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
