### PR TITLE
py-tensor*: use protobuf and/or py-protobuf

### DIFF
--- a/devel/protobuf/Portfile
+++ b/devel/protobuf/Portfile
@@ -1,0 +1,125 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       compiler_blacklist_versions 1.0
+PortGroup       github 1.0
+PortGroup       cmake 1.1
+PortGroup       legacysupport 1.1
+
+# clock_gettime needed for abseil
+# https://github.com/macports/macports-ports/pull/19905#issuecomment-1680281240
+legacysupport.newest_darwin_requires_legacy 15
+
+name            protobuf
+github.setup    protocolbuffers protobuf 30.2 v
+git.branch      v${version}
+revision        0
+
+dist_subdir     ${name}/${version}
+
+categories      devel
+maintainers     nomaintainer
+license         BSD
+
+description     Encode data in an efficient yet extensible format.
+long_description \
+                Google Protocol Buffers are a flexible, efficient, \
+                automated mechanism for serializing structured data -- \
+                think XML, but smaller, faster, and simpler.  You \
+                define how you want your data to be structured once, \
+                then you can use special generated source code to \
+                easily write and read your structured data to and from \
+                a variety of data streams and using a variety of \
+                languages.  You can even update your data structure \
+                without breaking deployed programs that are compiled \
+                against the "old" format.  You specify how you want \
+                the information you're serializing to be structured by \
+                defining protocol buffer message types in .proto \
+                files.  Each protocol buffer message is a small \
+                logical record of information, containing a series of \
+                name-value pairs.
+homepage        https://protobuf.dev
+
+checksums       rmd160  ef4d5bfc28aaec952d4300296016fd0ce8db3e66 \
+                sha256  fb06709acc393cc36f87c251bb28a5500a2e12936d4346099f2c6240f6c7a941 \
+                size    9506934
+
+github.tarball_from releases
+distname        protobuf-${version}
+worksrcdir      protobuf-${version}
+
+# Upstream adds zlib include - which is ${prefix}/include - before search path
+# of 3rd-party components, like gtest, gmock, etc. That causes the external
+# versions of those to be pulled in, and the build fails.
+# So don't let the project cmake add zlib; already added (last) by base.
+patchfiles-append cmake-zlib-include.diff
+
+compiler.cxx_standard   2017
+compiler.thread_local_storage   yes
+# error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
+compiler.blacklist {clang < 900}
+
+if { [string match *clang* ${configure.compiler}] } {
+    # Quiet deprecation warnings
+    configure.cxxflags-append \
+                -Wno-deprecated-declarations \
+                -Wno-error=unknown-warning-option \
+                -Wno-unknown-warning-option
+}
+
+# Clear optflags; controlled by project, via cmake build type
+configure.optflags
+
+if {[variant_isset debug]} {
+    cmake.build_type Debug
+} else {
+    cmake.build_type RelWithDebInfo
+}
+
+depends_lib-append \
+                port:abseil \
+                port:zlib
+
+configure.args-append \
+                -DBUILD_SHARED_LIBS:BOOL=ON \
+                -Dprotobuf_ABSL_PROVIDER=package \
+                -Dprotobuf_BUILD_LIBPROTOC:BOOL=ON \
+                -Dprotobuf_BUILD_PROTOC_BINARIES:BOOL=ON \
+                -Dprotobuf_BUILD_TESTS:BOOL=OFF
+
+post-destroot {
+    set docdir ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d -m 755 ${docdir}
+
+    foreach f {CONTRIBUTING.md CONTRIBUTORS.txt LICENSE README.md SECURITY.md editors examples} {
+        file copy ${worksrcpath}/${f} ${docdir}
+    }
+}
+
+proc port_test_ver_check {p_name p_ver p_rev} {
+    if { [catch {set port_ver_info [lindex [registry_active ${p_name}] 0]}] } {
+        error "Tests require that ${p_name} be active; install, then re-run tests"
+    } else {
+        set test_ver ${p_ver}_${p_rev}
+        set port_ver [lindex ${port_ver_info} 1]_[lindex ${port_ver_info} 2]
+        ui_info "port_test_ver_check: ${p_name}: test_ver: ${test_ver}; port_ver: ${port_ver}"
+
+        if { [vercmp ${port_ver} ${test_ver}] != 0 } {
+            error "Tests require installed version of ${p_name} to match port; update, then re-run tests"
+        }
+    }
+}
+
+variant tests description {Build with tests enabled} {
+    pre-configure {
+        port_test_ver_check ${subport} ${version} ${revision}
+    }
+
+    configure.args-replace \
+                -Dprotobuf_BUILD_TESTS:BOOL=OFF \
+                -Dprotobuf_BUILD_TESTS:BOOL=ON
+
+    test.run    yes
+    test.target check
+}

--- a/devel/protobuf/files/cmake-zlib-include.diff
+++ b/devel/protobuf/files/cmake-zlib-include.diff
@@ -1,0 +1,10 @@
+--- CMakeLists.txt.orig	2025-05-07 15:35:24
++++ CMakeLists.txt	2025-05-07 15:46:49
+@@ -259,7 +259,6 @@
+ endif (MSVC)
+ 
+ include_directories(
+-  ${ZLIB_INCLUDE_DIRECTORIES}
+   ${protobuf_BINARY_DIR}
+   # Support #include-ing other top-level directories, i.e. upb_generator.
+   ${protobuf_SOURCE_DIR}

--- a/python/py-protobuf/Portfile
+++ b/python/py-protobuf/Portfile
@@ -2,66 +2,25 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
 
 name                py-protobuf
-version             2.6.1
-revision            2
+version             6.30.2
+revision            0
 
 categories-append   devel
-platforms           darwin
-maintainers         nomaintainer
 license             BSD
+maintainers         nomaintainer
 
-description         Encode data in an efficient yet extensible format.
-long_description    Google Protocol Buffers are a flexible, efficient, \
-                    automated mechanism for serializing structured data -- \
-                    think XML, but smaller, faster, and simpler.  You \
-                    define how you want your data to be structured once, \
-                    then you can use special generated source code to \
-                    easily write and read your structured data to and from \
-                    a variety of data streams and using a variety of \
-                    languages.  You can even update your data structure \
-                    without breaking deployed programs that are compiled \
-                    against the "old" format.  You specify how you want \
-                    the information you're serializing to be structured by \
-                    defining protocol buffer message types in .proto \
-                    files.  Each protocol buffer message is a small \
-                    logical record of information, containing a series of \
-                    name-value pairs.
+description         Python bindings for Protocol Buffers
+long_description    {*}${description}
+homepage            https://protobuf.dev
 
-github.setup        google protobuf ${version} v
-github.tarball_from releases
-homepage            https://github.com/google/protobuf
-master_sites        https://github.com/google/protobuf/releases/download/v${version}
-distfiles           protobuf-${version}.tar.bz2
-worksrcdir          protobuf-${version}
+checksums           rmd160  100c89ce7d85341a14be71442165ebccc1f8db7d \
+                    sha256  35c859ae076d8c56054c25b59e5e59638d86545ed6e2b6efac6be0b6ea3ba048 \
+                    size    429315
 
-use_bzip2           yes
-checksums           sha1    6421ee86d8fb4e39f21f56991daa892a3e8d314b \
-                    sha256  ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910 \
-                    rmd160  654acfce84b4ba738a0332d0c967d1399ff6e4c2 \
-                    size    2021416
-
-python.versions     27
-
-livecheck.type      none
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     conflicts       py${python.version}-protobuf3
-
-    depends_build-append \
-                    port:py${python.version}-google-apputils
-
-    depends_lib-append \
-                    port:protobuf-cpp \
-                    port:py${python.version}-setuptools
-
-    worksrcdir      ${worksrcdir}/python
-
-    destroot.cmd-append    --cpp_implementation
-
-    test.run        yes
-    test.cmd        "${python.bin} setup.py"
-    test.target     test --cpp_implementation
 }

--- a/python/py-tensorboard/Portfile
+++ b/python/py-tensorboard/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-tensorboard
 version             2.9.0
-revision            0
+revision            1
 platforms           {darwin any}
 supported_archs     noarch
 license             Apache-2
@@ -43,7 +43,7 @@ if {${name} ne ${subport}} {
         port:py${python.version}-grpcio \
         port:py${python.version}-markdown \
         port:py${python.version}-numpy \
-        port:py${python.version}-protobuf3 \
+        port:py${python.version}-protobuf \
         port:py${python.version}-six \
         port:py${python.version}-werkzeug \
         port:py${python.version}-wheel

--- a/python/py-tensorboard1/Portfile
+++ b/python/py-tensorboard1/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-tensorboard1
 version             1.15.0
-revision            0
+revision            1
 
 supported_archs     noarch
 platforms           {darwin any}
@@ -42,7 +42,7 @@ if {${name} ne ${subport}} {
         port:py${python.version}-grpcio \
         port:py${python.version}-markdown \
         port:py${python.version}-numpy \
-        port:py${python.version}-protobuf3 \
+        port:py${python.version}-protobuf \
         port:py${python.version}-six \
         port:py${python.version}-werkzeug \
         port:py${python.version}-wheel

--- a/python/py-tensorboardX/Portfile
+++ b/python/py-tensorboardX/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 github.setup        lanpa tensorboardX 2.5.1 v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            2
+revision            3
 name                py-${github.project}
 categories-append   devel
 
@@ -35,11 +35,11 @@ python.versions     39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:protobuf3-cpp
+                    port:protobuf
 
     depends_run-append \
                     port:py${python.version}-numpy \
-                    port:py${python.version}-protobuf3 \
+                    port:py${python.version}-protobuf \
                     port:py${python.version}-six
 
     depends_test-append \

--- a/python/py-tensorflow-data-validation/Portfile
+++ b/python/py-tensorflow-data-validation/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 github.setup        tensorflow data-validation 0.28.0 v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            0
+revision            1
 name                py-${github.author}-${github.project}
 
 license             Apache-2
@@ -55,7 +55,7 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-joblib \
                     port:py${python.version}-numpy \
                     port:py${python.version}-pandas \
-                    port:py${python.version}-protobuf3 \
+                    port:py${python.version}-protobuf \
                     port:py${python.version}-pyarrow \
                     port:py${python.version}-six \
                     path:${python.pkgd}/tensorflow:py${python.version}-tensorflow \

--- a/python/py-tensorflow-datasets/Portfile
+++ b/python/py-tensorflow-datasets/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 github.setup        tensorflow datasets 4.9.2 v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            0
+revision            1
 name                py-${github.author}-${github.project}
 
 platforms           {darwin any}
@@ -36,7 +36,7 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-future \
                     port:py${python.version}-numpy \
                     port:py${python.version}-promise \
-                    port:py${python.version}-protobuf3 \
+                    port:py${python.version}-protobuf \
                     port:py${python.version}-requests \
                     port:py${python.version}-six \
                     port:py${python.version}-tensorflow-metadata \

--- a/python/py-tensorflow-macos/Portfile
+++ b/python/py-tensorflow-macos/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-tensorflow-macos
 version             2.11.0
-revision            0
+revision            1
 
 categories-append   lang
 license             Apache-2
@@ -112,7 +112,7 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-keras_preprocessing \
                     port:py${python.version}-numpy \
                     port:py${python.version}-opt_einsum \
-                    port:py${python.version}-protobuf3 \
+                    port:py${python.version}-protobuf \
                     port:py${python.version}-tensorflow_estimator \
                     port:py${python.version}-scipy \
                     port:py${python.version}-tensorboard \

--- a/python/py-tensorflow-metadata/Portfile
+++ b/python/py-tensorflow-metadata/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-tensorflow-metadata
 version             1.14.0
-revision            0
+revision            1
 
 license             Apache-2
 platforms           {darwin any}
@@ -34,7 +34,7 @@ if {${name} ne ${subport}} {
 
     depends_run-append \
                     port:py${python.version}-google-api \
-                    port:py${python.version}-protobuf3
+                    port:py${python.version}-protobuf
 
     build {}
 

--- a/python/py-tensorflow-transform/Portfile
+++ b/python/py-tensorflow-transform/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 github.setup        tensorflow transform 0.28.0 v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            0
+revision            1
 name                py-${github.author}-${github.project}
 
 platforms           {darwin any}
@@ -35,7 +35,7 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-absl \
                     port:py${python.version}-apache-beam \
                     port:py${python.version}-numpy \
-                    port:py${python.version}-protobuf3 \
+                    port:py${python.version}-protobuf \
                     port:py${python.version}-pydot \
                     port:py${python.version}-six \
                     port:py${python.version}-tensorflow-metadata \

--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                py-tensorflow
 version             2.12.0
-revision            0
+revision            1
 github.setup        tensorflow tensorflow ${version} v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
@@ -86,7 +86,7 @@ if {${name} ne ${subport}} {
         port:py${python.version}-keras \
         port:py${python.version}-numpy \
         port:py${python.version}-opt_einsum \
-        port:py${python.version}-protobuf3 \
+        port:py${python.version}-protobuf \
         port:py${python.version}-six \
         port:py${python.version}-tensorboard \
         port:py${python.version}-tensorflow_estimator \

--- a/python/py-tensorflow1/Portfile
+++ b/python/py-tensorflow1/Portfile
@@ -9,7 +9,7 @@ PortGroup           xcode_workaround               1.0
 
 name                py-tensorflow1
 version             1.15.5
-revision            0
+revision            1
 github.setup        tensorflow tensorflow ${version} v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
@@ -90,7 +90,7 @@ if {${name} ne ${subport}} {
         port:py${python.version}-grpcio \
         port:py${python.version}-keras \
         port:py${python.version}-numpy \
-        port:py${python.version}-protobuf3 \
+        port:py${python.version}-protobuf \
         port:py${python.version}-six \
         port:py${python.version}-tensorboard1 \
         port:py${python.version}-tensorflow_estimator1 \


### PR DESCRIPTION
#### Description
Spun off from #28321 to prevent CI from timing out.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

[skip notification]
