### PR TITLE
archivemount: Update to 1b

### DIFF
--- a/fuse/archivemount/Portfile
+++ b/fuse/archivemount/Portfile
@@ -6,7 +6,7 @@ PortGroup               sourcehut 1.0
 PortGroup               legacysupport 1.1
 PortGroup               makefile 1.0
 
-sourcehut.setup         nabijaczleweli archivemount-ng 1a
+sourcehut.setup         nabijaczleweli archivemount-ng 1b
 name                    archivemount
 revision                0
 categories              fuse
@@ -19,9 +19,9 @@ long_description        Archivemount is a piece of glue code between libarchive 
                         archive (as in .tar.gz or .tar.bz2) and use it like an \
                         ordinary filesystem.
 
-checksums               rmd160  5cfc50492f53074c902663d7b2d3cfbffeee31dd \
-                        sha256  ca8f77cd8621ecfc388106f4b725943d2a6119fc8e3b3ae5ce50a05cb894fe4d \
-                        size    29142
+checksums               rmd160  79974bc390766d313698ff63583394681df597e9 \
+                        sha256  de10cfee3bff8c1dd2b92358531d3c0001db36a99e1098ed0c9d205d110e903d \
+                        size    29224
 
 depends_lib-append      port:libarchive
 


### PR DESCRIPTION
#### Description

Update `archivemount` to its latest released version, 1b

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
