### PR TITLE
openstreetmap-carto: update to 5.9.0

### DIFF
--- a/gis/openstreetmap-carto/Portfile
+++ b/gis/openstreetmap-carto/Portfile
@@ -5,12 +5,14 @@ PortGroup           active_variants 1.1
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        gravitystorm openstreetmap-carto 5.8.0 v
+github.setup        gravitystorm openstreetmap-carto 5.9.0 v
 github.tarball_from archive
 revision            0
 
 categories          gis
 maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
+
+supported_archs     noarch
 
 # license CC0-1.0 (http://creativecommons.org/publicdomain/zero/1.0/)
 license             public-domain
@@ -20,11 +22,11 @@ description         A general-purpose OpenStreetMap mapnik style, in CartoCSS
 long_description    These are the CartoCSS map stylesheets for the Standard \
                     map layer on OpenStreetMap.org.
 
-checksums           rmd160  a2bc4b2445857a7334fc031e8397c8e16984e832 \
-                    sha256  fb8ab188d3677a81132948ceed14a7e6352f6cee3d7112db405712881f083c7b \
-                    size    3472021
+checksums           rmd160  6fded6263f911b4299f5c3bc25783e9edf3bfce0 \
+                    sha256  03b637652b13e3ed6bdb83979ff01cae2a26b33e60fdaca7ad3a8cd045ec4045 \
+                    size    3473752
 
-python.default_version 312
+python.default_version 313
 
 depends_lib-append  port:py${python.version}-psycopg2 \
                     port:py${python.version}-requests \
@@ -36,18 +38,27 @@ set configdir       ${prefix}/etc/${name}
 
 patchfiles          style-fonts-mss.diff
 
-variant postgresql15 conflicts postgresql16 description {Use with PostgreSQL 15} {
+variant postgresql15 conflicts postgresql16 postgresql17 \
+        description {Use with PostgreSQL 15} {
     require_active_variants py${python.version}-psycopg2 postgresql15
     depends_lib-append port:postgresql15
 }
 
-variant postgresql16 conflicts postgresql15 description {Use with PostgreSQL 16} {
+variant postgresql16 conflicts postgresql15 postgresql17 \
+        description {Use with PostgreSQL 16} {
     require_active_variants py${python.version}-psycopg2 postgresql16
     depends_lib-append port:postgresql16
 }
 
-if {![variant_isset postgresql15] && ![variant_isset postgresql16]} {
-    default_variants +postgresql16
+variant postgresql17 conflicts postgresql15 postgresql16 \
+        description {Use with PostgreSQL 17} {
+    require_active_variants py${python.version}-psycopg2 postgresql17
+    depends_lib-append port:postgresql17
+}
+
+if {![variant_isset postgresql15] && ![variant_isset postgresql16] && \
+        ![variant_isset postgresql17]} {
+    default_variants +postgresql17
 }
 
 post-patch {


### PR DESCRIPTION
#### Description

Add and default to postgresql17

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
