### PR TITLE
pnetcdf: Use MacPorts M4, fix Sonoma builds

### DIFF
--- a/science/pnetcdf/Portfile
+++ b/science/pnetcdf/Portfile
@@ -43,6 +43,11 @@ depends_build-append    port:perl5 \
 
 configure.args-append   --disable-silent-rules
 
+# M4 was accidentally left out of Xcode 15.3.  Affects some Sonoma builds.
+# Use MacPorts M4.  For background, see
+# https://github.com/macports/macports-ports/pull/22985 and related tickets.
+configure.env-append    M4=${prefix}/bin/gm4
+
 configure.env-append    MPICC=${mpi.cc} \
                         MPICXX=${mpi.cxx} \
                         MPIF77=${mpi.f77} \


### PR DESCRIPTION
#### Description

* Fixes Sonoma builder failures.
* Build fix only.  No rev bump needed.

Sets extra variable to redirect to MacPorts M4.
Fixes builds on some systems with Xcode 15.3 and 15.4, and Command Line Tools 15.3.
Affects some MacPorts builders as of 2025 May 23, with a down-level (?) CLT version.

M4 was accidentally left out of Xcode 15.3 (and later?).
For background, see https://github.com/macports/macports-ports/pull/22985 and related tickets.
This fix was copied from that ticket.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 14.6.1
Xcode 16.2
Command Line Tools 16.2.0
SDK 15.2

Also tested on CI: OS 13, 14, 15.

Waiting for merge to check results from MacPorts Sonoma builders.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `port -vs install`?
- [x] tested basic functionality of all ~~binary~~ executable files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?