### PR TITLE
qdmr: Update to v0.12.3

### DIFF
--- a/science/qdmr/Portfile
+++ b/science/qdmr/Portfile
@@ -8,8 +8,8 @@ PortGroup           qt5 1.0
 
 name                qdmr
 maintainers         @hmatuschek {ra1nb0w @ra1nb0w} openmaintainer
-version             0.12.1
-revision            1
+version             0.12.3
+revision            0
 
 categories          science
 license             GPL-3
@@ -28,9 +28,9 @@ github.setup        hmatuschek qdmr ${version} v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
 
-checksums           rmd160  b7c20e8a017907d09708fc76e0f185158f0e4f2c \
-                    sha256  3f90d618a98d1a641b663804ddea1a7fa5f8fd45383b10c9321020eb16528309 \
-                    size    6958534
+checksums           rmd160  854b56237d25bb4894197042b25b5cc83c690381 \
+                    sha256  ad99cf41f151eb758f04ea890702ea3509af173f6fa808ec657182b05b5e2dd0 \
+                    size    6974558
 
 qt5.depends_build_component \
     qttools


### PR DESCRIPTION
#### Description

qdmr: Update to v0.12.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
