### PR TITLE
osxphotos: update to 0.72.0

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.71.0
+version                 0.72.0
 revision                0
 
 categories              graphics python
@@ -25,9 +25,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  60c7087414828d9adec44c0df81ec11857c9ad1d \
-                        sha256  7d8ae7af09024537a2b66fa16bdce5c20e77b5e2cbd0a1e2033287c3ff121d5b \
-                        size    2256888
+checksums               rmd160  9ec9d43052447d608c47623339c53401b39a1c7a \
+                        sha256  26df36a1ae8e1c51046a50f10dddc1484ca91b541945a712b270de357cb13471 \
+                        size    2278460
 
 python.default_version  313
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.72.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?