### PR TITLE
nsc: new port at 2.11.0

### DIFF
--- a/security/nsc/Portfile
+++ b/security/nsc/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/nats-io/nsc 2.11.0 v
+go.offline_build    no
+revision            0
+categories          security
+maintainers         nomaintainer
+license             Apache-2
+
+description         A tool for creating NATS account and user access configurations
+
+long_description    NSC enables you to create and edit Operators, Accounts, Users, \
+                    manage publish and subscribe permissions for Users, define Service \
+                    and Stream exports from an account, reference Services and Streams \
+                    from another account, and generate Activation tokens that grant \
+                    access to private services or streams.
+
+checksums           rmd160  3d862b95be4a37cf87d35b09446becbbb4b0e220 \
+                    sha256  142e5c57445e2dda6072464303e9e3ef4d6745d66b517690326cfcd24ad5567f \
+                    size    267214
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port submission for nsc v2.11.0 - NATS Security CLI for managing NATS account and user security configurations.

nsc is the official command-line tool for creating and managing NATS Operators, Accounts, and Users. It handles permissions, generates activation tokens, and manages the complete NATS security ecosystem.

Key features:
- Create/edit Operators, Accounts, and Users
- Manage permissions and access controls  
- Generate activation tokens
- NATS security configuration management

###### Type(s)
- [x] submission

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?