### PR TITLE
cdargs: Add missing dependency, etc.

### DIFF
--- a/sysutils/cdargs/Portfile
+++ b/sysutils/cdargs/Portfile
@@ -4,7 +4,10 @@ name            cdargs
 version         1.35
 revision        1
 categories      sysutils
-maintainers     entropy.ch:reg.macports
+license         GPL-2
+maintainers     entropy.ch:reg.macports \
+                openmaintainer
+
 description     Bookmarks for the shell
 long_description \
     CDargs heavily enhances the navigation of the common unix \
@@ -17,15 +20,18 @@ long_description \
 
 homepage        http://www.skamphausen.de/cgi-bin/ska/CDargs
 
-platforms       darwin
-
 master_sites    http://www.skamphausen.de/downloads/cdargs/
 
-checksums       md5 50be618d67f0b9f2439526193c69c567 \
-                sha1 20017d09d3259fcd1385754554a3e17a1c975f9b \
-                rmd160 44cbe35281ab29fa48149792c34afa61d117e33d
+checksums       rmd160 44cbe35281ab29fa48149792c34afa61d117e33d \
+                sha256 ee35a8887c2379c9664b277eaed9b353887d89480d5749c9ad957adf9c57ed2c \
+                size   74103
 
-configure.args  --mandir=${prefix}/share/man
+depends_lib-append \
+                port:ncurses
+
+configure.args-append \
+                --with-ncurses \
+                --mandir=${prefix}/share/man
 
 patchfiles      patch-contrib-cdargs-bash.sh.diff
 


### PR DESCRIPTION
#### Description

cdargs @1.35:

* Add missing dependency: ncurses
* Add missing license: GPL-2
* Use modern checksums.
* Add openmaintainer.
* Remove obsolete platforms line. 

Closes https://trac.macports.org/ticket/72470

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?