### PR TITLE
paho.mqtt.cpp: update to 1.5.3

### DIFF
--- a/net/paho.mqtt.cpp/Portfile
+++ b/net/paho.mqtt.cpp/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           openssl 1.0
 
-github.setup        eclipse paho.mqtt.cpp 1.5.2 v
+github.setup        eclipse paho.mqtt.cpp 1.5.3 v
 github.tarball_from archive
 revision            0
 categories          net
@@ -30,9 +30,9 @@ configure.args-append \
                     -DPAHO_BUILD_STATIC=ON \
                     -DPAHO_WITH_SSL=ON
 
-checksums           rmd160  f0d957c6beee178158007d946601c550ab7131ed \
-                    sha256  3d8d9bfee614d74fa2e28dc244733c79e4868fa32a2d49af303ec176ccc55bfb \
-                    size    266145
+checksums           rmd160  32f282f6ce02fab2ea7ceb6ade58a179930836ee \
+                    sha256  8aab7761bcb43e2d65dbf266c8623d345f7612411363a97aa66370fb9822d0b9 \
+                    size    266347
 
 # Since 1.5.0 a C++17 compiler is required
 compiler.cxx_standard   2017


### PR DESCRIPTION
#### Description
https://github.com/eclipse-paho/paho.mqtt.cpp/releases/tag/v1.5.3

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
