### PR TITLE
py-protobuf3: Fetch tarball from PyPI instead of GitHub

### DIFF
--- a/python/py-protobuf3/Portfile
+++ b/python/py-protobuf3/Portfile
@@ -1,58 +1,34 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem      1.0
-PortGroup       compiler_blacklist_versions 1.0
-PortGroup       python 1.0
-PortGroup       github 1.0
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           python 1.0
 
 # note the python package is a major version greater than the cpp package
-set release_version \
-                21.12
-name            py-protobuf3
-version         4.${release_version}
-revision        2
+name                py-protobuf3
+python.rootname     protobuf
+version             4.21.12
+revision            3
 
-checksums       sha256  e2b976e67d6fcf7078f799143a73f2a4d9cf3126ca68a1a6f1bda30fe5f3585c \
-                rmd160  5cb0e68bcf7674138208d5acac258330d5a6d4dd \
-                size    5211420
+categories-append   devel
+license             BSD
+maintainers         nomaintainer
 
-categories-append  devel
-maintainers     nomaintainer
-license         BSD
-description     Encode data in an efficient yet extensible format.
-
-long_description \
-                Google Protocol Buffers are a flexible, efficient, \
-                automated mechanism for serializing structured data -- \
-                think XML, but smaller, faster, and simpler.  You \
-                define how you want your data to be structured once, \
-                then you can use special generated source code to \
-                easily write and read your structured data to and from \
-                a variety of data streams and using a variety of \
-                languages.  You can even update your data structure \
-                without breaking deployed programs that are compiled \
-                against the "old" format.  You specify how you want \
-                the information you're serializing to be structured by \
-                defining protocol buffer message types in .proto \
-                files.  Each protocol buffer message is a small \
-                logical record of information, containing a series of \
-                name-value pairs.
-
-supported_archs noarch
-platforms       {darwin any}
-
-github.setup    google protobuf ${version} v
-github.tarball_from releases
-homepage        https://github.com/google/protobuf
-master_sites    https://github.com/google/protobuf/releases/download/v${release_version}
-distfiles       protobuf-python-${version}.tar.gz
+description         Python bindings for Protocol Buffers
+long_description    {*}${description}
+homepage            https://protobuf.dev
 
 compiler.cxx_standard  \
-                2011
-# error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
-compiler.blacklist {clang < 900}
+                    2011
 
-python.versions 27 38 39 310 311 312 313
+checksums           rmd160  43dbb4824ab82fc445b78872a0920c118fa4485b \
+                    sha256  7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab \
+                    size    220324
+                    
+# error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
+compiler.blacklist  {clang < 900}
+
+python.versions     27 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
     conflicts       py${python.version}-protobuf
@@ -66,24 +42,17 @@ if {${name} ne ${subport}} {
 
     if {${python.version} == 27} {
         # Use the last compatible version.
-        set release_version \
-                        17.3
-        version         3.${release_version}
-        revision        0
-        checksums       sha256  3253c6d17ec0bb6f6382e555cf5ca0a9ffab8d81b691f100f96ce9f5e753018e \
-                        rmd160  548d88f3d75b8c75fe43eb0d620e8f40757e1566 \
-                        size    5038061
-        github.setup    google protobuf ${version} v
-        master_sites    https://github.com/google/protobuf/releases/download/v${release_version}
-        distfiles       protobuf-python-${version}.tar.gz
+        version         3.17.3
+        revision        1
+        checksums       sha256  72804ea5eaa9c22a090d2803813e280fb273b62d5ae497aaf3553d141c4fdd7b \
+                        rmd160  db4f62ffebdc89d250272f8b2f5af66652cf090f \
+                        size    228448
     }
 
     if {${python.version} > 36} {
            depends_lib-append \
                port:py${python.version}-flatbuffers
     }
-
-    worksrcdir      ${worksrcdir}/python
 
     if {${python.version} > 27} {
         # tricks to force the right -stdlib setting
@@ -131,4 +100,4 @@ if {${name} ne ${subport}} {
     }
 }
 
-github.livecheck.regex  {([0-9.]+)}
+livecheck           none

--- a/python/py-protobuf3/files/patch-protobuf-pyext-descriptor.cc.diff
+++ b/python/py-protobuf3/files/patch-protobuf-pyext-descriptor.cc.diff
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix build with Python 3.11
 
 The PyFrameObject structure members have been removed from the public C API.
 ---
- python/google/protobuf/pyext/descriptor.cc | 75 ++++++++++++++++++----
+ google/protobuf/pyext/descriptor.cc | 75 ++++++++++++++++++----
  1 file changed, 62 insertions(+), 13 deletions(-)
 
-diff --git a/python/google/protobuf/pyext/descriptor.cc b/python/google/protobuf/pyext/descriptor.cc
+diff --git a/google/protobuf/pyext/descriptor.cc b/google/protobuf/pyext/descriptor.cc
 index fc83acf01a78abce470b5d34a94258ff0733a6bb..fc97b0fa6c11966f9215eecf7690f00aa7cb02c9 100644
 --- google/protobuf/pyext/descriptor.cc
 +++ google/protobuf/pyext/descriptor.cc


### PR DESCRIPTION
#### Description
PyPI has tarballs containing identical source code to that of the tarballs from GitHub. They also only contain the necessary code for the Python package, as opposed to the GitHub tarball which has it in a subdirectory alongside the C++ code.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
