### PR TITLE
google-cloud-sdk: update to 525.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             524.0.0
+version             525.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4c873a00914b29f41604ebf3b297dee2b21e8a21 \
-                    sha256  bdad322159f3da820ad80e30e15146d86876fdec8c35ec4135eb8fda8900763a \
-                    size    54048724
+    checksums       rmd160  028b460dfa166298ba5bd3370ccfef2c4e13d30f \
+                    sha256  1df8120cbbbb40b2579f72872eeb94270f6a437e6d6ede1718204cc9f4222495 \
+                    size    54096583
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  63ad19c51a10ed9ab6fbf035cc91d0f27eb46d6c \
-                    sha256  8abf07d57fb2e363902bd2a63c8f7a6d5160fe1de5509a4558f22b3bce7a1385 \
-                    size    55512814
+    checksums       rmd160  48fd6c7877a31d77b30c4803212124b8c8668b76 \
+                    sha256  0faa1e4acb667372d5e76b61c340074747e724c5d1dddb87369db5f681eeeb05 \
+                    size    55566905
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  19282d6c138e4bcd9a5f4d8f7d48cb76f2992811 \
-                    sha256  40a5082485f66499341c6121b75ac2e84800ad5fd1b3fc363f33f8920b1f5821 \
-                    size    55455577
+    checksums       rmd160  84b22f519195015346ca0163423b9cbf4598bc6c \
+                    sha256  84c59742321b86f1a856e73fb2566cde4ce5816615ebaf4753f2c7a27fa92b6e \
+                    size    55510730
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 525.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?