### PR TITLE
vtk: Fix builds for 10.7-10.12

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -8,10 +8,12 @@ PortGroup           legacysupport 1.1
 PortGroup           mpi 1.0
 PortGroup           muniversal 1.0
 
-# strnlen
-legacysupport.newest_darwin_requires_legacy 10
+# Undefined symbols for std::bad_variant_access
+# 10.12 Sierra = Darwin 16
+legacysupport.newest_darwin_requires_legacy 16
+legacysupport.use_mp_libcxx                 yes
 
-# Require C++17
+# Upstream says require C++17
 compiler.cxx_standard 2017
 
 # some older Clang say they support C++11 when they don't


### PR DESCRIPTION
#### Description

* Legacy support:  Use Macports libcxx.
* Fixes undefined symbols for std::bad_variant_access.
* No rev bump.  Only fixes newly broken legacy builds.

###### Type(s)

- [x] bugfix

###### Tested on

* CI only.  OS 13, 14, 15 only.
* Needs testing on one of the target legacy OS versions.
* Test now, or merge and wait for builder results.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?