### PR TITLE
gitu: Update to 0.33.0

### DIFF
--- a/devel/gitu/Portfile
+++ b/devel/gitu/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            altsem gitu 0.32.0 v
+github.setup            altsem gitu 0.33.0 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -16,9 +16,9 @@ description             A TUI Git client inspired by Magit
 long_description        {*}${description}, launched straight from the terminal.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  065e6308a12d11c282216c480aee4137eabd6b24 \
-                        sha256  02197becacec15ff1b862ea7e1ddc283145b72fc8a212e98b87d02e6c0637c9b \
-                        size    3939619
+                        rmd160  a8505d1480a284d9fd115056480f5571ccaec14f \
+                        sha256  43dea7dae5f9aef9d3edb2f4e6ddd16d21664a6739b2856d53471846a97ded7d \
+                        size    3941447
 
 # Fix opportunistic linking with libiconv
 depends_lib-append      port:libiconv
@@ -51,7 +51,7 @@ cargo.crates \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     castaway                         0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
-    cc                             1.0.106  066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2 \
+    cc                              1.2.26  956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chrono                          0.4.40  1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
@@ -205,8 +205,9 @@ cargo.crates \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
     serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
     serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
-    serde_json                     1.0.128  6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8 \
+    serde_json                     1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
+    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
     signal-hook-mio                  0.2.4  34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd \
     signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
@@ -216,42 +217,44 @@ cargo.crates \
     smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+    streaming-iterator               0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
     strip-ansi-escapes               0.2.1  2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
-    syn                             2.0.85  5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56 \
+    syn                             2.0.87  25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     temp-dir                        0.1.14  bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72 \
-    thiserror                       1.0.64  d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84 \
-    thiserror-impl                  1.0.64  08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3 \
+    thiserror                       2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
+    thiserror-impl                  2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
     thread-id                        3.3.0  c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1 \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     toml                            0.8.20  cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148 \
     toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
     toml_edit                      0.22.24  17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474 \
-    tree-sitter                    0.20.10  e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d \
-    tree-sitter-bash                0.20.5  57da2032c37eb2ce29fd18df7d3b94355fec8d6d854d8f80934955df542b5906 \
-    tree-sitter-c                   0.20.8  4bbd5f3d8658c08581f8f2adac6c391c2e9fa00fe9246bf6c5f52213b9cc6b72 \
-    tree-sitter-c-sharp             0.20.0  b9ab3dc608f34924fa9e10533a95f62dbc14b6de0ddd7107722eba66fe19ae31 \
-    tree-sitter-cpp                 0.20.5  46b04a5ada71059afb9895966a6cc1094acc8d2ea1971006db26573e7dfebb74 \
-    tree-sitter-elixir               0.1.1  1bc0b1f3e6d9f12ca22ae5171f32fd154e3aea29dff565d05ef785c28931415b \
-    tree-sitter-go                  0.20.0  1ad6d11f19441b961af2fda7f12f5d0dac325f6d6de83836a1d3750018cc5114 \
-    tree-sitter-haskell             0.15.0  ac635b86d6cc127706bc0831f4b83f5503ed8ac2f8cd22831ba3e5535445b4f2 \
-    tree-sitter-highlight           0.20.1  042342584c5a7a0b833d9fc4e2bdab3f9868ddc6c4b339a1e01451c6720868bc \
-    tree-sitter-html                0.20.0  017822b6bd42843c4bd67fabb834f61ce23254e866282dd93871350fd6b7fa1d \
-    tree-sitter-java                0.20.2  2adc5696bf5abf761081d7457d2bb82d0e3b28964f4214f63fd7e720ef462653 \
-    tree-sitter-javascript          0.20.4  d015c02ea98b62c806f7329ff71c383286dfc3a7a7da0cc484f6e42922f73c2c \
-    tree-sitter-json                0.20.2  5a9a38a9c679b55cc8d17350381ec08d69fa1a17a53fcf197f344516e485ed4d \
-    tree-sitter-ocaml               0.20.4  fd1163abc658cf8ae0ecffbd8f4bd3ee00a2b98729de74f3b08f0e24f3ac208a \
-    tree-sitter-php                 0.20.0  18b689aaa57bd1f0707e5c0728004e7f737b16768644a7e745d23021330797de \
-    tree-sitter-python              0.20.4  e6c93b1b1fbd0d399db3445f51fd3058e43d0b4dcff62ddbdb46e66550978aa5 \
-    tree-sitter-ruby                0.20.1  44d50ef383469df8485f024c5fb01faced8cb90368192a7ba02605b43b2427fe \
-    tree-sitter-rust                0.20.4  b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594 \
-    tree-sitter-scala               0.20.3  44fcf4628a88a3b5cbac3ff52658b924f3e545abddfa245ab9cf683c1adda350 \
-    tree-sitter-toml                0.20.0  ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8 \
-    tree-sitter-typescript          0.20.5  c8bc1d2c24276a48ef097a71b56888ac9db63717e8f8d0b324668a27fd619670 \
+    tree-sitter                     0.25.6  a7cf18d43cbf0bfca51f657132cc616a5097edc4424d538bae6fa60142eaf9f0 \
+    tree-sitter-bash                0.25.0  871b0606e667e98a1237ebdc1b0d7056e0aebfdc3141d12b399865d4cb6ed8a6 \
+    tree-sitter-c                   0.24.1  1a3aad8f0129083a59fe8596157552d2bb7148c492d44c21558d68ca1c722707 \
+    tree-sitter-c-sharp             0.23.1  67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0 \
+    tree-sitter-cpp                 0.23.4  df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743 \
+    tree-sitter-elixir               0.3.4  e45d444647b4fd53d8fd32474c1b8bedc1baa22669ce3a78d083e365fa9a2d3f \
+    tree-sitter-go                  0.23.4  b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431 \
+    tree-sitter-haskell             0.23.1  977c51e504548cba13fc27cb5a2edab2124cf6716a1934915d07ab99523b05a4 \
+    tree-sitter-highlight           0.25.6  6eea684ab5dd71e19f6c0add355be96f2b4eb58327cb305337415208681761aa \
+    tree-sitter-html                0.23.2  261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee \
+    tree-sitter-java                0.23.5  0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6 \
+    tree-sitter-javascript          0.23.1  bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1 \
+    tree-sitter-json                0.24.8  4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471 \
+    tree-sitter-language             0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
+    tree-sitter-ocaml               0.24.2  7d19db582b3855f56b5f9ec484170fbfb9ee60b938ec7720d76d2ee788e8b640 \
+    tree-sitter-php                0.23.11  f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c \
+    tree-sitter-python              0.23.6  3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04 \
+    tree-sitter-ruby                0.23.1  be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95 \
+    tree-sitter-rust                0.24.0  4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1 \
+    tree-sitter-scala               0.23.4  efde5e68b4736e9eac17bfa296c6f104a26bffab363b365eb898c40a63c15d2f \
+    tree-sitter-toml-ng              0.7.0  e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1 \
+    tree-sitter-typescript          0.23.2  6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff \
     tui-prompts                      0.5.0  eb6e0d8a972545cc209b933a1c06dab8932674b54ae19947834ec854fec2364f \
     uncased                         0.9.10  e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697 \
     unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \


### PR DESCRIPTION
#### Description

Update `gitu` to its latest released version, 0.33.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
