### PR TITLE
got: update to 0.112

### DIFF
--- a/devel/got/Portfile
+++ b/devel/got/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 name                got
-version             0.110
+version             0.112
 revision            0
 distname            ${name}-portable-${version}
 categories          devel
@@ -22,10 +22,16 @@ long_description    Game of Trees is a version control system which \
                     possible to work with both Got and Git on the same \
                     repository.
 homepage            https://gameoftrees.org/
-master_sites        ${homepage}releases/portable/
-checksums           rmd160 98829f80a36fcaeb27daf63ba4a57a2a69f924a0 \
-                    sha256 3635e41205e7f85236a6e76ff785d3d8997131cf353c8cdf6f6d25c031661d29 \
-                    size 1560479
+# https://github.com/macports/macports-ports/pull/28252#issuecomment-2877457369
+# official page has greatly increased filtering against bots
+# this breaks CI and it doesn't look like it will be fixed yet
+# we can add a FreeBSD mirror to solve this issue, so make sure
+# the source package is mirrored
+master_sites        ${homepage}releases/portable/ \
+                    freebsd
+checksums           rmd160 200ecefb23646be50e55a1fdf4bebde85dfccf4b \
+                    sha256 e336694fe91112bf8c804a574e46f796e1538793e931dd7c4c0a0413672afd89 \
+                    size 1568016
 # error: implicit declaration of function 'stravis' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
 # https://trac.macports.org/ticket/71820
 # backport vis.c wrapper from tmux


### PR DESCRIPTION
* add FreeBSD mirror to master_sites

Closes: https://trac.macports.org/ticket/72492

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
