### PR TITLE
gstreamer1-gst-plugins-base: Disable graphene for arm64 & x86_64

### DIFF
--- a/gnome/gstreamer1-gst-plugins-base/Portfile
+++ b/gnome/gstreamer1-gst-plugins-base/Portfile
@@ -145,6 +145,16 @@ platform macosx {
         configure.args-append \
                     -Dgl_winsys=cocoa
     }
+
+    # graphene does not support +universal for arm64 & x86_64
+    # https://trac.macports.org/ticket/66888
+    if {${universal_possible} && [variant_isset universal] && "arm64" in ${configure.universal_archs}} {
+        depends_lib-delete \
+                    port:graphene
+        configure.args-replace \
+                    -Dgl-graphene=enabled \
+                    -Dgl-graphene=disabled
+    }
 }
 
 test.run            yes


### PR DESCRIPTION
graphene doesn't support arm64 & x86_64 universal builds

This change would make it possible to install for arm64 & x86_64 +universal, that’s a requirement for installing the `wine-*` ports for reference https://trac.macports.org/ticket/72005

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
