### PR TITLE
chromedriver: Update to version 136.0.7103.113

### DIFF
--- a/www/chromedriver/Portfile
+++ b/www/chromedriver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                chromedriver
-version             136.0.7103.92
+version             136.0.7103.113
 categories          www
 platforms           darwin
 maintainers         nomaintainer
@@ -18,20 +18,6 @@ long_description    WebDriver is an open source tool for automated testing of \
                     and more.
 
 homepage            https://chromedriver.chromium.org/
-
-# https://googlechromelabs.github.io/chrome-for-testing/
-
-platform arm {
-    master_sites    https://storage.googleapis.com/chrome-for-testing-public/${version}/mac-arm64
-    distname        ${name}-mac-arm64
-}
-platform i386 {
-    master_sites    https://storage.googleapis.com/chrome-for-testing-public/${version}/mac-x64
-    distname        ${name}-mac-x64
-}
-
-use_zip             yes
-distfiles           ${distname}${extract.suffix}
 
 if {${os.arch} ni [list arm i386]} {
     known_fail      yes
@@ -51,18 +37,68 @@ if {${os.platform} eq "darwin" && ${os.major} < 20} {
     }
 }
 
+platform arm {
+    set chrome_arch mac-arm64
+}
+platform i386 {
+    set chrome_arch mac-x64
+}
+
+# https://googlechromelabs.github.io/chrome-for-testing/
+master_sites        https://storage.googleapis.com/chrome-for-testing-public/${version}/${chrome_arch}
+
+use_zip             yes
+
+distname            ${name}-${chrome_arch}
+distfiles           ${distname}${extract.suffix}
+
+variant chrome_app \
+    description {Also install chrome-for-testing app with fixed version.} {
+    distfiles-append \
+                    chrome-${chrome_arch}${extract.suffix}
+    notes-append \
+        "Use ${name} with Google\\ Chrome\\ for\\ Testing.app, e.g.
+    with the port py${python_version}-undetected-chromedriver
+    (with your preferred Python version) and the Python code:
+
+    import undetected_chromedriver as uc
+    driver = uc.Chrome(
+        driver_executable_path='${prefix}/bin/${name}',
+        browser_executable_path='${applications_dir}/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing',
+    )"
+}
+
+default_variants-append +chrome_app
+
 # set build_arch by hand on arm64/x86_64 systems to get x86_64/arm64 checksums
+# sudo port -v checksum chromedriver os.arch=i386 build_arch=x86_64
 # sudo port -v checksum chromedriver os.arch=arm build_arch=arm64
 # run `port clean --all chromedriver` afterwards
 
 if {${configure.build_arch} eq {arm64}} {
-    checksums       rmd160  c4e6735210c5ef2523725aa6c3812e735d3a6765 \
-                    sha256  00c0e1a7ceaf22ae95a5f6ebcdda5e11519f17082d77db8b9622bdbd80259324 \
-                    size    8419833
+    checksums       ${name}-${chrome_arch}${extract.suffix} \
+                    rmd160  3b4e8bf5c14b957dd3a205491d67c1b85b0eefe4 \
+                    sha256  8c8a6956b93dc2ccbbc2d1146fa99da0af507c291567d421570e9912e91d2189 \
+                    size    8419908
+    if { [variant_isset "chrome_app"] } {
+        checksums-append \
+                    chrome-${chrome_arch}${extract.suffix} \
+                    rmd160  2b8df3fd6705af1f3d7bd021d4db54da36a4585f \
+                    sha256  8a0a23242157daa323127353e2c95c5d1c21c79d21c2d776b42b572399e087a0 \
+                    size    159581929
+    }
 } elseif {${configure.build_arch} eq {x86_64}} {
-    checksums       rmd160  b8547761e97c1743e209e5d8f1f3227bdc7938b5 \
+    checksums       ${name}-${chrome_arch}${extract.suffix} \
+                    rmd160  b8547761e97c1743e209e5d8f1f3227bdc7938b5 \
                     sha256  3c8ef934f9a37f23081f24fc4354ea37ad08202cc3cca157380bf6524c5bc6ec \
                     size    9207465
+    if { [variant_isset "chrome_app"] } {
+        checksums-append \
+                    chrome-${chrome_arch}${extract.suffix} \
+                    rmd160  ac4d696c48992a5908dadeac05f54268b2f538ae \
+                    sha256  4c7f9dc303fb16e028ed5430406ec2ff10664da15fedc5757c5672fbea58dd22 \
+                    size    167728647
+    }
 }
 
 # most recent versions via
@@ -77,7 +113,12 @@ build {}
 destroot {
     copy \
         ${worksrcpath}/${name} \
-        ${destroot}${prefix}/bin/${subport}
+        ${destroot}${prefix}/bin/${name}
+    if { [variant_isset "chrome_app"] } {
+        copy \
+            "${workpath}/chrome-${chrome_arch}/Google Chrome for Testing.app" \
+            ${destroot}${applications_dir}
+    }
 }
 
 # use these to specify python versions, python3 required
@@ -92,12 +133,13 @@ variant undetected \
 
     depends_lib-append \
                     port:python${python_version} \
-                    port:py${python_version}-undetected-chromedriver
+                    port:py${python_version}-undetected-chromedriver \
+                    port:py${python_version}-websockets
 
     post-patch {
         copy \
             ${worksrcpath}/${name} \
-            ${worksrcpath}/${subport}-${major_version}
+            ${worksrcpath}/${name}-${major_version}
 
         # patch the chromedriver binary through undetected_chromedriver.Patcher
         system -W ${worksrcpath} \
@@ -114,35 +156,35 @@ PATCH_CHROMEDRIVER_PY
         }
         move \
             ${worksrcpath}/${name} \
-            ${worksrcpath}/${subport}-undetected
+            ${worksrcpath}/${name}-undetected
         ln -s \
-            ${prefix}/bin/${subport}-undetected \
+            ${prefix}/bin/${name}-undetected \
             ${worksrcpath}/${name}
     }
 
     post-destroot {
         copy \
-            ${worksrcpath}/${subport}-${major_version} \
+            ${worksrcpath}/${name}-${major_version} \
             ${destroot}${prefix}/bin
         ln -s \
-            ${prefix}/bin/${subport}-${major_version} \
-            ${destroot}${prefix}/bin/${subport}-original
+            ${prefix}/bin/${name}-${major_version} \
+            ${destroot}${prefix}/bin/${name}-original
         copy \
-            ${worksrcpath}/${subport}-undetected \
+            ${worksrcpath}/${name}-undetected \
             ${destroot}${prefix}/bin
     }
 
     notes-append \
-        "The ${subport} binary has been patched to mitigate detection.\
-The original ${name} binary has been moved to ${subport}-original.\
-Use ${subport} with the port
+        "The ${name} binary has been patched to mitigate detection.\
+The original ${name} binary has been moved to ${name}-original.\
+Use ${name} with the port
 
     py${python_version}-undetected-chromedriver
 
 (with your preferred Python version) and the Python code:
 
     import undetected_chromedriver as uc
-    driver = uc.Chrome(driver_executable_path='${prefix}/bin/${subport}-undetected')
+    driver = uc.Chrome(driver_executable_path='${prefix}/bin/${name}-undetected')
 "
 }
 


### PR DESCRIPTION
* Update to version 136.0.7103.113
* Add `+chrome_app` variant default that included `Google Chrome for Testing.app` designed to be a fixed-version Chrome browser to be used with `chromedriver`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
