### PR TITLE
maven4: update to 4.0.0-rc4

### DIFF
--- a/java/maven4/Portfile
+++ b/java/maven4/Portfile
@@ -6,8 +6,8 @@ PortGroup java 1.0
 
 name            maven4
 # Until the final 4.0.0 release is out, we use a version that sorts before 4.0.0 to avoid upgrade problems
-version         3.9.9-rc3
-set real_version 4.0.0-rc-3
+version         3.9.9-rc4
+set real_version 4.0.0-rc-4
 revision        0
 
 categories      java devel
@@ -29,9 +29,9 @@ master_sites    apache:maven/maven-4/${real_version}/binaries
 distname        apache-maven-${real_version}-bin
 worksrcdir      apache-maven-${real_version}
 
-checksums       rmd160  74d3ae57078c375f91b00c5da51ce0406063cddf \
-                sha256  ef86d972e52a04866f5f78b457d21d7ecd96efa99c696998f2bd4b86ee020bcd \
-                size    14222843
+checksums       rmd160  7e0ae39764b17d90ceac0bd47cf1b97494281e11 \
+                sha256  454ab0fb07e6e9e365f7f56e6bcef18df1d619aa57e2bd6de527f0e0c85bdbbb \
+                size    14687761
 
 java.version    17+
 java.fallback   openjdk21


### PR DESCRIPTION
#### Description

Update to Apache Maven 4.0.0-rc4.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?