### PR TITLE
spring-boot-cli: update to 3.5.0

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.4.5
+version         3.5.0
 revision        0
 
 categories      java
@@ -30,15 +30,18 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  bf5c5fabf4f46557d030a3d28ace723c21f849a9 \
-                sha256  a7410759aa37ae02ff343c22abebeeeea1063d506cfd384bb5d4f41286e11881 \
-                size    5733506
+checksums       rmd160  6f992dac557a4ac71e018e5f2cbe7f508ae12bd3 \
+                sha256  7f8b495f642ad9695ffb43d85c6292cc6ccf65967c697b2f878aa151101cc090 \
+                size    5737034
 
 worksrcdir      spring-${version}
 
 use_configure   no
 
+# See https://docs.spring.io/spring-boot/system-requirements.html
+# Oldest supported Long Term Support version
 java.version    17+
+# Latest supported Long Term Support version
 java.fallback   openjdk21
 
 build {}


### PR DESCRIPTION
#### Description

Update to Spring Boot 3.5.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?