### PR TITLE
google-cloud-sdk: update to 522.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             521.0.0
+version             522.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e9b56ce60f89e45928249db3a90820b86f6d13ce \
-                    sha256  947d9bdb51a7980a12d8b40b7a3f4e42e9abe0b16e5a69471f09674276b7ddff \
-                    size    53848919
+    checksums       rmd160  109ab0babf5c1ceabe5c1d6319f374d43f808c18 \
+                    sha256  bda6955081890a099a3cb52ea7bdfd94e23cb93c83f540224993a5b1aaa2101b \
+                    size    53930267
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  db6c522a3fbbc8a6aecf992a3bab0a04a5b71b16 \
-                    sha256  9e0838c41c98052c0e15c03697f1c3a8b03faac1722dff3e9188eba76310e7e2 \
-                    size    55317632
+    checksums       rmd160  3c31626aae7d1d628b61b14720d4903d0ad67414 \
+                    sha256  5fbbf1455fa4529ea8b235ecd20d3834aa4257dbbe5b5571fbb342539b22f020 \
+                    size    55401036
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  41ca172436e2187e6b03a1f2514af92c397ee963 \
-                    sha256  765c5a2cf2bcb91cbd6180fedec715fad9d53c461057727b74abb646fe0d2760 \
-                    size    55256856
+    checksums       rmd160  235933ee2a9650bdf7ed92d506fd764a05a49bb0 \
+                    sha256  c9fb0dbf35db3fb96600e07b6f2054e2a8db5fae7ea0bb88771b0a7516ce56f1 \
+                    size    55338938
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -43,7 +43,7 @@ worksrcdir          ${name}
 
 # Most recent Python version that supports to both
 # glcoud (https://cloud.google.com/sdk/docs/install#mac) and
-# gsutil (https://cloud.google.com/storage/docs/gsutil_install#specifications)
+# gsutil (https://cloud.google.com/storage/docs/gsutil_install#before_you_begin)
 python.default_version 312
 
 post-patch {


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 522.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?