### PR TITLE
pnetcdf: Fix 10.7 build; fix livecheck

### DIFF
--- a/science/pnetcdf/Portfile
+++ b/science/pnetcdf/Portfile
@@ -35,6 +35,12 @@ if {${os.arch} eq "powerpc"} {
 
 #compilers.choose       fc f77 f90 cc cxx
 
+# Xcode clang of 10.7 fails with error: invalid instruction mnemonic 'cvtsi2ssl'
+# Copied from https://github.com/macports/macports-ports/pull/17269
+# Also see https://github.com/william-dawson/NTPoly/issues/192
+compiler.blacklist-append \
+                        {clang < 500} {*gcc-[34].*} {macports-gcc-[56]}
+
 depends_build-append    port:perl5 \
                         port:autoconf \
                         port:automake \
@@ -64,4 +70,4 @@ post-destroot {
 
 livecheck.type          regex
 livecheck.url           ${homepage}
-livecheck.regex         {New version \(([^)]+)\)}
+livecheck.regex         \[Rr\]elease \(\[0-9.\]+\)


### PR DESCRIPTION
#### Description

* Fix error: invalid instruction mnemonic 'cvtsi2ssl' on 10.7
* Blacklist early compiler versions.
* Also fix livecheck.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?