### PR TITLE
dagger: update to 0.18.9

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.8 v
+github.setup        dagger dagger 0.18.9 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  5f48c2935ec16601924e77bf3355b0a4a9a6c271 \
-                            sha256  7876679156db57577ef3486c2c5d3f4029822f2a39be229ffb37a125e42f6b79 \
-                            size    19067710
+        checksums           rmd160  212e04acdca1c6b68ae684e647cad4a155948743 \
+                            sha256  1c21c85deee5ba66ab25b5106e8a1ba49405b02b48e0d8b78e2aee79b9d135c9 \
+                            size    19080520
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  d77ef859a04711b6c6779eebb36c5089ed553cc9 \
-                            sha256  de5963a4017d4eaf0425fb4b28132774ea494afd7fe01a4b3a747f2baa1cff81 \
-                            size    18172100
+        checksums           rmd160  35b9245b350eb64d95cc62c9ac065d45a80980bc \
+                            sha256  577042f5e0a3ad977aed0ea6b051827fdbc452fc008d6ac22180b8902bd41c37 \
+                            size    18192841
     }
     default {
         known_fail  yes


### PR DESCRIPTION
###### Tested on
macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?