### PR TITLE
podman: update to 5.5.1

### DIFF
--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 # After the upgrade, it is highly recommended to test the `podman machine`.
 # This port has problems with this command from time to time.
 # See https://gist.github.com/judaew/85c6e8a62bf0e7f5be5188e020492e21
-go.setup            github.com/containers/podman 5.5.0 v
+go.setup            github.com/containers/podman 5.5.1 v
 revision            0
 epoch               0
 
@@ -22,9 +22,9 @@ long_description    \
     install the remote client and then setup ssh connection information.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  05ead0ff60be8337573ce99c70ca618cb54ecbfe \
-                        sha256  a4abfc72ef9a59ba80d081ea604ad2976ff967ae526e50e234edc1d2481bd9d1 \
-                        size    21333387
+                    rmd160  1b26732bd1f7f2275029c042a8900f078afc4f78 \
+                    sha256  00d02f85ad27a46e77456fef1be81865a43147544ed2487e6c4c8decd0e3748f \
+                    size    21338501
 
 set py_ver          3.13
 set py_ver_nodot    [string map {. {}} ${py_ver}]


### PR DESCRIPTION
#### Description

Update podman to version 5.5.1

###### Type(s)

- [x] enhancement

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
