### PR TITLE
lima: Restore build variants

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/lima-vm/lima 1.1.1 v
 go.offline_build    no
-revision            0
+revision            1
 
 homepage            https://lima-vm.io
 
@@ -33,6 +33,7 @@ checksums           rmd160  537cdb940ebbd891c34af018eb191b3426171fb5 \
                     size    7414060
 
 build.cmd           make
+build.args-append   native
 
 patchfiles          patch-Makefile.diff
 
@@ -40,17 +41,18 @@ platform darwin {
     # Lima defaults to VZ with macOS 13.5 and later; drop dependency from 14 onwards
     if {${os.major} < 23} {
         depends_run-append port:qemu
-    } else {
-        # added January 2025
-        notes {
-            Please note that the Lima now defaults to native\
-            virtualization support and not QEMU. If you rely on it,\
-            such as for emulating other architectures, you can install\
-            it explicitly:
-
-            port install qemu
-        }
     }
+}
+
+variant additional_guestagents description {Guest agents for all architectures} {
+  build.args-append  additional-guestagents
+  depends_run-append port:qemu
+}
+
+notes {
+    Lima 1.1 now has a variant (+additional_guestagents) disabled\
+    by default, which appends the qemu port and builds guest agents\
+    for all supported architectures.
 }
 
 post-patch {


### PR DESCRIPTION
#### Description

My update process failed me and the variants are new enough that I had missed the variant reversion. (This appears to be caused by the fact that I had not run `port sync` before using `seaport clip`; this is now part of my update steps.)

###### Type(s)

- [x] bugfix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the
      same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?