### PR TITLE
buf: Update to 1.54.0

### DIFF
--- a/devel/buf/Portfile
+++ b/devel/buf/Portfile
@@ -2,7 +2,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/bufbuild/buf 1.50.1 v
+go.setup            github.com/bufbuild/buf 1.54.0 v
 go.offline_build    no
 revision            0
 
@@ -16,11 +16,11 @@ long_description    The Buf CLI is a helpful tool for managing Protobuf schemas.
                     It works with your choice of plugins and languages and gives you access to a vast library of certified plugins in the Buf Schema Registry.
 homepage            https://buf.build/
 
-checksums           rmd160  be72fcd551d797aeb73f26060569c282e383e785 \
-                    sha256  2dc0e7eae6a9cc206de4421162e0f5895b9488a1614b8bf30eebd5588cd08df5 \
-                    size    1590934
+checksums           rmd160  3f1b388fb703faf9463e89c5570f914c93839018 \
+                    sha256  e64786bd2f17dc3731dd30280cf1ba24e0781300ea0f781251ce98ce13142f49 \
+                    size    1550634
 
-build.args-append   -trimpath ./cmd/buf
+build.args-append   -ldflags="-s -w" -trimpath ./cmd/buf
 
 destroot {
     xinstall -m 755 ${worksrcpath}/buf ${destroot}${prefix}/bin/buf


### PR DESCRIPTION
#### Description

buf update from v1.50.1 to v1.54.0. Includes binary size optimization using Go ldflags to reduce binary size by 31% (from 61MB to 42MB).

Notable changes in v1.54.0:
- Local bufplugins support for improved development workflow
- RISC-V binaries now available
- Improved `buf lint` and `buf config migrate` functionality  
- Build optimization with `-ldflags="-s -w"` for smaller binaries

###### Type(s)
- [x] update

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?