### PR TITLE
jsonnet-language-server: update to 0.16.0

### DIFF
--- a/devel/jsonnet-language-server/Portfile
+++ b/devel/jsonnet-language-server/Portfile
@@ -3,9 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/grafana/jsonnet-language-server 0.10.0 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+go.setup            github.com/grafana/jsonnet-language-server 0.16.0 v
 
 revision            0
 categories          devel
@@ -16,6 +14,9 @@ description         A Language Server Protocol (LSP) server for Jsonnet
 
 long_description    $description
 
+# Allow Go to fetch dependencies at build time
+go.offline_build    no
+
 build.args          -ldflags \"-X main.version=v${version}\"
 
 destroot {
@@ -23,223 +24,7 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  402955b652f5d0e0443ad79305389ee0d71bedf0 \
-                        sha256  549afbdff9d69be0a5f4f1f074a332455a701293ca7c93139d882e4797470343 \
-                        size    70646
+                        rmd160  d74b9fe65e49b4e813eb368b660877e4cb84cad3 \
+                        sha256  616fdfc5a5c9447762c1c1bb1522053d923d0415a68937ec48385eca5d49c2fa \
+                        size    1120290
 
-go.vendors          sigs.k8s.io/yaml \
-                        repo    github.com/kubernetes-sigs/yaml \
-                        lock    v1.3.0 \
-                        rmd160  2b8e5026ea0fa2fee9296ac715d489f372cbe61c \
-                        sha256  3d4d42aed1b6e5b776e7ab03c2aada7960996fbbed55b3f47dfdfe1d4a1379b3 \
-                        size    93182 \
-                    gopkg.in/yaml.v3 \
-                        lock    v3.0.1 \
-                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
-                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
-                        size    91208 \
-                    gopkg.in/yaml.v2 \
-                        lock    v2.4.0 \
-                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
-                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
-                        size    73231 \
-                    gopkg.in/check.v1 \
-                        lock    41f04d3bba15 \
-                        rmd160  1e5543a8e6a3159296ee63e28cbde9931a04f6b3 \
-                        sha256  c41575a73d10809f89b05ef9e783f2d53facdc6573697770d30efb05a9d2dc28 \
-                        size    31612 \
-                    golang.org/x/xerrors \
-                        lock    5ec99f83aff1 \
-                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
-                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
-                        size    13667 \
-                    golang.org/x/sys \
-                        lock    3c1f35247d10 \
-                        rmd160  9128b74566b92dbfa971dba1cf861722abd06807 \
-                        sha256  78465a4d4db5424b9cbc10c644fa1707a27c62cf110a0fe9156bd98e078a717b \
-                        size    1336890 \
-                    golang.org/x/net \
-                        lock    bea034e7d591 \
-                        rmd160  36a6cdfee8b5a1c679b4555e099c1cc58a730f62 \
-                        sha256  931a5438035243928b15e139d29e2f6a0fbc16a76b30f15c569882739a1328a3 \
-                        size    1226358 \
-                    golang.org/x/crypto \
-                        lock    7b82a4e95df4 \
-                        rmd160  b4f1ba2e353404c6dd4278074d0d348ebb053c60 \
-                        sha256  eeef0fe96ae1565d13d3fde36247d5a5c5da3e2846ac7eac46ca78682814249e \
-                        size    1630512 \
-                    github.com/yuin/goldmark \
-                        lock    v1.4.14 \
-                        rmd160  526eaeed4db31fdea6bcffb1f021dab27641ec7f \
-                        sha256  e1f755bd6dccf9eb63ff0b1b0adc127310cdf1688bc716453b14868858d0e5f4 \
-                        size    257817 \
-                    github.com/stretchr/testify \
-                        lock    v1.8.0 \
-                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
-                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
-                        size    97622 \
-                    github.com/stretchr/objx \
-                        lock    v0.4.0 \
-                        rmd160  7c15794276cc01606b1af8f7c1464f3c6267d669 \
-                        sha256  2e19a33cf951b8d9d19ce9ac9ddbdf7bf866e8ee5a730a08020e612418ef3f3a \
-                        size    163135 \
-                    github.com/spf13/cast \
-                        lock    v1.4.1 \
-                        rmd160  cb1d2c13bdd8a4aafd7c4e768554bab0a65c5759 \
-                        sha256  9e7890d9db7948b57974a86df8a23f235327990227c7d8f200fd1d114fa9ad07 \
-                        size    13391 \
-                    github.com/sirupsen/logrus \
-                        lock    v1.9.0 \
-                        rmd160  7298932f511bd852fe27d6227e945256ac512479 \
-                        sha256  559f22c05df7f356b90074d4b19035d9a5a8119fe504882fe413105a4f3b4675 \
-                        size    49102 \
-                    github.com/shopspring/decimal \
-                        lock    v1.3.1 \
-                        rmd160  a0d22aae3365af8ccd95b1ca7f126fd1ac3d705c \
-                        sha256  81f86b06dbf28b4473dbbba800a2f53ad19d26a64aee794799ecc48687e53237 \
-                        size    44579 \
-                    github.com/sergi/go-diff \
-                        lock    v1.2.0 \
-                        rmd160  0ee3ab8df694f8b9d8aeea2309da3512aa6ade66 \
-                        sha256  c01c182c57692b98bc38d787e7428c63a11338a8f1a1931427ab184bbdf59df0 \
-                        size    1333604 \
-                    github.com/sebdah/goldie \
-                        lock    v2.5.3 \
-                        rmd160  edc5e01b8adbfe985ce58053fccdbe36b9277759 \
-                        sha256  f6645b46ab2c80b604d77e10431b4bf8680ca4ba3ebccb3773460485d2bae9b7 \
-                        size    156899 \
-                    github.com/pmezard/go-difflib \
-                        lock    v1.0.0 \
-                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
-                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
-                        size    11409 \
-                    github.com/pkg/errors \
-                        lock    v0.9.1 \
-                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
-                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
-                        size    13422 \
-                    github.com/mitchellh/reflectwalk \
-                        lock    v1.0.2 \
-                        rmd160  0371e346bfe14926662afff3eeda22ce6dc6d2a4 \
-                        sha256  472ea8302bfe36cd5ea5a66cb9ee996d6984ce74bfc9b7c15e763f21687b3eff \
-                        size    6863 \
-                    github.com/mitchellh/mapstructure \
-                        lock    v1.5.0 \
-                        rmd160  c838fb22a642081963c8e6f236cdd4c6000bfaf4 \
-                        sha256  bd695f63e58f35f07aac6883ac5dc53d44db6cf24caa53efaadcf0842d03d762 \
-                        size    30135 \
-                    github.com/mitchellh/copystructure \
-                        lock    v1.2.0 \
-                        rmd160  401559c8d2db7a6becabf583dca6843e5cd3c5ac \
-                        sha256  e6cbd00eca63c91837cd094e89bda52d067163dc5b5db12758b8995c75fd3377 \
-                        size    9936 \
-                    github.com/mattn/go-isatty \
-                        lock    v0.0.14 \
-                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
-                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
-                        size    4705 \
-                    github.com/mattn/go-colorable \
-                        lock    v0.1.12 \
-                        rmd160  e2cc8dfa32f377718b887dd9493e277657206885 \
-                        sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
-                        size    9805 \
-                    github.com/kr/text \
-                        lock    v0.1.0 \
-                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
-                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
-                        size    8691 \
-                    github.com/kr/pretty \
-                        lock    v0.1.0 \
-                        rmd160  9aa7a5aad4c48840eecfd0f80186d1fb5ded0fd6 \
-                        sha256  f6c3f89667c63e5b7f1fc6ee2c06b6a6bfdce88f3a965ccd395b64c6f95c9a47 \
-                        size    8553 \
-                    github.com/karrick/godirwalk \
-                        lock    v1.16.1 \
-                        rmd160  8fb4d41a69f68133784172f95c03af798b07eaab \
-                        sha256  5be9a6cb67201740c0bd74ee3b62494cac2b0c47695efdc010e7be25c2b29d74 \
-                        size    27134 \
-                    github.com/jdbaldry/go-language-server-protocol \
-                        lock    3022da0884b2 \
-                        rmd160  f6dfd5af3aa3dcaa3ba59366bdcb076c1851360b \
-                        sha256  9bc2e56ff5e540ccf1a317a8ee22e3fdf46f8b934c7887a7a3773a64910b197e \
-                        size    136195 \
-                    github.com/imdario/mergo \
-                        lock    v0.3.12 \
-                        rmd160  44dbd1f58fd9ea7697f302c86f110ab796b5a041 \
-                        sha256  dadb5b52d2de5fe7336eda4c331eefb0d4be716a5844cc7ab15c96b9b6e07b2d \
-                        size    22341 \
-                    github.com/huandu/xstrings \
-                        lock    v1.3.2 \
-                        rmd160  b92c0e29b345b7f7cbe79e773f9855375e7bcb2c \
-                        sha256  97bda2aeca4ae1b66f4113ce16d5d861c124baf8f38e22064f5dbd0accb04c57 \
-                        size    17916 \
-                    github.com/hexops/gotextdiff \
-                        lock    v1.0.3 \
-                        rmd160  074c0503049683deb78ab28932d83837343f4ae9 \
-                        sha256  6ff3e645743eb9831a6325dd3edcce1f1f5c2f918c4981cec89143252d5e1dac \
-                        size    23250 \
-                    github.com/grafana/tanka \
-                        lock    v0.23.1 \
-                        rmd160  3f069dbe4779486f5ca9cc579940c6acb5689790 \
-                        sha256  f87f11ef89264a6233ed7fbc710485d5a01e1a742ff9ba238ff0f3de7837e3e3 \
-                        size    1462137 \
-                    github.com/google/uuid \
-                        lock    v1.3.0 \
-                        rmd160  300ea34c54ab7ce9d2a4bbd84a4fb49f11db02f8 \
-                        sha256  ef8b7d74d99c8abd9706909eb3bbd063460d1970fbf62619599b78092b8687db \
-                        size    16215 \
-                    github.com/google/go-jsonnet \
-                        lock    v0.18.0 \
-                        rmd160  fbf33bbfd6b243681fcc190c6c5debfbf294e68d \
-                        sha256  88e173a0f71c8bb6934fb54fbc72521026357d767737d71816bee5ca3627cef3 \
-                        size    677331 \
-                    github.com/google/go-cmp \
-                        lock    v0.5.8 \
-                        rmd160  8335ed233b7f0de3539ff5c88b2eb1400480a806 \
-                        sha256  a1b3d227b1d4a6c224f4597228e7380ac5dd4b886fe91644ba88ca0292b5f121 \
-                        size    104650 \
-                    github.com/gobwas/glob \
-                        lock    v0.2.3 \
-                        rmd160  1f472cf991498a8091446eb788fe85e0c5403185 \
-                        sha256  2de3694ee0ff41a96b66f9aa3eec51048e620cdd09acc8685f18c3abcd6e14ae \
-                        size    25971 \
-                    github.com/fatih/color \
-                        lock    v1.13.0 \
-                        rmd160  0c56533948a292eb8c5181e9a88a45fbd1267bf5 \
-                        sha256  a65b114bfe507384e1660730803ffb4437c63a24dd11a5d7f61c77f048caa55f \
-                        size    10828 \
-                    github.com/davecgh/go-spew \
-                        lock    v1.1.1 \
-                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
-                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
-                        size    42171 \
-                    github.com/andybalholm/cascadia \
-                        lock    v1.3.1 \
-                        rmd160  c9646a2a7dafdeac093fd99a8e27153cf24f5c92 \
-                        sha256  a567b37da6b02ae582740bf015864a29cfd3b44af4815b0ac1680040fe46f67d \
-                        size    33105 \
-                    github.com/PuerkitoBio/goquery \
-                        lock    v1.8.0 \
-                        rmd160  81d239bcf19ee6e8dcadea494b9fc04c96f9480f \
-                        sha256  ea72d407535c049adac1a50fd783a5e3a2563dd6e6b60ddfb8a00691c43d78bd \
-                        size    105214 \
-                    github.com/Masterminds/sprig \
-                        lock    v3.2.2 \
-                        rmd160  de63d703b69d403532a78ed15c4909eed4014dbe \
-                        sha256  c3b414bbdcf56fd071a61744fb8fb2fdec8ae98f49ab04021430f45865dcdd32 \
-                        size    55510 \
-                    github.com/Masterminds/semver \
-                        lock    v3.1.1 \
-                        rmd160  ef0a447415b81d00561b3559a38aebfbdf95b300 \
-                        sha256  e3f9518048841bde91680be27cb32cd1ac7d114fb99719855ecd5777bd221f98 \
-                        size    24515 \
-                    github.com/Masterminds/goutils \
-                        lock    v1.1.1 \
-                        rmd160  d50d8300ab7418bf2fe5bd0e7a5889f7906d082a \
-                        sha256  9c750be5c0666f133c0bf8d9439a2e428b800276d4ab28dfc406fad8d66face6 \
-                        size    14849 \
-                    github.com/JohannesKaufmann/html-to-markdown \
-                        lock    v1.3.6 \
-                        rmd160  741deb41874ecf656fa4ce986257d96a8631250a \
-                        sha256  cd0a8b148b8df2362cabaefb9164faf83db0d02ed58ab0034a6e4132bb70f225 \
-                        size    121371


### PR DESCRIPTION
#### Description

Update jsonnet-language-server from version 0.10.0 to 0.16.0.

This update removes the vendored dependencies approach and switches to online dependency resolution to handle the changed dependency tree in the newer version.

###### Type(s)

- [ ] bugfix
- [ ] enhancement  
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?