### PR TITLE
google-cloud-sdk: update to 526.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             525.0.0
-revision            1
+version             526.0.0
+revision            0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  028b460dfa166298ba5bd3370ccfef2c4e13d30f \
-                    sha256  1df8120cbbbb40b2579f72872eeb94270f6a437e6d6ede1718204cc9f4222495 \
-                    size    54096583
+    checksums       rmd160  b416c547607c4ea0e5915d76bc8a15176dc83238 \
+                    sha256  5382507eb0570b005f236319d729234e41a1394cff7f43a5dc53a1da18552454 \
+                    size    54148352
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  48fd6c7877a31d77b30c4803212124b8c8668b76 \
-                    sha256  0faa1e4acb667372d5e76b61c340074747e724c5d1dddb87369db5f681eeeb05 \
-                    size    55566905
+    checksums       rmd160  8e316132d808b8b927a90872ba83beff52d074a3 \
+                    sha256  2033efd5fada4d7f2d54afae8018c3a581991209d3c60391dec87cee4f468ff6 \
+                    size    55618500
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  84b22f519195015346ca0163423b9cbf4598bc6c \
-                    sha256  84c59742321b86f1a856e73fb2566cde4ce5816615ebaf4753f2c7a27fa92b6e \
-                    size    55510730
+    checksums       rmd160  d4ce9b075089f520f3ae6bb572b4ecd3ae6d6217 \
+                    sha256  55ea542909ff39237b0517072460067b6d1bf84d1ae14427b332101cb670c499 \
+                    size    55557343
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 526.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?