### PR TITLE
mise: Update to 2025.6.0

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.5.17 v
+github.setup        jdx mise 2025.6.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  4499fc9eae05eb4587894f346d8a09a2d6ea7282 \
-                    sha256  7f1dc52d000725603d5adc1ba397a710be2ef931be0e116d9eeba489d5d611aa \
-                    size    4185076
+                    rmd160  f97216b48b463ea773040bf2a5dfea38dc689169 \
+                    sha256  9b495ba075165f07d814b75f64635e1c9cdf18ae1aba786514e1716d4ce9e743 \
+                    size    4185012
 
 patchfiles          patch-src_cli_self_update.diff
 


### PR DESCRIPTION
#### Description

mise: Update to 2025.6.0

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
