### PR TITLE
lima: Improve additional guest agents message

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/lima-vm/lima 1.1.1 v
 go.offline_build    no
-revision            1
+revision            2
 
 homepage            https://lima-vm.io
 
@@ -35,7 +35,8 @@ checksums           rmd160  537cdb940ebbd891c34af018eb191b3426171fb5 \
 build.cmd           make
 build.args-append   native
 
-patchfiles          patch-Makefile.diff
+patchfiles          patch-Makefile.diff \
+                    patch-usrlocalsharelimago.diff
 
 platform darwin {
     # Lima defaults to VZ with macOS 13.5 and later; drop dependency from 14 onwards

--- a/sysutils/lima/files/patch-usrlocalsharelimago.diff
+++ b/sysutils/lima/files/patch-usrlocalsharelimago.diff
@@ -1,0 +1,11 @@
+--- pkg/usrlocalsharelima/usrlocalsharelima.go.orig	2025-06-11 22:58:53
++++ pkg/usrlocalsharelima/usrlocalsharelima.go	2025-06-11 22:59:47
+@@ -115,7 +115,7 @@
+ 	res, err := chooseGABinary([]string{comp, uncomp})
+ 	if err != nil {
+ 		logrus.Debug(err)
+-		return "", fmt.Errorf("guest agent binary could not be found for %s-%s (Hint: try installing `lima-additional-guestagents` package)", ostype, arch)
++		return "", fmt.Errorf("guest agent binary could not be found for %s-%s: %w (Hint: try installing variant `+additional_guestagents`)", ostype, arch, err)
+ 	}
+ 	return res, nil
+ }


### PR DESCRIPTION
#### Description

Lima contains a message for installing `lima-additional-guestagents` package when agents can't be found. This does not work for MacPorts because we have a variant (`+additional_guestagents`). Added a patch to update the message to refer to this variant instead of a package that does not exist.

Closes: https://trac.macports.org/ticket/72567

###### Type(s)

- [x] bugfix

###### Tested on

macOS 15.5 24F74 arm64  
Xcode 16.4 16F6

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?