### PR TITLE
quickjs, quickjs-devel: fix build on macOS <10.12

### DIFF
--- a/devel/quickjs/Portfile
+++ b/devel/quickjs/Portfile
@@ -2,6 +2,12 @@
 
 PortSystem       1.0
 PortGroup        github 1.0
+PortGroup        compiler_blacklist_versions 1.0
+PortGroup        legacysupport 1.1
+PortGroup        makefile 1.0
+
+# _clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 name             quickjs
 
@@ -21,7 +27,7 @@ if {${subport} eq ${name}} {
     github.setup    bellard ${name} 19abf1888db5884a5758036ff6e7fa2b340acedc
     github.tarball_from archive
     version         20250405
-    revision        0
+    revision        1
     checksums       rmd160  f7e78f2f04101f01a34fe2e8dc0d58e3d6d06064 \
                     sha256  20e931a015376de4c38609b889016e926ddbf17a741ced24ef741c1c721f9e53 \
                     size    570178
@@ -31,7 +37,7 @@ if {${subport} eq ${name}} {
     github.setup    bellard ${name} f10ef299a6ab4c36c4162cc5840f128f74ec197c
     github.tarball_from archive
     version         20250520
-    revision        0
+    revision        1
     checksums       rmd160 b1ac071d6601277d89c1900f8cb7a63e76bd302d \
                     sha256 6e1db4fc459f1eb4fc9f5c2716d02e5d6f6494937f7e24d7c3dd7a1777a62408 \
                     size   590714
@@ -41,7 +47,26 @@ if {${subport} eq ${name}} {
     }
 }
 
-use_configure    no
+compiler.c_standard  2011
+# fatal error: 'stdatomic.h' file not found
+compiler.blacklist-append {clang < 700}
+
+# without this linking to legacysupport is broken
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    configure.cflags-append \
+                    -D_DARWIN_C_SOURCE -isystem${prefix}/include/LegacySupport
+
+    # See https://github.com/bsekisser/quickjs/commit/c35e6bf
+    if {[string match *gcc* ${configure.compiler}]} {
+            patchfiles-append \
+                    patch-darwin-gcc.diff
+            configure.ldflags-append \
+                    -latomic
+    } elseif {[string match *clang* ${configure.compiler}]} {
+            patchfiles-append \
+                    patch-darwin-clang.diff
+    }
+}
 
 destroot.destdir PREFIX=${destroot}${prefix}
 

--- a/devel/quickjs/files/patch-darwin-clang.diff
+++ b/devel/quickjs/files/patch-darwin-clang.diff
@@ -1,0 +1,25 @@
+--- qjsc.c	2025-03-31 19:37:37.000000000 +0800
++++ qjsc.c	2025-04-01 09:58:55.000000000 +0800
+@@ -435,13 +435,11 @@
+     /* XXX: use the executable path to find the includes files and
+        libraries */
+     *arg++ = "-D";
+-    *arg++ = "_GNU_SOURCE";
++    *arg++ = "_DARWIN_C_SOURCE";
+     *arg++ = "-I";
+     *arg++ = inc_dir;
+     *arg++ = "-o";
+     *arg++ = out_filename;
+-    if (dynamic_export)
+-        *arg++ = "-rdynamic";
+     *arg++ = cfilename;
+     snprintf(libjsname, sizeof(libjsname), "%s/libquickjs%s%s.a",
+              lib_dir, bn_suffix, lto_suffix);
+@@ -449,6 +447,7 @@
+     *arg++ = "-lm";
+     *arg++ = "-ldl";
+     *arg++ = "-lpthread";
++    *arg++ = "-lMacportsLegacySupport";
+     *arg = NULL;
+ 
+     if (verbose) {

--- a/devel/quickjs/files/patch-darwin-gcc.diff
+++ b/devel/quickjs/files/patch-darwin-gcc.diff
@@ -1,0 +1,26 @@
+--- qjsc.c	2025-03-31 19:37:37.000000000 +0800
++++ qjsc.c	2025-04-01 09:58:55.000000000 +0800
+@@ -435,13 +435,11 @@
+     /* XXX: use the executable path to find the includes files and
+        libraries */
+     *arg++ = "-D";
+-    *arg++ = "_GNU_SOURCE";
++    *arg++ = "_DARWIN_C_SOURCE";
+     *arg++ = "-I";
+     *arg++ = inc_dir;
+     *arg++ = "-o";
+     *arg++ = out_filename;
+-    if (dynamic_export)
+-        *arg++ = "-rdynamic";
+     *arg++ = cfilename;
+     snprintf(libjsname, sizeof(libjsname), "%s/libquickjs%s%s.a",
+              lib_dir, bn_suffix, lto_suffix);
+@@ -449,6 +447,8 @@
+     *arg++ = "-lm";
+     *arg++ = "-ldl";
+     *arg++ = "-lpthread";
++    *arg++ = "-latomic";
++    *arg++ = "-lMacportsLegacySupport";
+     *arg = NULL;
+ 
+     if (verbose) {


### PR DESCRIPTION
* respect MacPorts compiler flags during build, revbump to pick changes

Closes: https://trac.macports.org/ticket/70286

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
