### PR TITLE
boost187: fix for older macOS versions

### DIFF
--- a/devel/boost187/Portfile
+++ b/devel/boost187/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       active_variants 1.1
 PortGroup       compiler_blacklist_versions 1.0
 PortGroup       legacysupport 1.1
 PortGroup       mpi 1.0
-PortGroup       active_variants 1.1
 
 # Needed for: TARGET_OS_IOS, dirfd
 legacysupport.newest_darwin_requires_legacy 14
@@ -61,12 +61,14 @@ post-extract {
     }
     # Enforce correct compiler and flags are used to build b2
     xinstall -m 755 -d ${workpath}/bin
-    ln -s ${configure.cxx} ${workpath}/bin/clang++
-    ln -s ${configure.cc}  ${workpath}/bin/clang
-    # Also link gcc/g++ for older systems
-    # https://trac.macports.org/ticket/63120
-    ln -s ${configure.cxx} ${workpath}/bin/g++
-    ln -s ${configure.cc}  ${workpath}/bin/gcc
+
+    if {[string match *clang* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/clang++
+        ln -s ${configure.cc}  ${workpath}/bin/clang
+    } elseif {[string match *gcc* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/g++
+        ln -s ${configure.cc}  ${workpath}/bin/gcc
+    }
 }
 configure.env-append  PATH=${workpath}/bin:$env(PATH)
 build.env-append      PATH=${workpath}/bin:$env(PATH)
@@ -122,6 +124,22 @@ post-patch {
 # ld: internal error: atom not found in symbolIndex(__ZNSt3__1plIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_12basic_stringIT_T0_T1_EERKS9_SB_) for architecture x86_64
 patchfiles-append patch-b2-build-older-OSes.diff
 
+# https://github.com/boostorg/test/pull/437
+# https://github.com/boostorg/test/pull/438
+patchfiles-append patch-test-PRIxPTR.diff
+
+# https://github.com/boostorg/process/issues/452
+patchfiles-append patch-process-PROC_PPID_ONLY.diff
+
+# https://github.com/boostorg/process/issues/453
+patchfiles-append patch-fix-environ.diff
+
+# https://github.com/boostorg/process/issues/461
+patchfiles-append patch-libs_process_src_posix_close__handles.diff
+
+# https://github.com/boostorg/interprocess/issues/248
+patchfiles-append patch-interprocess.diff
+
 proc write_jam s {
     global worksrcpath
     set config [open ${worksrcpath}/user-config.jam a]
@@ -157,6 +175,15 @@ configure.cmd       ./bootstrap.sh
 configure.args      --without-libraries=python \
                     --without-libraries=mpi \
                     --with-icu=${prefix}
+
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    patchfiles-append \
+                    patch-legacysupport.diff
+
+    post-patch {
+        reinplace "s|@PREFIX@|${prefix}|" ${worksrcpath}/bootstrap.sh
+    }
+}
 
 # boost build scripts default to clang on darwin
 if {[string match *gcc* ${configure.compiler}]} {
@@ -355,18 +382,18 @@ subport ${name}-numpy {
 }
 
 if {$subport eq $name} {
-    revision 1
+    revision 2
 
     patchfiles-append patch-disable-numpy-extension.diff
 
     variant regex_match_extra description \
         "Enable access to extended capture information of submatches in Boost.Regex" {
         notes-append "
-        You enabled the +regex_match_extra variant\; see the following page for an\
-        exhaustive list of the consequences of this feature:
+        You enabled the +regex_match_extra variant\; see the following page for\
+        an exhaustive list of the consequences of this feature:
 
-    http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
-"
+        http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
+        "
 
         post-patch {
             reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
@@ -422,7 +449,9 @@ if {$subport eq $name} {
         }
     }
 
-    livecheck.type  none
+    livecheck.type  regex
+    livecheck.url   http://www.boost.org/users/download/
+    livecheck.regex Version (\\d+\\.\\d+\\.\\d+)</span>
 } else {
     post-destroot {
         move {*}[glob ${destroot}${bprefix}/lib/libboost_numpy*] ${destroot}${bprefix}
@@ -502,6 +531,7 @@ variant universal {
     }
 }
 
+# TODO: Is this even needed? Is this correct for ppc64?
 platform powerpc {
     build.args-append   --disable-long-double
 }

--- a/devel/boost187/files/patch-fix-environ.diff
+++ b/devel/boost187/files/patch-fix-environ.diff
@@ -1,0 +1,135 @@
+From 94aa3b6b43cccdda370ebbef6b2e6fd603c3d922 Mon Sep 17 00:00:00 2001
+From: Klemens Morgenstern <klemens.morgenstern@gmx.net>
+Date: Thu, 27 Feb 2025 10:13:22 +0800
+Subject: [PATCH] fixed environ for OSX
+
+closes #453
+---
+ .../boost/process/v1/detail/posix/environment.hpp    |  4 ++--
+ include/boost/process/v1/detail/posix/executor.hpp   |  4 ++--
+ include/boost/process/v1/extend.hpp                  |  2 +-
+ .../boost/process/v2/detail/environment_posix.hpp    |  9 +++++++--
+ include/boost/process/v2/posix/default_launcher.hpp  | 12 ++++++++----
+ src/detail/environment_posix.cpp                     |  2 +-
+ 6 files changed, 21 insertions(+), 12 deletions(-)
+
+diff --git a/include/boost/process/v1/detail/posix/environment.hpp b/include/boost/process/v1/detail/posix/environment.hpp
+index 6ddfc559c..64bb63556 100644
+--- boost/process/v1/detail/posix/environment.hpp
++++ boost/process/v1/detail/posix/environment.hpp
+@@ -107,7 +107,7 @@ class native_environment_impl<char>
+     using string_type = std::basic_string<char_type>;
+     using native_handle_type = char_type **;
+ 
+-    void reload() {this->_env_impl = ::environ;}
++    void reload() {this->_env_impl = environ;}
+ 
+     string_type get(const pointer_type id) { return getenv(id); }
+     void        set(const pointer_type id, const pointer_type value)
+@@ -136,7 +136,7 @@ class native_environment_impl<char>
+     native_environment_impl & operator=(native_environment_impl && ) = default;
+     native_handle_type _env_impl = environ;
+ 
+-    native_handle_type native_handle() const {return ::environ;}
++    native_handle_type native_handle() const {return environ;}
+ };
+ 
+ 
+diff --git a/include/boost/process/v1/detail/posix/executor.hpp b/include/boost/process/v1/detail/posix/executor.hpp
+index cc1bcb6cf..b462e41d4 100644
+--- boost/process/v1/detail/posix/executor.hpp
++++ boost/process/v1/detail/posix/executor.hpp
+@@ -275,7 +275,7 @@ class executor
+         prepare_cmd_style_fn = exe;
+         if ((prepare_cmd_style_fn.find('/') == std::string::npos) && ::access(prepare_cmd_style_fn.c_str(), X_OK))
+         {
+-            const auto * e = ::environ;
++            const auto * e = environ;
+             while ((e != nullptr) && (*e != nullptr) && !boost::starts_with(*e, "PATH="))
+                 e++;
+ 
+@@ -316,7 +316,7 @@ class executor
+     const char * exe      = nullptr;
+     char *const* cmd_line = nullptr;
+     bool cmd_style = false;
+-    char **env      = ::environ;
++    char **env      = environ;
+     pid_t pid = -1;
+     std::shared_ptr<std::atomic<int>> exit_status = std::make_shared<std::atomic<int>>(still_active);
+ 
+diff --git a/include/boost/process/v1/extend.hpp b/include/boost/process/v1/extend.hpp
+index 185972225..cb7b05c79 100644
+--- boost/process/v1/extend.hpp
++++ boost/process/v1/extend.hpp
+@@ -249,7 +249,7 @@ struct posix_executor
+      ///A pointer to the argument-vector.
+      char *const* cmd_line = nullptr;
+      ///A pointer to the environment variables, as default it is set to [environ](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html)
+-     char **env      = ::environ;
++     char **env      = environ;
+      ///The pid of the process - it will be -1 before invoking [fork](http://pubs.opengroup.org/onlinepubs/009695399/functions/fork.html), and after forking either 0 for the new process or a positive value if in the current process. */
+      pid_t pid = -1;
+      ///This shared-pointer holds the exit code. It's done this way, so it can be shared between an `asio::io_context` and \ref child.
+diff --git a/include/boost/process/v2/detail/environment_posix.hpp b/include/boost/process/v2/detail/environment_posix.hpp
+index 756432d66..becd9f3e8 100644
+--- boost/process/v2/detail/environment_posix.hpp
++++ boost/process/v2/detail/environment_posix.hpp
+@@ -14,8 +14,13 @@
+ #include <boost/process/v2/detail/config.hpp>
+ #include <boost/process/v2/cstring_ref.hpp>
+ 
+-#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__sun)
+-extern "C" { extern char **environ; }
++#if defined(__APPLE__)
++# include <crt_externs.h>
++# if !defined(environ)
++#  define environ (*_NSGetEnviron())
++# endif
++#elif defined(__MACH__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__sun)
++ extern "C" { extern char **environ; }
+ #endif
+ 
+ BOOST_PROCESS_V2_BEGIN_NAMESPACE
+diff --git a/include/boost/process/v2/posix/default_launcher.hpp b/include/boost/process/v2/posix/default_launcher.hpp
+index d17bda5e7..fc826fea2 100644
+--- boost/process/v2/posix/default_launcher.hpp
++++ boost/process/v2/posix/default_launcher.hpp
+@@ -30,9 +30,13 @@
+ #include <sys/wait.h>
+ #include <unistd.h>
+ 
+-
+-#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__sun)
+-extern "C" { extern char **environ; }
++#if defined(__APPLE__)
++# include <crt_externs.h>
++# if !defined(environ)
++#  define environ (*_NSGetEnviron())
++# endif
++#elif defined(__MACH__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__sun)
++ extern "C" { extern char **environ; }
+ #endif
+ 
+ BOOST_PROCESS_V2_BEGIN_NAMESPACE
+@@ -260,7 +264,7 @@ inline void on_exec_error(Launcher & launcher, const filesystem::path &executabl
+ struct default_launcher
+ {
+     /// The pointer to the environment forwarded to the subprocess.
+-    const char * const * env = ::environ;
++    const char * const * env = environ;
+     /// The pid of the subprocess - will be assigned after fork.
+     int pid = -1;
+ 
+diff --git a/src/detail/environment_posix.cpp b/src/detail/environment_posix.cpp
+index 7a7913671..5c2f81260 100644
+--- libs/process/src/detail/environment_posix.cpp
++++ libs/process/src/detail/environment_posix.cpp
+@@ -51,7 +51,7 @@ void unset(basic_cstring_ref<char_type, key_char_traits<char_type>> key, error_c
+ }
+ 
+ 
+-native_handle_type load_native_handle() { return ::environ; }
++native_handle_type load_native_handle() { return environ; }
+ 
+ 
+ native_iterator next(native_iterator nh)

--- a/devel/boost187/files/patch-interprocess.diff
+++ b/devel/boost187/files/patch-interprocess.diff
@@ -1,0 +1,34 @@
+From 061bc6f8dfc2af90d9996a77317b21398f6bdda5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ion=20Gazta=C3=B1aga?= <igaztanaga@gmail.com>
+Date: Sun, 2 Mar 2025 23:23:56 +0100
+Subject: [PATCH] Fixes #248 ("gcc-14 errors out on segment_manager_helper.hpp,
+ error: no matching function...")
+
+---
+ .../boost/interprocess/detail/segment_manager_helper.hpp    | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/include/boost/interprocess/detail/segment_manager_helper.hpp b/include/boost/interprocess/detail/segment_manager_helper.hpp
+index 6d47e4aa..de788ce8 100644
+--- boost/interprocess/detail/segment_manager_helper.hpp
++++ boost/interprocess/detail/segment_manager_helper.hpp
+@@ -122,7 +122,7 @@ struct block_header
+       BOOST_ASSERT(namelen == m_num_char);
+       return get_rounded_size
+                ( size_type(sizeof(Header))
+-            , size_type(::boost::container::dtl::alignment_of<block_header<size_type> >::value))
++               , size_type(::boost::container::dtl::alignment_of<block_header<size_type> >::value))
+            + this->template total_named_size<0, char>(namelen);
+    }
+ 
+@@ -392,7 +392,9 @@ struct block_header
+ 
+    size_type name_length_offset() const
+    {
+-      return this->value_offset() + get_rounded_size(m_value_bytes, ::boost::move_detail::alignment_of<name_len_t>::value);
++      return this->value_offset() +
++         get_rounded_size( size_type(m_value_bytes)
++                         , size_type(::boost::move_detail::alignment_of<name_len_t>::value));
+    }
+ };
+ 

--- a/devel/boost187/files/patch-legacysupport.diff
+++ b/devel/boost187/files/patch-legacysupport.diff
@@ -1,0 +1,11 @@
+--- bootstrap.sh.orig	2024-12-05 08:53:27.000000000 +0800
++++ bootstrap.sh	2025-01-17 13:16:35.000000000 +0800
+@@ -226,7 +226,7 @@
+ if test "x$BJAM" = x; then
+   $ECHO "Building B2 engine.."
+   pwd=`pwd`
+-  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" ${TOOLSET}
++  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" --cxxflags="-isystem@PREFIX@/include/LegacySupport -Wl,-lMacportsLegacySupport" ${TOOLSET}
+   if [ $? -ne 0 ]; then
+       echo
+       echo "Failed to build B2 build engine"

--- a/devel/boost187/files/patch-libs_process_src_posix_close__handles.diff
+++ b/devel/boost187/files/patch-libs_process_src_posix_close__handles.diff
@@ -1,0 +1,24 @@
+From d7df711628fc69e133caeb3fc3ee8434213ef81b Mon Sep 17 00:00:00 2001
+From: Klemens Morgenstern <klemens.morgenstern@gmx.net>
+Date: Thu, 27 Feb 2025 10:12:55 +0800
+Subject: [PATCH] remove `::` from `dirfd`
+
+closes #461
+---
+ src/posix/close_handles.cpp | 2 +-
+ test/v1/limit_fd.cpp        | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/posix/close_handles.cpp b/src/posix/close_handles.cpp
+index 0da2b755e..5795a3b1c 100644
+--- libs/process/src/posix/close_handles.cpp
++++ libs/process/src/posix/close_handles.cpp
+@@ -185,7 +185,7 @@ void close_all(const std::vector<int> & whitelist, error_code & ec)
+         return ;
+     }
+ 
+-    auto dir_fd = ::dirfd(dir.get());
++    auto dir_fd = dirfd(dir.get());
+     if (dir_fd == -1)
+     {
+         ec = BOOST_PROCESS_V2_NAMESPACE::detail::get_last_error();

--- a/devel/boost187/files/patch-process-PROC_PPID_ONLY.diff
+++ b/devel/boost187/files/patch-process-PROC_PPID_ONLY.diff
@@ -1,0 +1,33 @@
+From 0ca663c8262b65ccee9a4e6abbafaef710f6b36f Mon Sep 17 00:00:00 2001
+From: Klemens Morgenstern <klemens.morgenstern@gmx.net>
+Date: Sun, 26 Jan 2025 21:49:25 +0800
+Subject: [PATCH] Set ENOTSUP when PROC_PPID_ONLY is undefined
+
+closes #452
+---
+ src/pid.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/pid.cpp b/src/pid.cpp
+index 7fa5f822c..322405907 100644
+--- libs/process/src/pid.cpp
++++ libs/process/src/pid.cpp
+@@ -178,6 +178,8 @@ pid_type parent_pid(pid_type pid, error_code & ec)
+ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+ {
+     std::vector<pid_type> vec;
++#if defined(PROC_PPID_ONLY)
++
+     vec.resize(proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, nullptr, 0) / sizeof(pid_type));
+     const auto sz = proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, &vec[0], sizeof(pid_type) * vec.size());
+     if (sz < 0)
+@@ -186,6 +188,9 @@ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+         return {};
+     }
+     vec.resize(sz);
++#else
++    BOOST_PROCESS_V2_ASSIGN_EC(ec, ENOTSUP, system_category());
++#endif
+     return vec;
+ }
+ 

--- a/devel/boost187/files/patch-test-PRIxPTR.diff
+++ b/devel/boost187/files/patch-test-PRIxPTR.diff
@@ -1,0 +1,60 @@
+From cc04b75a1b4e20e57b6dbad60a758d61074bb887 Mon Sep 17 00:00:00 2001
+From: Matt Borland <matt@mattborland.com>
+Date: Wed, 22 Jan 2025 11:41:14 -0500
+Subject: [PATCH] Add additional paths to guarantee BOOST_TEST_PRIxPTR is
+ defined
+
+---
+ include/boost/test/impl/execution_monitor.ipp | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/include/boost/test/impl/execution_monitor.ipp b/include/boost/test/impl/execution_monitor.ipp
+index 848670b80c..7753ed7854 100644
+--- boost/test/impl/execution_monitor.ipp
++++ boost/test/impl/execution_monitor.ipp
+@@ -207,7 +207,18 @@ namespace { void _set_se_translator( void* ) {} }
+ #  ifdef BOOST_TEST_DEFINED_STDC_FORMAT_MACROS
+ #    undef __STDC_FORMAT_MACROS
+ #  endif
+-#else
++#endif
++// If any modern toolchain did not pick up a definition from above it will here
++#ifndef BOOST_TEST_PRIxPTR
++#  ifdef __has_include
++#    if __has_include(<cinttypes>)
++#      include <cinttypes>
++#      define BOOST_TEST_PRIxPTR PRIxPTR
++#    endif
++#  endif
++#endif
++// Last resort
++#ifndef BOOST_TEST_PRIxPTR
+ #  define BOOST_TEST_PRIxPTR "08lx"
+ #endif
+ 
+
+From d19ff0b661e94f9f518e30b6303f5596199ef26d Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <barracuda@macos-powerpc.org>
+Date: Mon, 27 Jan 2025 04:22:28 +0800
+Subject: [PATCH] execution_monitor.ipp: follow-up fix for macOS
+
+This fixes https://github.com/boostorg/test/issues/436
+---
+ include/boost/test/impl/execution_monitor.ipp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git include/boost/test/impl/execution_monitor.ipp include/boost/test/impl/execution_monitor.ipp
+index 7753ed78..8d7500af 100644
+--- boost/test/impl/execution_monitor.ipp
++++ boost/test/impl/execution_monitor.ipp
+@@ -195,8 +195,8 @@ namespace { void _set_se_translator( void* ) {} }
+ #endif
+ 
+ #if (!defined(BOOST_MSSTL_VERSION) || (BOOST_MSSTL_VERSION >= 120)) && (!defined(__GLIBC__) || ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 2))))
+-// glibc 2.2 - 2.17 required __STDC_FORMAT_MACROS to be defined for use of PRIxPTR
+-#  if defined(__GLIBC__) && !((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 18)))
++// glibc 2.2 - 2.17 required __STDC_FORMAT_MACROS to be defined for use of PRIxPTR, as well as some versions of macOS.
++#  if (defined(__GLIBC__) && !((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 18)))) || defined(__APPLE__)
+ #    ifndef __STDC_FORMAT_MACROS
+ #      define __STDC_FORMAT_MACROS 1
+ #      define BOOST_TEST_DEFINED_STDC_FORMAT_MACROS


### PR DESCRIPTION
#### Description
commit changes from https://github.com/macos-powerpc/powerpc-ports/tree/main/devel/boost187 
discussion in https://github.com/macports/macports-ports/commit/16cc64f

Changes to be committed:
	modified:   devel/boost187/Portfile
	new file:   devel/boost187/files/patch-fix-environ.diff
	new file:   devel/boost187/files/patch-interprocess.diff
	new file:   devel/boost187/files/patch-legacysupport.diff
	new file:   devel/boost187/files/patch-libs_process_src_posix_close__handles.diff
	new file:   devel/boost187/files/patch-process-PROC_PPID_ONLY.diff
	new file:   devel/boost187/files/patch-test-PRIxPTR.diff

###### Type(s)

- [x] bugfix

###### Tested on
@barracuda156 has tested this