### PR TITLE
kubectl: update 1.33, 1.32, 1.31, 1.30 subports

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -45,11 +45,11 @@ subport kubectl-1.32 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     4
+    set patchNumber     5
     revision            0
-    checksums           rmd160  fed12ff15e62d83ac44936e2e38b0cb71d5d66b9 \
-                        sha256  e7c0249f28c69c686f586150126b1ae8b4ea7f6fb5ff28dd38f309bd1dc15d69 \
-                        size    36364806
+    checksums           rmd160  bd270c4820ef771fae1f9b706b2b016f0e4be505 \
+                        sha256  7e7e8d14e350833338c8feb3613acca4929193441f252befbf840379cdf61317 \
+                        size    36373026
 }
 
 subport kubectl-1.31 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -32,11 +32,11 @@ subport kubectl-1.33 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     0
+    set patchNumber     1
     revision            0
-    checksums           rmd160  e8e84e87fe30328f51140dd297578db518a07c9c \
-                        sha256  9b7ef4e7d8f8156a835c3050746e56afdf52c95fa3ae8e380fdb3080208d2db1 \
-                        size    40025426
+    checksums           rmd160  2827aa8a6d8ef5fa1a8a928675a32cc813fee6ec \
+                        sha256  f89203e326de4c827a23ef9aa430d8a3133f62cfa1f5a894e8c85784f01bf055 \
+                        size    37076955
 }
 
 subport kubectl-1.32 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -71,11 +71,11 @@ subport kubectl-1.30 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     12
+    set patchNumber     13
     revision            0
-    checksums           rmd160  e854f60719ea85f2f5860da1403d4de7a7933786 \
-                        sha256  20bc53ade6723fd62a704eaa27a9cdd6d5d817c076cd59b6adfb2f4a02cb320c \
-                        size    39634770
+    checksums           rmd160  97107c780b83ff6c894e6cc25133b45083ceb0dd \
+                        sha256  6b53d64104fd156eb03788fb67fc9b91fca0ceca290476d018e3212bf6fb168d \
+                        size    39634530
 }
 
 subport kubectl-1.29 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -58,11 +58,11 @@ subport kubectl-1.31 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     8
+    set patchNumber     9
     revision            0
-    checksums           rmd160  912c077238dab5206bfa622e4be27782077888ca \
-                        sha256  d0f3f8a65e41191817dca57180a67d575ee4cd0a16677bedd9fe0ad3993a0b12 \
-                        size    36591435
+    checksums           rmd160  c0ea38ce3637b81b6900a031d415e2f7b21f879f \
+                        sha256  9bb812b18a0e31724563ebc40b02a7e1841a96554d0469a264d7e403c4b9c605 \
+                        size    36598141
 }
 
 subport kubectl-1.30 {


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
