### PR TITLE
openjdk25-zulu: update to 25.0.37

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.33
-set build    19
+version      ${feature}.0.37
+set build    23
 revision     0
 
 set openjdk_version ${feature}.0.0
@@ -37,14 +37,14 @@ use_zip yes
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_x64
-    checksums    rmd160  4c2f59e869717f8c0c4d0d5d6d97826f51e12527 \
-                 sha256  39002b14953f1c090461adcb1064e0278a1347b1668e955235e520b16dfd644c \
-                 size    227762850
+    checksums    rmd160  baaa10adb7bfa0cc824e7c89124cf15f94bc6e58 \
+                 sha256  381341d7645acac20049002fb80d7aa345e627d2668e77bfbcb99d5926ce1c9f \
+                 size    228872094
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_aarch64
-    checksums    rmd160  79877f50c4a4e328362b11df1d9c224d5674c2d0 \
-                 sha256  a14e18def8c3f12381dab9ad32e046223a8db49972abb3a217be5f6faf5d7699 \
-                 size    225272117
+    checksums    rmd160  d3ab1bf365b6c9da5ae3757ce79e04e03e8150ca \
+                 sha256  cb5b1b1ab4c56df9a74fcd23fc092d9254c79fa949c604ddceec9136c724a7b5 \
+                 size    226361947
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.0.37.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?