### PR TITLE
py-pbs_installer: new port

### DIFF
--- a/python/py-pbs_installer/Portfile
+++ b/python/py-pbs_installer/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pbs_installer
+version             2025.5.17
+revision            0
+categories-append   devel
+platforms           {darwin any}
+license             MIT
+supported_archs     noarch
+
+python.versions     39 310 311 312 313
+
+maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
+
+description         An installer for indygreg's python-build-standalone
+
+long_description    The list of python versions are kept sync with the upstream automatically
+
+homepage            https://github.com/frostming/pbs-installer
+
+checksums           rmd160  c8e1d47fedd437a6cd85b88a7c8e028ad3d227e3 \
+                    sha256  8e319b17662ae583e607d5fd46900cb2a7b31ee9ae0c695126c1b9b38e6a78a0 \
+                    size    54998
+
+python.pep517_backend pdm
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+        port:py${python.version}-httpx \
+        port:py${python.version}-zstd
+}


### PR DESCRIPTION
#### Description

Another new dependency for poetry

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4 24E248 x86_64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
