### PR TITLE
mise: Update to 2025.5.4

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.5.3 v
+github.setup        jdx mise 2025.5.4 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  1a0eb73e9705751379f172c5e3cc87d8b8d3ad9f \
-                    sha256  0f2a627dc5a6c3a859c05d21dcecd50a26f2fcb050faf3dba43c8fb0c6b4ec8f \
-                    size    4160902
+                    rmd160  9565c5ef8149620a1e6a3c3510f72d092c457a30 \
+                    sha256  92e028dd7e9447f9f78196fdc5c9c6fb1c76730a29084c9ba54c039d85098f5c \
+                    size    4161722
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -146,8 +146,8 @@ cargo.crates \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
-    clap                            4.5.37  eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071 \
-    clap_builder                    4.5.37  efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2 \
+    clap                            4.5.38  ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000 \
+    clap_builder                    4.5.38  379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120 \
     clap_derive                     4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     clap_mangen                     0.2.26  724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a \
@@ -271,7 +271,7 @@ cargo.crates \
     gix-config                      0.45.1  48f3c8f357ae049bfb77493c2ec9010f58cfc924ae485e1116c3718fc0f0d881 \
     gix-config-value                0.15.0  439d62e241dae2dffd55bfeeabe551275cf9d9f084c5ebc6b48bad49d03285b7 \
     gix-credentials                 0.29.0  ce1c7307e36026b6088e5b12014ffe6d4f509c911ee453e22a7be4003a159c9b \
-    gix-date                        0.10.1  3a98593f1f1e14b9fa15c5b921b2c465e904d698b9463e21bb377be8376c3c1a \
+    gix-date                        0.10.2  139d1d52b21741e3f0c72b0fc65e1ff34d4eaceb100ef529d182725d2e09b8cb \
     gix-diff                        0.52.1  5e9b43e95fe352da82a969f0c84ff860c2de3e724d93f6681fedbcd6c917f252 \
     gix-dir                         0.14.1  01e6e2dc5b8917142d0ffe272209d1671e45b771e433f90186bc71c016792e87 \
     gix-discover                    0.40.1  dccfe3e25b4ea46083916c56db3ba9d1e6ef6dce54da485f0463f9fc0fe1837c \
@@ -282,7 +282,7 @@ cargo.crates \
     gix-hash                        0.18.0  8d4900562c662852a6b42e2ef03442eccebf24f047d8eab4f23bc12ef0d785d8 \
     gix-hashtable                    0.8.1  b5b5cb3c308b4144f2612ff64e32130e641279fcf1a84d8d40dad843b4f64904 \
     gix-ignore                      0.15.0  ae358c3c96660b10abc7da63c06788dfded603e717edbd19e38c6477911b71c8 \
-    gix-index                       0.40.0  e6d505aea7d7c4267a3153cb90c712a89970b4dd02a2cb3205be322891f530b5 \
+    gix-index                       0.40.1  b38e919efd59cb8275d23ad2394b2ab9d002007b27620e145d866d546403b665 \
     gix-lock                        17.1.0  570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796 \
     gix-mailmap                     0.27.1  5e7c52eb13d84ad26030d07a2c2975ba639dd1400a7996e6966c5aef617ed829 \
     gix-negotiate                   0.20.1  2e1ea901acc4d5b44553132a29e8697210cb0e739b2d9752d713072e9391e3c9 \
@@ -291,7 +291,7 @@ cargo.crates \
     gix-pack                        0.59.1  9d49c55d69c8449f2a0a5a77eb9cbacfebb6b0e2f1215f0fc23a4cb60528a450 \
     gix-packetline                  0.19.0  8ddc034bc67c848e4ef7596ab5528cd8fd439d310858dbe1ce8b324f25deb91c \
     gix-packetline-blocking         0.19.0  c44880f028ba46d6cf37a66d27a300310c6b51b8ed0e44918f93df061168e2f3 \
-    gix-path                       0.10.17  c091d2e887e02c3462f52252c5ea61150270c0f2657b642e8d0d6df56c16e642 \
+    gix-path                       0.10.18  567f65fec4ef10dfab97ae71f26a27fd4d7fe7b8e3f90c8a58551c41ff3fb65b \
     gix-pathspec                    0.11.0  ce061c50e5f8f7c830cacb3da3e999ae935e283ce8522249f0ce2256d110979d \
     gix-prompt                      0.11.0  d024a3fe3993bbc17733396d2cefb169c7a9d14b5b71dafb7f96e3962b7c3128 \
     gix-protocol                    0.50.1  f5c17d78bb0414f8d60b5f952196dc2e47ec320dca885de9128ecdb4a0e38401 \
@@ -307,7 +307,7 @@ cargo.crates \
     gix-tempfile                    17.1.0  c750e8c008453a2dba67a2b0d928b7716e05da31173a3f5e351d5457ad4470aa \
     gix-trace                       0.1.12  7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7 \
     gix-transport                   0.47.0  edfe22ba26d4b65c17879f12b9882eafe65d3c8611c933b272fce2c10f546f59 \
-    gix-traverse                    0.46.1  39094185f6d9a4d81101130fbbf7f598a06441d774ae3b3ae7930a613bbe1157 \
+    gix-traverse                    0.46.2  b8648172f85aca3d6e919c06504b7ac26baef54e04c55eb0100fa588c102cc33 \
     gix-url                         0.31.0  42a1ad0b04a5718b5cb233e6888e52a9b627846296161d81dcc5eb9203ec84b8 \
     gix-utils                        0.3.0  5351af2b172caf41a3728eb4455326d84e0d70fe26fc4de74ab0bd37df4191c5 \
     gix-validate                    0.10.0  77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d \
@@ -519,9 +519,9 @@ cargo.crates \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     rops                             0.1.5  5c830d8ae5c50ef149e290235ef564ac84d97181dce248ae30706cfaf1d3e7cc \
     rowan                          0.15.16  0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d \
-    rust-embed                       8.7.1  60e425e204264b144d4c929d126d0de524b40a961686414bab5040f7465c71be \
-    rust-embed-impl                  8.7.0  6bf418c9a2e3f6663ca38b8a7134cc2c2167c9d69688860e8961e3faa731702e \
-    rust-embed-utils                 8.7.0  08d55b95147fe01265d06b3955db798bdaed52e60e2211c41137701b3aba8e21 \
+    rust-embed                       8.7.2  025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a \
+    rust-embed-impl                  8.7.2  6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c \
+    rust-embed-utils                 8.7.2  f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
@@ -554,7 +554,7 @@ cargo.crates \
     serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
     serde-value                      0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
     serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
-    serde_ignored                   0.1.11  566da67d80e92e009728b3731ff0e5360cb181432b8ca73ea30bb1d170700d76 \
+    serde_ignored                   0.1.12  b516445dac1e3535b6d658a7b528d771153dfb272ed4180ca4617a20550365ff \
     serde_json                     1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
     serde_regex                      1.1.0  a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
@@ -601,7 +601,7 @@ cargo.crates \
     tabled_derive                   0.11.0  0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846 \
     taplo                           0.13.2  010941ac4171eaf12f1e26dfc11dadaf78619ea2330940fef01fe6bb0442d14d \
     tar                             0.4.44  1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a \
-    tempfile                        3.19.1  7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf \
+    tempfile                        3.20.0  e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1 \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                    0.4.2  45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed \


### PR DESCRIPTION
#### Description

mise: Update to 2025.5.4

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
