### PR TITLE
cdargs: Add missing rev bump

### DIFF
--- a/sysutils/cdargs/Portfile
+++ b/sysutils/cdargs/Portfile
@@ -2,7 +2,7 @@ PortSystem      1.0
 
 name            cdargs
 version         1.35
-revision        1
+revision        2
 categories      sysutils
 license         GPL-2
 maintainers     entropy.ch:reg.macports \


### PR DESCRIPTION
#### Description

* Add missing rev bump after PR #28479.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?