### PR TITLE
llama.cpp: update to b5415

### DIFF
--- a/llm/llama.cpp/Portfile
+++ b/llm/llama.cpp/Portfile
@@ -5,9 +5,9 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.1
 
-github.setup            ggerganov llama.cpp 4534 b
+github.setup            ggerganov llama.cpp 5415 b
 github.tarball_from     archive
-set git-commit          955a6c2
+set git-commit          6a2bc8b
 # This line is for displaying commit in CLI only
 revision                0
 categories              llm
@@ -19,9 +19,9 @@ long_description        The main goal of ${name} is to enable LLM inference with
                         setup and state-of-the-art performance on a wide variety of hardware\
                          - locally and in the cloud.
 
-checksums               rmd160  771fa15d2c7b6a3ef9114fd3c0afb676e0ba6559 \
-                        sha256  f4b57daa8d6bfe957f08a79f02ea9d24018ce9e73663c35a5c21f31ed3ccfcb8 \
-                        size    20496342
+checksums               rmd160  3f1d54605e48a6a36d1c36dbf0b1a2a48d478927 \
+                        sha256  a6546b9a7b901ad091e3303e16447c047b708571fdb4dc27c0d414d922ad96f3 \
+                        size    21790465
 
 # error: 'filesystem' file not found on 10.14
 legacysupport.newest_darwin_requires_legacy \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.5 23H527 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?~~ <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of ~~all binary files~~? (`llama-bench`, `llama-cli`, `llama-server`, `llama-simple`, `llama-simple-chat`)
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? (+blas+openmp)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
