### PR TITLE
gcc14: Add modula-2

### DIFF
--- a/lang/gcc14/Portfile
+++ b/lang/gcc14/Portfile
@@ -98,7 +98,7 @@ platform darwin {
     configure.pre_args-append --build=${gcc_triple}
 }
 
-set gcc_configure_langs {c c++ objc obj-c++ lto fortran}
+set gcc_configure_langs {c c++ objc obj-c++ lto fortran m2}
 if {${subport} eq ${name} && ${build_arch} ne "i386" && ${os.major} > 8} {
     # jit compiler is not building on i386 systems
     # https://trac.macports.org/ticket/61130


### PR DESCRIPTION
#### Description

* Add modula-2 to compiler suite (`gm2-mp-14`).
* No rev bump needed.  This PR only adds new files for modula-2.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 15.5
Xcode 16.2
Command Line Tools 16.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] compiled and run a sample modula-2 program?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -s install`?
- [x] tested basic functionality of all ~~binary files~~ executables?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?