### PR TITLE
lima: Update to 1.1.1

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 1.1.0 v
+go.setup            github.com/lima-vm/lima 1.1.1 v
 go.offline_build    no
 revision            0
 
@@ -28,32 +28,29 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  3ec50fca233273c7872ecf19d8a22836e9b573c2 \
-                    sha256  0c5e601c3788eaaa9f45bdf00d69e23b5720dd2f35e1be36ad21c032fdabf738 \
-                    size    7413280
+checksums           rmd160  537cdb940ebbd891c34af018eb191b3426171fb5 \
+                    sha256  82577e2223dc0ba06ea5aac539ab836e1724cdd0440d800e47c8b7d0f23d7de5 \
+                    size    7414060
 
 build.cmd           make
-
-build.args-append   native
 
 patchfiles          patch-Makefile.diff
 
 platform darwin {
     # Lima defaults to VZ with macOS 13.5 and later; drop dependency from 14 onwards
     if {${os.major} < 23} {
-        default_variants +additional_guestagents
+        depends_run-append port:qemu
+    } else {
+        # added January 2025
+        notes {
+            Please note that the Lima now defaults to native\
+            virtualization support and not QEMU. If you rely on it,\
+            such as for emulating other architectures, you can install\
+            it explicitly:
+
+            port install qemu
+        }
     }
-}
-
-variant additional_guestagents description {Guest agents for all architectures} {
-  build.args-append  additional-guestagents
-  depends_run-append port:qemu
-}
-
-notes {
-    Lima 1.1 now has a variant (+additional_guestagents) disabled\
-    by default, which appends the qemu port and builds guest agents\
-    for all supported architectures.
 }
 
 post-patch {

--- a/sysutils/lima/files/patch-Makefile.diff
+++ b/sysutils/lima/files/patch-Makefile.diff
@@ -1,6 +1,6 @@
---- ./Makefile	2024-11-08 15:41:57
-+++ ./Makefile	2024-11-08 15:42:13
-@@ -43,7 +43,7 @@
+--- Makefile.orig	2025-05-22 21:39:31
++++ Makefile	2025-05-22 21:40:13
+@@ -45,7 +45,7 @@
  
  PACKAGE := github.com/lima-vm/lima
  
@@ -8,4 +8,4 @@
 +VERSION := @@VERSION@@
  VERSION_TRIMMED := $(VERSION:v%=%)
  
- GO_BUILD_LDFLAGS := -ldflags="-s -w -X $(PACKAGE)/pkg/version.Version=$(VERSION)"
+ KEEP_SYMBOLS ?=


### PR DESCRIPTION
#### Description

Upgrade lima to 1.1.1

###### Tested on

macOS 15.5 24F74 arm64 Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our
      [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and
      [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open
      [pull requests](https://github.com/macports/macports-ports/pulls) for the
      same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important
      [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
