### PR TITLE
trojan: set compiler.cxx_standard 2011, blacklist clang < 700

### DIFF
--- a/net/trojan/Portfile
+++ b/net/trojan/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           boost 1.0
 PortGroup           openssl 1.0
 
@@ -26,6 +27,13 @@ checksums           rmd160  0174f9e903a70fb1ed15244b62a2098b80c44abd \
                     size    51683
 
 boost.version       1.81
+
+# config.h:23:19: error: cstdint: No such file or directory
+compiler.cxx_standard \
+                    2011
+# error: unknown type name 'max_align_t' on macOS <10.10
+compiler.blacklist-append \
+                    {clang < 700}
 
 configure.args-append \
                     -DCMAKE_INSTALL_SYSCONFDIR=${prefix}/etc \


### PR DESCRIPTION
https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/308119/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
