### PR TITLE
zdns: update to 2.0.4

### DIFF
--- a/net/zdns/Portfile
+++ b/net/zdns/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/zmap/zdns 2.0.0 v
+go.setup            github.com/zmap/zdns 2.0.4 v
 go.offline_build    no
 revision            0
 
@@ -25,9 +25,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  f1c5434b81ad93b9930886f3f94dad25319f8877 \
-                    sha256  5e0529f409f48b303388b66cbc564f0c4302107af307ff538df266f383af0a06 \
-                    size    1090193
+checksums           rmd160  78e1deab7c9cd5169f4b8e6a826f0604c5ad8930 \
+                    sha256  c776421cfd9a7c69498463f980696cd0e63b98cfb05123e17e8fd5c29cdd9cbc \
+                    size    1073698
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description
zdns: update to 2.0.4

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?