### PR TITLE
newsraft: update to 0.31

### DIFF
--- a/net/newsraft/Portfile
+++ b/net/newsraft/Portfile
@@ -5,7 +5,7 @@ PortGroup           codeberg 1.0
 PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
-codeberg.setup      newsraft newsraft 0.30 newsraft-
+codeberg.setup      newsraft newsraft 0.31 newsraft-
 revision            0
 
 categories          net
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Feed reader for terminal
 long_description    {*}${description}
 
-checksums           rmd160  25d7f0e714c489976d50190b2fc7c61056746208 \
-                    sha256  5ae782d7eb19042cd05e260c8ec0fe4d0544e51716885a4b1e96a673576bd998 \
-                    size    196870
+checksums           rmd160  0eca28d379a5b0833daaf214dae86f16659eb2e4 \
+                    sha256  de0d96664d9a276dbe58cf4b44a6861bc18b6fd4c0f41a97450c5b3509904ae8 \
+                    size    224575
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig
@@ -24,8 +24,10 @@ depends_build-append \
 depends_lib-append  port:curl \
                     port:expat \
                     port:gumbo-parser \
-                    port:ncurses \
                     port:sqlite3
+
+configure.cflags-append \
+                    -D_DARWIN_C_SOURCE
 
 # Otherwise linking to LegacySupport is not done,
 # and build fails on systems where it is needed.


### PR DESCRIPTION
#### Description
https://codeberg.org/newsraft/newsraft/releases/tag/newsraft-0.31

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
