### PR TITLE
google-cloud-sdk: update to 528.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             527.0.0
+version             528.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  b02c289575d3352ddcbd58f8a7cb3b467dbdbd93 \
-                    sha256  043a3a4cd20df4cef3a0f9342e6d81be901f0c9a9b9ce1f14c7d901045f212a8 \
-                    size    54181078
+    checksums       rmd160  643c942b9491135f0db3c18f5cf570167f6fdf2f \
+                    sha256  02278f8b051b5b11ae0b5c31abdf5ba7d3c0acba35ba5cc1ddfc50aabf2afe36 \
+                    size    54202327
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  2d4f01f959d1fca22edbe721302207e32e3f9f89 \
-                    sha256  aea4e9b895652ab335a245f46627f74489cd204bcb196fa4d9cee0006de157b8 \
-                    size    55713008
+    checksums       rmd160  a6c5029be140c0861c75512c6c7fa09ff985c094 \
+                    sha256  96d0d697ba970057a155cc6cb54b3bb3daa3ad02ae79e93ab53933c6cfd436ee \
+                    size    55735355
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  0596bd060232b8e53ed1e0883eaa50df10a2750f \
-                    sha256  4294ed93db21c079d4a3ccb31b134a9e60405b811f1ecfed3a0207e38d39bfbf \
-                    size    55648024
+    checksums       rmd160  38a15d051098217d666e0944ae4bdd077954256f \
+                    sha256  c8a175347e4a99d3f834c54ab922ba6a5276f6403f7a70c42e77dd3a0cfcf48e \
+                    size    55670081
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 528.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?