### PR TITLE
skaffold: update to 2.16.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.16.0 v
+github.setup        GoogleContainerTools skaffold 2.16.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  d80cdd486e964bfd1b5b54d9de5b0f839f89c6c2 \
-                    sha256  fed20031baaf2bf040920557dff966972dbdb24eb88d2814e56367af8ed0274f \
-                    size    64028705
+checksums           rmd160  8f85c1108fc27c3b042a9d3ff871c62ff56820e1 \
+                    sha256  ec40b593ffadfe8fcb96085d76db6638f56aebc2767e76046c4237bb925e6678 \
+                    size    64031398
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.16.1.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?