### PR TITLE
postgis3: update to 3.5.3; pgrouting: update to 3.8.0; add pg17 subports

### DIFF
--- a/databases/postgis3/Portfile
+++ b/databases/postgis3/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 name                postgis3
 categories          databases gis
 license             GPL-2+
-version             3.5.2
-revision            1
+version             3.5.3
+revision            0
 maintainers         {yahoo.com:n_larsson @nilason} {vince @Veence} openmaintainer
 
 description         PostGIS is the spatial extension to the\
@@ -21,9 +21,9 @@ homepage            https://postgis.net/
 master_sites        https://download.osgeo.org/postgis/source
 distname            postgis-${version}
 
-checksums           rmd160  b55b48183a46bfa7b34c0985628e577c8386c16b \
-                    sha256  fb9f95d56e3aaef6a296473c76a3b99005ac41864d486c197cd478c9b14f791a \
-                    size    15045553
+checksums           rmd160  eb4a59b62afc2f42658cc7108710faf68f48b02f \
+                    sha256  650e44de788d38175e3719df1d2ca4356bd987f54fe3d2030808de76464a2a06 \
+                    size    14899901
 
 patchfiles          patch-configure.diff
 
@@ -43,7 +43,7 @@ livecheck.url       ${master_sites}
 livecheck.regex     {postgis2?-(\d+(?:\.\d+)*)\.[tz]}
 
 # PostgreSQL subports
-set postgresql_suffixes {12 13 14 15 16}
+set postgresql_suffixes {12 13 14 15 16 17}
 set subport_names {}
 set docports {}
 foreach v ${postgresql_suffixes} {

--- a/gis/pgrouting/Portfile
+++ b/gis/pgrouting/Portfile
@@ -17,20 +17,20 @@ license             LGPL-2
 
 homepage            http://www.pgrouting.org/
 
-github.setup        pgRouting pgrouting 3.7.3 v
+github.setup        pgRouting pgrouting 3.8.0 v
 github.tarball_from releases
 revision            0
 
-checksums           rmd160  8720fb8d9ed75c63557c5ef520bb5c6e7d369de4 \
-                    sha256  949ebe7acd60565a5a1c206d8918caa371f836015f6a721bdc29482ca23b8298 \
-                    size    3873167
+checksums           rmd160  b92caa81f131fafb201f37befccebf2efaa86fb5 \
+                    sha256  b8a5f0472934fdf7cda3fb4754d01945378d920cdaddc01f378617ddbb9c447f \
+                    size    3878578
 
 compiler.cxx_standard   2014
 compiler.c_standard     1999
 cmake.build_type        Release
 
 # PostgreSQL subports
-set postgresql_suffixes {12 13 14 15 16}
+set postgresql_suffixes {12 13 14 15 16 17}
 set subport_names {}
 set docports {}
 foreach v ${postgresql_suffixes} {


### PR DESCRIPTION
#### Description

`postgis3`: update to 3.5.3, add PostgreSQL 17 subport
`pgrouting`: update to 3.8.0, add PostgreSQL 17 subport

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
