### PR TITLE
add port files for cdk and cdk-perl

### DIFF
--- a/devel/cdk-perl/Portfile
+++ b/devel/cdk-perl/Portfile
@@ -8,7 +8,7 @@ version         20240606
 categories      devel
 license         X11
 
-maintainers     {@ThomasDickey} openmaintainer
+maintainers     {@ThomasDickey invisible-island.net:dickey} openmaintainer
 
 description     Curses Development Kit -- Perl extension
 long_description  \

--- a/devel/cdk-perl/Portfile
+++ b/devel/cdk-perl/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            cdk-perl
+version         20240606
+
+categories      devel
+license         X11
+
+maintainers     ThomasDickey
+
+description     Curses Development Kit -- Perl extension
+long_description  \
+    Cdk stands for \"Curses Development Kit\".  It contains a large number of \
+    ready to use widgets which facilitate the speedy development of \
+    full-screen curses programs.
+
+homepage        https://invisible-island.net/cdk/
+master_sites    https://invisible-island.net/archives/cdk/ \
+                https://invisible-mirror.net/archives/cdk/
+extract.suffix  .tgz
+
+checksums       md5     8f03c6c6cc1f331346d89dc76bf30c9c \
+                sha1    09c979bba9143b0990b1941a0c8143dec8430ea3 \
+                rmd160  e05d7295a93e21e3900e6e7d2c01a1f71724569a \
+                sha256  910bc290441f6c73ca4f8c67748cc09633f7aebbc669cca7b95bc50bf4f1f21c \
+                size    227322
+
+depends_lib     port:cdk \
+                port:ncurses
+
+configure.args  --with-screen=ncursesw
+
+post-destroot {
+    foreach badfile [exec find ${destroot} -name perllocal.pod] {
+        ui_info "Removing ${badfile}"
+        file delete ${badfile}
+    }
+
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} CHANGES COPYING README VERSION \
+        ${destroot}${prefix}/share/doc/${name}
+    file copy ${worksrcpath}/demos \
+            ${destroot}${prefix}/share/doc/${name}/demos
+    file copy ${worksrcpath}/examples \
+            ${destroot}${prefix}/share/doc/${name}/examples
+    file copy ${worksrcpath}/fulldemo \
+            ${destroot}${prefix}/share/doc/${name}/fulldemo
+
+    foreach demofile [exec find ${destroot}${prefix}/share/doc -type f] {
+        ui_info "adjusting ${demofile}"
+        file attributes ${demofile} -permissions -x
+	reinplace -q "s|#!/usr/bin/perl|#!${prefix}/bin/perl|" ${demofile}
+    }
+}
+
+livecheck.type  regex
+livecheck.url   [lindex ${master_sites} 0]
+livecheck.regex ${name}-(\[0-9\]+)

--- a/devel/cdk-perl/Portfile
+++ b/devel/cdk-perl/Portfile
@@ -8,7 +8,7 @@ version         20240606
 categories      devel
 license         X11
 
-maintainers     ThomasDickey
+maintainers     {@ThomasDickey} openmaintainer
 
 description     Curses Development Kit -- Perl extension
 long_description  \
@@ -21,20 +21,18 @@ master_sites    https://invisible-island.net/archives/cdk/ \
                 https://invisible-mirror.net/archives/cdk/
 extract.suffix  .tgz
 
-checksums       md5     8f03c6c6cc1f331346d89dc76bf30c9c \
-                sha1    09c979bba9143b0990b1941a0c8143dec8430ea3 \
-                rmd160  e05d7295a93e21e3900e6e7d2c01a1f71724569a \
+checksums       rmd160  e05d7295a93e21e3900e6e7d2c01a1f71724569a \
                 sha256  910bc290441f6c73ca4f8c67748cc09633f7aebbc669cca7b95bc50bf4f1f21c \
                 size    227322
 
 depends_lib     port:cdk \
-                port:ncurses
+                port:ncurses \
+                port:perl5
 
 configure.args  --with-screen=ncursesw
 
 post-destroot {
     foreach badfile [exec find ${destroot} -name perllocal.pod] {
-        ui_info "Removing ${badfile}"
         file delete ${badfile}
     }
 
@@ -49,12 +47,9 @@ post-destroot {
             ${destroot}${prefix}/share/doc/${name}/fulldemo
 
     foreach demofile [exec find ${destroot}${prefix}/share/doc -type f] {
-        ui_info "adjusting ${demofile}"
         file attributes ${demofile} -permissions -x
-	reinplace -q "s|#!/usr/bin/perl|#!${prefix}/bin/perl|" ${demofile}
+        reinplace -q "s|#!/usr/bin/perl|#!${prefix}/bin/perl|" ${demofile}
     }
 }
 
-livecheck.type  regex
-livecheck.url   [lindex ${master_sites} 0]
 livecheck.regex ${name}-(\[0-9\]+)

--- a/devel/cdk/Portfile
+++ b/devel/cdk/Portfile
@@ -8,7 +8,7 @@ version         5.0-20250116
 categories      devel
 license         X11
 
-maintainers     {@ThomasDickey} openmaintainer
+maintainers     {@ThomasDickey invisible-island.net:dickey} openmaintainer
 
 description     Curses Development Kit -- widgets for curses
 long_description  \
@@ -27,7 +27,7 @@ checksums       rmd160  2698a9ca33e58a97ca3cd68ded5c15a7752ba4c8 \
 
 depends_lib     port:ncurses
 
-livecheck.regex cdk-(\[0-9\].\[0-9\]+-\[0-9\]+)
+livecheck.regex {cdk-([0-9]\.[0-9]+-[0-9]+)}
 
 configure.args  --mandir=${prefix}/share/man \
                 --with-libname=cdk \

--- a/devel/cdk/Portfile
+++ b/devel/cdk/Portfile
@@ -8,7 +8,7 @@ version         5.0-20250116
 categories      devel
 license         X11
 
-maintainers     ThomasDickey
+maintainers     {@ThomasDickey} openmaintainer
 
 description     Curses Development Kit -- widgets for curses
 long_description  \
@@ -27,8 +27,6 @@ checksums       rmd160  2698a9ca33e58a97ca3cd68ded5c15a7752ba4c8 \
 
 depends_lib     port:ncurses
 
-livecheck.type  regex
-livecheck.url   [lindex ${master_sites} 0]
 livecheck.regex cdk-(\[0-9\].\[0-9\]+-\[0-9\]+)
 
 configure.args  --mandir=${prefix}/share/man \

--- a/devel/cdk/Portfile
+++ b/devel/cdk/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            cdk
+version         5.0-20250116
+
+categories      devel
+license         X11
+
+maintainers     ThomasDickey
+
+description     Curses Development Kit -- widgets for curses
+long_description  \
+    Cdk stands for \"Curses Development Kit\".  It contains a large number of \
+    ready to use widgets which facilitate the speedy development of \
+    full-screen curses programs.
+
+homepage        https://invisible-island.net/cdk/
+master_sites    https://invisible-island.net/archives/${name}/ \
+                https://invisible-mirror.net/archives/${name}/
+extract.suffix  .tgz
+
+checksums       rmd160  2698a9ca33e58a97ca3cd68ded5c15a7752ba4c8 \
+                sha256  1500d41224d50b72728ccafe23c4ee096bc8535fd6fdb9e876da4cdeeddadc83 \
+                size    549798
+
+depends_lib     port:ncurses
+
+livecheck.type  regex
+livecheck.url   [lindex ${master_sites} 0]
+livecheck.regex cdk-(\[0-9\].\[0-9\]+-\[0-9\]+)
+
+configure.args  --mandir=${prefix}/share/man \
+                --with-libname=cdk \
+                --with-screen=ncursesw
+
+build.target    sources manpages cdklib
+
+post-destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} CHANGES COPYING README VERSION \
+        ${destroot}${prefix}/share/doc/${name}
+    file copy ${worksrcpath}/cli \
+            ${destroot}${prefix}/share/doc/${name}/cli
+    file copy ${worksrcpath}/demos \
+            ${destroot}${prefix}/share/doc/${name}/demos
+    file copy ${worksrcpath}/examples \
+            ${destroot}${prefix}/share/doc/${name}/examples
+}


### PR DESCRIPTION
#### Description

Add port files for cdk and cdk-perl

###### Type(s)
submission (new Portfile)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 x86_64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
