### PR TITLE
mod_tile: update to 0.8.1

### DIFF
--- a/gis/mod_tile/Portfile
+++ b/gis/mod_tile/Portfile
@@ -5,9 +5,9 @@ PortGroup           active_variants 1.1
 PortGroup           boost 1.0
 PortGroup           github 1.0
 
-github.setup        openstreetmap mod_tile 0.7.2 v
+github.setup        openstreetmap mod_tile 0.8.1 v
 github.tarball_from archive
-revision            1
+revision            0
 
 categories-append   gis
 maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
@@ -24,9 +24,9 @@ long_description    mod_tile is a system to serve raster tiles for example to us
                     a high performance serving and can support several thousand requests \
                     per second.
 
-checksums           rmd160  191b6eb0886efc0c7f3fb8b6170eb5d581dcc706 \
-                    sha256  7988335986d9dadc5275cd955c5af14d3648addb68b16866bb79f27aa76797e3 \
-                    size    1483176
+checksums           rmd160  6b6df6cc45757624039cf3fa9f5a16b09093ffd5 \
+                    sha256  65488da5e4bb79e8766b1f9fea55cde0e262f7bf726b9d5fc1d2fcedb412492d \
+                    size    1512525
 
 # boost.version must follow that of the `mapnik` port.
 boost.version       1.76
@@ -43,7 +43,7 @@ depends_lib         port:curl \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
                     port:mapnik \
-                    port:proj7 \
+                    port:proj9 \
                     port:tiff \
                     port:webp \
                     port:zlib

--- a/gis/mod_tile/files/README_MacPorts.md
+++ b/gis/mod_tile/files/README_MacPorts.md
@@ -65,17 +65,34 @@ man pages for further information.
 To delete the imported data and start afresh, delete the database and the
 `mod_tile` tile cache.
 
-As a PostgreSQL super user, drop the database (default `gis`):
+1.  As a PostgreSQL super user, drop the database (default `gis`):
 
-	$ dropdb gis
+		$ dropdb gis
 
-Remove the tile cache with:
+2.  Remove the tile cache with:
 
-	$ sudo rm -rf @PREFIX@/var/lib/mod_tile/*
+		$ sudo rm -rf @PREFIX@/var/lib/mod_tile/*
 
-Remove the state files for incremental updates with:
+3.  Remove the state files for incremental updates with:
 
-	$ sudo rm -rf @PREFIX@/var/lib/mod_tile/.osmosis
+		$ sudo rm -rf @PREFIX@/var/lib/mod_tile/.osmosis
+
+Optionally, re-create the `mapnik.xml` file in order to use the latest
+stylesheets from the `openstreetmap-carto` port.  e.g.
+
+1.  Rename the current `mapnik.xml`
+
+		$ cd @PREFIX@/etc/renderd/
+		$ sudo mv mapnik.xml mapnik.xml~
+
+2.  If necessary, install the `carto` port:
+
+		$ sudo port install carto
+
+3.  Use `carto` to create an updated version of `mapnik.xml`:
+
+		$ carto @PREFIX@/share/openstreetmap-carto/project.mml | \
+		sudo tee @PREFIX@/etc/renderd/mapnik.xml
 
 ## Noto Fonts
 
@@ -84,7 +101,8 @@ are available under `@PREFIX@/lib/mapnik/fonts`.  Download the fonts and
 create a symbolic to their installed location:
 
 1.	Download a zip containing the fonts from
-    <https://www.google.com/get/noto/help/install/>
+    <https://github.com/google/fonts> - there is a link under `Download All
+    Google Fonts` - or from <https://github.com/notofonts/notofonts.github.io/releases>.
 
 		$ sudo mkdir -p /usr/local/share/fonts/noto
 		$ sudo chown $USER /usr/local/share/fonts/noto
@@ -97,6 +115,26 @@ The debug information written to `@PREFIX@/var/lib/renderd/renderd.log`
 during the daemon startup reports whether fonts are loaded successfully or
 not.  The configuration is fundamentally a priority preference for normal,
 bold and oblique fonts.  It is expected some font varieties will not be found.
+
+**Note:** sorting out the fonts you want from the downloads is cumbersome.
+Installing the `findutils` package and using `gfind` (needed for using
+extended regular expresssions) can ease the process.
+
+E.g. list how many files the release from
+[notofonts releases](https://github.com/notofonts/notofonts.github.io/releases)
+contain:
+
+	$ gfind ~/Downloads/notofonts.github.io-noto-monthly-release-2025.02.01/ \
+	-type f -regextype posix-extended \
+	-regex '.*/googlefonts/ttf/Noto(Sans|Serif).*\.ttf' | \
+	wc -l
+
+and copying those files to the font folder:
+
+	$ gfind ~/Downloads/notofonts.github.io-noto-monthly-release-2025.02.01/
+	-type f -regextype posix-extended -regex
+	'.*/googlefonts/ttf/Noto(Sans|Serif).*\.ttf' \
+	-exec cp '{}' /usr/local/share/fonts/noto/ \;
 
 ## Changing the Default Database name
 
@@ -114,7 +152,7 @@ its original source file as follows:
 1.  Make a copy of `@PREFIX@/share/openstreetmap-carto/project.mml` and edit
     the `dbname` attribute appropriately in the copy.
 
-1.  Use `carto` to re-create `mapnik.xml` using the copy of the `project.mml`
+2.  Use `carto` to re-create `mapnik.xml` using the copy of the `project.mml`
     source file:
 
 		$ sudo port install carto

--- a/gis/mod_tile/files/osm_setup_db.sh
+++ b/gis/mod_tile/files/osm_setup_db.sh
@@ -37,9 +37,9 @@
 #      OSM2PGSQL_RAM=4096 OSM2PGSQL_CPUS=4 ./osm_setup_db.sh
 #
 # Before running this script, you need to ensure that PostgreSQL has been
-# configured for the 'nobody' to be able to access the 'gis' database without
+# configured for the 'nobody' user to be able to access the 'gis' database without
 # a password.  Refer to the Ident Authentication section in the PostgreSQL
-# Manual, https://www.postgresql.org/docs/12/auth-ident.html to understand any
+# Manual, https://www.postgresql.org/docs/16/auth-ident.html to understand any
 # security implications of this approach.
 #
 # The simplest way to configure this is to add an 'ident' method for 'gis' and
@@ -56,7 +56,7 @@
 #
 # Reload the PostgreSQL server configuration after making the change.  E.g
 #
-# sudo port reload  postgresql12-server
+# sudo port reload  postgresql16-server
 #
 # If the file specified by $PBF_FILENAME exists, it is imported as-is.  If it
 # does not exist, it is assumed to be a file hosted at $PBF_DOWNLOAD_BASE_URL,
@@ -194,6 +194,16 @@ createDatabase()
 	    >&2 echo "Error creating indexes in PostgreSQL"
 	    exit 1
 	fi
+	if [ -f "$PREFIX/share/openstreetmap-carto/functions.sql" ]; then
+	    >&2 echo "Creating functions..."
+	    sudo -u "$GIS_USER" "$PGSQLBINPATH/psql" -d "$GIS_DB" -U "$GIS_DB_USER" \
+		 -f "$PREFIX/share/openstreetmap-carto/functions.sql" >/dev/null
+	    if [ $? -ne 0 ]; then
+		>&2 echo "Error creating functions in PostgreSQL"
+		exit 1
+	    fi
+	fi
+
     fi
 }
 

--- a/gis/mod_tile/files/osmosis-db_replag.diff
+++ b/gis/mod_tile/files/osmosis-db_replag.diff
@@ -1,5 +1,5 @@
---- utils/osmosis-db_replag~	2024-12-26 18:40:12
-+++ utils/osmosis-db_replag	2024-12-26 18:49:23
+--- utils/osmosis-db_replag~	2025-05-17 15:19:08
++++ utils/osmosis-db_replag	2025-05-17 15:18:20
 @@ -15,15 +15,27 @@
  # You should have received a copy of the GNU General Public License
  # along with this program; If not, see http://www.gnu.org/licenses/.
@@ -24,12 +24,12 @@
 +    awk '{split($0, a, "="); print a[2]}' |
 +    tr 'T' ' ' |
 +    xargs -I{} ${BINPATH}date --utc --date "{}" +%s)
-+  is=$(date --utc +%s)
++  is=$(date -u +%s)
 +else
 +  rep=$(cat ${STATE} |\
 +    awk '/timestamp=/{d = substr($1, 11, 10);t = substr($1, 22, 10); z = substr($1, 32); if (z = "Z") {z = "UTC";}; print d " " t z;}' |\
 +    xargs -I{} ${BINPATH}date -ju -f "%Y-%m-%d %H:%M:%S%Z" "{}" +%s)
-+  is=$(date --utc +%s)
++  is=$(date -u +%s)
 +fi
 +
  lag=$(($is - $rep))


### PR DESCRIPTION
#### Description

- Update `proj7` dependency to `proj9`
- Updated README on where to obtain Noto fonts and updating `mapnik.xml`
- Updated notes in `osm_setup_db.sh` script to refer to PostgreSQL 16
- Added executing `functions.sql` to `osm_setup_db.sh` script
- Fix formatting time difference message in log output `osmosis-db_replag.diff`

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
