### PR TITLE
pinact: Update to 3.1.2

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.1.1 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.1.2 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,9 +16,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b0c1c84c8093b7bd76ff2456aa4cd675a52c2c1c \
-                    sha256  9988045463cb1769253fe04ed40754c7cee9b267dfd7e381c6c887752d002d45 \
-                    size    36673
+                    rmd160  d648476d281950718a6b8fbcbd1c35918e83f0c4 \
+                    sha256  a58de86006fef4bb92d2a5a7d46e9de2a671815cdd5cfdad12161435ceb9163c \
+                    size    36689
 
 livecheck.regex     "v(\\d+\\.\\d+\\.\\d+)\$"
 
@@ -36,6 +36,7 @@ notes {
   If you have an existing .pinact.yaml file, you will need to use pinact 2.2 and run
   'pinact migrate' to fix the pinact configuration file for pinact 3.0.
 }
+
 
 
 
@@ -81,10 +82,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  c7caff4ba164feeebdcc568d6598931a20719827e05dfa18ac7d7c495d36b883 \
                         size    20797 \
                     github.com/urfave/cli \
-                        lock    v3.3.2 \
-                        rmd160  e94bc7b255d5cea87598ffa74b9d270de0fb9bdb \
-                        sha256  e2a1cae8a67ea295dfcc9293726eb1c55025b4d01897cdedeca890c0e27337d5 \
-                        size    6801176 \
+                        lock    v3.3.3 \
+                        rmd160  98d2a4512038d2f2ff3e54db4d07441fba74ac0f \
+                        sha256  e3d0978d9c2ec9dc9e4eec944281b8f0e624c25e5ad4ce95c95a668e940fe04b \
+                        size    6801433 \
                     github.com/suzuki-shunsuke/urfave-cli-v3-util \
                         lock    v0.0.5 \
                         rmd160  7790fbae62fea70864b484feb621a785d7b7899e \


### PR DESCRIPTION
#### Description

pinact: Update to 3.1.2

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
