### PR TITLE
cppman: 0.5.9

### DIFF
--- a/lang/cppman/Portfile
+++ b/lang/cppman/Portfile
@@ -4,10 +4,13 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               python 1.0
 
-github.setup            aitjcize cppman 0.5.7
+
+github.setup            aitjcize cppman 0.5.9
 github.tarball_from     archive
 revision                0
-python.default_version  312
+
+# Seems odd, but this successfully triggers linking the binary into bin/
+python.default_version  [python_get_default_version]
 
 maintainers             {eborisch @eborisch} \
                         openmaintainer
@@ -21,9 +24,9 @@ description             C++ 98/11/14/17/20 manual page fetcher / interface.
 long_description        {*}${description} Sourced from cplusplus.com and \
                         cppreference.com.
 
-checksums               rmd160  668576af2c7edc583257c8dcf4ade86243983792 \
-                        sha256  df42088a9c8601289e18589aba3506a803eba8bb31446c183153de6936700526 \
-                        size    3820843
+checksums               rmd160  d582c7a4b3dd5123402251505c23411b88060c0d \
+                        sha256  4413b62af0e2abeb158ae2ddef65d4c0c13fe389c8fca71503ec178c7a9462ce \
+                        size    4657401
 
 depends_lib-append \
     port:groff \


### PR DESCRIPTION
Maintainer update. Migrate to tracking default python flavor.