### PR TITLE
weechat: update to 4.6.3

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.6.1
+version             4.6.3
 revision            0
-checksums           rmd160  629e8d7f373d6f9620e8217fc0b20cbf9ef7358f \
-                    sha256  d4344bd816a7f1ddb21ea7fb8135af87bebbcbb9e1b8362cd7432901d1902065 \
-                    size    2763220
+checksums           rmd160  2993420724648d78525b3b1addc1b5d6cfd7acf2 \
+                    sha256  5c0b5efa969b873c4be582019b18523ee403e7430b8223825bcdb44a89f5815d \
+                    size    2763576
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 4.6.3

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?