### PR TITLE
mise: Update to 2025.6.4

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.6.2 v
+github.setup        jdx mise 2025.6.4 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  da2aa27fa52f3a937131406da59db4cbaf90863d \
-                    sha256  c0ac618f1bc22dd8a3ca6726e550a7f4c565533ff9077e6ce7491f6a9946b0c3 \
-                    size    4185625
+                    rmd160  36dbb6330fbc621acfd9f927c0460aa6d1cdf25a \
+                    sha256  ea8e4681dfa52a7c514f88d35a28e5456ecdc317232fc890360d6d68abd8dff0 \
+                    size    4185841
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -650,7 +650,7 @@ cargo.crates \
     type-map                         0.5.1  cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90 \
     typeid                           1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
     typenum                         1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
-    ubi                              0.6.1  6935e5064a326520a375603b9cddc9058796e39a041bf50e9e1eaa23da785adc \
+    ubi                              0.7.1  238b7537b01c08edeef5dcb31e9ef882ec46e26a09875cffdab428e518204f19 \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     uluru                            3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
     unic-char-property               0.9.0  a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.6.4

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
