### PR TITLE
paps: submission

### DIFF
--- a/print/paps/Portfile
+++ b/print/paps/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           meson 1.0
+
+github.setup        dov paps 0.8.0 v
+revision            0
+checksums           rmd160  d8f016024a599774407c5a5b196cf97ac96213fe \
+                    sha256  bb5a826db364117a5ae79c833c4a000197f3b5b3eff10e31fb1513a583f96ff2 \
+                    size    224643
+
+categories          print
+platforms           {darwin any}
+license             GPL-3+
+maintainers         nomaintainer
+
+description         Command line program for converting Unicode text encoded in UTF-8 to postscript and pdf by using pango
+long_description    ${description}
+
+compiler.cxx_standard 2017
+
+set port_libfmt     libfmt9
+configure.pkg_config_path-append \
+                    ${prefix}/lib/${port_libfmt}/pkgconfig
+
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  path:lib/pkgconfig/cairo.pc:cairo \
+                    port:${port_libfmt} \
+                    port:libpaper \
+                    path:lib/pkgconfig/pango.pc:pango


### PR DESCRIPTION
#### Description

Submitting `paps`, a command line program for converting Unicode text encoded in UTF-8 to postscript and pdf by using pango.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

macOS 15.5 24F74 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
