### PR TITLE
google-cloud-sdk: update to 526.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             526.0.0
+version             526.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  b416c547607c4ea0e5915d76bc8a15176dc83238 \
-                    sha256  5382507eb0570b005f236319d729234e41a1394cff7f43a5dc53a1da18552454 \
-                    size    54148352
+    checksums       rmd160  d7808f766f918bc17afc2b63af540ce47adb1d80 \
+                    sha256  d77a09ff17611298a80c0a2895dc396730e3c2ab642fd829ba4c66df597699b0 \
+                    size    54148310
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  8e316132d808b8b927a90872ba83beff52d074a3 \
-                    sha256  2033efd5fada4d7f2d54afae8018c3a581991209d3c60391dec87cee4f468ff6 \
-                    size    55618500
+    checksums       rmd160  e4eda8cee1d2bb78f4154dc80439213676c64df0 \
+                    sha256  51be55b1a988fa5392b841a003c80caf7a5e889089c1ade19d8ac69bf7210a48 \
+                    size    55618516
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  d4ce9b075089f520f3ae6bb572b4ecd3ae6d6217 \
-                    sha256  55ea542909ff39237b0517072460067b6d1bf84d1ae14427b332101cb670c499 \
-                    size    55557343
+    checksums       rmd160  ef8143328e781e99a1514dd1afa984da1bb97cb0 \
+                    sha256  6ebdb5012f43bb52e914865a5b46fc45418fb70a03603898427b5a9187361176 \
+                    size    55557385
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 526.0.1.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?