### PR TITLE
nano: update to 8.5

### DIFF
--- a/editors/nano/Portfile
+++ b/editors/nano/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 8
 
 name                nano
-version             8.4
+version             8.5
 revision            0
 categories          editors
 license             GPL-3
@@ -23,9 +23,9 @@ long_description \
 homepage            https://www.nano-editor.org
 master_sites        ${homepage}/dist/v[strsed ${version} {/\.[0-9]*$//}]/ gnu
 
-checksums           rmd160  705799bd1717811acfe3720b37a1ac5fdb4aecca \
-                    sha256  35acc088bc190943382b4da2752563d28cf31351c1478419c4c82908fba94456 \
-                    size    3543039
+checksums           rmd160  24be9374e0cd5d58fd6bc7e5f50da9535bf2d7ad \
+                    sha256  64538a1032ce02f11acce6603aa6a4c9d8f03f5f42504c2f7ee4aeed0cffe822 \
+                    size    3567680
 
 depends_build       port:gettext
 


### PR DESCRIPTION
#### Description

nano: update to 8.5

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?