### PR TITLE
symfony-cli: update to 5.12.0

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.11.0
+version             5.12.0
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,17 +44,17 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  da1f3a46d647090ba6718dc01bc7b3d6f7a355a1 \
-                        sha256  29996a4f7f2032fe1e3b1d8df734843f84ee7e2ac9db10e1e690ffc37df88713 \
-                        size    276515
+    checksums           rmd160  f907ad2b837416d515a7554ea257bca39dff665e \
+                        sha256  327f8cc77e3ddec57a560520521a2da5aeee1dc8b9a45d53ac2e60487b0fba48 \
+                        size    290034
 } else {
     build {}
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  b02e90d27dcce76ef57372e16c8d34c3812985b6 \
-                        sha256  d7fc4d0c2e03d12f741c9dd71d7f3f441230a86285df84fd0c446e5251ccf74a \
-                        size    12171160
+    checksums           rmd160  d10d8473e3e3f74ae5e42281af47b3fb8dc5e001 \
+                        sha256  596f0aeed501aa6d37e4c8d173154ff7854d7ed2260f04a8148215d90bd1ed02 \
+                        size    12600046
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.12.0

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
