### PR TITLE
osxphotos: update to 0.71.0

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.70.0
+version                 0.71.0
 revision                0
 
 categories              graphics python
@@ -25,9 +25,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  c54e0a6bc1d7f3a8191ced4cf8d503001e5a2b26 \
-                        sha256  9fc8b45667bdcc67452f9c05ea79ef3b1ba5035e6dec13178269e6b03799e4e4 \
-                        size    2238375
+checksums               rmd160  60c7087414828d9adec44c0df81ec11857c9ad1d \
+                        sha256  7d8ae7af09024537a2b66fa16bdce5c20e77b5e2cbd0a1e2033287c3ff121d5b \
+                        size    2256888
 
 python.default_version  313
 
@@ -57,6 +57,7 @@ depends_lib-append      port:py${python.version}-bitmath \
                         port:py${python.version}-tenacity \
                         port:py${python.version}-textx \
                         port:py${python.version}-toml \
+                        port:py${python.version}-whenever \
                         port:py${python.version}-wrapt \
                         port:py${python.version}-wurlitzer \
                         port:py${python.version}-xdg-base-dirs \


### PR DESCRIPTION
#### Description

Update to osxphotos 0.71.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?