### PR TITLE
google-cloud-sdk: update to 527.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             526.0.1
+version             527.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  d7808f766f918bc17afc2b63af540ce47adb1d80 \
-                    sha256  d77a09ff17611298a80c0a2895dc396730e3c2ab642fd829ba4c66df597699b0 \
-                    size    54148310
+    checksums       rmd160  b02c289575d3352ddcbd58f8a7cb3b467dbdbd93 \
+                    sha256  043a3a4cd20df4cef3a0f9342e6d81be901f0c9a9b9ce1f14c7d901045f212a8 \
+                    size    54181078
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  e4eda8cee1d2bb78f4154dc80439213676c64df0 \
-                    sha256  51be55b1a988fa5392b841a003c80caf7a5e889089c1ade19d8ac69bf7210a48 \
-                    size    55618516
+    checksums       rmd160  2d4f01f959d1fca22edbe721302207e32e3f9f89 \
+                    sha256  aea4e9b895652ab335a245f46627f74489cd204bcb196fa4d9cee0006de157b8 \
+                    size    55713008
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  ef8143328e781e99a1514dd1afa984da1bb97cb0 \
-                    sha256  6ebdb5012f43bb52e914865a5b46fc45418fb70a03603898427b5a9187361176 \
-                    size    55557385
+    checksums       rmd160  0596bd060232b8e53ed1e0883eaa50df10a2750f \
+                    sha256  4294ed93db21c079d4a3ccb31b134a9e60405b811f1ecfed3a0207e38d39bfbf \
+                    size    55648024
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 527.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?