### PR TITLE
py-h5py: 3.14.0

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               python 1.0
 PortGroup               mpi 1.0
 
-github.setup            h5py h5py 3.13.0
+github.setup            h5py h5py 3.14.0
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from     tarball
 name                    py-h5py
@@ -15,9 +15,9 @@ name                    py-h5py
 revision                0
 
 checksums \
-    rmd160  e2a523086a2efe94b19a344fa70d18ade2c5a43d \
-    sha256  f03d551e5b45b832e9f7ded2ed4cc76d03b16de69ca054e8947bcbcf561581e7 \
-    size    430963
+    rmd160  89f234518cc6e911b99187269a1404f496c99987 \
+    sha256  9ebb94b13dbbed12ef59fbf2d150a98352449b850ebde27d873b47664342d416 \
+    size    440210
 
 license                 BSD
 maintainers             {eborisch @eborisch} openmaintainer

--- a/python/py-h5py/files/patch-oldest-supported-numpy.diff
+++ b/python/py-h5py/files/patch-oldest-supported-numpy.diff
@@ -9,3 +9,24 @@
      "pkgconfig",
      "setuptools >=61",
  ]
+--- setup_build.py.orig	2025-06-06 15:46:36
++++ setup_build.py	2025-06-06 15:47:18
+@@ -24,7 +24,7 @@
+     return op.abspath(op.join(op.dirname(__file__), *args))
+ 
+ 
+-MODULES_NUMPY2 = ['_npystrings']
++MODULES_NUMPY2 = [] #'_npystrings']
+ MODULES = ['defs', '_errors', '_objects', '_proxy', 'h5fd', 'h5z',
+             'h5', 'h5i', 'h5r', 'utils', '_selector',
+             '_conv', 'h5t', 'h5s',
+@@ -127,8 +127,8 @@
+         settings = copy.deepcopy(settings)
+         settings['libraries'] += EXTRA_LIBRARIES.get(module, [])
+ 
+-        assert numpy.__version__ >= '2.0'  # See build dependencies in pyproject.toml
+         if module in MODULES_NUMPY2:
++            assert numpy.__version__ >= '2.0'  # See build dependencies in pyproject.toml
+             # Enable NumPy 2.0 C API for modules that require it.
+             # These modules will not be importable when NumPy 1.x is installed.
+             settings['define_macros'].append(('NPY_TARGET_VERSION', 0x00000012))


### PR DESCRIPTION
Disabled new npystrings module until NumPy 2 in ports.

Maintainer update.