### PR TITLE
update mariadb-10.11 & mariadb-11.4

### DIFF
--- a/databases/mariadb-10.11/Portfile
+++ b/databases/mariadb-10.11/Portfile
@@ -7,7 +7,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-10.11
 set name_mysql      ${name}
-version             10.11.11
+version             10.11.13
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
@@ -26,7 +26,7 @@ if {$subport eq $name} {
     PortGroup           boost 1.0
     PortGroup           openssl 1.0
 
-    boost.version       1.78
+    boost.version       1.87
     compiler.cxx_standard 2011
 
     openssl.branch      3
@@ -44,9 +44,9 @@ if {$subport eq $name} {
 
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160  715741d6f86e0c0d1f60ae19b70c85b8cbb703db \
-                    sha256  6f29d4d7e40fc49af4a0fe608984509ef2d153df3cd8afe4359dce3ca0e27890 \
-                    size    105754084
+    checksums       rmd160  c4d314d228a267e4a0dc83797408b51e16b97cba \
+                    sha256  f8b734749fbd652ea4e255be8cc7880f98d07b6a7feb4e1ea8c736cb480d23e4 \
+                    size    109323757
 
     depends_build-append port:bison
     depends_lib-append  port:curl \

--- a/databases/mariadb-11.4/Portfile
+++ b/databases/mariadb-11.4/Portfile
@@ -7,7 +7,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-11.4
 set name_mysql      ${name}
-version             11.4.5
+version             11.4.7
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
@@ -26,7 +26,7 @@ if {$subport eq $name} {
     PortGroup           boost 1.0
     PortGroup           openssl 1.0
 
-    boost.version       1.81
+    boost.version       1.87
     compiler.cxx_standard 2011
 
     openssl.branch      3
@@ -44,9 +44,9 @@ if {$subport eq $name} {
 
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160  ddb367fd80a8bbcbe236af8b5dc66c713a6d712a \
-                    sha256  ff6595f8c482f9921e39b97fa1122377a69f0dcbd92553c6b9032cbf0e9b5354 \
-                    size    112382453
+    checksums       rmd160  f4876652040b93526ae2dc090f3e038a95b37445 \
+                    sha256  bf20687ca12fa7efda8df89cab1f2a661288cea41acf8f53189b69d5294347d0 \
+                    size    115980754
 
     depends_build-append port:bison
     depends_lib-append  port:curl \


### PR DESCRIPTION
tested on 
```
Model Identifier: MacPro5,1                 Model Identifier: Macmini6,1
macOS 14.7.5 23H527 x86_64                  macOS 10.15.7 19H2026 x86_64
Xcode 16.2 16C5032a                         Xcode 12.4 12D4e
Command Line Tools 16.2.0.0.1.1733547573    Command Line Tools 12.4.0.0.1.1610135815
```