### PR TITLE
libomp: Fix installation

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -28,7 +28,7 @@ epoch                   1
 if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
 
     version             20.1.6
-    revision            0
+    revision            1
 
     livecheck.regex {"llvmorg-([0-9.]+)".*}
 
@@ -144,6 +144,8 @@ if {${os.major} <= 10} {
     set hnames              {omp-tools.h omp.h ompt.h ompx.h}
 }
 
+set lnames {libiomp5.dylib libomp.dylib libgomp.dylib libgomp.1.dylib}
+
 variant top_level description \
     "Install (links to) omp.h and libs into ${prefix}/(include|lib)" {}
 
@@ -164,18 +166,16 @@ post-destroot {
     }
 
     xinstall -d ${instdest}/lib/libomp
-    foreach p {libiomp5.dylib libomp.dylib libgomp.dylib} {
+    foreach p ${lnames} {
         move ${instdest}/tmp/lib/${p} ${instdest}/lib/libomp/
     }
 
     if {[variant_isset top_level]} {
         foreach h ${hnames} {
-            system -W ${instdest}/include \
-              "ln -s libomp/${h}"
+            ln -s libomp/${h} ${instdest}/include/${h}
         }
-        foreach p {libiomp5.dylib libomp.dylib libgomp.dylib} {
-            system -W ${instdest}/lib/ \
-              "ln -s libomp/${p}"
+        foreach p ${lnames} {
+            ln -s libomp/${p} ${instdest}/lib/${p}
         }
     }
 


### PR DESCRIPTION
  Fixes https://trac.macports.org/ticket/72605 [Missed new lib name]
  Fixes https://trac.macports.org/ticket/72607 [use port's ln]