### PR TITLE
allegro5: update to 5.2.10.1; adopt

### DIFF
--- a/devel/allegro5/Portfile
+++ b/devel/allegro5/Portfile
@@ -9,12 +9,15 @@ cmake.out_of_source yes
 PortGroup muniversal 1.0
 
 PortGroup           github 1.0
-github.setup        liballeg allegro5 5.2.7.0
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-revision            2
 
-maintainers         nomaintainer
+github.setup        liballeg allegro5 5.2.10.1
+github.tarball_from releases
+use_7z              yes
+distname            allegro-${github.version}
+worksrcdir          allegro
+revision            0
+
+maintainers         {gmail.com:awkravchuk @lockie} openmaintainer
 categories          devel games
 license             Permissive
 homepage            https://liballeg.org/
@@ -25,9 +28,9 @@ long_description \
                     C/C++ developers distributed freely, supporting \
                     many platforms.
 
-checksums           rmd160  b43768ab070c4e369e805b2cdaf376f15ee03989 \
-                    sha256  3be4ffaaabb7a0d27d0cc109704c374a089686f2297be84774282d00a0b84da2 \
-                    size    7102101
+checksums           rmd160  f86eaf0b6ab9b1b7da7596ced1f6dd3aaadfc268 \
+                    sha256  dfb85131d0de682399099907d46e9c3971b2769330fef99207fc553ba4313125 \
+                    size    8502343
 
 depends_build-append \
                     port:libxslt \


### PR DESCRIPTION
#### Description

Update devel/allegro5 port to the current latest version and take maintainership, since it is unmaintained.
Current 5.2.7 version contains plethora of bugs, like e.g. this one https://github.com/liballeg/allegro5/issues/1643.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.7.6 22H625 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->