### PR TITLE
h3: update to 4.3.0

### DIFF
--- a/gis/h3/Portfile
+++ b/gis/h3/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        uber h3 4.2.1 v
+github.setup        uber h3 4.3.0 v
 github.tarball_from archive
 revision            0
-checksums           rmd160  67dc92ecb7c93dc9715b3a5cc1c284d808c9d2d5 \
-                    sha256  1b51822b43f3887767c5a5aafd958fca72b72fc454f3b3f6eeea31757d74687d \
-                    size    18324978
+checksums           rmd160  ffc34bd5d4cd54f1becd9c96b21c344df9968d40 \
+                    sha256  a47cfa36e255e4bf16c63015aaff8e6fe2afc14ffaa3f6b281718158446c0e9b \
+                    size    18334180
 
 description         A hexagonal hierarchical geospatial indexing system
 


### PR DESCRIPTION
#### Description
h3: update to 4.3.0

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?