### PR TITLE
Update quickjs to 2025-04-26

### DIFF
--- a/devel/quickjs/Portfile
+++ b/devel/quickjs/Portfile
@@ -10,7 +10,7 @@ license          MIT
 maintainers      nomaintainer
 description      A small and embeddable Javascript engine
 long_description ${name} is a small and embeddable Javascript engine. It \
-    supports the ES2020 specification including modules, asynchronous \
+    supports the ES2023 specification including modules, asynchronous \
     generators, proxies and BigInt.
 homepage         https://bellard.org/quickjs/
 
@@ -18,34 +18,32 @@ subport          ${name}-devel {}
 
 if {${subport} eq ${name}} {
     conflicts       ${name}-devel
-    github.setup    bellard ${name} b5e62895c619d4ffc75c9d822c8d85f1ece77e5b
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    github.tarball_from tarball
-    version         20210327
+    github.setup    bellard ${name} 19abf1888db5884a5758036ff6e7fa2b340acedc
+    github.tarball_from archive
+    version         20250405
     revision        0
-    checksums       rmd160  9a6bbc8c7900a77d181120cb498fa7cb51a41b94 \
-                    sha256  758df41d9864202c189040e7c5378f34a4c1c65bca3b1d0a54cbcf7650c35bb3 \
-                    size    597758
+    checksums       rmd160  f7e78f2f04101f01a34fe2e8dc0d58e3d6d06064 \
+                    sha256  20e931a015376de4c38609b889016e926ddbf17a741ced24ef741c1c721f9e53 \
+                    size    570178
 } else {
     # quickjs-devel
     conflicts       ${name}
-    github.setup    bellard ${name} 2788d71e823b522b178db3b3660ce93689534e6d
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    github.tarball_from tarball
-    version         20220306
+    github.setup    bellard ${name} f10ef299a6ab4c36c4162cc5840f128f74ec197c
+    github.tarball_from archive
+    version         20250520
     revision        0
-    checksums       rmd160 548cedf046daaeaeb84cabfc11f5044757714412 \
-                    sha256 06f001604ae8df9bdc7377d088320e698a014ec3434283f49e2c84f609233102 \
-                    size   598937
+    checksums       rmd160 b1ac071d6601277d89c1900f8cb7a63e76bd302d \
+                    sha256 6e1db4fc459f1eb4fc9f5c2716d02e5d6f6494937f7e24d7c3dd7a1777a62408 \
+                    size   590714
     post-extract {
         # `VERSION` is only updated for "real" releases.
-        reinplace "s|2021.03.27|${version}|" ${worksrcpath}/VERSION
+        reinplace "s|2025-04-26|${version}|" ${worksrcpath}/VERSION
     }
 }
 
 use_configure    no
 
-destroot.destdir prefix=${destroot}${prefix}
+destroot.destdir PREFIX=${destroot}${prefix}
 
 post-destroot {
     file mkdir ${destroot}${prefix}/lib/pkgconfig


### PR DESCRIPTION
#### Description

Updates quickjs to 2025-04-26 and quickjs-devel to 2025-05-20

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->