### PR TITLE
pkgconf: Update to 2.5.0

### DIFF
--- a/devel/pkgconf/Portfile
+++ b/devel/pkgconf/Portfile
@@ -7,7 +7,7 @@ PortGroup                   legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 13
 
 name                        pkgconf
-version                     2.4.3
+version                     2.5.0
 revision                    0
 categories                  devel
 license                     ISC
@@ -19,9 +19,9 @@ long_description            pkgconf is ${description}. \
 homepage                    https://github.com/pkgconf/pkgconf
 master_sites                https://distfiles.ariadne.space/pkgconf/
 
-checksums                   rmd160  64ef5d57908267686c1946ab786d63d833c0877a \
-                            sha256  cf6be37c79265802f2cb1dfc412e18de23a35b5204fc5868bc09fcfd092ac225 \
-                            size    468948
+checksums                   rmd160  a6d326a9abfe7f3a98c0627e87fdab5d0eb432ef \
+                            sha256  fafa613fee321790b04e960ba0d67a98461f3cb915ba732f5572b59ab8ef90d2 \
+                            size    477704
 
 # both ports install ${prefix}/share/aclocal/pkg.m4
 conflicts                   pkgconfig


### PR DESCRIPTION
#### Description

Update `pkgconf` to its latest released version, 2.5.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
