### PR TITLE
ipsw: Update to 3.1.616

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -7,7 +7,7 @@ PortGroup               golang 1.0
 # maintains a release schedule. Update every 5th release, unless
 # a hotfix is necessary, only.
 
-go.setup                github.com/blacktop/ipsw 3.1.611 v
+go.setup                github.com/blacktop/ipsw 3.1.616 v
 revision                0
 categories              security devel
 license                 MIT
@@ -21,9 +21,9 @@ long_description        {*}${description}. Everything you need to start \
 
 homepage                https://blacktop.github.io/ipsw
 
-checksums               rmd160  37514106016183a3b4d32e3c01c319eff13add67 \
-                        sha256  968397253f8d7d55a748454cde567da083dc8678d8824b2788e2407fcbb36b32 \
-                        size    29258537
+checksums               rmd160  22c53c149fa0beac8449a15c5d7fd952ef043b99 \
+                        sha256  9d79fa220ecc91b08d4d6ee169c175a7a3d9de0b2056ab0efc45de9be0c0991f \
+                        size    12804434
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, 3.1.616

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
