### PR TITLE
zizmor: Upgrade to 1.8.0

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        woodruffw zizmor 1.7.0 v
+github.setup        zizmorcore zizmor 1.8.0 v
 github.tarball_from archive
 revision            0
-
 
 description         A static analysis tool for GitHub Actions
 
@@ -20,9 +19,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6ff9f415efa0023be51c6bea0b3a14f0304d24cc \
-                    sha256  9564db26f6e134a8f23f6d92c48a25c7cf457fed5de5ac76643cd45abf098129 \
-                    size    347698
+                    rmd160  197831448dac52f7a94e8f686ac36939bf3c9629 \
+                    sha256  6f5f4da30eb7e0fa4b7558a9418b58abd7c5ab467cb2dce330c8189a00668355 \
+                    size    421199
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -65,9 +64,9 @@ cargo.crates \
     cc                                 1.2.20  04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a \
     cfg-if                              1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                         0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    clap                               4.5.37  eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071 \
+    clap                               4.5.38  ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000 \
     clap-verbosity-flag                 3.0.2  2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84 \
-    clap_builder                       4.5.37  efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2 \
+    clap_builder                       4.5.38  379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120 \
     clap_complete                      4.5.50  c91d3baa3bcd889d60e6ef28874126a0b384fd225ab83aa6d8a801c519194ce1 \
     clap_derive                        4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
@@ -112,7 +111,6 @@ cargo.crates \
     getrandom                          0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
     getrandom                           0.3.2  73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0 \
     gimli                              0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
-    github-actions-models              0.28.1  90f4e09b721ac4c2c4af87cbdeac88fff82284dbcf71702066eecc17c3717dff \
     globset                            0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     hashbrown                          0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                                0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
@@ -189,7 +187,7 @@ cargo.crates \
     os_info                            3.10.0  2a604e53c24761286860eba4e2c8b23a0161526476b1de520139d69cdb85a6b5 \
     outref                              0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
     overload                            0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
-    owo-colors                          4.2.0  1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564 \
+    owo-colors                          4.2.1  26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec \
     parking_lot                        0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                   0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     percent-encoding                    2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
@@ -243,7 +241,7 @@ cargo.crates \
     schemafy_lib                        0.6.0  af3d87f1df246a9b7e2bfd1f4ee5f88e48b11ef9cfc62e63f0dead255b1a6f5f \
     scopeguard                          1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     serde                             1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
-    serde-sarif                         0.7.0  b39432f20e354de863582451c54bac03ffa63f7dd77f8b1e0ddee211950ab2a2 \
+    serde-sarif                         0.8.0  a053c46f18a8043570d4e32fefc4c6377f82bf29ec310a33e93f273048e3b0be \
     serde_derive                      1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
     serde_json                        1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
     serde_json_path                     0.7.2  b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33 \
@@ -266,8 +264,8 @@ cargo.crates \
     stable_deref_trait                  1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     streaming-iterator                  0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
     strsim                             0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
-    strum                              0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
-    strum_macros                       0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
+    strum                              0.27.1  f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32 \
+    strum_macros                       0.27.1  c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8 \
     subtle                              2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     syn                               1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                               2.0.101  8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf \
@@ -289,7 +287,7 @@ cargo.crates \
     tinystr                             0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                             1.9.0  09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71 \
     tinyvec_macros                      0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                              1.44.2  e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48 \
+    tokio                              1.45.0  2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165 \
     tokio-macros                        2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-rustls                       0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
     tokio-stream                       0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
@@ -306,14 +304,14 @@ cargo.crates \
     tracing-indicatif                   0.3.9  8201ca430e0cd893ef978226fd3516c06d9c494181c8bf4e5b32e30ed4b40aa1 \
     tracing-log                         0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber                 0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
-    tree-sitter                        0.25.3  b9ac5ea5e7f2f1700842ec071401010b9c59bf735295f6e9fa079c3dc035b167 \
+    tree-sitter                        0.25.4  69aff09fea9a41fb061ae6b206cb87cac1b8db07df31be3ba271fbc26760f213 \
     tree-sitter-bash                   0.23.3  329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e \
     tree-sitter-language                0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
     tree-sitter-powershell             0.25.2  377974a9bbd11ef11aa298d60def669f78b579d11745066a59bc4167e53d360b \
     tree-sitter-yaml                    0.7.0  d0c99f2b92b677f1a18b6b232fa9329afb5758118238a7d0b29cae324ef50d5e \
     try-lock                            0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
-    typed-builder                      0.20.1  cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7 \
-    typed-builder-macro                0.20.1  3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28 \
+    typed-builder                      0.21.0  ce63bcaf7e9806c206f7d7b9c1f38e0dce8bb165a80af0898161058b19248534 \
+    typed-builder-macro                0.21.0  60d8d828da2a3d759d3519cdf29a5bac49c77d039ad36d0782edadbf9cd5415b \
     typenum                            1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
     ucd-trie                            0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     unicode-ident                      1.0.18  5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512 \
@@ -389,7 +387,6 @@ cargo.crates \
     writeable                           0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     xattr                               1.5.0  0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e \
     xxhash-rust                        0.8.15  fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3 \
-    yamlpath                           0.16.0  87c585ad15cb2a723978a39719af264133486ee68bd980e214ff43402e7b674a \
     yansi                               1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                         0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \


### PR DESCRIPTION

#### Description

Upgrade to Zizmor 1.8.0; also change the repo origin.

###### Tested on

macOS 15.5 24F74 arm64 Xcode 16.3 16E140

###### Verification

Have you

- [x] followed our
      [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and
      [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open
      [pull requests](https://github.com/macports/macports-ports/pulls) for the
      same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?