### PR TITLE
Update to socket_vmnet 1.2.1

### DIFF
--- a/net/socket_vmnet/Portfile
+++ b/net/socket_vmnet/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        lima-vm socket_vmnet 1.1.4 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        lima-vm socket_vmnet 1.2.1 v
+github.tarball_from archive
 
 categories          net
 maintainers         {sub-pop.net:link @subpop} \
@@ -18,9 +17,9 @@ description         vmnet.framework support for rootless QEMU
 long_description    Daemon to provide access to vmnet.framework for rootless QEMU
 homepage            https://github.com/lima-vm/socket_vmnet
 
-checksums           rmd160  71e08771484d80458c72dba91f987122d17b3a06 \
-                    sha256  1e4152732b355b22cdba88cd28f35f25cce4aab499589d236a95ccb47a90d855 \
-                    size    18851
+checksums           rmd160  2ef824924c19760fe3708fbcf7466ce8a1d0730b \
+                    sha256  c44600fb9d4a44d533cfb5fa530264576952e887b065fd0b04aeb2500c812055 \
+                    size    22179
 
 post-extract {
     # Base doesn't set SOURCE_DATE_EPOCH so we have to.
@@ -47,13 +46,13 @@ pre-build {
                     SOURCE_DATE_EPOCH=${latest}
 }
 
-use_configure       no
-build.args          VERSION=${version} \
-                    CFLAGS="${configure.cflags}" \
-                    LDFLAGS="${configure.ldflags}" \
-                    PREFIX=${prefix}
-destroot.target     install.bin install.doc
-destroot.args       ${build.args}
+use_configure           no
+configure.cflags-append -DVERSION='\"${version}\"'
+build.args              CFLAGS="${configure.cflags}" \
+                        LDFLAGS="${configure.ldflags}" \
+                        PREFIX=${prefix}
+destroot.target         install.bin install.doc
+destroot.args           ${build.args}
 
 startupitem.create     yes
 startupitem.logfile    /var/log/${name}.log


### PR DESCRIPTION
#### Description

- Update socket_vmnet to 1.2.1
- Correctly include the version in the binary by way of CFLAGS

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] update

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
