### PR TITLE
erlang: variant ssl: add dep zlib

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -141,6 +141,8 @@ variant ssl description {Build SSL support} {
     openssl.branch              3
     configure.args-delete       --without-ssl
     configure.args-append       --with-ssl=[openssl::install_area]
+
+    depends_lib-append          port:zlib
     configure.ldflags-append    -lz
 }
 


### PR DESCRIPTION
### Description

While openssl3 always brings in zlib, erlang directly links to it without declaring a dependency. This corrects that minor oversight.