### PR TITLE
postgresql16: Restore previous fix for curl-ca-bundle

### DIFF
--- a/databases/postgresql16/Portfile
+++ b/databases/postgresql16/Portfile
@@ -8,7 +8,7 @@ PortGroup legacysupport 1.1
 
 name                postgresql16
 version             16.9
-revision            0
+revision            1
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -43,7 +43,7 @@ depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib \
 depends_build       port:bison port:pkgconfig \
                     port:docbook-xml-4.5 port:docbook-xsl-nons
 depends_run         port:postgresql_select-16 \
-                    path:share/curl/curl-ca-bundle.crt:certsync
+                    path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 
 # https://trac.macports.org/ticket/66060
 # https://trac.macports.org/ticket/67365


### PR DESCRIPTION
#### Description

* Restore previous certificate fix which was accidentally reverted here:
* https://github.com/macports/macports-ports/commit/edac8ddd08f6e8f18e0e5f738442eaa8604b6111
* Also see https://trac.macports.org/ticket/72215
* Rev bump needed to clear out file conflicts.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?