### PR TITLE
py-whenever: new submission

### DIFF
--- a/python/py-whenever/Portfile
+++ b/python/py-whenever/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-whenever
+version             0.8.4
+revision            0
+
+supported_archs     noarch
+platforms           {darwin any}
+license             MIT
+
+maintainers         {breun.nl:nils @breun} openmaintainer
+
+description         Typed and DST-safe datetimes for Python.
+long_description    {*}${description} \
+                    \n\
+                    Whenever helps you write correct and type checked datetime \
+                    code, using well-established concepts from modern \
+                    libraries in other languages. It's also way faster than \
+                    other third-party libraries, and usually the standard \
+                    library as well.
+
+homepage            https://pypi.org/project/whenever/
+
+checksums           rmd160  a05452bba7d62f8f2902c2629b52c15af14cd694 \
+                    sha256  701f1fa558c6ea8fc4cb467d75ceddf1fb5964122235df20caf64a9ab7110b9d \
+                    size    127500
+
+python.versions     313
+
+if {${name} ne ${subport}} {
+    # setuptools-rust must be present, even when not building the Rust extension
+    # See: https://github.com/ariebovenberg/whenever/issues/240
+    depends_build-append port:py${python.version}-setuptools-rust
+
+    # Use pure Python version: https://whenever.readthedocs.io/en/latest/faq.html#how-can-i-use-the-pure-python-version
+    build.env           WHENEVER_NO_BUILD_RUST_EXT=1
+}


### PR DESCRIPTION
#### Description

New port for whenever.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?