### PR TITLE
retry: Update to 1.0.6

### DIFF
--- a/sysutils/retry/Portfile
+++ b/sysutils/retry/Portfile
@@ -1,27 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               legacysupport 1.1
 PortGroup               github 1.0
 
-github.setup            minfrin retry 1.0.5 retry-
+github.setup            minfrin retry 1.0.6 retry-
 github.tarball_from     releases
 revision                0
 categories              sysutils
 license                 Apache-2
-maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
 description             Repeat a command until a command succeeds
 long_description        {*}${description}. Retry captures stdin into memory as the data is passed to \
                         the repeated command, and this captured stdin is then replayed should the command \
                         be repeated. This makes it possible to embed the retry tool into shell pipelines.
 
-checksums               rmd160  8fafffee444a9d1345dcb041b1c26ebbd1519676 \
-                        sha256  68e241d10f0e2d784a165634bb2eb12b7baf0a9fd9d27c4d54315382597d892e \
-                        size    260264
+checksums               rmd160  a6966e6caab947cbfa2386e1e78e6afbf7f14d0f \
+                        sha256  b5bbdaee16436fabae608fbc58f47df9726b87b945c9eca1524648500b9afdf3 \
+                        size    281571
 
 use_bzip2               yes
 
 configure.args-append   --disable-silent-rules
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update `retry` to its latest released version, 1.0.6

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
