### PR TITLE
atuin: use protobuf

### DIFF
--- a/devel/protobuf/Portfile
+++ b/devel/protobuf/Portfile
@@ -1,0 +1,125 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       compiler_blacklist_versions 1.0
+PortGroup       github 1.0
+PortGroup       cmake 1.1
+PortGroup       legacysupport 1.1
+
+# clock_gettime needed for abseil
+# https://github.com/macports/macports-ports/pull/19905#issuecomment-1680281240
+legacysupport.newest_darwin_requires_legacy 15
+
+name            protobuf
+github.setup    protocolbuffers protobuf 30.2 v
+git.branch      v${version}
+revision        0
+
+dist_subdir     ${name}/${version}
+
+categories      devel
+maintainers     nomaintainer
+license         BSD
+
+description     Encode data in an efficient yet extensible format.
+long_description \
+                Google Protocol Buffers are a flexible, efficient, \
+                automated mechanism for serializing structured data -- \
+                think XML, but smaller, faster, and simpler.  You \
+                define how you want your data to be structured once, \
+                then you can use special generated source code to \
+                easily write and read your structured data to and from \
+                a variety of data streams and using a variety of \
+                languages.  You can even update your data structure \
+                without breaking deployed programs that are compiled \
+                against the "old" format.  You specify how you want \
+                the information you're serializing to be structured by \
+                defining protocol buffer message types in .proto \
+                files.  Each protocol buffer message is a small \
+                logical record of information, containing a series of \
+                name-value pairs.
+homepage        https://protobuf.dev
+
+checksums       rmd160  ef4d5bfc28aaec952d4300296016fd0ce8db3e66 \
+                sha256  fb06709acc393cc36f87c251bb28a5500a2e12936d4346099f2c6240f6c7a941 \
+                size    9506934
+
+github.tarball_from releases
+distname        protobuf-${version}
+worksrcdir      protobuf-${version}
+
+# Upstream adds zlib include - which is ${prefix}/include - before search path
+# of 3rd-party components, like gtest, gmock, etc. That causes the external
+# versions of those to be pulled in, and the build fails.
+# So don't let the project cmake add zlib; already added (last) by base.
+patchfiles-append cmake-zlib-include.diff
+
+compiler.cxx_standard   2017
+compiler.thread_local_storage   yes
+# error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
+compiler.blacklist {clang < 900}
+
+if { [string match *clang* ${configure.compiler}] } {
+    # Quiet deprecation warnings
+    configure.cxxflags-append \
+                -Wno-deprecated-declarations \
+                -Wno-error=unknown-warning-option \
+                -Wno-unknown-warning-option
+}
+
+# Clear optflags; controlled by project, via cmake build type
+configure.optflags
+
+if {[variant_isset debug]} {
+    cmake.build_type Debug
+} else {
+    cmake.build_type RelWithDebInfo
+}
+
+depends_lib-append \
+                port:abseil \
+                port:zlib
+
+configure.args-append \
+                -DBUILD_SHARED_LIBS:BOOL=ON \
+                -Dprotobuf_ABSL_PROVIDER=package \
+                -Dprotobuf_BUILD_LIBPROTOC:BOOL=ON \
+                -Dprotobuf_BUILD_PROTOC_BINARIES:BOOL=ON \
+                -Dprotobuf_BUILD_TESTS:BOOL=OFF
+
+post-destroot {
+    set docdir ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d -m 755 ${docdir}
+
+    foreach f {CONTRIBUTING.md CONTRIBUTORS.txt LICENSE README.md SECURITY.md editors examples} {
+        file copy ${worksrcpath}/${f} ${docdir}
+    }
+}
+
+proc port_test_ver_check {p_name p_ver p_rev} {
+    if { [catch {set port_ver_info [lindex [registry_active ${p_name}] 0]}] } {
+        error "Tests require that ${p_name} be active; install, then re-run tests"
+    } else {
+        set test_ver ${p_ver}_${p_rev}
+        set port_ver [lindex ${port_ver_info} 1]_[lindex ${port_ver_info} 2]
+        ui_info "port_test_ver_check: ${p_name}: test_ver: ${test_ver}; port_ver: ${port_ver}"
+
+        if { [vercmp ${port_ver} ${test_ver}] != 0 } {
+            error "Tests require installed version of ${p_name} to match port; update, then re-run tests"
+        }
+    }
+}
+
+variant tests description {Build with tests enabled} {
+    pre-configure {
+        port_test_ver_check ${subport} ${version} ${revision}
+    }
+
+    configure.args-replace \
+                -Dprotobuf_BUILD_TESTS:BOOL=OFF \
+                -Dprotobuf_BUILD_TESTS:BOOL=ON
+
+    test.run    yes
+    test.target check
+}

--- a/devel/protobuf/files/cmake-zlib-include.diff
+++ b/devel/protobuf/files/cmake-zlib-include.diff
@@ -1,0 +1,10 @@
+--- CMakeLists.txt.orig	2025-05-07 15:35:24
++++ CMakeLists.txt	2025-05-07 15:46:49
+@@ -259,7 +259,6 @@
+ endif (MSVC)
+ 
+ include_directories(
+-  ${ZLIB_INCLUDE_DIRECTORIES}
+   ${protobuf_BINARY_DIR}
+   # Support #include-ing other top-level directories, i.e. upb_generator.
+   ${protobuf_SOURCE_DIR}

--- a/sysutils/atuin/Portfile
+++ b/sysutils/atuin/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        ellie atuin 18.6.0
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://atuin.sh/
 
@@ -32,7 +32,7 @@ checksums           ${distname}${extract.suffix} \
 set atuin_bin       ${worksrcpath}/target/[cargo.rust_platform]/release/${name}
 
 depends_build-append \
-                    port:protobuf3-cpp
+                    port:protobuf
 
 post-build {
     # Generate shell completions


### PR DESCRIPTION
#### Description
Spun off from #28321 to prevent CI from timing out.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

[skip notification]
