### PR TITLE
legacy-support: Update to v1.5.0

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -22,7 +22,7 @@ long_description    {*}${description}
 epoch               1
 
 # Primary release version
-set release_ver     1.4.0
+set release_ver     1.5.0
 
 # Binary compatibility version
 set compat_ver      1.0.0
@@ -34,9 +34,9 @@ subport ${name} {
     # N.B.: That's a nice theory, but neither choice works correctly
     github.tarball_from tarball
     revision            0
-    checksums           rmd160  7869ee1f847476a90364b00550006608d008d653 \
-                        sha256  336e98b306fd3d928b43342664daa550953f8f25233467670486c62544c80f67 \
-                        size    163812
+    checksums           rmd160  02d6f192a75ffacda4530d82464240f404cc224c \
+                        sha256  18f4df8850aebe64f66ed80eae14b50cc87cbe1d1dabfbdd432ff0aaf87b44f4 \
+                        size    214986
 }
 
 subport ${name}-devel {


### PR DESCRIPTION
Notable changes since last release (v1.4.0):

- Complete rewrite of clock functions, including:
  - CLOCK_MONOTONIC is no longer non-monotonic
  - CLOCK_MONOTONIC is no longer completely broken on ppc64
  - Mach-based clocks are no longer horribly inaccurate on some ppc models
  - High-precision thread time is now reported on 10.10+
  - "Approximate" clocks work as intended on 10.10+
  - Fallbacks for missing mach_time clocks are provided
  - A corner case in CLOCK_THREAD_CPUTIME_ID is fixed
  - Bad clock IDs no longer fail to set errno
  - Most functions are now faster.
- Two packet timestamp bugs are fixed:
  - 10.5 x86_64 no longer supplies an unexpected timestamp format
  - Timestamps now have correct endianness under Rosetta
- The SDK 15 TargetConditionals.h now compiles with GCC 4.2

- Several header fixes, including:
  - Fixes dirent.h+sys/stat.h for 10.4 build with _POSIX_C_SOURCE See: https://trac.macports.org/ticket/72406
  - Fixes dirent.h for C89/C90 mode See: https://trac.macports.org/ticket/72428
  - Various other error/warning fixes

- Implements sleep-time accounting in clock functions (except on ppc64 for now). See: https://trac.macports.org/ticket/68007
- Implements degenerate *clonefile*(). See: https://trac.macports.org/ticket/72272

TESTED:
Tested both normal and -devel versions -/+universal on 10.4-10.5 ppc, 10.4-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-15.x arm64.
Builds and passes all tests on all tested platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, PPC (i386 Rosetta), Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.6 22H625, arm64, Xcode 15.2 15C500b
macOS 14.7.6 23H626, arm64, Xcode 16.2 16C5032a
macOS 15.5 24F74, arm64, Xcode 16.3 16E140
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
