### PR TITLE
QtPBFImagePlugin: update to 4.2

### DIFF
--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 QtPBFImagePlugin 3.0
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        tumic0 QtPBFImagePlugin 4.2
+github.tarball_from archive
 revision            0
 categories          graphics
 license             LGPL-3
@@ -15,18 +14,14 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
 
-checksums           rmd160  0078133ec58927ee14282d7b0f427d24a74a0027 \
-                    sha256  0a6f57b5d86a3f5e8b8bf19633f3b177f035d037567280d3d49cad6c984380ad \
-                    size    197701
-
-# Upstream links to static 'libprotobuf-lite', but needs to be dylib
-patchfiles-append   patch-protobuf-dylib.diff
+checksums           rmd160  5cc8d22f928beb0a699ec0f50cc2f7abb10e7a26 \
+                    sha256  335ca81fcc4f49ae98c962444739da451545a7c5395f87f64a45c04c26c0f51d \
+                    size    198821
 
 configure.args-append \
                     PROTOBUF=${prefix} ZLIB=${prefix}
 
-depends_lib-append  port:protobuf3-cpp \
-                    port:zlib
+depends_lib-append  port:zlib
 
 # Workaround xcrun: error: SDK "macosx12" cannot be located
 configure.sdk_version


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
