### PR TITLE
gunits: fix builds on legacy platforms

### DIFF
--- a/math/gunits/Portfile
+++ b/math/gunits/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                gunits
 version             2.24
-revision            0
+revision            1
 checksums           rmd160  1ca0be0968d71450cd5c28dd2c229f0a56520861 \
                     sha256  1e502c4edfacf20b29284716c72e5ddb51a495a2365d7b03e7960494c4a0c902 \
                     size    1493600
@@ -32,6 +33,13 @@ depends_lib         port:py${python_ver_no_dot}-requests \
 configure.args      ac_cv_path_PYTHON=${prefix}/bin/python${python_version} \
                     --program-prefix=g \
                     --sharedstatedir=${prefix}/var/lib
+
+compiler.c_standard 2011
+
+# C11 floating point macros, like DBL_DECIMAL_DIG,
+# were not present until (LLVM) clang 3.9
+# see llvm/llvm-project issue 26657
+compiler.blacklist-append   {clang < 800}
 
 post-destroot {
     # gunits_cur wants to be able to update these files.


### PR DESCRIPTION
#### Description

I inadvertently broke builds on OS X 10.7 through 10.11 in #28645.
Here is an apologetic patch.  I specifically tested on 10.8.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.8.5 12F45 x86_64
Xcode 5.1.1 5B1008

and

macOS 14.7.6 23H626 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
  (tracing still busted?  OK without `-t`)
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
