### PR TITLE
virglrenderer: Avoid binary when libepoxy is +quartz

### DIFF
--- a/graphics/virglrenderer/Portfile
+++ b/graphics/virglrenderer/Portfile
@@ -5,12 +5,13 @@
 PortSystem          1.0
 PortGroup           gitlab 1.0
 PortGroup           meson 1.0
+PortGroup           active_variants 1.1
 
 gitlab.instance     https://gitlab.freedesktop.org
 gitlab.setup        slp virglrenderer 0.10.4b "" -krunkit
 distname            ${gitlab.project}-${gitlab.version}${gitlab.tag_suffix}
 
-revision            0
+revision            1
 
 categories          graphics
 license             MIT
@@ -40,6 +41,30 @@ depends_lib         port:libepoxy \
 configure.args \
             -Dvenus=true \
             -Drender-server=false
+
+# This port builds different depending on whether libepoxy is installed +x11 or
+# +quartz. If libepoxy is +quartz and virglrenderer is installed from a binary,
+# it fails to run because it expects an X11-specific symbol in libepoxy that
+# isn't there.
+#
+# Add empty variants that do nothing but ensure this port is built with the
+# same variants as libepoxy, and that a binary isn't used when libepoxy +quartz
+# is installed.
+variant x11 conflicts quartz {
+    require_active_variants libepoxy x11 quartz
+}
+
+variant quartz conflicts x11 {
+    require_active_variants libepoxy quartz x11
+}
+
+# If libepoxy is installed with +quartz, automatically default to using +quartz
+# for this port. Otherwise, default to +x11.
+if {![catch {set result [active_variants libepoxy quartz x11]}] && $result} {
+    default_variants +quartz
+} elseif {![variant_isset quartz]} {
+    default_variants +x11
+}
 
 # TODO: Any tests?
 # TODO: Currently this Portfile is only for the variant required for use in libkrun. There should (maybe) be a normal variant and then a +krunkit or +libkrun variant which is the equivalent of this. Look at that later, just get krunkit working for now.


### PR DESCRIPTION
#### Description

libvirglrenderer.1.dylib fails when it is installed from a binary archive compiled on the buildserver against libepoxy +x11, but the user has libepoxy +quartz installed:

```
Termination Reason:    Namespace DYLD, Code 4 Symbol missing
Symbol not found: _epoxy_glXChooseFBConfig
Referenced from: <44D61F46-2561-3257-886E-71513200EEFC> /opt/local/lib/libvirglrenderer.1.dylib
Expected in:     <789F52DB-263C-319B-B70E-560271F22A8F> /opt/local/lib/libepoxy.0.dylib
```

Rebuilding virglrenderer locally fixes this, but we should prevent the use of the binary archive in this situation to avoid breakage on a user's system.

Introduce empty `+x11` and `+quartz` variants and automatically switch the default variant based on the one chosen for libepoxy.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140
ramalama version 0.8.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
