### PR TITLE
google-cloud-sdk: workaround for unwanted Python installation attempt

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                google-cloud-sdk
 version             525.0.0
-revision            0
+revision            1
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -107,6 +107,13 @@ variant skaffold description {Add Skaffold} { dict set variant_to_component skaf
 variant terraform_tools description {Add Terraform Tools} { dict set variant_to_component terraform_tools terraform-tools }
 
 patch {
+    # Make sure the installer script will not attempt to install its own Python,
+    # even though `--install-python false` is passed to it.
+    # This is a workaround for https://issuetracker.google.com/issues/422318565
+    reinplace "s|python_manager.PromptAndInstallPythonOnMac|#python_manager.PromptAndInstallPythonOnMac|" \
+        ${worksrcpath}/lib/googlecloudsdk/core/updater/update_manager.py
+
+    # Define the basic installation command
     set install_command "CLOUDSDK_CONFIG=${worksrcpath}/.config CLOUDSDK_PYTHON=${python.bin} ./install.sh \
         --usage-reporting false \
         --command-completion false \
@@ -114,13 +121,13 @@ patch {
         --quiet \
         --install-python false"
 
+    # Determine flags for installation of additional components
     set additional_components {}
     foreach component_variant [dict keys ${variant_to_component}] {
         if {[variant_isset ${component_variant}]} {
             lappend additional_components [dict get ${variant_to_component} ${component_variant}]
         }
     }
-
     if { [llength ${additional_components}] > 0 } {
         append install_command " --additional-components"
         foreach additional_component ${additional_components} {
@@ -128,6 +135,7 @@ patch {
         }
     }
 
+    # Run installer script
     system -W ${worksrcpath} ${install_command}
 }
 


### PR DESCRIPTION
#### Description

Make sure that the installation doesn't attempt to install its own Python (even though `--install-python false` is passed to it). This is a workaround for https://trac.macports.org/ticket/72553.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?