### PR TITLE
Postgresql{13..17}: update to newest versions

### DIFF
--- a/databases/postgresql13-doc/Portfile
+++ b/databases/postgresql13-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql13-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc \
                     postgresql12-doc postgresql14-doc postgresql15-doc
-version             13.20
+version             13.21
 revision            0
 categories          databases
 platforms           any
@@ -24,9 +24,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql13
 
-checksums           rmd160  1c263ce84754d31cbd3e13358708730dc0311979 \
-                    sha256  8134b685724d15e60d93bea206fbe0f14c8295e84f1cc91d5a3928163e4fb288 \
-                    size    21730844
+checksums           rmd160  5e30f9419c3d0a5bea241b6dffc86a0536fde104 \
+                    sha256  dcda1294df45f033b0656cf7a8e4afbbc624c25e1b144aec79530f74d7ef4ab4 \
+                    size    21759813
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql13-server/Portfile
+++ b/databases/postgresql13-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql13-server
-version             13.20
+version             13.21
 categories          databases
 platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql13/Portfile
+++ b/databases/postgresql13/Portfile
@@ -5,9 +5,8 @@ PortGroup compilers 1.0
 PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
 
-#remember to update the -doc and -server as well
 name                postgresql13
-version             13.20
+version             13.21
 revision            0
 
 categories          databases
@@ -27,9 +26,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
                     postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  1c263ce84754d31cbd3e13358708730dc0311979 \
-                    sha256  8134b685724d15e60d93bea206fbe0f14c8295e84f1cc91d5a3928163e4fb288 \
-                    size    21730844
+checksums           rmd160  5e30f9419c3d0a5bea241b6dffc86a0536fde104 \
+                    sha256  dcda1294df45f033b0656cf7a8e4afbbc624c25e1b144aec79530f74d7ef4ab4 \
+                    size    21759813
 
 use_bzip2           yes
 
@@ -140,9 +139,9 @@ variant python27 conflicts python3 description {add support for python 2.7} {
 }
 
 variant python3 conflicts python27 description {add support for python 3.x} {
-    depends_lib-append      port:python39
+    depends_lib-append      port:python313
     configure.args-append   --with-python
-    configure.python        ${prefix}/bin/python3.9
+    configure.python        ${prefix}/bin/python3.13
 }
 
 variant perl description {add Perl support} {
@@ -157,17 +156,12 @@ variant tcl description {add Tcl support} {
 }
 
 variant llvm description {add support for JIT compilation} {
-    set llvm_ver 11
+    set llvm_ver 20
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
             set clang_port_ver [string range ${clang} 5 6]
-
-            if { ${clang_port_ver} >= 50 } {
-                set llvm_ver [string index ${clang} end-1].[string index ${clang} end]
-            } else {
-                set llvm_ver ${clang_port_ver}
-            }
+            set llvm_ver ${clang_port_ver}
         }
     }
 

--- a/databases/postgresql14-doc/Portfile
+++ b/databases/postgresql14-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql14-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc \
                     postgresql12-doc postgresql13-doc postgresql15-doc
-version             14.17
+version             14.18
 revision            0
 categories          databases
 platforms           any
@@ -24,9 +24,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql14
 
-checksums           rmd160  58f979d80e63ad5b340570619634489ba8b7f3d2 \
-                    sha256  6ce0ccd6403bf7f0f2eddd333e2ee9ba02edfa977c66660ed9b4b1057e7630a1 \
-                    size    22488812
+checksums           rmd160  2f8fb562333968c53c677d99671fba5ca57149e0 \
+                    sha256  83ab29d6bfc3dc58b2ed3c664114fdfbeb6a0450c4b8d7fa69aee91e3ca14f8e \
+                    size    22503241
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql14-server/Portfile
+++ b/databases/postgresql14-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql14-server
-version             14.17
+version             14.18
 categories          databases
 platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -140,9 +140,9 @@ variant python27 conflicts python3 description {add support for python 2.7} {
 }
 
 variant python3 conflicts python27 description {add support for python 3.x} {
-    depends_lib-append      port:python39
+    depends_lib-append      port:python313
     configure.args-append   --with-python
-    configure.python        ${prefix}/bin/python3.9
+    configure.python        ${prefix}/bin/python3.13
 }
 
 variant perl description {add Perl support} {
@@ -157,17 +157,12 @@ variant tcl description {add Tcl support} {
 }
 
 variant llvm description {add support for JIT compilation} {
-    set llvm_ver 13
+    set llvm_ver 20
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
             set clang_port_ver [string range ${clang} 5 6]
-
-            if { ${clang_port_ver} >= 50 } {
-                set llvm_ver [string index ${clang} end-1].[string index ${clang} end]
-            } else {
-                set llvm_ver ${clang_port_ver}
-            }
+            set llvm_ver ${clang_port_ver}
         }
     }
 

--- a/databases/postgresql15-doc/Portfile
+++ b/databases/postgresql15-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql15-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc \
                     postgresql12-doc postgresql13-doc postgresql14-doc
-version             15.12
+version             15.13
 revision            0
 categories          databases
 platforms           any
@@ -24,9 +24,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql15
 
-checksums           rmd160  f3b4728a7f40ce24c9c5c6e15e198200c0975f8d \
-                    sha256  3bc8462a38ca0857270cc88b949a3f6659f0d5c44c029c482355835b61a0f6f7 \
-                    size    23170228
+checksums           rmd160  fd01093d6114c6840572e781e351a4b1d2ae7313 \
+                    sha256  4f62e133d22ea08a0401b0840920e26698644d01a80c34341fb732dd0a90ca5d \
+                    size    23190593
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql15-server/Portfile
+++ b/databases/postgresql15-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql15-server
-version             15.12
+version             15.13
 categories          databases
 platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql15/Portfile
+++ b/databases/postgresql15/Portfile
@@ -132,13 +132,10 @@ if {!${universal_possible} || ![variant_isset universal]} {
     }
 }
 
-variant python requires python3 description {add support for python} {
-}
-
 variant python3 description {add support for python 3.x} {
-    depends_lib-append      port:python310
+    depends_lib-append      port:python313
     configure.args-append   --with-python
-    configure.python        ${prefix}/bin/python3.10
+    configure.python        ${prefix}/bin/python3.13
 }
 
 variant perl description {add Perl support} {
@@ -153,17 +150,12 @@ variant tcl description {add Tcl support} {
 }
 
 variant llvm description {add support for JIT compilation} {
-    set llvm_ver 15
+    set llvm_ver 20
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
             set clang_port_ver [string range ${clang} 5 6]
-
-            if { ${clang_port_ver} >= 50 } {
-                set llvm_ver [string index ${clang} end-1].[string index ${clang} end]
-            } else {
-                set llvm_ver ${clang_port_ver}
-            }
+            set llvm_ver ${clang_port_ver}
         }
     }
 

--- a/databases/postgresql16-server/Portfile
+++ b/databases/postgresql16-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql16-server
-version             16.8
+version             16.9
 revision            0
 categories          databases
 platforms           {darwin any}

--- a/databases/postgresql16/Portfile
+++ b/databases/postgresql16/Portfile
@@ -154,7 +154,7 @@ if {!${universal_possible} || ![variant_isset universal]} {
 variant python3 description {add support for python 3.x} {
     depends_lib-append      port:python311
     configure.args-append   --with-python
-    configure.python        ${prefix}/bin/python3.11
+    configure.python        ${prefix}/bin/python3.13
 }
 
 variant perl description {add Perl support} {
@@ -169,17 +169,12 @@ variant tcl description {add Tcl support} {
 }
 
 variant llvm description {add support for JIT compilation} {
-    set llvm_ver 17
+    set llvm_ver 20
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
             set clang_port_ver [string range ${clang} 5 6]
-
-            if { ${clang_port_ver} >= 50 } {
-                set llvm_ver [string index ${clang} end-1].[string index ${clang} end]
-            } else {
-                set llvm_ver ${clang_port_ver}
-            }
+            set llvm_ver ${clang_port_ver}
         }
     }
 

--- a/databases/postgresql17-server/Portfile
+++ b/databases/postgresql17-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql17-server
-version             17.4
+version             17.5
 revision            0
 categories          databases
 platforms           {darwin any}

--- a/databases/postgresql17/Portfile
+++ b/databases/postgresql17/Portfile
@@ -148,9 +148,9 @@ if {!${universal_possible} || ![variant_isset universal]} {
 }
 
 variant python3 description {add support for python 3.x} {
-    depends_lib-append      port:python312
+    depends_lib-append      port:python313
     configure.args-append   --with-python
-    configure.python        ${prefix}/bin/python3.12
+    configure.python        ${prefix}/bin/python3.13
 }
 
 variant perl description {add Perl support} {
@@ -165,7 +165,7 @@ variant tcl description {add Tcl support} {
 }
 
 variant llvm description {add support for JIT compilation} {
-    set llvm_ver 19
+    set llvm_ver 20
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {


### PR DESCRIPTION
```
Model Identifier: MacPro5,1                 Model Identifier: Macmini6,1
macOS 14.7.5 23H527 x86_64                  macOS 10.15.7 19H2026 x86_64
Xcode 16.2 16C5032a                         Xcode 12.4 12D4e
Command Line Tools 16.2.0.0.1.1733547573    Command Line Tools 12.4.0.0.1.1610135815
```
```
port -cuN -f uninstall postgresql*
for pgsql in {13..17}; do port clean --all postgresql${pgsql}; done
for pgsql in {13..17}; do port -cuN -d install postgresql${pgsql}; done
for pgsql in {13..17}; do port -cuN -d install postgresql${pgsql}-server; done
for pgsql in {13..17}; do port -cuN -d upgrade --enforce-variants postgresql${pgsql} +python3; done
port install -cuN llvm-20
for pgsql in {13..17}; do port -cuN -d upgrade --enforce-variants postgresql${pgsql} +llvm -python3; done
for pgsql in {13..17}; do port -cuN -d upgrade --enforce-variants postgresql${pgsql} +llvm +python3; done
```
update to newest versions
update variant python to python313
update variant llvm to llvm-20
