### PR TITLE
ruby-build: Update to 20250610

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250529.1 v
+github.setup        rbenv ruby-build 20250610 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  7bad2801da00a8f4a86dcbe540edd30d23c399f1 \
-                    sha256  8b3b2198ec436ac8dfc761cbafd58e00d73f44b357d0ac134ee35ec3ed3ea3fd \
-                    size    96968
+checksums           rmd160  1aaaab8cfae2d524c3d77c45f2ef4e222a0dd221 \
+                    sha256  4f826176027d30c8ddb35b73970f92caa14ea1e4ea7352dc573f3c372e1e5c13 \
+                    size    97020
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250610

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
