### PR TITLE
MoarVM: fix build on macOS 10.7-10.9 and 10.12

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -6,8 +6,8 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-# strnlen, arc4random_buf, clock_gettime
-legacysupport.newest_darwin_requires_legacy 15
+# strnlen, arc4random_buf, clock_gettime, utimensat
+legacysupport.newest_darwin_requires_legacy 16
 
 github.setup        MoarVM MoarVM 2025.05
 github.tarball_from releases

--- a/lang/MoarVM/files/patch-libuv-legacy.diff
+++ b/lang/MoarVM/files/patch-libuv-legacy.diff
@@ -149,7 +149,7 @@ Fix breakage from https://github.com/libuv/libuv/commit/1c778bd001543371c915a79b
  
  static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
 -#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
-+#if defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1070))
++#if defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101000))
    struct sockaddr_in6 peers[20];
    struct iovec iov[ARRAY_SIZE(peers)];
    struct mmsghdr msgs[ARRAY_SIZE(peers)];
@@ -158,10 +158,10 @@ Fix breakage from https://github.com/libuv/libuv/commit/1c778bd001543371c915a79b
    }
    return nread;
 -#else  /* __linux__ || ____FreeBSD__ || __APPLE__ */
-+#else  /* __linux__ || __FreeBSD__ || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)) */
++#else  /* __linux__ || __FreeBSD__ || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101000)) */
    return UV_ENOSYS;
 -#endif  /* __linux__ || ____FreeBSD__ || __APPLE__ */
-+#endif  /* __linux__ || __FreeBSD__ || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)) */
++#endif  /* __linux__ || __FreeBSD__ || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101000)) */
  }
  
  static void uv__udp_recvmsg(uv_udp_t* handle) {
@@ -179,7 +179,7 @@ Fix breakage from https://github.com/libuv/libuv/commit/1c778bd001543371c915a79b
    nsent = 0;
  
 -#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
-+#if defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1070))
++#if defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101000))
    if (count > 1) {
      for (i = 0; i < count; /*empty*/) {
        struct mmsghdr m[20];
@@ -188,7 +188,7 @@ Fix breakage from https://github.com/libuv/libuv/commit/1c778bd001543371c915a79b
      goto exit;
    }
 -#endif  /* defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) */
-+#endif  /* defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)) */
++#endif  /* defined(__linux__) || defined(__FreeBSD__) || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101000)) */
  
    for (i = 0; i < count; i++, nsent++)
      if ((r = uv__udp_sendmsg1(fd, bufs[i], nbufs[i], addrs[i])))


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?