### PR TITLE
xnec2c: Update Portfiles to add c11+ requirement

### DIFF
--- a/science/xnec2c/Portfile
+++ b/science/xnec2c/Portfile
@@ -26,6 +26,7 @@ checksums           rmd160  4cc1d731f8f57c2a785337f9b7a9bbc626007da8 \
                     size    1516554
 
 use_autoreconf      yes
+compiler.c_standard 2011
 
 depends_build-append \
                     port:pkgconfig \
@@ -34,35 +35,34 @@ depends_build-append \
 depends_lib-append \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3
 
+if {[active_variants gtk3 x11 quartz]} {
+    notes-append "
+        The X11 version of GTK3 is installed so xnec2c will require
+        the port xorg-server to display the application.
 
-notes-append {
-If you haven't installed any gtk3 apps before, then this will build the
-X11 version of GTK3 so will require the port "xorg-server" to display
-the application.
+        To avoid needing xorg-server, switch gtk3 over to using Quartz
+        by doing the following:
 
-To switch your gtk3 over to using Quartz instead do the following:
+        sudo port install glib2 +quartz -x11
+        sudo port install libepoxy +quartz -x11
+        sudo port install gtk3 +quartz -x11
 
-sudo port install glib2 +quartz -x11
-sudo port install libepoxy +quartz -x11
-sudo port install gtk3 +quartz -x11
+        This will switch *all* gtk3 apps over to using Quartz.
+        You should probably reinstall any affected gtk3 ports after switching.
 
-This will switch *all* gtk3 apps over to using Quartz.
-You should probably reinstall any affected gtk3 ports after switching.
+        To make Quartz the default for all apps you can add
 
-To make Quartz the default for all apps you can add
+        -x11 +quartz
 
--x11 +quartz
+        to the ${prefix}/etc/macports/variants.conf file and rebuild the
+        affected ports.
+
+        An app to run xnec2c has been placed in Applications/MacPorts.
+        "
 }
-notes-append " "
-notes-append "to the ${prefix}/etc/macports/variants.conf file"
-notes-append {
-and rebuild the affected ports.
 
-An app to run xnec2c has been placed in Applications/MacPorts.
-}
-notes-append " "
 notes-append "Examples are in ${prefix}/share/xnec2c/examples"
-
+    
 app.create yes
 app.name xnec2c
 app.executable xnec2c


### PR DESCRIPTION
#### Description

Update the Portfile to set a compiler restriction that the code needs a compiler with C11 or better.

Closes: https://trac.macports.org/ticket/72617

Also update the notes section to only appear if the x11 variant of gtk3 is installed and active.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
