### PR TITLE
ruby-build: Update to 20250516

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250507 v
+github.setup        rbenv ruby-build 20250516 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  d2525218c298c3abdf42254f920a653966be7860 \
-                    sha256  59992f934dccb48d2547969efd3075a5338617e02a5bff8c566ca1e51b6d349d \
-                    size    96694
+checksums           rmd160  e5c588945e4b2a1d8b8446ab56d0013532bd25db \
+                    sha256  16b3778d6a8ab04dec53078bedb728d87dec97727b9e88c0acd8194a9728c269 \
+                    size    96894
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250516

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
