### PR TITLE
flux: Update to 2.6.0

### DIFF
--- a/sysutils/flux/Portfile
+++ b/sysutils/flux/Portfile
@@ -3,14 +3,14 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/fluxcd/flux2 2.2.3 v
+go.setup                github.com/fluxcd/flux2 2.6.0 v
 go.offline_build        no
 revision                0
 name                    flux
 
-checksums               rmd160  ca8d5761149958b023bfc3f5bbff200d6d0e27ff \
-                        sha256  bd7a284be9c7d16bc080ec9f559def1e3489bfa8fec49d7e95c352dc002b9724 \
-                        size    388802
+checksums               rmd160  16ae401532fcabfd3559782f851b3d575b7a8ff5 \
+                        sha256  74ce9e30c8dee0f89d802761f482e81b29de1b7780afb1dfff1b536b45b7ba49 \
+                        size    1355421
 
 homepage                https://fluxcd.io/
 description             Flux CLI


### PR DESCRIPTION
#### Description
Update flux from v2.2.3 to v2.6.0

###### Type(s)
- [x] update

###### Tested on
macOS 15.5 24.5.0 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification
Have you
- [x] followed our Commit Message Guidelines?
- [x] squashed and minimized your commits?
- [x] checked that there aren't other open pull requests for the same change?
- [x] checked your Portfile with port lint --nitpick?
- [x] tried existing tests with sudo port test?
- [x] tried a full install with sudo port -vst install?
- [x] tested basic functionality of all binary files?

## Notable Changes
- General availability of Flux OCI Artifacts APIs  
- Support for OCI digest pinning
- Object-level workload identity authentication
- Improved authentication and credential caching
- Compatible with Kubernetes 1.31, 1.32, and 1.33