### PR TITLE
legcord: updated to 1.1.5

### DIFF
--- a/net/Legcord/Portfile
+++ b/net/Legcord/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        Legcord Legcord 1.1.4 v
+github.setup        Legcord Legcord 1.1.5 v
 github.tarball_from archive
 
 categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  39cb251c6e984437b33b030e20d5c98005a26fe7 \
-                    sha256  8287b7d895d726f969989fc3211c53fcfbaf7f1e3882303fe6243ee162476969 \
-                    size    3283365
+checksums           rmd160  29e2e3897d29bf41364919c7f213b97373197f23 \
+                    sha256  3ffa56c43c6018a5cb8ba4df8fd0205b037251a38be393f989cc7a856390efe3 \
+                    size    3284506
 
 description         lightweight alternative to the regular Discord application
 long_description    ${name} is a {*}${description}. It wraps the Discord web \
@@ -28,6 +28,8 @@ depends_build       port:npm10 \
                     port:pnpm
 
 use_configure       no
+
+patchfiles          package-version-bump.diff
 
 build {
     system -W ${worksrcpath} "pnpm install"

--- a/net/Legcord/files/package-version-bump.diff
+++ b/net/Legcord/files/package-version-bump.diff
@@ -1,0 +1,10 @@
+--- package.json.orig	2025-05-28 14:21:00
++++ package.json	2025-05-28 14:21:07
+@@ -1,6 +1,6 @@
+ {
+     "name": "legcord",
+-    "version": "1.1.4",
++    "version": "1.1.5",
+     "description": "Legcord is a custom client designed to enhance your Discord experience while keeping everything lightweight.",
+     "main": "ts-out/main.js",
+     "engines": {


### PR DESCRIPTION
#### Description

- Updates legcord to v1.1.5
- Upstream didn't bump the package.json version number, patch will fix that. Otherwise, legcord will issue a warning at startup that there's a new version, despite being on the latest version.

[as previously noted](https://github.com/macports/macports-ports/pull/28335), github CI will fail, but it will build just fine on MacPorts buildbots, cf. https://build.macports.org/builders/ports-14_arm64-watcher/builds/21076


###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
