### PR TITLE
google-cloud-sdk: update to 523.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             522.0.0
+version             523.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  109ab0babf5c1ceabe5c1d6319f374d43f808c18 \
-                    sha256  bda6955081890a099a3cb52ea7bdfd94e23cb93c83f540224993a5b1aaa2101b \
-                    size    53930267
+    checksums       rmd160  a6406c6d5dda5e91b214e45d346d746d492c0929 \
+                    sha256  10acdbc09b18c2bb8877e31cf4557c42bc23b733e17616ba11cbcc6406543928 \
+                    size    54027922
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3c31626aae7d1d628b61b14720d4903d0ad67414 \
-                    sha256  5fbbf1455fa4529ea8b235ecd20d3834aa4257dbbe5b5571fbb342539b22f020 \
-                    size    55401036
+    checksums       rmd160  d5ef7113dad7791d5916dccf812201193f989538 \
+                    sha256  e33a1adf893461ecd7d1565a75cf3361f384d6daccd7b0fb468886eefbf9dd89 \
+                    size    55498026
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  235933ee2a9650bdf7ed92d506fd764a05a49bb0 \
-                    sha256  c9fb0dbf35db3fb96600e07b6f2054e2a8db5fae7ea0bb88771b0a7516ce56f1 \
-                    size    55338938
+    checksums       rmd160  1f93612157fdd023b61af4dc0e078a5465e8714a \
+                    sha256  346c0550daa201a408032c0697326f8bd358e46a407cb0decdc00b257cc0243a \
+                    size    55435938
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 523.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?