### PR TITLE
libomp: update to 20.1.6

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -27,7 +27,7 @@ epoch                   1
 
 if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
 
-    version             20.1.1
+    version             20.1.6
     revision            0
 
     livecheck.regex {"llvmorg-([0-9.]+)".*}
@@ -36,14 +36,14 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
     distfiles       ${distname}.tar.xz cmake-${version}.src.tar.xz
 
     checksums \
-        openmp-20.1.1.src.tar.xz \
-        rmd160  67ccc02cad70b9f4714e0a7d200ab2ec20eaeca5 \
-        sha256  a5d2bba7bc4e7d159ce3fe8d09bdadeb59ff00af967b0a2bf5993fc1528f569e \
-        size    1093888 \
-        cmake-20.1.1.src.tar.xz \
-        rmd160  49696af4a2acec9d52919ca16a9dbeaac2150d1d \
-        sha256  b5988c9e3df3a61249fa82db54061f733756e74f73dfb299ff6314873a732d61 \
-        size    8648 
+        openmp-20.1.6.src.tar.xz \
+        rmd160  60f8defe957f7b5a4d56ce585a6caa3902ae065a \
+        sha256  ff8dabd89212cd41b4fc5c26433bcde368873e4f10ea0331792e6b6e7707eff9 \
+        size    1093988 \
+        cmake-20.1.6.src.tar.xz \
+        rmd160  64eee290f5fe98fe397f416886ac0ac3099cf67d \
+        sha256  b4b3efa5d5b01b3f211f1ba326bb6f0c318331f828202d332c95b7f30fca5f8c \
+        size    8644
 
     if {${os.major} <= 12} {
         # kmp_alloc.c includes <atomic> but libc++ is not the default on


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4 16F6


###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
