### PR TITLE
pinact: Update to 3.1.1

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.1.0-0 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.1.1 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,9 +16,11 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b0d087fb6221b4f7534cba6cc99380b1d0d77851 \
-                    sha256  f6a8faf155b85e18be29fe1b6bfd39b35cd8bda8d7adbefd2727787e27a5fec2 \
-                    size    36343
+                    rmd160  b0c1c84c8093b7bd76ff2456aa4cd675a52c2c1c \
+                    sha256  9988045463cb1769253fe04ed40754c7cee9b267dfd7e381c6c887752d002d45 \
+                    size    36673
+
+livecheck.regex     "v(\\d+\\.\\d+\\.\\d+)\$"
 
 build.args-append   -ldflags \"-X main.version=${version} -X main.commit=MacPorts \" \
                     ./cmd/pinact
@@ -34,6 +36,7 @@ notes {
   If you have an existing .pinact.yaml file, you will need to use pinact 2.2 and run
   'pinact migrate' to fix the pinact configuration file for pinact 3.0.
 }
+
 
 
 
@@ -53,15 +56,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  fe8e1d49b2c470afa75311e5336594399227ddbb272cb0fb3dbef77efea30d63 \
                         size    8974449 \
                     golang.org/x/term \
-                        lock    v0.31.0 \
-                        rmd160  9955bd92d2cc8266fab627e129f4f17cbf1ec66a \
-                        sha256  62582c2da67b0726f8a32170383edc9ca3bc63bf67e72a4508a76f7cfd072f9e \
-                        size    14905 \
-                    golang.org/x/sys \
                         lock    v0.32.0 \
-                        rmd160  be748f58461f9537913e1ce3b69815e4a7e4c8c6 \
-                        sha256  82c933346569d1a26b3ca51991dc2dd805f6ae4e55b5a1da8bc19ca0c204da34 \
-                        size    1526498 \
+                        rmd160  b245db46f202e1df70d376b326aef1afe88b8a7b \
+                        sha256  3dfccbf825f88320abe0dbc0ea98661da62c3b9e5088868b2c736bf708b68a43 \
+                        size    15448 \
+                    golang.org/x/sys \
+                        lock    v0.33.0 \
+                        rmd160  1c0c8967ed410be496af17ad009aacd0fb89034c \
+                        sha256  2564f2911a5c695a9ad5720065ce58783b97a2d2f3fdaa2e8742a44fc0df4e2e \
+                        size    1529295 \
                     golang.org/x/oauth2 \
                         lock    v0.30.0 \
                         rmd160  63353a82f136c21da2c2613e3393b724d52b6f92 \
@@ -83,10 +86,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  e2a1cae8a67ea295dfcc9293726eb1c55025b4d01897cdedeca890c0e27337d5 \
                         size    6801176 \
                     github.com/suzuki-shunsuke/urfave-cli-v3-util \
-                        lock    v0.0.4 \
-                        rmd160  79a3caab2c0f86d15f21cf81ef041bd3c190e3bd \
-                        sha256  9303b5a5238c8c8c84dcc89ea1ddb43057398905cc7e5ffb5725602b93d997a8 \
-                        size    9238 \
+                        lock    v0.0.5 \
+                        rmd160  7790fbae62fea70864b484feb621a785d7b7899e \
+                        sha256  9076093018eba5a9175a63f54a82d0e2889c58e0565e9308c2cc5d8e3adf3cd9 \
+                        size    9236 \
                     github.com/suzuki-shunsuke/logrus-error \
                         lock    v0.1.4 \
                         rmd160  d52b0d1f07e0dde083a4deaea70d508880b724ba \
@@ -158,10 +161,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
                         size    10418 \
                     github.com/google/go-github \
-                        lock    v71.0.0 \
-                        rmd160  29ff4ca0039b79c675f3b02a88fb14883baf1b6c \
-                        sha256  0824925a59c1c602872fb2c43f26147eba7971bc4de5067cf6d301e307ed3cad \
-                        size    815939 \
+                        lock    v72.0.0 \
+                        rmd160  ca4ecae25d3837f8c8b445fc8d731653c59649ce \
+                        sha256  a6de1954f2dad7fcaf36ff6191a0696162cab65c5b4cfbc958129a587ee0212f \
+                        size    815113 \
                     github.com/google/go-cmp \
                         lock    v0.7.0 \
                         rmd160  3f04a79c291d786f9c69c2944bdd521402052a5c \


### PR DESCRIPTION
#### Description

pinact: Update to 3.1.1

##### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
