### PR TITLE
mise: Update to 2025.5.17

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.5.15 v
+github.setup        jdx mise 2025.5.17 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ec6ef89e8d449ef846bf73b49d6a259b1d477bc3 \
-                    sha256  a0e9426865db306012dfaba28d482cc4e9d27a29fbb648e8541f58747995e363 \
-                    size    4182541
+                    rmd160  4499fc9eae05eb4587894f346d8a09a2d6ea7282 \
+                    sha256  7f1dc52d000725603d5adc1ba397a710be2ef931be0e116d9eeba489d5d611aa \
+                    size    4185076
 
 patchfiles          patch-src_cli_self_update.diff
 


### PR DESCRIPTION
#### Description

mise: Update to 2025.5.17

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
