### PR TITLE
turbovnc-viewer: update to 3.2

### DIFF
--- a/x11/turbovnc-viewer/Portfile
+++ b/x11/turbovnc-viewer/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        TurboVNC turbovnc 3.1.4
+github.setup        TurboVNC turbovnc 3.2
 
 name                turbovnc-viewer
 license             GPL-2
@@ -15,13 +15,13 @@ categories          x11 net
 description         TurboVNC VNC viewer.
 long_description    {*}${description}
 
-checksums           rmd160  2a3b608aaf600d928b326210c3459decc01c047a \
-                    sha256  bfb8f059bde36d6e80a8d16fa758cbb264fe456930253ce444ce05961d980ee5 \
-                    size    9047653
+checksums           rmd160  848115e201577b13ad87b63aa2a0fb23267fd38b \
+                    sha256  a4fd895ebb8a40a5962db8c38e3de61e4d22c77d64d2ea0afe8fd78c7a8aff72 \
+                    size    5488973
 
 depends_lib-append  path:include/turbojpeg.h:libjpeg-turbo
 
-java.version        1.8+
+java.version        15+
 
 require_active_variants     openjdk11       JNI
 require_active_variants     libjpeg-turbo   java


### PR DESCRIPTION
#### Description

Updating TurboVNC-Viewer to latest version, 3.2.

Minimum Java version to build is now 15. E.g. source file `java/com/jcraft/jsch/jce/KeyPairGenEdDSA.java` imports `java.security.interfaces.EdECPrivateKey` which, according to https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/security/interfaces/EdECPrivateKey.html, was introduced in Java 15.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.2 16C5032a

macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
