### PR TITLE
scrcpy: Update to version 3.3

### DIFF
--- a/multimedia/scrcpy/Portfile
+++ b/multimedia/scrcpy/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 # needed for clock_gettime and static_assert to work on older OS X versions
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        Genymobile scrcpy 3.2 v
+github.setup        Genymobile scrcpy 3.3 v
 revision            0
 github.tarball_from archive
 
@@ -28,13 +28,13 @@ extract.only        ${distfiles}
 distfiles-append    ${name}-server-v${version}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  077662193dd933a1a3c164d91aae8229b79d5a6a \
-                    sha256  9902a3afd75f9a5da64898ac06ffaf77065dd713a58f47a408630b98f03ba9ce \
-                    size    464967 \
+                    rmd160  af82fa5a71ec6275bd21fb255e4c2a296150167b \
+                    sha256  6636f97f3a5446e3a1c845545108cf692bbd9cdc02cacfda099a2789ca7f6d56 \
+                    size    464716 \
                     ${name}-server-v${version} \
-                    rmd160  870d556649797a36e56a6af5230e832d2f260b9e \
-                    sha256  b920e0ea01936bf2482f4ba2fa985c22c13c621999e3d33b45baa5acfc1ea3d0 \
-                    size    90888
+                    rmd160  d6468c1eff3785b0f8b4be02bfe957cb9c4dffdb \
+                    sha256  351cb2edc7e4c2c75f09a7933fdabcf137be52e2602df154f24ec02db46e9e51 \
+                    size    90752
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
