### PR TITLE
jsonnet: update to 0.21.0

### DIFF
--- a/devel/jsonnet/Portfile
+++ b/devel/jsonnet/Portfile
@@ -3,24 +3,22 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        google jsonnet 0.17.0 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        google jsonnet 0.21.0 v
+github.tarball_from archive
 revision            0
-categories          devel
 
+categories          devel
 license             Apache-2
 maintainers         nomaintainer
 
 description         The data templating language
-
 long_description    A data templating language for app and tool developers
 
 homepage            https://jsonnet.org/
 
-checksums           rmd160  e43a5cee00aaea3782407c9ce0b87d28f34fc3b9 \
-                    sha256  9f4450ff784952a0f5c593ce7dabd83cbda2eed62a4b01cc2ba507b32483c8dd \
-                    size    21859800
+checksums           rmd160  ede35215597fb03123292a80c0feb24263ad393b \
+                    sha256  a12ebca72e43e7061ffe4ef910e572b95edd7778a543d6bf85f6355bd290300e \
+                    size    22128398
 
 patchfiles-append   patch-Makefile.diff
 
@@ -29,7 +27,7 @@ post-patch {
 }
 
 compiler.c_standard 1999
-compiler.cxx_standard 2011
+compiler.cxx_standard 2017
 
 if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
     configure.ldflags-append -stdlib=${configure.cxx_stdlib}
@@ -54,7 +52,7 @@ if {${name} eq ${subport}} {
 # Name consistency with ${python.branch} and ${python.version} in
 # ${prefix}/var/macports/sources/rsync.macports.org/macports/release/tarballs/ports/_resources/port1.0/group/python-1.0.tcl
 
-set python_branches {3.7 3.8 3.9}
+set python_branches {3.9 3.10 3.11 3.12 3.13}
 foreach python_branch ${python_branches} {
     set python_version [join [lrange [split ${python_branch} .] 0 1] ""]
     subport py${python_version}-${name} {
@@ -62,8 +60,7 @@ foreach python_branch ${python_branches} {
 
         python.default_version ${python_version}
 
-        categories-append \
-                    devel
+        categories      devel python
 
         master_sites \
                     ${github.master_sites}
@@ -71,11 +68,12 @@ foreach python_branch ${python_branches} {
 }
 
 if {[string match "py*" ${subport}]} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
     depends_lib-append \
                     port:jsonnet
 
     test.run        yes
+    depends_test-append \
+                    port:py${python.version}-yaml
 }
+
+github.livecheck.regex {([0-9.]+)}

--- a/devel/jsonnet/files/patch-Makefile.diff
+++ b/devel/jsonnet/files/patch-Makefile.diff
@@ -1,5 +1,5 @@
---- Makefile.orig	2021-02-16 20:31:03.000000000 -0500
-+++ Makefile	2021-02-16 20:33:25.000000000 -0500
+--- Makefile.orig	2024-04-17 00:00:00.000000000 +0000
++++ Makefile	2024-04-17 00:00:01.000000000 +0000
 @@ -27,15 +27,11 @@
  CP ?= cp
  OD ?= od
@@ -8,14 +8,14 @@
 -
  PREFIX ?= /usr/local
  
--CXXFLAGS ?= -g $(OPT) -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++0x -fPIC
--CXXFLAGS += -Iinclude -Ithird_party/md5 -Ithird_party/json
+-CXXFLAGS ?= -g $(OPT) -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++17 -fPIC
+-CXXFLAGS += -Iinclude -Ithird_party/md5 -Ithird_party/json -Ithird_party/rapidyaml/
 -CFLAGS ?= -g $(OPT) -Wall -Wextra -pedantic -std=c99 -fPIC
 -CFLAGS += -Iinclude
 -MAKEDEPENDFLAGS += -Iinclude -Ithird_party/md5 -Ithird_party/json
-+CXXFLAGS += -g -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++0x -fPIC -Iinclude -Ithird_party/md5 -I@@PREFIX@@/include/nlohmann
++CXXFLAGS += -g -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++17 -fPIC -Iinclude -Ithird_party/md5 -I@@PREFIX@@/include/nlohmann -Ithird_party/rapidyaml/
 +CFLAGS ?= -g -Wall -Wextra -pedantic -std=c99 -fPIC -Iinclude -I@@PREFIX@@/include/nlohmann
-+MAKEDEPENDFLAGS += -Iinclude -Ithird_party/md5 -I@@PREFIX@@/include/nhlomann
- EMCXXFLAGS = $(CXXFLAGS) --memory-init-file 0 -s DISABLE_EXCEPTION_CATCHING=0 -s INLINING_LIMIT=50 -s RESERVED_FUNCTION_POINTERS=20 -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1
- EMCFLAGS = $(CFLAGS) --memory-init-file 0 -s DISABLE_EXCEPTION_CATCHING=0 -s ASSERTIONS=1 -s ALLOW_MEMORY_GROWTH=1
++MAKEDEPENDFLAGS += -Iinclude -Ithird_party/md5 -I@@PREFIX@@/include/nlohmann
  LDFLAGS ?=
+ 
+ 


### PR DESCRIPTION
#### Description

Update jsonnet from 0.17.0 to 0.21.0

###### Changes
- Update version from 0.17.0 to 0.21.0
- Update checksums for new version
- Fix Python subport categories (categories devel python) 
- Update Python versions from {3.7 3.8 3.9} to {3.9 3.10 3.11 3.12 3.13}
- Update patch file for new Makefile structure (C++17, rapidyaml support)

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24.5.0 arm64
Xcode 16.4 16.4.0.0.1.1747106510

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <\!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
