### PR TITLE
mise: Update to 2025.5.10

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.5.9 v
+github.setup        jdx mise 2025.5.10 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  38290474c4545aea8a57caed032b473d38b81895 \
-                    sha256  000306d25c99a7beb2f6afdb3e289714c0d4ef64dffa407101e2e49ecbf8ab99 \
-                    size    4164898
+                    rmd160  16c63ef51475f79ac18d575de84bffb1b899a155 \
+                    sha256  ac64cd4eccedd9ee46f3982ad40493b5e72a89a00dae61104ddae62faf29425b \
+                    size    4168375
 
 patchfiles          patch-src_cli_self_update.diff
 


### PR DESCRIPTION
#### Description

mise: Update to 2025.5.10

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
