### PR TITLE
py-urllib3: allow hatch-vcs 0.5.0

### DIFF
--- a/python/py-urllib3/Portfile
+++ b/python/py-urllib3/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-urllib3
 version             2.4.0
-revision            0
+revision            1
 categories-append   devel net
 platforms           {darwin any}
 supported_archs     noarch
@@ -60,6 +60,9 @@ if {${name} ne ${subport}} {
         checksums           rmd160  d7cae25f270a0b852d9d4ddbac12995c4da216a6 \
                             sha256  e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9 \
                             size    300677
+    } else {
+        # drop this upon the next upstream release
+        patchfiles          allow-hatch-vcs-0.5.patch
     }
 
     livecheck.type      none

--- a/python/py-urllib3/files/allow-hatch-vcs-0.5.patch
+++ b/python/py-urllib3/files/allow-hatch-vcs-0.5.patch
@@ -1,0 +1,11 @@
+--- pyproject.toml
++++ pyproject.toml
+@@ -1,7 +1,7 @@
+ # This file is protected via CODEOWNERS
+ 
+ [build-system]
+-requires = ["hatchling>=1.6.0,<2", "hatch-vcs==0.4.0"]
++requires = ["hatchling>=1.6.0,<2", "hatch-vcs>=0.4.0,<0.6.0", "setuptools-scm>=8,<9"]
+ build-backend = "hatchling.build"
+ 
+ [project]


### PR DESCRIPTION
https://trac.macports.org/ticket/72588

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
