### PR TITLE
spring-boot-cli: update to 3.5.3

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.5.0
+version         3.5.3
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  6f992dac557a4ac71e018e5f2cbe7f508ae12bd3 \
-                sha256  7f8b495f642ad9695ffb43d85c6292cc6ccf65967c697b2f878aa151101cc090 \
-                size    5737034
+checksums       rmd160  279d38803855d89eb832b75e5313ed1b1a7d207c \
+                sha256  b389572d77cf7ae521315f8066355a52d92820ecc1f24fddd3fd4bc558fc69e3 \
+                size    7151413
 
 worksrcdir      spring-${version}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.5.3.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?