### PR TITLE
chezmoi: Update to 2.62.6

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 2.62.5 v
+go.setup            github.com/twpayne/chezmoi 2.62.6 v
 go.offline_build    no
 revision            0
 
@@ -20,9 +20,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  c7aa7424c574da427a341996f0daae9e4b509cab \
-                    sha256  7c61756eb0de7a4f319e9ac86788fcc04b8863518477c1541454974c08742755 \
-                    size    2561572
+checksums           rmd160  e7a6656a2c9767de68646436e8bba866569646e5 \
+                    sha256  8df2d2334a41bf129842d390420c6a4630d9f4557e52f965a1672ed0e129658e \
+                    size    2583330
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

chezmoi: Update to 2.62.6

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
