### PR TITLE
libosmium: update to 2.22.0

### DIFF
--- a/gis/libosmium/Portfile
+++ b/gis/libosmium/Portfile
@@ -5,9 +5,9 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0
 
-github.setup        osmcode libosmium 2.20.0 v
+github.setup        osmcode libosmium 2.22.0 v
 github.tarball_from archive
-revision            2
+revision            0
 
 categories          gis
 maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
@@ -32,9 +32,9 @@ long_description    The Osmium Library has extensive support for all types of \
 
 homepage            https://osmcode.org/libosmium/
 
-checksums           rmd160  9eaf7f451e11967dc247b43c920db77220f6fb71 \
-                    sha256  3d3e0873c6aaabb3b2ef4283896bebf233334891a7a49f4712af30ca6ed72477 \
-                    size    565349
+checksums           rmd160  5953deb5fc78bb3d0f1aad9f9c15062cba8ea533 \
+                    sha256  8f74e3f6ba295baa7325ae5606e8f74ad9056f1d6ab4555c50bff6aa8246f366 \
+                    size    563148
 
 compiler.cxx_standard 2011
 


### PR DESCRIPTION
#### Description

update to 2.22.0

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.4.1 24E263 arm64

Xcode 16.3 16E140

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
