### PR TITLE
mercurial: fix issues in port

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -1,11 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           python 1.0
 
-if {[variant_isset rust]} {
+if {${subport} eq "mercurial-rustext"} {
     # see https://trac.macports.org/ticket/63834
-    PortGroup       rust 1.0
+    PortGroup       cargo 1.0
 }
 
 name                mercurial
@@ -14,7 +15,7 @@ name                mercurial
 # also, please remember that the rust variant needs love too:
 # cargo2port rust/Cargo.lock | pbcopy
 version             7.0.2
-revision            2
+revision            3
 categories          devel python
 license             GPL-2+
 maintainers         {danchr @danchr}
@@ -43,101 +44,151 @@ checksums           ${distname}${extract.suffix}  \
                     size    8981974
 
 python.default_version 313
-python.pep517       no
+python.pep517       yes
 
-# https://trac.macports.org/ticket/65938
-compiler.blacklist-append \
+if {${name} eq ${subport}} {
+    # https://trac.macports.org/ticket/65938
+    compiler.blacklist-append \
                     *gcc-4.0 *gcc-4.2 {clang < 421}
 
-depends_build-append \
-                    bin:${prefix}/bin/make:gmake \
+    depends_build-append \
+                    bin:${prefix}/bin/gmake:gmake \
                     port:gettext \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm \
                     port:py${python.version}-docutils
 
-depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle \
+    depends_run     \
+                    path:share/curl/curl-ca-bundle.crt:curl-ca-bundle \
                     port:py${python.version}-re2 \
                     port:py${python.version}-gnureadline
 
-patch.pre_args-replace  -p0 -p1
-patchfiles          setup_py.diff \
+    patch.pre_args-replace  -p0 -p1
+    patchfiles      setup_py.diff \
+                    allow_rust.diff \
                     hg.diff \
                     makefile.diff
 
-build.env-append    PYTHON=${python.bin} \
+    build.env-append \
+                    PYTHON=${python.bin} \
                     COMPILERFLAG=-j${build.jobs} \
                     HGPATH=${prefix}/bin/hg \
                     HGEXTDIR=${python.pkgd}/hgext
-destroot.env-append \
+    destroot.env-append \
                     PYTHON=${python.bin} \
                     COMPILERFLAG=-j${build.jobs} \
                     HGPATH=${prefix}/bin/hg \
                     HGEXTDIR=${python.pkgd}/hgext
 
-post-patch {
-    reinplace "s/@BUILD_JOBS@/${build.jobs}/" ${worksrcpath}/setup.py
-}
+    post-patch {
+        reinplace "s/@BUILD_JOBS@/${build.jobs}/" ${worksrcpath}/setup.py
+    }
 
-# https://trac.macports.org/ticket/71405
-if {[string match *gcc* ${configure.compiler}]} {
-    build.cmd-prepend \
+    # https://trac.macports.org/ticket/71405
+    if {[string match *gcc* ${configure.compiler}]} {
+        build.cmd-prepend \
                     CFLAGS=-Wno-error=incompatible-pointer-types
-}
+    }
 
-post-destroot {
-    reinplace "1s,.*,#!${python.bin}," ${destroot}${python.prefix}/bin/hg
+    post-build {
+        # build manual pages
+        system -W "${worksrcpath}/doc" \
+            "gmake -j ${build.jobs} all PYTHON=${python.bin}"
+    }
 
-    # configure ssl certificates
-    xinstall -d -m 755 ${destroot}${prefix}/etc/mercurial
-    xinstall -d -m 755 ${destroot}${prefix}/etc/mercurial/hgrc.d
-    xinstall -d -m 755 ${destroot}${prefix}/share/doc/mercurial
-    xinstall -m 644 ${filespath}/hgrc \
-        ${destroot}${prefix}/etc/mercurial/hgrc.default
-    reinplace "s|%%PREFIX%%|${prefix}|g" \
-        ${destroot}${prefix}/etc/mercurial/hgrc.default
+    post-destroot {
+        reinplace "1s,.*,#!${python.bin}," ${destroot}${python.prefix}/bin/hg
 
-    # install html docs
-    xinstall -m 644 -W ${worksrcpath}/doc hg.1.html hgrc.5.html hgignore.5.html \
-        ${destroot}${prefix}/share/doc/mercurial
+        # install manual pages
+        system -W "${worksrcpath}/doc"  \
+            "gmake -j ${build.jobs} install PYTHON=${python.bin} DESTDIR=${destroot} PREFIX=${prefix}"
 
-    # install contrib
-    xinstall -d -m 755 ${destroot}${prefix}/share/mercurial
-    file copy ${worksrcpath}/contrib ${destroot}${prefix}/share/mercurial/contrib
-    file copy ${worksrcpath}/tests/run-tests.py ${destroot}${prefix}/share/mercurial/contrib
+        # configure ssl certificates
+        xinstall -d -m 755 ${destroot}${prefix}/etc/mercurial
+        xinstall -d -m 755 ${destroot}${prefix}/etc/mercurial/hgrc.d
+        xinstall -d -m 755 ${destroot}${prefix}/share/doc/mercurial
+        xinstall -m 644 ${filespath}/hgrc \
+            ${destroot}${prefix}/etc/mercurial/hgrc.default
+        reinplace "s|%%PREFIX%%|${prefix}|g" \
+            ${destroot}${prefix}/etc/mercurial/hgrc.default
 
-    # exclude some cruft and nested packages
-    file delete -force \
-        ${destroot}${prefix}/share/mercurial/contrib/automation \
-        ${destroot}${prefix}/share/mercurial/contrib/chg \
-        ${destroot}${prefix}/share/mercurial/contrib/fuzz \
-        ${destroot}${prefix}/share/mercurial/contrib/packaging \
-        ${destroot}${prefix}/share/mercurial/contrib/plan9 \
-        ${destroot}${prefix}/share/mercurial/contrib/python-zstandard \
-        ${destroot}${prefix}/share/mercurial/contrib/win32 \
-        ${destroot}${python.pkgd}/hgext3rd
+        # install html docs
+        xinstall -m 644 -W ${worksrcpath}/doc hg.1.html hgrc.5.html hgignore.5.html \
+            ${destroot}${prefix}/share/doc/mercurial
 
-    # copy hgweb.cgi hgwebdir.cgi
-    file copy ${worksrcpath}/hgweb.cgi ${destroot}${prefix}/share/mercurial/
+        # install contrib
+        xinstall -d -m 755 ${destroot}${prefix}/share/mercurial
+        file copy ${worksrcpath}/contrib ${destroot}${prefix}/share/mercurial/contrib
+        file copy ${worksrcpath}/tests/run-tests.py ${destroot}${prefix}/share/mercurial/contrib
 
-    # copy hgk, the visual history browser
-    file copy ${worksrcpath}/contrib/hgk ${destroot}${prefix}/bin/hgk
+        # exclude some cruft and nested packages
+        file delete -force \
+            ${destroot}${prefix}/share/mercurial/contrib/automation \
+            ${destroot}${prefix}/share/mercurial/contrib/chg \
+            ${destroot}${prefix}/share/mercurial/contrib/fuzz \
+            ${destroot}${prefix}/share/mercurial/contrib/packaging \
+            ${destroot}${prefix}/share/mercurial/contrib/plan9 \
+            ${destroot}${prefix}/share/mercurial/contrib/python-zstandard \
+            ${destroot}${prefix}/share/mercurial/contrib/win32 \
+            ${destroot}${python.pkgd}/hgext3rd
 
-    # copy completions, etc.
-    foreach f [glob ${destroot}${python.prefix}/share/*] {
-        file rename $f ${destroot}${prefix}/share/
+        # copy hgweb.cgi hgwebdir.cgi
+        file copy ${worksrcpath}/hgweb.cgi ${destroot}${prefix}/share/mercurial/
+
+        # copy hgk, the visual history browser
+        file copy ${worksrcpath}/contrib/hgk ${destroot}${prefix}/bin/hgk
+
+        # copy completions, etc.
+        foreach f [glob ${destroot}${python.prefix}/share/*] {
+            file rename $f ${destroot}${prefix}/share/
+        }
+    }
+
+    post-activate {
+        if {![file exists ${prefix}/etc/mercurial/hgrc]} {
+            copy ${prefix}/etc/mercurial/hgrc.default ${prefix}/etc/mercurial/hgrc
+        }
     }
 }
 
-post-activate {
-    if {![file exists ${prefix}/etc/mercurial/hgrc]} {
-        copy ${prefix}/etc/mercurial/hgrc.default ${prefix}/etc/mercurial/hgrc
-    }
-}
+subport mercurial-rustext {
+    description \
+        Experimental Rust optimizations for Mercurial
+    long_description ${description}
 
-variant rust description {Enable experimental Rust optimizations} {
-    build.env-append HGWITHRUSTEXT=cpython CARGO_BUILD_TARGET=
-    destroot.env-append HGWITHRUSTEXT=cpython CARGO_BUILD_TARGET=
+    depends_run \
+        port:mercurial
+
+    build.dir       ${worksrcpath}/rust
+    build.env-append \
+        PYTHON_SYS_EXECUTABLE=${python.bin} \
+        PYTHONEXECUTABLE=${python.bin} \
+        PYTHON=${python.bin} \
+        PYO3_PYTHON=${python.bin}
+
+    patch.pre_args-replace  -p0 -p1
+    patchfiles      rust_darwin.diff
+
+    destroot {
+        set targetpath \
+            ${worksrcpath}/rust/target/[cargo.rust_platform]/release
+        set suffix \
+            [exec \
+                 ${python.bin} -c \
+                 "import sysconfig; print(sysconfig.get_config_var(\"EXT_SUFFIX\"))" \
+                ]
+
+        xinstall -d ${destroot}${python.pkgd}/mercurial ${prefix}/bin
+        xinstall \
+            ${targetpath}/librusthg.dylib \
+            ${destroot}${python.pkgd}/mercurial/rustext${suffix}
+        xinstall \
+            ${targetpath}/librusthgpyo3.dylib \
+            ${destroot}${python.pkgd}/mercurial/pyo3_rustext${suffix}
+        xinstall \
+            ${targetpath}/rhg \
+            ${destroot}${prefix}/bin
+    }
 
     cargo.crates \
     adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \

--- a/devel/mercurial/files/allow_rust.diff
+++ b/devel/mercurial/files/allow_rust.diff
@@ -1,0 +1,28 @@
+# HG changeset patch
+# User Dan Villiom Podlaski Christiansen <danchr@gmail.com>
+# Date 1747228504 -7200
+#      Wed May 14 15:15:04 2025 +0200
+# Branch stable
+# Node ID 2f32cc33c8c68d1a20bd8427e293433e5d15b8cd
+# Parent  809a4c4725436a6f3755e58cb864faed4264ad25
+# EXP-Topic patches
+allow_rust
+
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -495,13 +495,7 @@ class hgbuildpy(build_py):
+ 
+     def run(self):
+         rust = self.distribution.rust
+-        if self.distribution.pure:
+-            modulepolicy = 'py'
+-        elif self.build_lib == '.':
+-            # in-place build should run without rebuilding and Rust extensions
+-            modulepolicy = 'rust+c-allow' if rust else 'allow'
+-        else:
+-            modulepolicy = 'rust+c' if rust else 'c'
++        modulepolicy = 'rust+c-allow'
+ 
+         content = b''.join(
+             [

--- a/devel/mercurial/files/hg.diff
+++ b/devel/mercurial/files/hg.diff
@@ -3,8 +3,8 @@
 # Date 1678122146 -3600
 #      Mon Mar 06 18:02:26 2023 +0100
 # Branch stable
-# Node ID e6286ab9d66a0661fe5a34444be9621181f54530
-# Parent  010a86744bfc6ede2e3ed3ecef3faee0de804f47
+# Node ID 6299de7640978d4ac095f8f2f39e531ef5b06409
+# Parent  a498a90c2455a9da9b71cf208274572152b9826e
 # EXP-Topic patches
 hg
 

--- a/devel/mercurial/files/makefile.diff
+++ b/devel/mercurial/files/makefile.diff
@@ -3,8 +3,8 @@
 # Date 1678122147 -3600
 #      Mon Mar 06 18:02:27 2023 +0100
 # Branch stable
-# Node ID 6008a4450ee3d85a2aa88eaae601984cd10441fe
-# Parent  e6286ab9d66a0661fe5a34444be9621181f54530
+# Node ID c499b1c999728ea3d078dee36b83508bbebe003d
+# Parent  6299de7640978d4ac095f8f2f39e531ef5b06409
 # EXP-Topic patches
 makefile
 

--- a/devel/mercurial/files/rust_darwin.diff
+++ b/devel/mercurial/files/rust_darwin.diff
@@ -1,0 +1,29 @@
+# HG changeset patch
+# User Dan Villiom Podlaski Christiansen <danchr@gmail.com>
+# Date 1747225899 -7200
+#      Wed May 14 14:31:39 2025 +0200
+# Branch stable
+# Node ID 809a4c4725436a6f3755e58cb864faed4264ad25
+# Parent  8c0474a25ff0c788b147ce6381ffbb2435c1c4c2
+# EXP-Topic patches
+rust_darwin
+
+diff --git a/rust/.cargo/config.toml b/rust/.cargo/config.toml
+--- a/rust/.cargo/config.toml
++++ b/rust/.cargo/config.toml
+@@ -5,3 +5,15 @@
+ # (which would be loaded first).
+ [target.'cfg(target_os = "windows")']
+ rustflags = ["-Ctarget-feature=+crt-static"]
++
++[target.x86_64-apple-darwin]
++rustflags = [
++  "-C", "link-arg=-undefined",
++  "-C", "link-arg=dynamic_lookup",
++]
++
++[target.aarch64-apple-darwin]
++rustflags = [
++  "-C", "link-arg=-undefined",
++  "-C", "link-arg=dynamic_lookup",
++]

--- a/devel/mercurial/files/setup_py.diff
+++ b/devel/mercurial/files/setup_py.diff
@@ -3,8 +3,8 @@
 # Date 1678122149 -3600
 #      Mon Mar 06 18:02:29 2023 +0100
 # Branch stable
-# Node ID 45f995017b191ad504ac6dced4f694b39e0747e7
-# Parent  6008a4450ee3d85a2aa88eaae601984cd10441fe
+# Node ID 8c0474a25ff0c788b147ce6381ffbb2435c1c4c2
+# Parent  c499b1c999728ea3d078dee36b83508bbebe003d
 # EXP-Topic patches
 setup_py
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This reinstates the experimental Rust extensions as a separate subport, configures Mercurial to optionally load them, and reintroduces the manual pages, which still require GNU Make to build.

Fixes: https://trac.macports.org/ticket/72455

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
