### PR TITLE
py-incremental: update to 24.7.2

### DIFF
--- a/python/py-incremental/Portfile
+++ b/python/py-incremental/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-incremental
-version             21.3.0
+version             24.7.2
 revision            0
 
 categories-append   devel
@@ -17,13 +17,20 @@ long_description    Incremental is a small library that versions your Python pro
 
 homepage            https://github.com/twisted/incremental
 
-checksums           rmd160  58a17ce949f8b06c0efdd9f09e79d942f3318543 \
-                    sha256  02f5de5aff48f6b9f665d99d48bfc7ec03b6e3943210de7cfc88856d755d6f57 \
-                    size    17058
+checksums           rmd160  f9711f9d7761d820eda12fd9aa434ba378e2a3bb \
+                    sha256  fb4f1d47ee60efe87d4f6f0ebb5f70b9760db2b2574c59c8e8912be4ebd464c9 \
+                    size    28157
 
-python.versions     27 37 38 39 310 311 312
+python.versions     27 38 39 310 311 312 313
 
 if {${name} ne ${subport}} {
+    if {${python.version} == 27} {
+        version     22.10.0
+
+        checksums   rmd160  7f1f7ddbe346e726abd21c96ff72487c55298db0 \
+                    sha256  912feeb5e0f7e0188e6f42241d2f450002e11bbc0937c65865045854c24c0bd0 \
+                    size    18305
+    }
     # see https://pypi.python.org/pypi/incremental/
     #depends_lib-append port:py${python.version}-twisted
     if {[catch {set installed [lindex [registry_active py${python.version}-twisted] 0]}]} {

--- a/python/py-twisted/Portfile
+++ b/python/py-twisted/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  96019de2a84e84b7d9d150b05432dc6418a5cbed \
                     sha256  32acbd40a94f5f46e7b42c109bfae2b302250945561783a8b7a059048f2d4d31 \
                     size    3524935
 
-python.versions 27 37 38 39 310 311 312
+python.versions 27 39 310 311 312
 
 if {${name} ne ${subport}} {
     # uses "from pkg_resources import load_entry_point"


### PR DESCRIPTION
#### Description
Github action currently failing due to py38-twisted missing py38-bcrypt, which has been removed. This is not related to any changed I made. Currently only py38-txgithub still uses py38-twisted.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
