### PR TITLE
gitleaks: Update to 8.26.0

### DIFF
--- a/security/gitleaks/Portfile
+++ b/security/gitleaks/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/zricethezav/gitleaks 8.25.1 v
+go.setup            github.com/zricethezav/gitleaks 8.26.0 v
 go.package          github.com/zricethezav/gitleaks/v8
 go.offline_build    no
 revision            0
@@ -24,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  bda4c2880a09c928adb950e3d65f0ac860251501 \
-                    sha256  f39df96c18cbd03a38a882cad5e8ae6699d49f374cd63b540c4b5a8cf06beb05 \
-                    size    243460
+checksums           rmd160  0620278d7ef946d2ab877d4b4d05f1e8229493ae \
+                    sha256  08fcf0ec5e7c3e5e8b6c5085df11478c06a4063cb58a64636e74e7f2a2ba903f \
+                    size    248706
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

gitleaks: Update to 8.26.0

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
