### PR TITLE
libgit2: update to 1.9.0

### DIFF
--- a/R/R-gert/Portfile
+++ b/R/R-gert/Portfile
@@ -5,7 +5,7 @@ PortGroup           R 1.0
 
 # Revert to GitHub once updated there.
 R.setup             cran r-lib gert 2.1.4
-revision            0
+revision            1
 categories-append   devel www
 maintainers         nomaintainer
 license             MIT

--- a/R/R-git2r/Portfile
+++ b/R/R-git2r/Portfile
@@ -5,7 +5,7 @@ PortGroup           openssl 1.0
 PortGroup           R 1.0
 
 R.setup             github ropensci git2r 0.35.0 v
-revision            0
+revision            1
 categories-append   devel
 maintainers         nomaintainer
 license             GPL-2

--- a/devel/cargo-c/Portfile
+++ b/devel/cargo-c/Portfile
@@ -6,7 +6,7 @@ PortGroup                   cargo  1.0
 
 github.setup                lu-zero cargo-c 0.10.8 v
 github.tarball_from         archive
-revision                    0
+revision                    1
 
 license                     MIT
 categories                  devel

--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -18,7 +18,7 @@ if {${os.platform} eq "darwin" && ${os.major} > 16} {
     rust_build.version  1.78.0
 }
 
-revision                1
+revision                2
 epoch                   1
 
 categories              devel

--- a/devel/cocogitto/Portfile
+++ b/devel/cocogitto/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo 1.0
 
 github.setup        cocogitto cocogitto 6.3.0
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          devel
 license             MIT, Apache-2

--- a/devel/committed/Portfile
+++ b/devel/committed/Portfile
@@ -7,7 +7,7 @@ PortGroup           cargo  1.0
 github.setup        crate-ci committed 1.1.7 v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            0
+revision            1
 
 categories          devel
 license             Apache-2 MIT

--- a/devel/dura/Portfile
+++ b/devel/dura/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 
 github.setup        tkellogg dura 0.2.0 v
 github.tarball_from archive
-revision            3
+revision            4
 
 description         You shouldn\'t ever lose your work if you\'re using Git
 

--- a/devel/git-branchless/Portfile
+++ b/devel/git-branchless/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 
 github.setup        arxanas git-branchless 0.10.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         A suite of advanced tools for Git, such as `git undo`, \
                     and `git sl` (smartlog)

--- a/devel/gitui/Portfile
+++ b/devel/gitui/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        extrawurst gitui 0.26.3 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Blazing fast terminal-ui for git written in Rust.
 

--- a/devel/gitweb/Portfile
+++ b/devel/gitweb/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo 1.0
 PortGroup           openssl 1.0
 
 github.setup        yoannfleurydev gitweb 0.3.5 v
-revision            3
+revision            4
 
 description         Open the current remote git repository in your browser
 

--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -11,7 +11,7 @@ conflicts           libgit2-devel
 set my_name         libgit2
 
 # don't forget to update py-pygit2 and libgit2-glib as well
-github.setup        libgit2 libgit2 1.7.2 v
+github.setup        libgit2 libgit2 1.9.0 v
 github.tarball_from archive
 revision            0
 epoch               1
@@ -30,12 +30,12 @@ homepage            https://libgit2.org/
 
 dist_subdir         ${my_name}
 
-checksums           rmd160  53aa89485a37b91cf11aae5ef63bfa6193f6246b \
-                    sha256  de384e29d7efc9330c6cdb126ebf88342b5025d920dcb7c645defad85195ea7f \
-                    size    7548186
+checksums           rmd160  cf1c29dbeaf0e0651bdee529af06ecc10c35aab7 \
+                    sha256  75b27d4d6df44bd34e2f70663cfd998f5ec41e680e1e593238bbe517a84c7ed2 \
+                    size    7660744
 
 depends_build-append \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append \
                     port:curl \

--- a/devel/onefetch/Portfile
+++ b/devel/onefetch/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo 1.0
 
 github.setup        o2sh onefetch 2.13.2 v
 github.tarball_from archive
-revision            1
+revision            2
 
 description         Git repository summary on your terminal
 

--- a/devel/stgit/Portfile
+++ b/devel/stgit/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo  1.0
 
 github.setup        stacked-git stgit 2.4.12 v
 github.tarball_from releases
-revision            0
+revision            1
 
 categories          devel
 license             GPL-2

--- a/editors/lapce/Portfile
+++ b/editors/lapce/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        lapce lapce 0.4.2 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://lapce.dev/
 

--- a/fortran/fortran-git/Portfile
+++ b/fortran/fortran-git/Portfile
@@ -5,7 +5,7 @@ PortGroup           fortran 1.0
 
 github.setup        interkosmos fortran-git b87f3d118621cdc39f895f8a850e45dc39f1f69d
 version             2023.04.27
-revision            1
+revision            2
 categories-append   devel
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer

--- a/gnome/gitg/Portfile
+++ b/gnome/gitg/Portfile
@@ -9,7 +9,7 @@ PortGroup           meson 1.0
 
 gitlab.instance     https://gitlab.gnome.org
 gitlab.setup        GNOME gitg 44 v
-revision            0
+revision            1
 
 categories          gnome devel
 license             GPL-2+
@@ -101,27 +101,32 @@ proc py_setup {py_ver} {
                     port:py${py_ver_nodot}-gobject3
 }
 
-variant python38 conflicts python39 python310 python311 description {Enable Python support using python38} {
-    py_setup 3.8
-}
-
-variant python39 conflicts python38 python310 python311 description {Enable Python support using python39} {
+variant python39 conflicts python310 python311 python312 python313 description {Enable Python support using python39} {
     py_setup 3.9
 }
 
-variant python310 conflicts python38 python39 python311 description {Enable Python support using python310} {
+variant python310 conflicts python39 python311 python312 python313 description {Enable Python support using python310} {
     py_setup 3.10
 }
 
-variant python311 conflicts python38 python39 python310 description {Enable Python support using python311} {
+variant python311 conflicts python39 python310 python312 python313 description {Enable Python support using python311} {
     py_setup 3.11
 }
 
-if {![variant_isset python38] && \
-    ![variant_isset python39] && \
+variant python312 conflicts python39 python310 python311 python313 description {Enable Python support using python312} {
+    py_setup 3.12
+}
+
+variant python313 conflicts python39 python310 python311 python312 description {Enable Python support using python313} {
+    py_setup 3.13
+}
+
+if {![variant_isset python39] && \
     ![variant_isset python310] && \
-    ![variant_isset python311]} {
-    default_variants +python311
+    ![variant_isset python311] && \
+    ![variant_isset python312] && \
+    ![variant_isset python313]} {
+    default_variants +python313
 }
 
 variant quartz {}

--- a/gnome/libgit2-glib/Portfile
+++ b/gnome/libgit2-glib/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson  1.0
 
 gitlab.instance     https://gitlab.gnome.org
 gitlab.setup        GNOME libgit2-glib 1.2.1 v
-revision            0
+revision            1
 
 categories          gnome devel
 license             LGPL-2+

--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -32,7 +32,7 @@ if {${os.platform} eq "darwin" && ${os.major} > 16} {
     version                 1.78.0
 }
 
-revision                    0
+revision                    1
 subport rust-src            {revision  0}
 
 categories                  lang devel

--- a/python/py-pygit2/Portfile
+++ b/python/py-pygit2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        libgit2 pygit2 1.14.1 v
+github.setup        libgit2 pygit2 1.18.0 v
 github.tarball_from archive
 name                py-pygit2
 revision            0
@@ -18,11 +18,11 @@ description         Python bindings for libgit2
 long_description    Pygit2 is a set of Python bindings to the libgit2 shared \
                     library, libgit2 implements the core of Git.
 
-checksums           rmd160  7f608a1a0a15b106ec32d09f9273f9057e6549a2 \
-                    sha256  2e60ee9ae0ccbf8f61d5ff29e59c8ac69a07b9be4ae44c5545f2cc35fe070b41 \
-                    size    788770
+checksums           rmd160  d985b18506d3533d93fa88b982f63d6479d8a1fe \
+                    sha256  688cbaab1c52fde358589270fbfdf09a87f8e0fbaa68d120e7a2c923ac8e5c34 \
+                    size    796059
 
-python.versions     38 39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/science/gnuastro/Portfile
+++ b/science/gnuastro/Portfile
@@ -5,7 +5,7 @@ PortGroup               compiler_blacklist_versions 1.0
 
 name                    gnuastro
 version                 0.23
-revision                0
+revision                1
 categories              science
 license                 GPL-3+
 maintainers             {@sikmir disroot.org:sikmir} openmaintainer

--- a/sysutils/broot/Portfile
+++ b/sysutils/broot/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        Canop broot 1.46.4 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://dystroy.org/broot
 

--- a/sysutils/caps-log/Portfile
+++ b/sysutils/caps-log/Portfile
@@ -9,7 +9,7 @@ PortGroup           openssl 1.0
 boost.version       1.81
 
 github.setup        NikolaDucak caps-log 1.2.1
-revision            0
+revision            1
 categories          sysutils
 license             MIT
 maintainers         {NikolaDucak @NikolaDucak} \

--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -7,7 +7,7 @@ PortGroup           cargo   1.0
 
 github.setup        eza-community eza 0.21.3 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://eza.rocks
 

--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 
 github.setup        starship starship 1.23.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://starship.rs
 

--- a/textproc/bat/Portfile
+++ b/textproc/bat/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        sharkdp bat 0.25.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         A cat(1) clone with syntax highlighting and Git integration.
 

--- a/textproc/git-delta/Portfile
+++ b/textproc/git-delta/Portfile
@@ -7,7 +7,7 @@ PortGroup           github  1.0
 github.setup        dandavison delta 0.18.2
 github.tarball_from archive
 name                git-delta
-revision            0
+revision            1
 
 homepage            https://dandavison.github.io/delta
 

--- a/www/stagit/Portfile
+++ b/www/stagit/Portfile
@@ -5,7 +5,7 @@ PortGroup           makefile 1.0
 
 name                stagit
 version             1.2
-revision            3
+revision            4
 license             MIT
 
 categories          www


### PR DESCRIPTION
### Description

* libgit2: update to 1.9.0
* py-pygit2: update to 1.18.0
* gitg: add py312, py313; drop py38
* libgit2 dependents: rev-bump

CC: https://github.com/macports/macports-ports/pull/28554