### PR TITLE
gimp3-devel: update to 3.2.6

### DIFF
--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -50,7 +50,6 @@ depends_build-append \
 depends_lib-append \
                     port:aalib \
                     port:appstream \
-                    port:appstream-glib \
                     port:atk \
                     path:lib/pkgconfig/babl-0.1.pc:babl \
                     port:bzip2 \
@@ -88,6 +87,7 @@ depends_lib-append \
                     port:libxml2 \
                     port:libxslt \
                     port:libyaml \
+                    port:maxflow \
                     port:mypaint-brushes \
                     port:nasm \
                     port:openexr \
@@ -98,12 +98,11 @@ depends_lib-append \
                     port:poppler-data \
                     port:qoi \
                     port:shared-mime-info \
+                    port:suitesparse_umfpack \
                     port:tiff \
                     port:webp \
                     port:x265 \
-                    port:xdg-utils \
                     port:xmlto \
-                    port:xpm \
                     port:xz \
                     port:zlib
 
@@ -247,6 +246,8 @@ variant x11 conflicts quartz {
     require_active_variants gtk3 x11
 
     depends_lib-append \
+                    port:xdg-utils \
+                    port:xpm \
                     port:xorg-libXcursor \
                     port:xorg-libXmu \
                     port:xorg-libXext \

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -9,8 +9,8 @@ PortGroup           perl5 1.0
 name                gimp3-devel
 set my_name         gimp3
 conflicts           gimp2 gimp2-devel
-version             2.99.rc1
-revision            4
+version             3.0.4
+revision            0
 license             GPL-3+
 categories          graphics
 maintainers         {devans @dbevans} {mascguy @mascguy}
@@ -25,23 +25,22 @@ long_description    The GNU Image Manipulation Program (GIMP) is a powerful \
                     git master.
 homepage            https://gimp.org/
 
-# TODO: Once 3.0 officially released, eliminate these versions hacks
-set branch          3.0
-#set branch          [join [lrange [split ${version} .] 0 1] .]
+set branch          [join [lrange [split ${version} .] 0 1] .]
 master_sites        gimp:gimp/v${branch}/
 dist_subdir         ${my_name}
-distname            gimp-3.0.0-RC1
+distname            gimp-${version}
 use_xz              yes
 
-checksums           rmd160  18f197f32e38304dba69b2d5af62534174892852 \
-                    sha256  b3d0b264c5e38e789faaf3417003397f3240014c59c7f417f9ca3bd39c5ffb66 \
-                    size    28863948
+checksums           rmd160  7df3757374e899505d9fe5c8c2763aea8dcdc313 \
+                    sha256  8caa2ec275bf09326575654ac276afc083f8491e7cca45d19cf29e696aecab25 \
+                    size    27060240
 
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload
 
+set py_ver          3.13
+
 depends_build-append \
-                    port:appstream-glib \
                     port:gettext \
                     port:gtk-doc \
                     port:perl${perl5.major} \
@@ -50,6 +49,7 @@ depends_build-append \
 
 depends_lib-append \
                     port:aalib \
+                    port:appstream-glib \
                     port:atk \
                     path:lib/pkgconfig/babl-0.1.pc:babl \
                     port:bzip2 \
@@ -66,7 +66,9 @@ depends_lib-append \
                     port:glib-networking \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                    path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:iso-codes \
+                    port:json-glib \
                     port:lcms2 \
                     port:libheif \
                     path:include/turbojpeg.h:libjpeg-turbo \
@@ -81,10 +83,14 @@ depends_lib-append \
                     port:mypaint-brushes1 \
                     port:openexr \
                     port:openjpeg \
+                    path:lib/pkgconfig/pango.pc:pango \
                     path:lib/pkgconfig/poppler.pc:poppler \
+                    port:shared-mime-info \
                     port:tiff \
                     port:webp \
                     port:xdg-utils \
+                    port:xpm \
+                    port:xz \
                     port:zlib
 
 depends_run-append \
@@ -102,12 +108,14 @@ patchfiles-append   patch-etc-gimprc.in.diff
 patchfiles-append   patch-quartz-32bit.diff
 patchfiles-append   MYPAINT_BRUSHES_DIR.patch
 
-if {${os.platform} eq "darwin" && ${os.major} < 11} {
-    # avoid Cursor type conflict between X11 and Quickdraw
-    # error: typedef redefinition with different types ('struct Cursor' vs 'XID' (aka 'unsigned long'))
-    # not an issue on 10.7 and later
-    patchfiles-append \
+platform darwin {
+    if {${os.major} < 11} {
+        # avoid Cursor type conflict between X11 and Quickdraw
+        # error: typedef redefinition with different types ('struct Cursor' vs 'XID' (aka 'unsigned long'))
+        # not an issue on 10.7 and later
+        patchfiles-append \
                     patch-x11-widgets-fix.diff
+    }
 }
 
 post-patch {
@@ -139,18 +147,25 @@ if {[vercmp $xcodeversion 4.3] < 0 && [string match "*macports*" ${configure.com
 
 configure.args-append \
                     -Dalsa=disabled \
-                    -Denable-console-bin=true \
                     -Dbug-report-url=https://guide.macports.org/#project.tickets \
+                    -Denable-console-bin=true \
                     -Dgi-docgen=disabled \
-                    -Dg-ir-doc=false \
                     -Dgudev=disabled \
+                    -Dheif=enabled \
+                    -Djpeg2000=enabled \
+                    -Djpeg-xl=enabled \
+                    -Dheif=enabled \
                     -Dilbm=disabled \
                     -Djavascript=disabled \
                     -Dlibbacktrace=false \
                     -Dlibunwind=false \
                     -Dlua=false \
+                    -Dmng=enabled \
+                    -Dopenexr=enabled \
                     -Dopenmp=disabled \
-                    -Dwebkit-unmaintained=false
+                    -Dvala=disabled \
+                    -Dwebkit-unmaintained=false \
+                    -Dwebp=enabled
 
 # keep empty GIMP font directory
 # silences warning message on startup:
@@ -158,8 +173,6 @@ configure.args-append \
 # - /opt/local/share/gimp/3.0/fonts/
 destroot.keepdirs-append \
                     ${destroot}${prefix}/share/gimp/3.0/fonts
-
-# requires python >= 3.6.0
 
 proc py_setup {py_ver} {
     global env prefix frameworks_dir
@@ -212,8 +225,7 @@ variant x11 conflicts quartz {
                     port:xorg-libXcursor \
                     port:xorg-libXmu \
                     port:xorg-libXext \
-                    port:xorg-libXfixes \
-                    port:xpm
+                    port:xorg-libXfixes
 }
 
 variant quartz conflicts x11 {
@@ -232,4 +244,6 @@ post-activate {
     system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
 }
 
-livecheck.type      none
+livecheck.type      regex
+livecheck.url       https://download.gimp.org/mirror/pub/gimp/v${branch}/
+livecheck.regex     "gimp-(${branch}(?:\\.\\d+)*)${extract.suffix}"

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -11,8 +11,9 @@ set my_name         gimp3
 conflicts           gimp2 gimp2-devel
 version             3.0.4
 revision            0
-license             GPL-3+
+
 categories          graphics
+license             GPL-3+
 maintainers         {devans @dbevans} {mascguy @mascguy}
 
 description         The GNU Image Manipulation Program
@@ -42,7 +43,6 @@ set py_ver          3.13
 
 depends_build-append \
                     port:gettext \
-                    port:gtk-doc \
                     port:perl${perl5.major} \
                     path:bin/pkg-config:pkgconfig \
                     port:realpath
@@ -67,34 +67,48 @@ depends_lib-append \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
+                    path:lib/pkgconfig/icu-uc.pc:icu \
                     port:iso-codes \
+                    port:jasper \
+                    port:json-c \
                     port:json-glib \
                     port:lcms2 \
+                    port:libarchive \
+                    port:libde265 \
                     port:libheif \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libjxl \
                     port:libmng \
                     port:libmypaint \
                     port:libpng \
+                    port:libraw \
                     path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
                     port:libwmf \
                     port:libxml2 \
                     port:libxslt \
+                    port:libyaml \
                     port:mypaint-brushes1 \
+                    port:nasm \
                     port:openexr \
                     port:openjpeg \
                     path:lib/pkgconfig/pango.pc:pango \
+                    port:poly2tri-c \
                     path:lib/pkgconfig/poppler.pc:poppler \
+                    port:poppler-data \
+                    port:qoi \
                     port:shared-mime-info \
                     port:tiff \
                     port:webp \
+                    port:x265 \
                     port:xdg-utils \
+                    port:xmlto \
                     port:xpm \
                     port:xz \
                     port:zlib
 
 depends_run-append \
-                    port:adwaita-icon-theme
+                    port:adwaita-icon-theme \
+                    port:hicolor-icon-theme
 
 # gcc-4.2 5493 and 5666.3_13: gimpcpuaccel.c:180: error: can't find a register in class 'BREG' while reloading 'asm'
 # redefinition of typedef is invalid in C [-Wtypedef-redefinition] (#50329)
@@ -105,7 +119,7 @@ compiler.blacklist-append \
                     *gcc-3.* *gcc-4.* {clang < 700}
 
 patchfiles-append   patch-etc-gimprc.in.diff
-patchfiles-append   patch-quartz-32bit.diff
+#patchfiles-append   patch-quartz-32bit.diff
 patchfiles-append   MYPAINT_BRUSHES_DIR.patch
 
 platform darwin {
@@ -115,6 +129,12 @@ platform darwin {
         # not an issue on 10.7 and later
         patchfiles-append \
                     patch-x11-widgets-fix.diff
+    }
+
+    # gimppickbutton-quartz.c:187:20: error: 'CGWindowListCreateImage' is unavailable: obsoleted in macOS 15.0 -
+    #   Please use ScreenCaptureKit instead.
+    if {${os.major} >= 24} {
+        macosx_deployment_target 14.0
     }
 }
 
@@ -152,11 +172,10 @@ configure.args-append \
                     -Dgi-docgen=disabled \
                     -Dgudev=disabled \
                     -Dheif=enabled \
-                    -Djpeg2000=enabled \
-                    -Djpeg-xl=enabled \
-                    -Dheif=enabled \
                     -Dilbm=disabled \
                     -Djavascript=disabled \
+                    -Djpeg2000=enabled \
+                    -Djpeg-xl=enabled \
                     -Dlibbacktrace=false \
                     -Dlibunwind=false \
                     -Dlua=false \
@@ -246,4 +265,4 @@ post-activate {
 
 livecheck.type      regex
 livecheck.url       https://download.gimp.org/mirror/pub/gimp/v${branch}/
-livecheck.regex     "gimp-(${branch}(?:\\.\\d+)*)${extract.suffix}"
+livecheck.regex     "${my_name}-(${branch}(?:\\.\\d+)*)${extract.suffix}"

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -69,7 +69,6 @@ depends_lib-append \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     path:lib/pkgconfig/icu-uc.pc:icu \
                     port:iso-codes \
-                    port:jasper \
                     port:json-c \
                     port:json-glib \
                     port:lcms2 \
@@ -81,19 +80,16 @@ depends_lib-append \
                     port:libmng \
                     port:libmypaint \
                     port:libpng \
-                    port:libraw \
                     path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
                     port:libwmf \
                     port:libxml2 \
                     port:libxslt \
-                    port:libyaml \
                     port:maxflow \
                     port:mypaint-brushes \
                     port:nasm \
                     port:openexr \
                     port:openjpeg \
                     path:lib/pkgconfig/pango.pc:pango \
-                    port:poly2tri-c \
                     path:lib/pkgconfig/poppler.pc:poppler \
                     port:poppler-data \
                     port:qoi \

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -9,7 +9,7 @@ PortGroup           perl5 1.0
 name                gimp3-devel
 set my_name         gimp3
 conflicts           gimp2 gimp2-devel
-version             3.2.4
+version             3.2.6
 revision            0
 
 categories          graphics
@@ -32,9 +32,9 @@ dist_subdir         ${my_name}
 distname            gimp-${version}
 use_xz              yes
 
-checksums           rmd160  25e1da9b1a8dee53c32134c81fbbce8b07d92505 \
-                    sha256  7312bc53e9c6d2d0056ca7b93f1c6b98707946dd934f714c21b8746ecb601588 \
-                    size    34912956
+checksums           rmd160  bc906db0803eff8d2eea40d22436de072702dece \
+                    sha256  40b15e90ad0c0c631b76da3c467ea9847fa5c24f37413ac5b492804860a28cd8 \
+                    size    35004888
 
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -9,7 +9,7 @@ PortGroup           perl5 1.0
 name                gimp3-devel
 set my_name         gimp3
 conflicts           gimp2 gimp2-devel
-version             3.0.4
+version             3.2.4
 revision            0
 
 categories          graphics
@@ -32,9 +32,9 @@ dist_subdir         ${my_name}
 distname            gimp-${version}
 use_xz              yes
 
-checksums           rmd160  7df3757374e899505d9fe5c8c2763aea8dcdc313 \
-                    sha256  8caa2ec275bf09326575654ac276afc083f8491e7cca45d19cf29e696aecab25 \
-                    size    27060240
+checksums           rmd160  25e1da9b1a8dee53c32134c81fbbce8b07d92505 \
+                    sha256  7312bc53e9c6d2d0056ca7b93f1c6b98707946dd934f714c21b8746ecb601588 \
+                    size    34912956
 
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload
@@ -49,6 +49,7 @@ depends_build-append \
 
 depends_lib-append \
                     port:aalib \
+                    port:appstream \
                     port:appstream-glib \
                     port:atk \
                     path:lib/pkgconfig/babl-0.1.pc:babl \
@@ -87,7 +88,7 @@ depends_lib-append \
                     port:libxml2 \
                     port:libxslt \
                     port:libyaml \
-                    port:mypaint-brushes1 \
+                    port:mypaint-brushes \
                     port:nasm \
                     port:openexr \
                     port:openjpeg \
@@ -218,22 +219,27 @@ proc py_setup {py_ver} {
                     port:py${py_ver_nodot}-gobject3
 }
 
-variant python310 description {Build with python plugin support using python 3.10} {
+variant python310 conflicts python311 python312 python313 description {Build with python plugin support using python 3.10} {
     py_setup 3.10
 }
 
-variant python311 description {Build with python plugin support using python 3.11} {
+variant python311 conflicts python310 python312 python313 description {Build with python plugin support using python 3.11} {
     py_setup 3.11
 }
 
-variant python312 description {Build with python plugin support using python 3.12} {
+variant python312 conflicts python310 python311 python313 description {Build with python plugin support using python 3.12} {
     py_setup 3.12
+}
+
+variant python313 conflicts python310 python311 python312 description {Build with python plugin support using python 3.12} {
+    py_setup 3.13
 }
 
 if {![variant_isset python310] && \
     ![variant_isset python311] && \
-    ![variant_isset python312]} {
-    default_variants-append +python312
+    ![variant_isset python312] && \
+    ![variant_isset python313]} {
+    default_variants-append +python313
 }
 
 # meson.build uses the GTK+ 3 backend to determine whether to enable X11.
@@ -264,5 +270,5 @@ post-activate {
 }
 
 livecheck.type      regex
-livecheck.url       https://download.gimp.org/mirror/pub/gimp/v${branch}/
-livecheck.regex     "${my_name}-(${branch}(?:\\.\\d+)*)${extract.suffix}"
+livecheck.url       https://download.gimp.org/gimp/v${branch}/
+livecheck.regex     "gimp-(${branch}(?:\\.\\d+)*)${extract.suffix}"

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -113,6 +113,9 @@ compiler.cxx_standard 2014
 compiler.blacklist-append \
                     *gcc-3.* *gcc-4.* {clang < 700}
 
+# Patch the build files, to support formal Quartz option
+patchfiles-append   patch-meson-quartz-build-flag.diff
+
 patchfiles-append   patch-etc-gimprc.in.diff
 #patchfiles-append   patch-quartz-32bit.diff
 patchfiles-append   MYPAINT_BRUSHES_DIR.patch
@@ -247,6 +250,9 @@ variant x11 conflicts quartz {
                     port:xorg-libXext \
                     port:xorg-libXfixes \
                     port:xpm
+
+    configure.args-append \
+                    -Dquartz=false
 }
 
 variant quartz conflicts x11 {
@@ -254,6 +260,9 @@ variant quartz conflicts x11 {
 
     depends_lib-append \
                     port:gtk-osx-application-gtk3
+
+    configure.args-append \
+                    -Dquartz=true
 }
 
 if {![variant_isset quartz]} {

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -39,8 +39,6 @@ checksums           rmd160  bc906db0803eff8d2eea40d22436de072702dece \
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload
 
-set py_ver          3.13
-
 depends_build-append \
                     port:gettext \
                     port:perl${perl5.major} \
@@ -53,6 +51,7 @@ depends_lib-append \
                     port:atk \
                     path:lib/pkgconfig/babl-0.1.pc:babl \
                     port:bzip2 \
+                    path:lib/pkgconfig/cairo.pc:cairo \
                     port:cfitsio \
                     port:curl \
                     port:dbus-glib \
@@ -214,27 +213,27 @@ proc py_setup {py_ver} {
                     port:py${py_ver_nodot}-gobject3
 }
 
-variant python310 conflicts python311 python312 python313 description {Build with python plugin support using python 3.10} {
-    py_setup 3.10
-}
-
-variant python311 conflicts python310 python312 python313 description {Build with python plugin support using python 3.11} {
+variant python311 conflicts python312 python313 python314 description {Build with python plugin support using python 3.11} {
     py_setup 3.11
 }
 
-variant python312 conflicts python310 python311 python313 description {Build with python plugin support using python 3.12} {
+variant python312 conflicts python311 python313 python314 description {Build with python plugin support using python 3.12} {
     py_setup 3.12
 }
 
-variant python313 conflicts python310 python311 python312 description {Build with python plugin support using python 3.12} {
+variant python313 conflicts python311 python312 python314 description {Build with python plugin support using python 3.13} {
     py_setup 3.13
 }
 
-if {![variant_isset python310] && \
-    ![variant_isset python311] && \
+variant python314 conflicts python311 python312 python313 description {Build with python plugin support using python 3.14} {
+    py_setup 3.14
+}
+
+if {![variant_isset python311] && \
     ![variant_isset python312] && \
-    ![variant_isset python313]} {
-    default_variants-append +python313
+    ![variant_isset python313] && \
+    ![variant_isset python314]} {
+    default_variants-append +python314
 }
 
 # meson.build uses the GTK+ 3 backend to determine whether to enable X11.
@@ -243,11 +242,11 @@ variant x11 conflicts quartz {
 
     depends_lib-append \
                     port:xdg-utils \
-                    port:xpm \
                     port:xorg-libXcursor \
                     port:xorg-libXmu \
                     port:xorg-libXext \
-                    port:xorg-libXfixes
+                    port:xorg-libXfixes \
+                    port:xpm
 }
 
 variant quartz conflicts x11 {

--- a/graphics/gimp3-devel/files/patch-meson-quartz-build-flag.diff
+++ b/graphics/gimp3-devel/files/patch-meson-quartz-build-flag.diff
@@ -1,0 +1,23 @@
+#==================================================================================================
+# Patch to add formal Quartz build option; required to easily toggle between Quartz and X11
+#==================================================================================================
+--- meson_options.txt.orig	2026-09-12 10:57:41.000000000 -0400
++++ meson_options.txt	2026-09-12 10:59:09.000000000 -0400
+@@ -1,4 +1,5 @@
+ # Build properties
++option('quartz',            type: 'boolean', value: true,   description: 'Enable quartz for macOS')
+ option('ansi',              type: 'boolean', value: false,  description: 'Turn on strict ansi')
+ option('enable-console-bin',type: 'boolean', value: true,   description: 'Build a console-only binary which does not link GTK')
+ option('enable-multiproc',  type: 'boolean', value: true,   description: 'Support for multiple processors')
+--- meson.build.orig	2026-09-12 10:57:34.000000000 -0400
++++ meson.build	2026-09-12 11:00:58.000000000 -0400
+@@ -497,7 +497,8 @@
+ 
+ gtk3_minver       = '3.24.0'
+ gtk3              = dependency('gtk+-3.0',           version: '>='+gtk3_minver)
+-gdk_specific_name = platform_osx ? 'gdk-quartz-3.0' : 'gdk-3.0'
++gdk_quartz        = get_option('quartz')
++gdk_specific_name = gdk_quartz ? 'gdk-quartz-3.0' : 'gdk-3.0'
+ gdk_specific      = dependency(gdk_specific_name)
+ gtk_version_split = gtk3_minver.split('.')
+ gtk_major = gtk_version_split[0].to_int()


### PR DESCRIPTION
### Description

Update to 3.2.6

Supersedes: https://github.com/macports/macports-ports/pull/28480