### PR TITLE
dagger: update to 0.18.10

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.9 v
+github.setup        dagger dagger 0.18.10 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  212e04acdca1c6b68ae684e647cad4a155948743 \
-                            sha256  1c21c85deee5ba66ab25b5106e8a1ba49405b02b48e0d8b78e2aee79b9d135c9 \
-                            size    19080520
+        checksums           rmd160  96f4ad75493cd7ec13e70b6667605e2992388750 \
+                            sha256  81bffbd9400a2aa370c5034e5eb2a0d7cf35644a414aec54cc3b96c43ece6f82 \
+                            size    19124115
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  35b9245b350eb64d95cc62c9ac065d45a80980bc \
-                            sha256  577042f5e0a3ad977aed0ea6b051827fdbc452fc008d6ac22180b8902bd41c37 \
-                            size    18192841
+        checksums           rmd160  0bff629f5d61e46f0b7eb4a8a02ddf997d7f17eb \
+                            sha256  cee9df08a37f47a67f7165982580dd6441414d59f4fc82ee94f7aa78ce121807 \
+                            size    18229145
     }
     default {
         known_fail  yes


### PR DESCRIPTION
###### Tested on
macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?