### PR TITLE
R-RProtobuf: update to 0.4.24

### DIFF
--- a/R/R-RProtoBuf/Portfile
+++ b/R/R-RProtoBuf/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran eddelbuettel RProtoBuf 0.4.22
-revision            1
+R.setup             cran eddelbuettel RProtoBuf 0.4.24
+revision            0
 categories-append   devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-2+
 description         R interface to the Protocol Buffers API
 long_description    {*}${description}
 homepage-append     https://dirk.eddelbuettel.com/code/rprotobuf.html
-checksums           rmd160  e9f6d049b1f696a17c9179190400d36fa0c78d23 \
-                    sha256  75b802176722052d1ef2c6b36adff9204ee86fb8f2e1fcecd897571bd8ed8d7e \
-                    size    1010658
+checksums           rmd160  98732fea1e3f14f8fb36984b1f9aa7ace895bfe8 \
+                    sha256  f22c16013d8cbedf5a09bb854ce092466434db740092fc0d7554fb5d33896168 \
+                    size    1013085
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
     # Symbol not found: __ZN6google8protobuf8compiler10SourceTree19GetLastErrorMessageB5cxx11Ev


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
