### PR TITLE
wireguard-tools: update to 1.0.20250521

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20210914
-revision            1
-checksums           rmd160  a989471297b6713c59dc3e850aee59fef9e4cd2a \
-                    sha256  97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac \
-                    size    99744
+version             1.0.20250521
+revision            0
+checksums           rmd160  dcf5c503db9c41c95f8fe99d7bb506fac9a2f485 \
+                    sha256  b6f2628b85b1b23cc06517ec9c74f82d52c4cdbd020f3dd2f00c972a1782950e \
+                    size    100340
 
 categories          net
 platforms           darwin
 license             GPL-2
-maintainers         {isi.edu:calvin @cardi} openmaintainer
+maintainers         {acm.org:cardi @cardi} openmaintainer
 description         Tools for the WireGuard VPN
 long_description    \
     wireguard-tools contains command-line tools to interact with \


### PR DESCRIPTION
#### Description
wireguard-tools: update to 1.0.20250521
* update maintainer email

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
