### PR TITLE
mise: Update to 2025.5.15

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.5.14 v
+github.setup        jdx mise 2025.5.15 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  682f6db9d4504de2b19f876d19c19b04dfda60ac \
-                    sha256  aaae94bff1df40ee0a337e465b355ee1749433c54b669bef89562cb50be77613 \
-                    size    4181634
+                    rmd160  ec6ef89e8d449ef846bf73b49d6a259b1d477bc3 \
+                    sha256  a0e9426865db306012dfaba28d482cc4e9d27a29fbb648e8541f58747995e363 \
+                    size    4182541
 
 patchfiles          patch-src_cli_self_update.diff
 


### PR DESCRIPTION
#### Description

mise: Update to 2025.5.15

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.3 16E140

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
