### PR TITLE
openjdk25-zulu: update to 25.0.39

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.37
-set build    23
+version      ${feature}.0.39
+set build    27
 revision     0
 
 set openjdk_version ${feature}.0.0
@@ -37,14 +37,14 @@ use_zip yes
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_x64
-    checksums    rmd160  baaa10adb7bfa0cc824e7c89124cf15f94bc6e58 \
-                 sha256  381341d7645acac20049002fb80d7aa345e627d2668e77bfbcb99d5926ce1c9f \
-                 size    228872094
+    checksums    rmd160  bddfd01a7f22e6defb45a3f5c2e6c70a14078bb9 \
+                 sha256  a918f9acc5c6d731ce8b03afb071ac4fb3cf1122c72a9966c1f94243f65246f5 \
+                 size    229888869
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_aarch64
-    checksums    rmd160  d3ab1bf365b6c9da5ae3757ce79e04e03e8150ca \
-                 sha256  cb5b1b1ab4c56df9a74fcd23fc092d9254c79fa949c604ddceec9136c724a7b5 \
-                 size    226361947
+    checksums    rmd160  727cd43bfd3bd68e032926aca250fb0c745cbfb1 \
+                 sha256  46ae0dbaae8f7fe4a8371fedd52f030c0c45f7968590743c18161899bd401cdc \
+                 size    227376197
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.0.39.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?