### PR TITLE
rb-mime-types: Update to 3.7.0

### DIFF
--- a/ruby/rb-mime-types-data/Portfile
+++ b/ruby/rb-mime-types-data/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           ruby 1.0
 
-ruby.branches       3.3 3.2 3.1
-ruby.setup          mime-types-data 3.2024.0206 gem {} rubygems
+ruby.branches       3.4 3.3 3.2 3.1
+ruby.setup          mime-types-data 3.2025.0610 gem {} rubygems
 license             MIT
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 description         ${name} provides a registry for information \
                     about MIME media type definitions.
 long_description    {*}${description}
-checksums           rmd160  7287abceff59cfc90c5d8113b5680c7a36d2a129 \
-                    sha256  c5ee2f4c4d1243f575ef15ea93cc69dd81d1f25c2114190f9caab8d6f32af67e \
-                    size    205824
+checksums           rmd160  03f1757d1b84f35b30e73130c0c88d1e521fb933 \
+                    sha256  223b3fedf92848ea6a4a407e0977175a36a018fb94d48edaa454ff4298ad68c0 \
+                    size    169472
 platforms           any
 supported_archs     noarch
 homepage            https://github.com/mime-types/mime-types-data

--- a/ruby/rb-mime-types/Portfile
+++ b/ruby/rb-mime-types/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           ruby 1.0
 
-ruby.branches       3.3 3.2 3.1
-ruby.setup          mime-types 3.5.2 gem {} rubygems
+ruby.branches       3.4 3.3 3.2 3.1
+ruby.setup          mime-types 3.7.0 gem {} rubygems
 license             {Ruby Artistic-1 GPL-2+}
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -13,9 +13,9 @@ description         Manages a MIME content-type that will return \
 long_description    This library allows for the identification of a file's \
                     likely MIME content type. The identification of MIME \
                     content type is based on a file's filename extensions.
-checksums           rmd160  01bbd77fe22c70259193971f1ec27cbb24d0021b \
-                    sha256  c1299f10fa34c75a6f168e99e9dadbd11bc507d9d62dc5cf98c4e65f2af8c4e4 \
-                    size    37888
+checksums           rmd160  fc6e7194baa0c6e3742849ed1502e0f48b553be9 \
+                    sha256  dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56 \
+                    size    41984
 platforms           any
 supported_archs     noarch
 homepage            https://github.com/mime-types/ruby-mime-types


### PR DESCRIPTION

#### Description

Upgrade rb-mime-types and rb-mime-types-data (rb-mime-types >= 3.7 requires rb-mime-types-data >= 3.2025.0507). Also add support for installing with `ruby34`.

###### Tested on

macOS 15.5 24F74 arm64  
Xcode 16.4 16F6

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
x [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?