### PR TITLE
ports: update references to protobuf in comments

### DIFF
--- a/gnome/Chatty/Portfile
+++ b/gnome/Chatty/Portfile
@@ -60,7 +60,7 @@ depends_lib-append  port:abseil \
 depends_run-append  port:gsettings-desktop-schemas \
                     port:libsecret
 
-# protobuf3-cpp used by libphonenumber-cpp needs at least C++11,
+# protobuf used by libphonenumber-cpp needs at least C++11,
 # also: https://gitlab.gnome.org/World/Chatty/-/issues/951
 compiler.cxx_standard   2017
 compiler.blacklist-append \

--- a/graphics/opencv3-devel/Portfile
+++ b/graphics/opencv3-devel/Portfile
@@ -126,7 +126,7 @@ patchfiles-append   patch-find-openexr.diff
 # recognize dylib as a valid library suffix
 patchfiles-append   patch-dylib_suffix.diff
 
-# do not find protobuf3-cpp header files if installed
+# do not find protobuf header files if installed
 configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
 patchfiles-append   patch-local_protobuf.diff
 

--- a/graphics/opencv3/Portfile
+++ b/graphics/opencv3/Portfile
@@ -126,7 +126,7 @@ patchfiles-append   patch-find-openexr.diff
 # recognize dylib as a valid library suffix
 patchfiles-append   patch-dylib_suffix.diff
 
-# do not find protobuf3-cpp header files if installed
+# do not find protobuf header files if installed
 configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
 patchfiles-append   patch-local_protobuf.diff
 


### PR DESCRIPTION
#### Description
Spun off from #28321 to prevent CI from timing out.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

[skip notification]
