### PR TITLE
fuse-archive: new submission at 1.12

### DIFF
--- a/fuse/fuse-archive/Portfile
+++ b/fuse/fuse-archive/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+# Fuse3 building doesn't work right, hande stuff manually for now.
+#PortGroup           fuse 1.0
+configure.cppflags-prepend -I${prefix}/include/fuse3
+depends_lib-append   port:macfuse
+depends_build-append path:bin/pkg-config:pkgconfig
+
+PortGroup           github 1.0
+PortGroup           boost 1.0
+PortGroup           makefile 1.0
+
+github.setup        google fuse-archive 1.12 v
+github.tarball_from archive
+revision            0
+categories          fuse
+license             Apache-2
+maintainers         nomaintainer
+description         Mount archives with FUSE
+long_description    \
+    Mount an archive or compressed file as a FUSE file system.
+
+checksums           rmd160  4a55ca94cc1792698697cf0d8b77d957cad71dde \
+                    sha256  cf05bc4f23de0985fb578a2d02f95d6cb82eb6bc2f6e740f57702a172e0088df \
+                    size    624697
+
+depends_lib-append   port:libarchive
+boost.version        1.81
+patchfiles           make.diff apple.diff
+use_configure        no
+build.target         all
+compiler.cxx_standard 2020
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/out/fuse-archive ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 644 ${worksrcpath}/fuse-archive.1 ${destroot}${prefix}/share/man/man1
+}

--- a/fuse/fuse-archive/files/apple.diff
+++ b/fuse/fuse-archive/files/apple.diff
@@ -1,0 +1,20 @@
+--- fuse-archive.cc	2025-03-19 16:19:28
++++ fuse-archive.cc	2025-06-10 03:33:48
+@@ -951,7 +951,7 @@
+ 
+   std::string const cache_dir = GetCacheDir();
+ 
+-#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
++#if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__APPLE__)
+   g_cache_fd = open(cache_dir.c_str(), O_TMPFILE | O_RDWR | O_EXCL, 0);
+   if (g_cache_fd >= 0) {
+     LOG(DEBUG) << "Created anonymous cache file in " << Path(cache_dir);
+@@ -2929,7 +2929,7 @@
+   // Get a file descriptor to the parent directory of the mount point.
+   int mount_point_parent_fd =
+       open(!mount_point_parent.empty() ? mount_point_parent.c_str() : ".",
+-           O_DIRECTORY | O_PATH);
++           O_DIRECTORY | O_EXEC);
+   if (mount_point_parent_fd < 0) {
+     PLOG(ERROR) << "Cannot access directory " << Path(mount_point_parent);
+     throw ExitCode::CANNOT_CREATE_MOUNT_POINT;

--- a/fuse/fuse-archive/files/make.diff
+++ b/fuse/fuse-archive/files/make.diff
@@ -1,0 +1,10 @@
+--- Makefile
++++ Makefile
+@@ -17,6 +17,7 @@ CXXFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
+ LDFLAGS += $(shell $(PKG_CONFIG) --libs $(DEPS))
+ CXXFLAGS += -std=c++20 -Wall -Wextra -Wno-missing-field-initializers -Wno-sign-compare -Wno-unused-parameter
+ CXXFLAGS += -D_FILE_OFFSET_BITS=64
++CXXFLAGS += -std=gnu++20 -DFUSE_DARWIN_ENABLE_EXTENSIONS=0
+ 
+ ifeq ($(DEBUG), 1)
+ CXXFLAGS += -O0 -g


### PR DESCRIPTION
#### Description

New port for https://github.com/google/fuse-archive
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] submission

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
