### PR TITLE
lima: Update to 1.1.0

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 1.0.7 v
+go.setup            github.com/lima-vm/lima 1.1.0 v
 go.offline_build    no
 revision            0
 
@@ -28,29 +28,32 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  ac93199a0b3d9baa17721ad6e508fff3f5f3fd19 \
-                    sha256  90f682e96a370c342c3b16deb1858f37ee28ce88e888e1d6b2634ba24228fdbb \
-                    size    7385799
+checksums           rmd160  3ec50fca233273c7872ecf19d8a22836e9b573c2 \
+                    sha256  0c5e601c3788eaaa9f45bdf00d69e23b5720dd2f35e1be36ad21c032fdabf738 \
+                    size    7413280
 
 build.cmd           make
+
+build.args-append   native
 
 patchfiles          patch-Makefile.diff
 
 platform darwin {
     # Lima defaults to VZ with macOS 13.5 and later; drop dependency from 14 onwards
     if {${os.major} < 23} {
-        depends_run-append port:qemu
-    } else {
-        # added January 2025
-        notes {
-            Please note that the Lima now defaults to native\
-            virtualization support and not QEMU. If you rely on it,\
-            such as for emulating other architectures, you can install\
-            it explicitly:
-
-            port install qemu
-        }
+        default_variants +additional_guestagents
     }
+}
+
+variant additional_guestagents description {Guest agents for all architectures} {
+  build.args-append  additional-guestagents
+  depends_run-append port:qemu
+}
+
+notes {
+    Lima 1.1 now has a variant (+additional_guestagents) disabled\
+    by default, which appends the qemu port and builds guest agents\
+    for all supported architectures.
 }
 
 post-patch {


### PR DESCRIPTION
#### Description

Upgrade to lima 1.1.0. This introduces `+additional_guestagents`, as recommended in the ["Hint for package maintainers"][1] link, where native guest agents are built and installed by default, but additional architecture guest agents are not.

For macOS < 14, this variant is enabled by default; with macOS >= 14 it is disabled by default. **This may be considered a breaking change.**

This is similar to the change where we disabled the installation of `qemu` by default with Lima 1.0, but I am happy to change the configuration so that the guest agents are built by default, but I would also remove `depends_run-append port:qemu` from the variant (and add it back to the macOS < 14 option).

If it's possible to have the build bots build both the default and `+additional_guestagents` variants, this would make things much easier for all users.

For what it's worth, adding `+additional_guestagents` more than triples the build time (206s to 692s).

[1]: https://github.com/lima-vm/lima/releases/tag/v1.1.0#:~:text=Hint%20for%20package%20maintainers

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
