### PR TITLE
mise: Update to 2025.5.14

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.5.10 v
+github.setup        jdx mise 2025.5.14 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  16c63ef51475f79ac18d575de84bffb1b899a155 \
-                    sha256  ac64cd4eccedd9ee46f3982ad40493b5e72a89a00dae61104ddae62faf29425b \
-                    size    4168375
+                    rmd160  682f6db9d4504de2b19f876d19c19b04dfda60ac \
+                    sha256  aaae94bff1df40ee0a337e465b355ee1749433c54b669bef89562cb50be77613 \
+                    size    4181634
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -103,12 +103,14 @@ cargo.crates \
     anstyle                         1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
     anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
-    anstyle-wincon                   3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
+    anstyle-wincon                   3.0.8  6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa \
     anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
     arbitrary                        1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
+    async-backtrace                  0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
+    async-backtrace-attributes       0.2.7  affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7 \
     async-compression               0.4.23  b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07 \
     async-trait                     0.1.88  e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
@@ -136,7 +138,7 @@ cargo.crates \
     bzip2-sys                 0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                              1.2.23  5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766 \
+    cc                              1.2.24  16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
@@ -167,7 +169,7 @@ cargo.crates \
     contracts                        0.6.6  dc486fc59d4d0e52ea0b4461a12720c8617338c9ee955cc4013fb7319d264abd \
     cookie-factory                   0.3.3  9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2 \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
-    core-foundation                 0.10.0  b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63 \
+    core-foundation                 0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     countme                          3.0.1  7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636 \
     cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
@@ -189,6 +191,7 @@ cargo.crates \
     darling                        0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
     darling_core                   0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
     darling_macro                  0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
+    dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     dashmap                          6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
     demand                           1.7.0  081fee97d4d3dfb2baf0333ccf376b5cae24448afe5c5652861bb987853d685c \
@@ -256,6 +259,7 @@ cargo.crates \
     futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
     futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
     fuzzy-matcher                    0.3.7  54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94 \
+    generator                        0.7.5  5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                       0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
     getrandom                        0.3.3  26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4 \
@@ -339,7 +343,7 @@ cargo.crates \
     human_format                     1.1.0  5c3b1f728c459d27b12448862017b96ad4767b1ec2ec5e6434e99f1577f085b8 \
     humansize                        2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
     hyper                            1.6.0  cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80 \
-    hyper-rustls                    0.27.5  2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2 \
+    hyper-rustls                    0.27.6  03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d \
     hyper-tls                        0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                      0.1.12  cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710 \
     i18n-config                      0.4.7  8e88074831c0be5b89181b05e6748c4915f77769ecc9a4c372f88b169a8509c9 \
@@ -369,7 +373,7 @@ cargo.crates \
     indoc                            2.0.6  f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
     inout                            0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
     insta                           1.43.1  154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371 \
-    intl-memoizer                    0.5.2  fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda \
+    intl-memoizer                    0.5.3  310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f \
     intl_pluralrules                 7.0.2  078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972 \
     io-close                         0.3.7  9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc \
     io_tee                           0.1.1  4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304 \
@@ -403,6 +407,7 @@ cargo.crates \
     log                             0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
     logos                           0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                    0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
+    loom                             0.5.6  ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5 \
     lru-slab                         0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
     lua-src                        547.0.0  1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42 \
     luajit-src            210.5.12+a4f56a4  b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671 \
@@ -420,9 +425,9 @@ cargo.crates \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     minisign-verify                  0.2.4  e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43 \
     miniz_oxide                      0.8.8  3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a \
-    mio                              1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
+    mio                              1.0.4  78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c \
     mlua                            0.10.3  d3f763c1041eff92ffb5d7169968a327e1ed2ebfe425dac0ee5a35f29082534b \
-    mlua-sys                         0.6.7  1901c1a635a22fe9250ffcc4fcc937c16b47c2e9e71adba8784af8bca1f69594 \
+    mlua-sys                         0.6.8  380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93 \
     mlua_derive                     0.10.1  870d71c172fcf491c6b5fb4c04160619a2ee3e5a42a1402269c66bcbf1dd4deb \
     mockito                          1.7.0  7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48 \
     native-tls                      0.2.14  87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e \
@@ -444,6 +449,7 @@ cargo.crates \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     object                          0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
     once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
+    once_cell_polyfill              1.70.1  a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad \
     opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
     openssl                        0.10.72  fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
@@ -452,7 +458,7 @@ cargo.crates \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     os-release                       0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
-    os_pipe                          1.2.1  5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982 \
+    os_pipe                          1.2.2  db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     owo-colors                       4.2.1  26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec \
     papergrid                       0.15.0  30268a8d20c2c0d126b2b6610ab405f16517f6ba9f244d8c59ac2c512a8a1ce7 \
@@ -504,8 +510,6 @@ cargo.crates \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
-    rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
-    rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                   0.5.12  928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af \
     redox_users                      0.5.0  dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
@@ -534,12 +538,13 @@ cargo.crates \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.12.0  229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79 \
     rustls-webpki                  0.103.3  e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435 \
-    rustversion                     1.0.20  eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2 \
+    rustversion                     1.0.21  8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d \
     ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     salsa20                         0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scc                              2.3.4  22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4 \
     schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
+    scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scrypt                          0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
     sdd                              3.0.8  584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21 \
@@ -584,7 +589,7 @@ cargo.crates \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     slug                             0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
     smallvec                        1.15.0  8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9 \
-    socket2                          0.5.9  4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef \
+    socket2                         0.5.10  e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678 \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
@@ -622,7 +627,7 @@ cargo.crates \
     tinystr                          0.8.1  5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b \
     tinyvec                          1.9.0  09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.45.0  2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165 \
+    tokio                           1.45.1  75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779 \
     tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                    0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
@@ -642,7 +647,7 @@ cargo.crates \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber              0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
-    type-map                         0.5.0  deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f \
+    type-map                         0.5.1  cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90 \
     typeid                           1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
     typenum                         1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
     ubi                              0.6.1  6935e5064a326520a375603b9cddc9058796e39a041bf50e9e1eaa23da785adc \
@@ -698,6 +703,7 @@ cargo.crates \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows                         0.48.0  e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f \
     windows                         0.57.0  12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143 \
     windows-core                    0.57.0  d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d \
     windows-core                    0.61.2  c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3 \
@@ -713,22 +719,30 @@ cargo.crates \
     windows-strings                  0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
     windows-targets                 0.53.0  b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
     windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
     windows_aarch64_gnullvm         0.53.0  86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
     windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
     windows_aarch64_msvc            0.53.0  c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
     windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
     windows_i686_gnu                0.53.0  c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3 \
     windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
     windows_i686_gnullvm            0.53.0  9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11 \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
     windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
     windows_i686_msvc               0.53.0  581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
     windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
     windows_x86_64_gnu              0.53.0  2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_gnullvm          0.53.0  0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
     winnow                          0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
@@ -754,7 +768,7 @@ cargo.crates \
     zerovec-derive                  0.11.1  5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f \
     zip                              2.4.2  fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50 \
     zip                              3.0.0  12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308 \
-    zipsign-api                      0.1.4  a9240c17ab9e129def0c16b56608e90a734724dfb2bcf73af30f63e340cac495 \
+    zipsign-api                      0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
     zlib-rs                          0.5.0  868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8 \
     zopfli                           0.8.2  edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7 \
     zstd                            0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \


### PR DESCRIPTION
#### Description

mise: Update to 2025.5.14

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
