### PR TITLE
vtk: Rev bump dependencies for VTK 9.5.0 update

### DIFF
--- a/science/gdcm/Portfile
+++ b/science/gdcm/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                    gdcm
 version                 3.0.22
-revision                2
+revision                3
 categories              science graphics
 license                 BSD
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/openEMS/Portfile
+++ b/science/openEMS/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 
 github.setup        thliebig openEMS 1ccf0942477e9178b27f5e00dddd4d62bff78d29
 version             20240312-[string range ${github.version} 0 7]
-revision            1
+revision            2
 
 checksums           rmd160  c29d96ef9a7c08f6d6295aa6fe5eb0feddcb2362 \
                     sha256  984f5263562bb32d104bffd4f66c148abe2ee57df48c3ac6dd9751a15b83a312 \


### PR DESCRIPTION
#### Description

Wait for PR #28753, VTK update, before merging this.

* Rev bumps for 2 dependent ports of VTK.
* 12 other dependent ports, including 7 subports, are excluded.
* These others have broken builds and will not pass CI.
* They will have to be fixed manually, later.

###### Type(s)

- [x] update

###### Tested on

CI only.  OS 13, 14, 15, only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?