### PR TITLE
mysql8: use protobuf

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -67,7 +67,7 @@ if {$subport eq $name} {
                         port:libfido2       \
                         port:libevent       \
                         path:lib/libldap.dylib:openldap       \
-                        port:protobuf3-cpp  \
+                        port:protobuf       \
                         port:zlib           \
                         port:zstd
 

--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -13,8 +13,8 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     1
-set revision_server     0
+set revision_client     2
+set revision_server     1
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]

--- a/devel/protobuf/Portfile
+++ b/devel/protobuf/Portfile
@@ -1,0 +1,136 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       compiler_blacklist_versions 1.0
+PortGroup       github 1.0
+PortGroup       cmake 1.1
+PortGroup       legacysupport 1.1
+
+# clock_gettime needed for abseil
+# https://github.com/macports/macports-ports/pull/19905#issuecomment-1680281240
+legacysupport.newest_darwin_requires_legacy 15
+
+name            protobuf
+github.setup    protocolbuffers protobuf 30.2 v
+git.branch      v${version}
+revision        0
+
+dist_subdir     ${name}/${version}
+
+categories      devel
+maintainers     nomaintainer
+license         BSD
+
+description     Encode data in an efficient yet extensible format.
+long_description \
+                Google Protocol Buffers are a flexible, efficient, \
+                automated mechanism for serializing structured data -- \
+                think XML, but smaller, faster, and simpler.  You \
+                define how you want your data to be structured once, \
+                then you can use special generated source code to \
+                easily write and read your structured data to and from \
+                a variety of data streams and using a variety of \
+                languages.  You can even update your data structure \
+                without breaking deployed programs that are compiled \
+                against the "old" format.  You specify how you want \
+                the information you're serializing to be structured by \
+                defining protocol buffer message types in .proto \
+                files.  Each protocol buffer message is a small \
+                logical record of information, containing a series of \
+                name-value pairs.
+homepage        https://protobuf.dev
+
+checksums       rmd160  ef4d5bfc28aaec952d4300296016fd0ce8db3e66 \
+                sha256  fb06709acc393cc36f87c251bb28a5500a2e12936d4346099f2c6240f6c7a941 \
+                size    9506934
+
+github.tarball_from releases
+distname        protobuf-${version}
+worksrcdir      protobuf-${version}
+
+# Upstream adds zlib include - which is ${prefix}/include - before search path
+# of 3rd-party components, like gtest, gmock, etc. That causes the external
+# versions of those to be pulled in, and the build fails.
+# So don't let the project cmake add zlib; already added (last) by base.
+patchfiles-append cmake-zlib-include.diff
+
+# generated_message_tctable_decl.h:260:34: error: static assertion failed
+# static_assert(sizeof(MapAuxInfo) <= 8, "");
+# generated_message_tctable_decl.h:260:34: note: the comparison reduces to '(12 <= 8)'
+patchfiles-append patch-fix-bools.diff
+
+compiler.cxx_standard   2017
+compiler.thread_local_storage   yes
+# error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
+compiler.blacklist {clang < 900}
+
+if { [string match *clang* ${configure.compiler}] } {
+    # Quiet deprecation warnings
+    configure.cxxflags-append \
+                -Wno-deprecated-declarations \
+                -Wno-error=unknown-warning-option \
+                -Wno-unknown-warning-option
+}
+
+# https://github.com/protocolbuffers/protobuf/issues/21814
+if {[string match *gcc* ${configure.compiler}] && ${configure.build_arch} in [list arm i386 ppc]} {
+    configure.ldflags-append \
+                -latomic
+}
+
+# Clear optflags; controlled by project, via cmake build type
+configure.optflags
+
+if {[variant_isset debug]} {
+    cmake.build_type Debug
+} else {
+    cmake.build_type RelWithDebInfo
+}
+
+depends_lib-append \
+                port:abseil \
+                port:zlib
+
+configure.args-append \
+                -DBUILD_SHARED_LIBS:BOOL=ON \
+                -Dprotobuf_ABSL_PROVIDER=package \
+                -Dprotobuf_BUILD_LIBPROTOC:BOOL=ON \
+                -Dprotobuf_BUILD_PROTOC_BINARIES:BOOL=ON \
+                -Dprotobuf_BUILD_TESTS:BOOL=OFF
+
+post-destroot {
+    set docdir ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d -m 755 ${docdir}
+
+    foreach f {CONTRIBUTING.md CONTRIBUTORS.txt LICENSE README.md SECURITY.md editors examples} {
+        file copy ${worksrcpath}/${f} ${docdir}
+    }
+}
+
+proc port_test_ver_check {p_name p_ver p_rev} {
+    if { [catch {set port_ver_info [lindex [registry_active ${p_name}] 0]}] } {
+        error "Tests require that ${p_name} be active; install, then re-run tests"
+    } else {
+        set test_ver ${p_ver}_${p_rev}
+        set port_ver [lindex ${port_ver_info} 1]_[lindex ${port_ver_info} 2]
+        ui_info "port_test_ver_check: ${p_name}: test_ver: ${test_ver}; port_ver: ${port_ver}"
+
+        if { [vercmp ${port_ver} ${test_ver}] != 0 } {
+            error "Tests require installed version of ${p_name} to match port; update, then re-run tests"
+        }
+    }
+}
+
+variant tests description {Build with tests enabled} {
+    pre-configure {
+        port_test_ver_check ${subport} ${version} ${revision}
+    }
+
+    configure.args-replace \
+                -Dprotobuf_BUILD_TESTS:BOOL=OFF \
+                -Dprotobuf_BUILD_TESTS:BOOL=ON
+
+    test.run    yes
+    test.target check
+}

--- a/devel/protobuf/files/cmake-zlib-include.diff
+++ b/devel/protobuf/files/cmake-zlib-include.diff
@@ -1,0 +1,10 @@
+--- CMakeLists.txt.orig	2025-05-07 15:35:24
++++ CMakeLists.txt	2025-05-07 15:46:49
+@@ -259,7 +259,6 @@
+ endif (MSVC)
+ 
+ include_directories(
+-  ${ZLIB_INCLUDE_DIRECTORIES}
+   ${protobuf_BINARY_DIR}
+   # Support #include-ing other top-level directories, i.e. upb_generator.
+   ${protobuf_SOURCE_DIR}

--- a/devel/protobuf/files/patch-fix-bools.diff
+++ b/devel/protobuf/files/patch-fix-bools.diff
@@ -1,0 +1,40 @@
+--- src/google/protobuf/generated_message_tctable_decl.h	2025-03-26 23:20:57.000000000 +0800
++++ src/google/protobuf/generated_message_tctable_decl.h	2025-05-18 08:12:04.000000000 +0800
+@@ -154,7 +154,7 @@
+  public:
+   MapTypeCard() = default;
+   constexpr MapTypeCard(int number, WireFormatLite::WireType wiretype,
+-                        bool is_signed, bool is_zigzag, bool is_utf8)
++                        uint8_t is_signed, uint8_t is_zigzag, uint8_t is_utf8)
+       : tag_(static_cast<uint8_t>(WireFormatLite::MakeTag(number, wiretype))),
+         is_signed_(is_signed),
+         is_zigzag_(is_zigzag),
+@@ -166,22 +166,22 @@
+     return static_cast<WireFormatLite::WireType>(tag_ & 7);
+   }
+ 
+-  bool is_signed() const { return is_signed_; }
++  uint8_t is_signed() const { return is_signed_; }
+ 
+-  bool is_zigzag() const {
++  uint8_t is_zigzag() const {
+     ABSL_DCHECK(wiretype() == WireFormatLite::WIRETYPE_VARINT);
+     return is_zigzag_;
+   }
+-  bool is_utf8() const {
++  uint8_t is_utf8() const {
+     ABSL_DCHECK(wiretype() == WireFormatLite::WIRETYPE_LENGTH_DELIMITED);
+     return is_utf8_;
+   }
+ 
+  private:
+   uint8_t tag_;
+-  bool is_signed_ : 1;
+-  bool is_zigzag_ : 1;
+-  bool is_utf8_ : 1;
++  uint8_t is_signed_ : 1;
++  uint8_t is_zigzag_ : 1;
++  uint8_t is_utf8_ : 1;
+ };
+ 
+ // Make the map entry type card for a specified field type.


### PR DESCRIPTION
#### Description
Spun off from #28321 to prevent CI from timing out.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.3 16E140

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

[skip notification]
