### PR TITLE
OpenBLAS: Build fix for "argument list too long"

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -61,6 +61,12 @@ if {[string first "-devel" $subport] > 0} {
                     patch-cc.cmake-use-force_cpusubtype_ALL-for-Darwin-PPC.diff \
                     patch-PPC970-drop-mcpu-970-which-seems-to-produce-faulty-c.diff
 
+    # https://trac.macports.org/ticket/72638
+    # Fixes "Argument list too long" on earlier macOS versions.
+    # Remove after next release > 0.3.30.  Should be fixed upstream.
+    patchfiles-append \
+                    patch-CMakeLists.txt.diff
+
     if {![variant_isset native]} {
         notes "
         This version is built based on a base architecture for convenience,

--- a/math/OpenBLAS/files/patch-CMakeLists.txt.diff
+++ b/math/OpenBLAS/files/patch-CMakeLists.txt.diff
@@ -1,0 +1,23 @@
+# 2025 June 25: Copied from OpenBLAS upstream commit:
+# https://github.com/OpenMathLib/OpenBLAS/commit/fdc1c323404be6f9551b10ea11b6c4cd7254e9b0
+# https://github.com/OpenMathLib/OpenBLAS/pull/5336
+#
+# Supposed to fix "Argument list too long" when linking dylib
+# on earlier macOS versions.
+#
+# Applies to OpenBLAS 0.3.30, also maybe earlier versions.
+# Remove at next upstream release, should be fixed then.
+
+--- orig/CMakeLists.txt	2025-06-19 03:45:39
++++ CMakeLists.txt	2025-06-25 15:46:54
+@@ -305,8 +305,8 @@
+   endif()
+ endif()
+ 
+-# Fix "Argument list too long" for macOS with Intel CPUs and DYNAMIC_ARCH turned on
+-if(APPLE AND DYNAMIC_ARCH AND (NOT CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64"))
++# Fix "Argument list too long" for macOS with POWERPC or Intel CPUs 
++if(APPLE AND (NOT CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64"))
+   # Use response files
+   set(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+   # Always build static library first


### PR DESCRIPTION
#### Description

* Copied from upstream commit after release 0.3.30.
* Closes https://trac.macports.org/ticket/72638
* Build fixes for macOS 10.6 through 10.15 (Catalina).
* No rev bump needed.  Fixes only builds that are currently broken.

Committers, please squash commits on merge.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?