### PR TITLE
pinact: Update to 3.3.0

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.1.2 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.3.0 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,9 +16,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d648476d281950718a6b8fbcbd1c35918e83f0c4 \
-                    sha256  a58de86006fef4bb92d2a5a7d46e9de2a671815cdd5cfdad12161435ceb9163c \
-                    size    36689
+                    rmd160  68891d967b8db3611935cc71978baf5a1782a982 \
+                    sha256  2646a3857f59accf33812cb926ac8b1eb2d139de487686f08adff56c531eb83b \
+                    size    40237
 
 livecheck.regex     "v(\\d+\\.\\d+\\.\\d+)\$"
 
@@ -36,6 +36,7 @@ notes {
   If you have an existing .pinact.yaml file, you will need to use pinact 2.2 and run
   'pinact migrate' to fix the pinact configuration file for pinact 3.0.
 }
+
 
 
 
@@ -82,10 +83,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  c7caff4ba164feeebdcc568d6598931a20719827e05dfa18ac7d7c495d36b883 \
                         size    20797 \
                     github.com/urfave/cli \
-                        lock    v3.3.3 \
-                        rmd160  98d2a4512038d2f2ff3e54db4d07441fba74ac0f \
-                        sha256  e3d0978d9c2ec9dc9e4eec944281b8f0e624c25e5ad4ce95c95a668e940fe04b \
-                        size    6801433 \
+                        lock    v3.3.7 \
+                        rmd160  f6db18b3f81861fd9c87eb5cfcd40cd0dc0d6666 \
+                        sha256  130637bbd55c0eb4afa5a6d78b5ca208381d1c447166537aea4d470263dfdbea \
+                        size    6802058 \
                     github.com/suzuki-shunsuke/urfave-cli-v3-util \
                         lock    v0.0.5 \
                         rmd160  7790fbae62fea70864b484feb621a785d7b7899e \
@@ -177,10 +178,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  870c356aa2ab1d1ea7f18afef3cfc4f5a4795c66c3d542e309f5dfa0e21a1be1 \
                         size    74088 \
                     github.com/goccy/go-yaml \
-                        lock    v1.17.1 \
-                        rmd160  7f85a843b0f541b5d327d7f882a53ee345f60e6f \
-                        sha256  d938ecb6f9e781ecd2af5401e186536e6dcd7a744602ff5d8cc31bbf988608df \
-                        size    663056 \
+                        lock    v1.18.0 \
+                        rmd160  c744e001484fef8e280f4e236a70117ba33fdbbf \
+                        sha256  ecd15de49f96a88ea01cc618f5e8c1e4bf04cc37c29ab43bd4b63ebacd6b5f91 \
+                        size    663118 \
+                    github.com/fatih/color \
+                        lock    v1.18.0 \
+                        rmd160  cea38fd7fdad5b4b20f519ebd1301bc2c277f54b \
+                        sha256  e085d36aabb91de9adfa7ff605a06a342b6bc583e3bbb8ce49605590f4e0bd71 \
+                        size    12711 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \


### PR DESCRIPTION
#### Description

pinact: Update to 3.3.0

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
