### PR TITLE
i2pd: use boost 1.81

### DIFF
--- a/security/i2pd/Portfile
+++ b/security/i2pd/Portfile
@@ -9,7 +9,7 @@ PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
 
 github.setup            PurpleI2P i2pd 2.56.0
-revision                0
+revision                1
 categories              security net
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
 license                 BSD
@@ -23,6 +23,7 @@ checksums               rmd160  c661419d254d8ea245ecf7d7dbb4519f76e04e08 \
                         sha256  eb83f7e98afeb3704d9ee0da2499205f73bab0b1becaf4494ccdcbe4295f8550 \
                         size    694510
 
+boost.version           1.81
 depends_lib-append      port:zlib
 
 patchfiles-append       0001-i2pd.conf-adjust-for-MacPorts.patch


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
