### PR TITLE
pnetcdf: Specify MPI compilers, fix builds

### DIFF
--- a/science/pnetcdf/Portfile
+++ b/science/pnetcdf/Portfile
@@ -41,9 +41,21 @@ depends_build-append    port:perl5 \
                         port:libtool \
                         port:m4
 
+configure.args-append   --disable-silent-rules
+
+configure.env-append    MPICC=${mpi.cc} \
+                        MPICXX=${mpi.cxx} \
+                        MPIF77=${mpi.f77} \
+                        MPIF90=${mpi.f90}
+
 default_variants        +gcc12 +mpich
 
 use_parallel_build      yes
+
+post-destroot {
+    reinplace "s|${destroot}||g" ${destroot}${prefix}/lib/pkgconfig/pnetcdf.pc
+    reinplace "s|${destroot}||g" ${destroot}${prefix}/bin/pnetcdf-config
+}
 
 livecheck.type          regex
 livecheck.url           ${homepage}


### PR DESCRIPTION
#### Description

* Specify MPI compilers for configure, fix broken builds.
* Fix install paths in config and pkg-config files.

Closes: https://trac.macports.org/ticket/71977

###### Type(s)

- [x] bugfix

###### Tested on

macOS 14.6.1
Xcode 16.2
Command Line Tools 16.2.0
SDK 15.2

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -s install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?