### PR TITLE
legacysupport-1.1.tcl: Remove temporary bug fix

### DIFF
--- a/_resources/port1.0/group/legacysupport-1.1.tcl
+++ b/_resources/port1.0/group/legacysupport-1.1.tcl
@@ -91,13 +91,6 @@ proc legacysupport::get_newest_darwin_with_missing_symbols {} {
     return ${ls_max_darwin_support}
 }
 
-# please remove when a86f95c has been in a released MacPorts version for at least two weeks
-# see https://github.com/macports/macports-base/commit/a86f95c5ab86ee52c8fec2271e005591179731de
-if {![info exists compiler.limit_flags]} {
-    options compiler.limit_flags
-    default compiler.limit_flags        no
-}
-
 proc legacysupport::get_depends_type {} {
     if {[option legacysupport.use_static]} {
         return depends_build


### PR DESCRIPTION
#### Description

* Housekeeping.  Remove temporary options block, as requested.
* The related base bug was resolved with earlier commit:
* https://github.com/macports/macports-base/commit/a86f95c5ab86ee52c8fec2271e005591179731de

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
