### PR TITLE
libimobiledevice-glue: Update to 1.3.2

### DIFF
--- a/devel/libimobiledevice-glue/Portfile
+++ b/devel/libimobiledevice-glue/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        libimobiledevice libimobiledevice-glue 1.3.1
+github.setup        libimobiledevice libimobiledevice-glue 1.3.2
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ long_description    The main functionality provided by this library are socket h
 
 homepage            https://www.libimobiledevice.org/
 
-checksums           rmd160  6566bc82f3904708724293ba2207536b21e3008d \
-                    sha256  6e2849f221e6ab970566a115d42f3c20f8848e4d40c2ed61ac20dc85f40fa54f \
-                    size    339881
+checksums           rmd160  20747d1a724e33234307a17ae17d560d4efa9b6a \
+                    sha256  6489a3411b874ecd81c87815d863603f518b264a976319725e0ed59935546774 \
+                    size    338101
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig
@@ -59,9 +59,6 @@ subport libimobiledevice-glue-devel {
 
     livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
 }
-
-# https://github.com/libimobiledevice/libimobiledevice-glue/pull/46
-patchfiles-append   0001-socket.c-define-AI_NUMERICSERV-if-undefined.patch
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases


### PR DESCRIPTION
#### Description

Update `libimobiledevice-glue` to its latest released version, 1.3.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
