### PR TITLE
gitleaks: Update to 8.27.1

### DIFF
--- a/security/gitleaks/Portfile
+++ b/security/gitleaks/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/zricethezav/gitleaks 8.27.0 v
+go.setup            github.com/zricethezav/gitleaks 8.27.1 v
 go.package          github.com/zricethezav/gitleaks/v8
 go.offline_build    no
 revision            0
@@ -24,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  7cbd6347a06622b6b6c2da03cb0ae2aee0c9079a \
-                    sha256  7be328508fc73b6e530266741b518e1a685f70e441e581483bf6304d34d2b02a \
-                    size    289942
+checksums           rmd160  ba16c35882b88a36237bbed87331ee2c16bca91e \
+                    sha256  5f6ff5bfa50f64dc784318b4aaff18c3d1a7656b12b0e77e5977f7a4eecc5def \
+                    size    291136
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

gitleaks: Update to 8.27.1

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
