### PR TITLE
tenv: update to 4.7.1

### DIFF
--- a/sysutils/tenv/Portfile
+++ b/sysutils/tenv/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/tofuutils/tenv 4.7.0 v
+go.setup            github.com/tofuutils/tenv 4.7.1 v
 go.offline_build    no
 revision            0
 
@@ -22,9 +22,9 @@ license             Apache-2
 maintainers         {icloud.com:github.ssk @suhailskhan} \
                     openmaintainer
 
-checksums           rmd160  03bff4d65dcdca4074bbac0b18b54d11546748e1 \
-                    sha256  55f61bc1a03cd140d5f0102cd4bb2977f3b3b81f868ea1b330de2b66e2db39e7 \
-                    size    812555
+checksums           rmd160  0cf5175c59f5dff270b3f2057074849a91d7d7b3 \
+                    sha256  beb41f5b45bf45055f7bea584c77cea1be51cf2ae212a464886c8bdd757c84c2 \
+                    size    812959
 
 build.env-append    CGO_ENABLED=0
 build.args-append   -o ${worksrcpath}/build/ \


### PR DESCRIPTION
#### Description

Created with [seaport](https://seaport.rtfd.io/), the modern MacPorts portfile updater.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?