### PR TITLE
fpm: update to 0.11.0 and fix 71644

### DIFF
--- a/_resources/port1.0/group/fortran-1.0.tcl
+++ b/_resources/port1.0/group/fortran-1.0.tcl
@@ -21,15 +21,6 @@ if {${os.major} < 14} {
 	git.cmd                 ${prefix}/bin/git
 }
 
-# https://github.com/fortran-lang/fpm/issues/1059
-# Drop this upon the next release of FPM:
-compiler.blacklist-append \
-                    macports-gcc-14
-if {${os.platform} ne "darwin" || ${os.major} > 9} {
-    default_variants-append \
-                    +gcc13
-}
-
 # Clang of 10.7 fails with multiple packages: error: invalid instruction mnemonic 'cvtsi2sdl'
 compiler.blacklist-append \
                     *gcc-4.* {clang < 500}

--- a/devel/fpm/Portfile
+++ b/devel/fpm/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        fortran-lang fpm 0.10.1 v
+github.setup        fortran-lang fpm 0.11.0 v
 revision            0
 categories          devel fortran
 license             MIT
@@ -17,9 +17,9 @@ long_description    Fortran Package Manager (fpm) is a package manager and build
                     run the executables, tests and examples, and distribute it as a dependency \
                     to other Fortran projects.
 homepage            https://fpm.fortran-lang.org
-checksums           rmd160  c27064b9afdbcf8add3eeaaad7bc7da3a21f094c \
-                    sha256  835db9ea28b2983b5db3e71de8e8530ac0d3f63c4e1bd99d4253fe40e7c817cb \
-                    size    252512
+checksums           rmd160  70165608dc38e5b72ff8cdccaaa5d58edf6c4225 \
+                    sha256  46eeda5e5fa56307d51e30aee556da732d4ed43253dbcf520bac9a6c6cf0dabd \
+                    size    263484
 github.tarball_from archive
 
 depends_build-append \
@@ -39,14 +39,6 @@ post-patch {
     reinplace "s,@PREFIX@,${worksrcpath}${prefix}," ${worksrcpath}/install.sh
 
     file attributes ${worksrcpath}/install.sh -permissions +x
-}
-
-# https://github.com/fortran-lang/fpm/issues/1059
-# Drop this block upon the next release. Also drop it from fortran PG.
-compiler.blacklist-append \
-                        macports-gcc-14
-if {${os.platform} ne "darwin" || ${os.major} > 9} {
-    default_variants    +gcc13
 }
 
 # Xcode clang of 10.7 fails with error: invalid instruction mnemonic 'cvtsi2ssl'

--- a/devel/fpm/files/patch-install.diff
+++ b/devel/fpm/files/patch-install.diff
@@ -9,15 +9,7 @@
  
  while [ "$1" != "" ]; do
      PARAM=$(echo "$1" | awk -F= '{print $1}')
-@@ -75,14 +75,14 @@
- 
- # Fallback to a latest known release if network timeout
- if [ -z "$LATEST_RELEASE" ]; then
--   LATEST_RELEASE="0.8.0"
-+   LATEST_RELEASE="0.10.0"
- fi
- 
- SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v${LATEST_RELEASE}/fpm-${LATEST_RELEASE}.F90"
+@@ -77,7 +77,7 @@
  BOOTSTRAP_DIR="build/bootstrap"
  
  if [ -z ${FC+x} ]; then


### PR DESCRIPTION
#### Description

The update fixes https://trac.macports.org/ticket/71644

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
