### PR TITLE
osxbom: switch to lib-style dependency on libunwind

### DIFF
--- a/sysutils/osxbom/Portfile
+++ b/sysutils/osxbom/Portfile
@@ -26,7 +26,7 @@ depends_build-append \
                     bin:nroff:groff \
                     path:libexec/coreutils/libstdbuf.so:coreutils \
                     port:libmacho-headers
-depends_lib-append  port:libunwind
+depends_lib-append  lib:libunwind:libunwind
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
In https://trac.macports.org/ticket/66250 it says that Macports-built libunwind can cause problems with other ports. This PR tweaks `osxbom`'s dependency on libunwind to use a `lib:`-style dependency instead, so that the system libunwind can satisfy it instead.

#### Description

###### Type(s)
- [x] enhancement

###### Tested on
macOS 15.5 24F74 x86_64
Xcode 16.4 16F6

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
