### PR TITLE
natscli: update to 0.2.3

### DIFF
--- a/devel/natscli/Portfile
+++ b/devel/natscli/Portfile
@@ -3,10 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/nats-io/natscli 0.0.35 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
-# Allow Go to fetch dependencies at build time.
+go.setup            github.com/nats-io/natscli 0.2.3 v
 go.offline_build    no
 revision            0
 categories          devel
@@ -24,6 +21,6 @@ destroot {
     xinstall -m 0755 ${worksrcpath}/nats/nats ${destroot}${prefix}/bin/
 }
 
-checksums           rmd160  969ee2be67ad5fb7821fcbbf5483c43dd1e3d569 \
-                    sha256  b1e55354ed2414a95747ad1efe40a8c2c1f2eab13d8399ac518b9c6d85b95b40 \
-                    size    156346
+checksums           rmd160  65a84eace517c9f97aa94c7c04b5f01235b09bfa \
+                    sha256  8f889526185f160265fb4988b7cad4d3dee36bedaede85ac859a134f2b1ba975 \
+                    size    290358


### PR DESCRIPTION
#### Description

natscli update from v0.0.35 to v0.2.3. Includes migration away from deprecated GitHub tarball_from tarball to use golang PortGroup default 'archive' method.

Notable changes:
- Significant version jump with new features and fixes
- Simplified port configuration by removing explicit tarball_from setting
- Maintained golang PortGroup offline_build no for dependency resolution

###### Type(s)
- [x] update

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?