### PR TITLE
pnetcdf: Fix broken mpi setup

### DIFF
--- a/science/pnetcdf/Portfile
+++ b/science/pnetcdf/Portfile
@@ -5,7 +5,7 @@ PortGroup               mpi 1.0
 
 name                    pnetcdf
 version                 1.14.0
-revision                0
+revision                1
 maintainers             {@thiagoveloso gmail.com:thiagoveloso} openmaintainer
 categories              science devel
 license                 Permissive
@@ -27,13 +27,14 @@ checksums               rmd160  51b2a5bc3f7dc19ce17d152b4059e00a0e492127 \
                         sha256  575f189fb01c53f93b3d6ae0e506f46e19694807c81af0b9548e947995acf704 \
                         size    2419346
 
-if {${os.arch} eq "powerpc"} {
-   mpi.setup            require -clang -gfortran
+if {${os.platform} eq "darwin" && ${os.arch} eq "powerpc"} {
+    mpi.setup           require require_fortran \
+                        -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 \
+                        -clang -fortran
 } else {
-   mpi.setup            require -gcc12 -gfortran
+    mpi.setup           require require_fortran \
+                        -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5
 }
-
-#compilers.choose       fc f77 f90 cc cxx
 
 # Xcode clang of 10.7 fails with error: invalid instruction mnemonic 'cvtsi2ssl'
 # Copied from https://github.com/macports/macports-ports/pull/17269
@@ -41,17 +42,19 @@ if {${os.arch} eq "powerpc"} {
 compiler.blacklist-append \
                         {clang < 500} {*gcc-[34].*} {macports-gcc-[56]}
 
-depends_build-append    port:perl5 \
-                        port:autoconf \
+depends_build-append    port:autoconf \
                         port:automake \
                         port:libtool \
-                        port:m4
+                        port:m4 \
+                        path:bin/perl:perl5
 
-configure.args-append   --disable-silent-rules
+configure.args-append   --disable-silent-rules \
+                        --with-mpi=${prefix}
 
 # M4 was accidentally left out of Xcode 15.3.  Affects some Sonoma builds.
-# Use MacPorts M4.  For background, see
-# https://github.com/macports/macports-ports/pull/22985 and related tickets.
+# Use MacPorts M4.  For background, see:
+# https://github.com/macports/macports-ports/pull/22985
+# and related tickets.
 configure.env-append    M4=${prefix}/bin/gm4
 
 configure.env-append    MPICC=${mpi.cc} \
@@ -59,9 +62,12 @@ configure.env-append    MPICC=${mpi.cc} \
                         MPIF77=${mpi.f77} \
                         MPIF90=${mpi.f90}
 
-default_variants        +gcc12 +mpich
-
 use_parallel_build      yes
+
+if {![variant_isset openmpi]} {
+    default_variants-append \
+                        +mpich
+}
 
 post-destroot {
     reinplace "s|${destroot}||g" ${destroot}${prefix}/lib/pkgconfig/pnetcdf.pc


### PR DESCRIPTION
#### Description

* Fix MPI setup.
* Rev bump for possible compiler changes.
* May fix broken builds on older OS versions.
* See previous discussions in #28540 and https://github.com/macports/macports-ports/commit/15b0e2510c97d128e2b39aed6d3974a9e6683d51 .
* Thanks to @barracuda156 for assistance.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?