### PR TITLE
influxdb: update to 3.0.2

### DIFF
--- a/sysutils/influxdb/Portfile
+++ b/sysutils/influxdb/Portfile
@@ -3,9 +3,7 @@
 PortSystem                  1.0
 PortGroup                   golang 1.0
 
-go.setup                    github.com/influxdata/influxdb 2.7.10 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from         tarball
+go.setup                    github.com/influxdata/influxdb 3.0.2 v
 go.offline_build            no
 revision                    0
 


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?