### PR TITLE
google-cloud-sdk: update to 523.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             523.0.0
+version             523.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  a6406c6d5dda5e91b214e45d346d746d492c0929 \
-                    sha256  10acdbc09b18c2bb8877e31cf4557c42bc23b733e17616ba11cbcc6406543928 \
-                    size    54027922
+    checksums       rmd160  810f5ab5c7b140b45adf8533b94b322281d4f308 \
+                    sha256  e1adb36ef3263a0771e90d39400a824e04e50410e76c28cea4552e7b9b41a44b \
+                    size    54027976
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  d5ef7113dad7791d5916dccf812201193f989538 \
-                    sha256  e33a1adf893461ecd7d1565a75cf3361f384d6daccd7b0fb468886eefbf9dd89 \
-                    size    55498026
+    checksums       rmd160  9aaa88cf264d2b53efec1e1cc57115d101220741 \
+                    sha256  498d55c26ac08b2e1f006f51afa07633b14d6c073be727f13c5cdfbe9cd2c013 \
+                    size    55498171
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  1f93612157fdd023b61af4dc0e078a5465e8714a \
-                    sha256  346c0550daa201a408032c0697326f8bd358e46a407cb0decdc00b257cc0243a \
-                    size    55435938
+    checksums       rmd160  4b62821fca92eeeccbd00832f58efab511709510 \
+                    sha256  264d88a7486c906b9f41171680d3a214e3154db8636857afd2c361d5239dfaab \
+                    size    55436199
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 523.0.1.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?