### PR TITLE
libgee: Update to 0.20.8

### DIFF
--- a/devel/libgee/Portfile
+++ b/devel/libgee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           gobject_introspection 1.0
 
 name                libgee
-version             0.20.6
+version             0.20.8
 revision            0
 license             LGPL-2.1+
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -12,30 +12,25 @@ categories          devel
 maintainers         nomaintainer
 description         Collection library providing GObject-based interfaces
 
-long_description    Libgee is a collection library providing GObject-based interfaces and \
-                    classes for commonly used data structures.
+long_description    Libgee is a collection library providing GObject-based \
+                    interfaces and classes for commonly used data structures. \
+                    Old home page on Gnome wiki is retired, but \
+                    has more info: https://wiki.gnome.org/Projects/Libgee. \
+                    Also see https://valadoc.org and search for package 'gee'.
 
-homepage            https://wiki.gnome.org/Projects/Libgee
+homepage            https://gitlab.gnome.org/GNOME/libgee
 master_sites        gnome:sources/${name}/${branch}
 
 use_xz              yes
 
-checksums           rmd160  94cc2a8ec68b166b9df9913c6bd80d7d521ea845 \
-                    sha256  1bf834f5e10d60cc6124d74ed3c1dd38da646787fbf7872220b8b4068e476d4d \
-                    size    690436
+checksums           rmd160  0dbcb5ba5f31c3211dd84ba0733df81cf646c491 \
+                    sha256  189815ac143d89867193b0c52b7dc31f3aa108a15f04d6b5dca2b6adfad0b0ee \
+                    size    692112
 
 depends_build       port:pkgconfig \
                     path:bin/vala:vala
 
 patchfiles          patch-typelib-use-absolute-sharedlib-path.diff
-
-post-patch {
-    # Recompile with Vala to resolve error. Should be fixed with newer tarballs
-    # hashmap.c:4089:23: error: incompatible function pointer types
-    delete ${worksrcpath}/gee/libgee_0_8_la_vala.stamp
-    # testcase.c:281:59: error: incompatible function pointer types
-    delete ${worksrcpath}/tests/tests_vala.stamp
-}
 
 compiler.c_standard 2011
 


### PR DESCRIPTION
#### Description

* Update libgee 0.20.6 --> 0.20.8.
* Fixes recent broken builds due to newly occurring pointer type errors.
* Switch to new nearest approximation of a home page.  Old home page was retired.
* Remove obsolete Vala recompile trick for fixing previous errors.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 15.5
Xcode 16.2
Command Line Tools 16.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -s install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?