### PR TITLE
jsonnet-bundler: update to 0.6.0

### DIFF
--- a/devel/jsonnet-bundler/Portfile
+++ b/devel/jsonnet-bundler/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jsonnet-bundler/jsonnet-bundler 0.5.1 v
+go.setup            github.com/jsonnet-bundler/jsonnet-bundler 0.6.0 v
 # Delete this on next update to use golang PortGroup's default ('archive')
 github.tarball_from tarball
 categories          devel
@@ -29,9 +29,9 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  80a73b7d8c110e19c4a879584f41ba2532c93317 \
-                        sha256  812cdf4710a563ed58912663345c2dedbec993d749068d13f966b58d2d03153b \
-                        size    1103707
+                        rmd160  a6013d5a9fae8500f6fc1e0261596d2c9fac772c \
+                        sha256  722738b1520b7021c2d679e80f69e4fba78a54bdc6409a101111daea94f14cf5 \
+                        size    1103644
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \


### PR DESCRIPTION
## Summary
- Update jsonnet-bundler from version 0.5.1 to 0.6.0 (released August 23, 2024)
- Added arm64 support for macOS binary compilation
- Stabilized transitive dependencies
- CI infrastructure migrated from Drone to GitHub Actions

## Type
- [ ] bugfix
- [ ] enhancement 
- [ ] security fix

## Tested on
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

## Verification checklist
- [x] Followed [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)
- [x] Squashed and [minimized commits](https://guide.macports.org/#project.github)
- [x] Checked no other [open PRs](https://github.com/macports/macports-ports/pulls) for same change
- [x] Ran `port lint` with 0 errors/warnings
- [x] Tested `sudo port -vst install` (full install successful)
- [x] Tested basic functionality of all binaries (`jb --version` returns v0.6.0, `jb --help` displays commands)

🤖 Generated with [Claude Code](https://claude.ai/code)