### PR TITLE
py-awscli2: update to 2.27.40

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.27.22
+github.setup        aws aws-cli 2.27.40
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  d66bef5e426ffde41358d2a6079f7f5395c2ccb4 \
-                    sha256  ff044550d92d2984eeb76134d8a84183e16b2032f4f4cc4ceedb5c565910e5d6 \
-                    size    16345294
+checksums           rmd160  8947aad72ddf54d29ead6f84e7c59166c5ba0156 \
+                    sha256  a3a5a37d0124c47bb8b3d997001d53bcb3ad26ba5f6a72dc728e61c7d8c9f3c0 \
+                    size    16578179
 
 python.versions     39 310 311 312 313
 python.pep517       yes
@@ -39,7 +39,6 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                         port:py${python.version}-awscrt \
                         port:py${python.version}-colorama \
-                        port:py${python.version}-cryptography \
                         port:py${python.version}-dateutil \
                         port:py${python.version}-distro \
                         port:py${python.version}-docutils \

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -1,9 +1,9 @@
 Keep awscrt pinned. This is the only user, and presumably
 Amazon has a good reason for not bumping the version yet.
 
-diff -ru aws-cli-2.26.5-orig/pyproject.toml aws-cli-2.26.5/pyproject.toml
---- aws-cli-2.26.5-orig/pyproject.toml	2025-04-19 19:07:31.783354675 -0400
-+++ aws-cli-2.26.5/pyproject.toml	2025-04-19 19:08:43.051611599 -0400
+diff -ru aws-cli-2.27.40-orig/pyproject.toml aws-cli-2.27.40/pyproject.toml
+--- aws-cli-2.27.40-orig/pyproject.toml	2025-06-22 00:00:00.000000000 +0000
++++ aws-cli-2.27.40/pyproject.toml	2025-06-22 00:00:00.000000000 +0000
 @@ -1,6 +1,6 @@
  [build-system]
  requires = [
@@ -12,17 +12,15 @@ diff -ru aws-cli-2.26.5-orig/pyproject.toml aws-cli-2.26.5/pyproject.toml
  ]
  build-backend = "pep517"
  backend-path = ["backends"]
-@@ -30,21 +30,21 @@
+@@ -30,20 +30,20 @@
      "Programming Language :: Python :: 3.13",
  ]
  dependencies = [
 -    "colorama>=0.2.5,<0.4.7",
 -    "docutils>=0.10,<0.20",
--    "cryptography>=40.0.0,<43.0.2",
 -    "ruamel.yaml>=0.15.0,<=0.17.21",
 +    "colorama",
 +    "docutils",
-+    "cryptography",
 +    "ruamel.yaml",
      # ruamel.yaml only requires ruamel.yaml.clib for Python versions
      # less than or equal to Python 3.10. In order to ensure we have


### PR DESCRIPTION
#### Description

Upgrade to the latest version, [removing the cryptography dependency](https://github.com/aws/aws-cli/commit/87ff9881e29f399b9dbb67c0a1a4bdbfcbf5d230).

###### Tested on
macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510

```
> aws --version
aws-cli/2.27.40 Python/3.13.4 Darwin/24.5.0 source/arm64
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?