### PR TITLE
openssl3: Fix CVE-2025-4575

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -14,7 +14,7 @@ set major_v         3
 epoch               1
 github.setup        openssl openssl ${major_v}.5.0 openssl-
 name                openssl3
-revision            0
+revision            1
 
 github.tarball_from releases
 checksums           rmd160  a91cd921f76ba9833d2539a980f4366088f3ea8a \
@@ -55,6 +55,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
         replaced_by         ${name}
     }
 }
+
+# CVE-2025-4575
+patchfiles-append   0001-apps-x509.c-Fix-the-addreject-option-adding-trust-in.patch
 
 # https://github.com/macports/macports-ports/pull/26250#issuecomment-2437709579
 # OpenSSL 3.4.0 implements new intrinsic code that increases compiler

--- a/devel/openssl3/files/0001-apps-x509.c-Fix-the-addreject-option-adding-trust-in.patch
+++ b/devel/openssl3/files/0001-apps-x509.c-Fix-the-addreject-option-adding-trust-in.patch
@@ -1,0 +1,66 @@
+From e96d22446e633d117e6c9904cb15b4693e956eaa Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Tue, 20 May 2025 16:34:10 +0200
+Subject: [PATCH] apps/x509.c: Fix the -addreject option adding trust instead
+ of rejection
+
+Fixes CVE-2025-4575
+
+Reviewed-by: Dmitry Belyavskiy <beldmit@gmail.com>
+Reviewed-by: Paul Dale <ppzgs1@gmail.com>
+(Merged from https://github.com/openssl/openssl/pull/27672)
+
+(cherry picked from commit 0eb9acc24febb1f3f01f0320cfba9654cf66b0ac)
+Generator: git format-patch -1 --no-numbered --minimal --patience --src-prefix=./ --dst-prefix=./ e96d2244
+Upstream-status: Backport [e96d2244]
+---
+ apps/x509.c                 |  2 +-
+ test/recipes/25-test_x509.t | 12 +++++++++++-
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git ./apps/x509.c ./apps/x509.c
+index fdae8f383a..0c340c15b3 100644
+--- ./apps/x509.c
++++ ./apps/x509.c
+@@ -465,7 +465,7 @@ int x509_main(int argc, char **argv)
+                            prog, opt_arg());
+                 goto opthelp;
+             }
+-            if (!sk_ASN1_OBJECT_push(trust, objtmp))
++            if (!sk_ASN1_OBJECT_push(reject, objtmp))
+                 goto end;
+             trustout = 1;
+             break;
+diff --git ./test/recipes/25-test_x509.t ./test/recipes/25-test_x509.t
+index 09b61708ff..dfa0a428f5 100644
+--- ./test/recipes/25-test_x509.t
++++ ./test/recipes/25-test_x509.t
+@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
+ 
+ setup("test_x509");
+ 
+-plan tests => 134;
++plan tests => 138;
+ 
+ # Prevent MSys2 filename munging for arguments that look like file paths but
+ # aren't
+@@ -110,6 +110,16 @@ ok(run(app(["openssl", "x509", "-new", "-force_pubkey", $key, "-subj", "/CN=EE",
+ && run(app(["openssl", "verify", "-no_check_time",
+             "-trusted", $ca, "-partial_chain", $caout])));
+ 
++# test trust decoration
++ok(run(app(["openssl", "x509", "-in", $ca, "-addtrust", "emailProtection",
++            "-out", "ca-trusted.pem"])));
++cert_contains("ca-trusted.pem", "Trusted Uses: E-mail Protection",
++              1, 'trusted use - E-mail Protection');
++ok(run(app(["openssl", "x509", "-in", $ca, "-addreject", "emailProtection",
++            "-out", "ca-rejected.pem"])));
++cert_contains("ca-rejected.pem", "Rejected Uses: E-mail Protection",
++              1, 'rejected use - E-mail Protection');
++
+ subtest 'x509 -- x.509 v1 certificate' => sub {
+     tconversion( -type => 'x509', -prefix => 'x509v1',
+                  -in => srctop_file("test", "testx509.pem") );
+-- 
+2.49.0
+


### PR DESCRIPTION
#### Description

No revbump of dependents, since this is a very minor CVE fix only and the OpenSSL version stays the same.
Advisory is at https://openssl-library.org/news/secadv/20241016.txt.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
