### PR TITLE
paps: fixing platform and license

### DIFF
--- a/print/paps/Portfile
+++ b/print/paps/Portfile
@@ -5,14 +5,13 @@ PortGroup           github 1.0
 PortGroup           meson 1.0
 
 github.setup        dov paps 0.8.0 v
-revision            0
+revision            1
 checksums           rmd160  d8f016024a599774407c5a5b196cf97ac96213fe \
                     sha256  bb5a826db364117a5ae79c833c4a000197f3b5b3eff10e31fb1513a583f96ff2 \
                     size    224643
 
 categories          print
-platforms           {darwin any}
-license             GPL-3+
+license             GPL-2+
 maintainers         nomaintainer
 
 description         Command line program for converting Unicode text encoded in UTF-8 to postscript and pdf by using pango


### PR DESCRIPTION
#### Description

This fixes the platform and license in the portfile of the recently submitted `paps` port.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
