### PR TITLE
mise: Update to 2025.5.6

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.5.4 v
+github.setup        jdx mise 2025.5.6 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  9565c5ef8149620a1e6a3c3510f72d092c457a30 \
-                    sha256  92e028dd7e9447f9f78196fdc5c9c6fb1c76730a29084c9ba54c039d85098f5c \
-                    size    4161722
+                    rmd160  73d37c5e2cc892f55f26404cb3743e2665a7520f \
+                    sha256  81d32a117dfe0b602aaea4fbf11875cbd0853d7f4df83d2a60328ffea22f1213 \
+                    size    4163358
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -123,7 +123,7 @@ cargo.crates \
     binstall-tar                    0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
     bit-set                          0.6.0  f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f \
     bit-vec                          0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
-    bitflags                         2.9.0  5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd \
+    bitflags                         2.9.1  1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967 \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     bstr                            1.12.0  234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4 \
     built                            0.8.0  f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64 \
@@ -136,7 +136,7 @@ cargo.crates \
     bzip2-sys                 0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                              1.2.22  32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1 \
+    cc                              1.2.23  5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
@@ -208,6 +208,7 @@ cargo.crates \
     dtor                             0.0.6  97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8 \
     dtor-proc-macro                  0.0.5  7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055 \
     duct                            0.13.7  e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c \
+    duct                             1.0.0  b6ce170a0e8454fa0f9b0e5ca38a6ba17ed76a50916839d217eb5357e05cdfde \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                    2.1.1  4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871 \
@@ -221,7 +222,7 @@ cargo.crates \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     erased-serde                     0.4.6  e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7 \
     errno                            0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
-    errno                           0.3.11  976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e \
+    errno                           0.3.12  cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18 \
     errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
     exec                             0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
     expr-lang                        0.3.0  8ecf48d3d55edfb3a2960f8cd3d13412af146b912446a9e04812af69761e3b56 \
@@ -262,11 +263,11 @@ cargo.crates \
     gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     gix                             0.72.1  01237e8d3d78581f71642be8b0c2ae8c0b2b5c251c9c5d9ebbea3c1ea280dce8 \
     gix-actor                       0.35.1  6b300e6e4f31f3f6bd2de5e2b0caab192ced00dc0fcd0f7cc56e28c575c8e1ff \
-    gix-archive                     0.21.1  85e59cc5867c40065122324265d99416ca0ddeb51d007870868b5f835423fb6c \
-    gix-attributes                  0.26.0  e7e26b3ac280ddb25bb6980d34f4a82ee326f78bf2c6d4ea45eef2d940048b8e \
+    gix-archive                     0.21.2  8826f20d84822a9abd9e81d001c61763a25f4ec96caa073fb0b5457fe766af21 \
+    gix-attributes                  0.26.1  6f50d813d5c2ce9463ba0c29eea90060df08e38ad8f34b8a192259f8bce5c078 \
     gix-bitmap                      0.2.14  b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540 \
     gix-chunk                       0.4.11  0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f \
-    gix-command                      0.6.0  d2f47f3fb4ba33644061e8e0e1030ef2a937d42dc969553118c320a205a9fb28 \
+    gix-command                      0.6.1  d05dd813ef6bb798570308aa7f1245cefa350ec9f30dc53308335eb22b9d0f8b \
     gix-commitgraph                 0.28.0  e05050fd6caa6c731fe3bd7f9485b3b520be062d3d139cb2626e052d6c127951 \
     gix-config                      0.45.1  48f3c8f357ae049bfb77493c2ec9010f58cfc924ae485e1116c3718fc0f0d881 \
     gix-config-value                0.15.0  439d62e241dae2dffd55bfeeabe551275cf9d9f084c5ebc6b48bad49d03285b7 \
@@ -276,9 +277,9 @@ cargo.crates \
     gix-dir                         0.14.1  01e6e2dc5b8917142d0ffe272209d1671e45b771e433f90186bc71c016792e87 \
     gix-discover                    0.40.1  dccfe3e25b4ea46083916c56db3ba9d1e6ef6dce54da485f0463f9fc0fe1837c \
     gix-features                    0.42.1  56f4399af6ec4fd9db84dd4cf9656c5c785ab492ab40a7c27ea92b4241923fed \
-    gix-filter                      0.19.1  f90c21f0d61778f518bbb7c431b00247bf4534b2153c3e85bcf383876c55ca6c \
+    gix-filter                      0.19.2  ecf004912949bbcf308d71aac4458321748ecb59f4d046830d25214208c471f1 \
     gix-fs                          0.15.0  67a0637149b4ef24d3ea55f81f77231401c8463fae6da27331c987957eb597c7 \
-    gix-glob                        0.20.0  2926b03666e83b8d01c10cf06e5733521aacbd2d97179a4c9b1fdddabb9e937d \
+    gix-glob                        0.20.1  90181472925b587f6079698f79065ff64786e6d6c14089517a1972bca99fb6e9 \
     gix-hash                        0.18.0  8d4900562c662852a6b42e2ef03442eccebf24f047d8eab4f23bc12ef0d785d8 \
     gix-hashtable                    0.8.1  b5b5cb3c308b4144f2612ff64e32130e641279fcf1a84d8d40dad843b4f64904 \
     gix-ignore                      0.15.0  ae358c3c96660b10abc7da63c06788dfded603e717edbd19e38c6477911b71c8 \
@@ -313,7 +314,7 @@ cargo.crates \
     gix-validate                    0.10.0  77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d \
     gix-worktree                    0.41.0  54f1916f8d928268300c977d773dd70a8746b646873b77add0a34876a8c847e9 \
     gix-worktree-state              0.19.0  f81e31496d034dbdac87535b0b9d4659dbbeabaae1045a0dce7c69b5d16ea7d6 \
-    gix-worktree-stream             0.21.1  9c7731f9e7ffc45f1f79d6601a37169be0697d4e2bd015495b4f53dffd80b42e \
+    gix-worktree-stream             0.21.2  5acc0f942392e0cae6607bfd5fe39e56e751591271bdc8795c6ec34847d17948 \
     glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
     globset                         0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
@@ -453,7 +454,7 @@ cargo.crates \
     os-release                       0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
     os_pipe                          1.2.1  5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
-    owo-colors                       4.2.0  1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564 \
+    owo-colors                       4.2.1  26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec \
     papergrid                       0.15.0  30268a8d20c2c0d126b2b6610ab405f16517f6ba9f244d8c59ac2c512a8a1ce7 \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
@@ -570,6 +571,7 @@ cargo.crates \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shared_child                     1.0.2  7e297bd52991bbe0686c086957bee142f13df85d1e79b0b21630a99d374ae9dc \
+    shared_thread                    0.1.0  c7a6f98357c6bb0ebace19b22220e5543801d9de90ffe77f8abb27c056bac064 \
     shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
     shell-words                      1.1.0  24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
@@ -698,7 +700,7 @@ cargo.crates \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     windows                         0.57.0  12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143 \
     windows-core                    0.57.0  d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d \
-    windows-core                    0.61.0  4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980 \
+    windows-core                    0.61.1  46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40 \
     windows-implement               0.57.0  9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7 \
     windows-implement               0.60.0  a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836 \
     windows-interface               0.57.0  29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7 \
@@ -706,9 +708,9 @@ cargo.crates \
     windows-link                     0.1.1  76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38 \
     windows-registry                 0.4.0  4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3 \
     windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
-    windows-result                   0.3.2  c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252 \
+    windows-result                   0.3.3  4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d \
     windows-strings                  0.3.1  87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319 \
-    windows-strings                  0.4.0  7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97 \
+    windows-strings                  0.4.1  2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
@@ -736,7 +738,7 @@ cargo.crates \
     writeable                        0.6.1  ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb \
     x25519-dalek                     2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
     xattr                            1.5.0  0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e \
-    xx                               2.1.0  e9a93c5b2191a4bdcbd320bb847ad302defbf37f2e517b1fe93984ed5217aa90 \
+    xx                               2.1.1  a0b0d18c02f29d5a0a5e543a90c0190a17370d4f9820b15ee347992d212c22db \
     xz2                              0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                             0.8.0  5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc \
@@ -750,8 +752,9 @@ cargo.crates \
     zerotrie                         0.2.2  36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595 \
     zerovec                         0.11.2  4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428 \
     zerovec-derive                  0.11.1  5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f \
-    zip                              2.5.0  27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88 \
-    zipsign-api                      0.1.3  8e7c724c3a8e5833aad6b7028f4f0989fa3a640ce799bf8c352f417b8ef9db3e \
+    zip                              2.4.2  fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50 \
+    zip                              3.0.0  12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308 \
+    zipsign-api                      0.1.4  a9240c17ab9e129def0c16b56608e90a734724dfb2bcf73af30f63e340cac495 \
     zlib-rs                          0.5.0  868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8 \
     zopfli                           0.8.2  edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7 \
     zstd                            0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \


### PR DESCRIPTION
#### Description

mise: Update to 2025.5.6

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
