### PR TITLE
py-whenever: update to 0.8.5

### DIFF
--- a/python/py-whenever/Portfile
+++ b/python/py-whenever/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-whenever
-version             0.8.4
+version             0.8.5
 revision            0
 
 supported_archs     noarch
@@ -24,17 +24,13 @@ long_description    {*}${description} \
 
 homepage            https://pypi.org/project/whenever/
 
-checksums           rmd160  a05452bba7d62f8f2902c2629b52c15af14cd694 \
-                    sha256  701f1fa558c6ea8fc4cb467d75ceddf1fb5964122235df20caf64a9ab7110b9d \
-                    size    127500
+checksums           rmd160  7ab4a0e5e021f98b22c5267015c7c12f3b4e89df \
+                    sha256  23c7e0119103ef71aab080caf332e17b2b8ee4cb5e0ab61b393263755c377e19 \
+                    size    234290
 
 python.versions     313
 
 if {${name} ne ${subport}} {
-    # setuptools-rust must be present, even when not building the Rust extension
-    # See: https://github.com/ariebovenberg/whenever/issues/240
-    depends_build-append port:py${python.version}-setuptools-rust
-
     # Use pure Python version: https://whenever.readthedocs.io/en/latest/faq.html#how-can-i-use-the-pure-python-version
     build.env           WHENEVER_NO_BUILD_RUST_EXT=1
 }


### PR DESCRIPTION
#### Description

Update to whenever 0.8.5, which no longer requires setuptools-rust.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?