### PR TITLE
hamlib: Update to v4.6.3

### DIFF
--- a/science/hamlib/Portfile
+++ b/science/hamlib/Portfile
@@ -20,46 +20,14 @@ long_description    Flexible and portable shared libraries that offer a \
 
 homepage            https://hamlib.github.io
 
-subport hamlib-devel {}
-if {[string first "-devel" $subport] > 0} {
+github.setup    Hamlib Hamlib 4.6.3
+github.tarball_from releases
+checksums       rmd160  0e90d6fdb838267f4011c348d3fc847b021ae54f \
+                sha256  aefd1b1e53a8548870a266ae362044ad3ff43008d10f1050c965cf99ac5a9630 \
+                size    2922305
+revision        0
 
-    github.setup    Hamlib Hamlib d06244c47f4dffdf9f47172385c8dfac738c24e2
-    version         20230305-[string range ${github.version} 0 7]
-    checksums       rmd160  a89e2e1bc1d3b4ee2cc95db7ea4e514020a38d55 \
-                    sha256  c9af3aee0728341954bb19f51a8a89cdb56f238994e9bb5473e8ae20a1c41230 \
-                    size    2163459
-    revision        0
-
-    github.tarball_from archive
-
-    name            hamlib-devel
-    long_description ${long_description} This port is kept up with the Hamlib \
-        GIT 'master' branch, is typically updated weekly to monthly.
-    conflicts       hamlib
-
-    use_autoconf    yes
-    autoconf.cmd    ./bootstrap
-
-    # need for autoconf
-    depends_build-append \
-        port:autoconf    \
-        port:automake    \
-        port:libtool
-
-} else {
-
-    github.setup    Hamlib Hamlib 4.6.2
-    github.tarball_from releases
-    checksums       rmd160  940a1977232d9ec75094681e139ba91618d49261 \
-                    sha256  b2ac73f44dd1161e95fdee6c95276144757647bf92d7fdb369ee2fe41ed47ae8 \
-                    size    2909790
-
-    revision        0
-
-    distname        hamlib-${version}
-
-    conflicts       hamlib-devel
-}
+distname        hamlib-${version}
 
 depends_build-append \
     port:pkgconfig


### PR DESCRIPTION
#### Description

Update hamlib to v4.6.3

Closes: https://trac.macports.org/ticket/72614

This is a new attempt to get the pr working since something weird happened with 
https://github.com/macports/macports-ports/pull/28704

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
