### PR TITLE
vtk: Update to 9.5.0

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -129,7 +129,7 @@ variant qt5 description {Add Qt5 support.} {
 }
 
 # Supported pythons
-set python_versions {39 310 311 312}
+set python_versions {39 310 311 312 313}
 
 foreach pyver ${python_versions} {
     # Conflicting python versions

--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           gitlab 1.0
 PortGroup           legacysupport 1.1
 PortGroup           mpi 1.0
 PortGroup           muniversal 1.0
@@ -10,38 +11,35 @@ PortGroup           muniversal 1.0
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-# Require C++11
-compiler.cxx_standard 2011
+# Require C++17
+compiler.cxx_standard 2017
 
 # some older Clang say they support C++11 when they don't
 # this is the same blacklisting as for jsoncpp, on which vtk depends.
 compiler.blacklist-append {clang < 900}
 
-name                vtk
-version             9.4.1
-revision            1
+# Note, gitlab instance downloads distfile from gitlab tag in bz2 format,
+# not from the official VTK download page in gz format.
+
+gitlab.instance     https://gitlab.kitware.com
+gitlab.setup        vtk vtk 9.5.0 v
+revision            0
 categories          graphics devel
 license             BSD
-
-set branch          [join [lrange [split ${version} .] 0 1] .]
 
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \
                     openmaintainer
 
 description         Visualization Toolkit (VTK)
-
-long_description    Visualization Toolkit (VTK) is an open-source, freely \
+long_description    ${description} is an open-source, freely \
                     available software system for 3D computer graphics, \
                     image processing and visualization.
 
 homepage            https://www.vtk.org
-master_sites        ${homepage}/files/release/${branch}
 
-distname            VTK-${version}
-
-checksums           rmd160  7165ecf0a7c79776033fb1fdb30c1380be3170e4 \
-                    sha256  c253b0c8d002aaf98871c6d0cb76afc4936c301b72358a08d5f3f72ef8bc4529 \
-                    size    118618515
+checksums           rmd160  71620582086344c5117bb9aea908ba151412950c \
+                    sha256  cf5f0a42c62bc784eb91670434bf1d3d1f15befed16c8d1a9446d96b3f7c7193 \
+                    size    40292755
 
 mpi.setup
 
@@ -196,7 +194,3 @@ if {[mpi_variant_isset]} {
     configure.args-append \
         -DVTK_Group_MPI:BOOL=ON
 }
-
-livecheck.type      regex
-livecheck.url       http://www.vtk.org/VTK/resources/software.html
-livecheck.regex     {[vV][tT][kK]-(\d+(?:\.\d+)*)\.[tz]}


### PR DESCRIPTION
#### Description

* Update vtk 9.4.1 --> 9.5.0.
* Use gitlab instance.
* Switch distfile format from gz to bz2.
* Update C++ standard from 2011 to 2017, as indicated by upstream.
* Add python 3.13 to supported versions.

###### Type(s)

###### Tested on

macOS 15.5
Xcode 16.2
Command Line Tools 16.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -s install`?
- [x] tested basic functionality of all ~~binary files~~ executables?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?