### PR TITLE
minikube: update to 1.36

### DIFF
--- a/sysutils/minikube/Portfile
+++ b/sysutils/minikube/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubernetes/minikube 1.35.0 v
+go.setup            github.com/kubernetes/minikube 1.36.0 v
 go.package          k8s.io/minikube
 go.offline_build    no
 revision            0
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 supported_archs     arm64 x86_64
 
-checksums           rmd160  b9a311734e736e03c1225fe553f30be3eaf21dbf \
-                    sha256  6e19aa1441a3bcf6d3ba3d71df0515f23d3fd2c6f6fbf9f1438c746675e652e1 \
-                    size    104887585
+checksums           rmd160  da54db2035ed2eff524f2b7e2a23734555ee6516 \
+                    sha256  d78302d4ad1745341f5c26f49b1cfb42a3e78b486c371c279ae6820a73cd4c26 \
+                    size    105046227
 
 depends_build-append \
                     port:go-bindata


### PR DESCRIPTION
#### Description

Update of minikube from 1.35 to 1.36

###### Type(s)
Update

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Remark on variants: To my understanding variant "hyperkit" cannot be tested on arm64