### PR TITLE
libusbmuxd: Update to 2.1.1

### DIFF
--- a/devel/libusbmuxd/Portfile
+++ b/devel/libusbmuxd/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        libimobiledevice libusbmuxd 2.1.0
+github.setup        libimobiledevice libusbmuxd 2.1.1
 revision            0
 
 categories          devel
@@ -16,12 +16,12 @@ long_description    {*}${description} by connecting to a socket provided by a us
 license             LGPL-2.1
 conflicts           libusbmuxd-devel
 
-checksums           rmd160  9ba9806615a6121a80927a4c133843cb1e80fa50 \
-                    sha256  c35bf68f8e248434957bd5b234c389b02206a06ecd9303a7fb931ed7a5636b16 \
+checksums           rmd160  5fa6163d9e3cea93554ae8024f8d41ce3e2c5226 \
+                    sha256  5546f1aba1c3d1812c2b47d976312d00547d1044b84b6a461323c621f396efce \
                     size    325055
 
 depends_build-append \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append  port:libimobiledevice-glue \
                     port:libplist


### PR DESCRIPTION
#### Description

Update `libusbmuxd` to its latest released version, 2.1.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
