### PR TITLE
golangci-lint: update to 2.1.6

### DIFF
--- a/devel/golangci-lint/Portfile
+++ b/devel/golangci-lint/Portfile
@@ -3,17 +3,18 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/golangci/golangci-lint 1.61.0 v
+go.setup            github.com/golangci/golangci-lint 2.1.6 v
 revision            0
 
 homepage            https://golangci-lint.run
 
-description         Linters Runner for Go.
+description         Fast linters runner for Go.
 
 long_description    \
-    GolangCI-Lint is a linters aggregator. It's fast: on average 5 times \
-    faster than gometalinter. It's easy to integrate and use, has nice output \
-    and has a minimum number of false positives. It supports Go modules.
+    GolangCI-Lint is a fast linters runner for Go that runs linters in \
+    parallel, uses caching, and supports YAML configuration. It includes \
+    over 100 linters, integrates with major IDEs, has minimal false \
+    positives, and supports multiple output formats.
 
 categories          devel
 installs_libs       no
@@ -22,11 +23,12 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {@steenzout} \
                     openmaintainer
 
-checksums           rmd160  bd69eb2c025dd13646f97dc49d0c591dee5c7b8c \
-                    sha256  f4efcc09dde3eb81ba7e2fc4230d3e99375a4b176dd28c31cab07371cf5c07db \
-                    size    1738919
+checksums           rmd160  e2c21330fbc733e38c3908569d589434571a27ce \
+                    sha256  0ae50c50dbc7603ed27a6f559dca194cb8851f030410c5635270866e78cb3400 \
+                    size    2350726
 
-build.args          ./cmd/golangci-lint
+build.args          -ldflags="-s -w -X main.version=${version} -X main.commit=${version}" \
+                    ./cmd/golangci-lint
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
#### Description

Update golangci-lint from version 1.61.0 to 2.1.6

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24.5.0 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?