### PR TITLE
py-pylsqpack: actually use port ls-qpack

### DIFF
--- a/python/py-pylsqpack/Portfile
+++ b/python/py-pylsqpack/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pylsqpack
 version             0.3.22
-revision            0
+revision            1
 license             BSD
 maintainers         {mps @Schamschula} openmaintainer
 description         pylsqpack is a wrapper around the ls-qpack library.
@@ -20,12 +20,17 @@ checksums           rmd160  0b12f1d6ba49aa1146a51d12eff87ada6323fb78 \
 python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
-    depends_lib-append  \
+    depends_build-append  \
                     port:ls-qpack
 
     # error: #pragma GCC diagnostic not allowed inside functions
     compiler.blacklist-append \
                     *gcc-4.0 *gcc-4.2
 
-    patchfiles      patch-pyproject.toml.diff
+    patchfiles      patch-pyproject.toml.diff \
+                    patch-setup.py.diff
+
+    post-patch {
+        reinplace "s|/usr|${prefix}|g" ${worksrcpath}/setup.py
+    }
 }

--- a/python/py-pylsqpack/files/patch-setup.py.diff
+++ b/python/py-pylsqpack/files/patch-setup.py.diff
@@ -1,0 +1,37 @@
+--- setup.py.orig
++++ setup.py
+@@ -4,17 +4,6 @@
+ import setuptools
+ from wheel.bdist_wheel import bdist_wheel
+ 
+-extra_compile_args = []
+-include_dirs = [
+-    os.path.join("vendor", "ls-qpack"),
+-    os.path.join("vendor", "ls-qpack", "deps", "xxhash"),
+-]
+-if sys.platform == "win32":
+-    include_dirs.append(os.path.join("vendor", "ls-qpack", "wincompat"))
+-else:
+-    extra_compile_args = ["-std=c99"]
+-
+-
+ class bdist_wheel_abi3(bdist_wheel):
+     def get_tag(self):
+         python, abi, plat = super().get_tag()
+@@ -30,13 +19,12 @@
+         setuptools.Extension(
+             "pylsqpack._binding",
+             define_macros=[("Py_LIMITED_API", "0x03080000")],
+-            extra_compile_args=extra_compile_args,
+-            include_dirs=include_dirs,
++            include_dirs=["/usr/include"],
++            library_dirs=["/usr/lib"],
++            libraries=["ls-qpack"],
+             py_limited_api=True,
+             sources=[
+                 "src/pylsqpack/binding.c",
+-                "vendor/ls-qpack/lsqpack.c",
+-                "vendor/ls-qpack/deps/xxhash/xxhash.c",
+             ],
+         ),
+     ],


### PR DESCRIPTION
#### Description
Patches `setup.py` to actually leverage the port dependency specified. This wasn't the case before this PR, so the dependency was extraneous.

Refer to https://github.com/aiortc/pylsqpack/issues/42 for the discussion initiated by Gentoo's maintainer. Other distros also currently package `pylsqpack` without such a dependency, relying fully on the vendored source code at the specific commit frozen by upstream upon release. As the strategy for platform-dependent searching of dependency hasn't been decided yet, I'm fixing this here *ad hoc*.

Note the situation with MacPorts is different from most Linux distros: there is no separate packaging for `-devel`. As of now, `ls-qpack` is built purely statically with vendored `xxhash`, providing no shared libraries. Should this change in the future, the `depends_build` here should be changed back to `depends_lib`, and `ls-qpack` itself would depend on `xxhashlib`. I didn't bother going down that route since there may be performance benefits with the current approach.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.3 12D78 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
