### PR TITLE
zizmor: Update to 1.10.0

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.9.0 v
+github.setup        zizmorcore zizmor 1.10.0 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  3500a1f62ad025cc4b1c5e09e0274f7c55b3fd4f \
-                    sha256  27da51a31dfb553a9fe0acfa3a129f0d5e55b8593c502f2c99b332e5f3156e0e \
-                    size    477035
+                    rmd160  6b20262b29ed01f78fa1af06cb54ffc131274d2b \
+                    sha256  f87f6298325b980f5b5415ac2d381302e00cd624528d6b858ed54487655ef1ce \
+                    size    529006
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -36,7 +36,7 @@ cargo.crates \
     ahash                              0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                        1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     annotate-snippets                  0.11.5  710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4 \
-    anstream                           0.6.18  8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b \
+    anstream                           0.6.19  301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933 \
     anstyle                            1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
     anstyle-parse                       0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                       1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
@@ -60,16 +60,16 @@ cargo.crates \
     bytecount                           0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
     bytes                              1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
     cacache                            13.1.0  5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b \
-    camino                              1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
+    camino                             1.1.10  0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab \
     cc                                 1.2.20  04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a \
     cfg-if                              1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                         0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    clap                               4.5.38  ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000 \
+    clap                               4.5.40  40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f \
     clap-verbosity-flag                 3.0.3  eeab6a5cdfc795a05538422012f20a5496f050223c91be4e5420bfd13c641fb1 \
-    clap_builder                       4.5.38  379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120 \
-    clap_complete                      4.5.50  c91d3baa3bcd889d60e6ef28874126a0b384fd225ab83aa6d8a801c519194ce1 \
-    clap_complete_nushell               4.5.5  c6a8b1593457dfc2fe539002b795710d022dc62a65bf15023f039f9760c7b18a \
-    clap_derive                        4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
+    clap_builder                       4.5.40  e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e \
+    clap_complete                      4.5.54  aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677 \
+    clap_complete_nushell               4.5.7  cdb8335b398d197fb3176efe9400c6c053a41733c26794316c73423d212b2f3d \
+    clap_derive                        4.5.40  d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     colorchoice                         1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     console                           0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
@@ -96,7 +96,7 @@ cargo.crates \
     fancy-regex                        0.14.0  6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298 \
     fastrand                            2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     filetime                           0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
-    flate2                              1.1.1  7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece \
+    flate2                              1.1.2  4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d \
     fluent-uri                          0.3.2  1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5 \
     fnv                                 1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     form_urlencoded                     1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
@@ -132,7 +132,7 @@ cargo.crates \
     human-panic                         2.0.2  80b84a66a325082740043a6c28bbea400c129eac0d3a27673a1de971e44bf1f7 \
     hyper                               1.6.0  cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80 \
     hyper-rustls                       0.27.5  2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2 \
-    hyper-util                         0.1.11  497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2 \
+    hyper-util                         0.1.13  b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8 \
     icu_collections                     1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
     icu_locid                           1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
     icu_locid_transform                 1.5.0  01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e \
@@ -151,6 +151,7 @@ cargo.crates \
     insta                              1.43.1  154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371 \
     inventory                          0.3.20  ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83 \
     ipnet                              2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
+    iri-string                          0.7.8  dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2 \
     is_terminal_polyfill               1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                          0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                               1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
@@ -169,7 +170,6 @@ cargo.crates \
     memmap2                            0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
     miette                             5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
     miette-derive                      5.10.0  49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c \
-    mime                               0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                     0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                         0.8.8  3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a \
     mio                                 1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
@@ -195,10 +195,10 @@ cargo.crates \
     parking_lot                        0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                   0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     percent-encoding                    2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    pest                                2.8.0  198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6 \
-    pest_derive                         2.8.0  d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5 \
-    pest_generator                      2.8.0  db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841 \
-    pest_meta                           2.8.0  7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0 \
+    pest                                2.8.1  1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323 \
+    pest_derive                         2.8.1  bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc \
+    pest_generator                      2.8.1  87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966 \
+    pest_meta                           2.8.1  edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5 \
     pin-project-lite                   0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                           0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     portable-atomic                    1.11.0  350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e \
@@ -228,14 +228,13 @@ cargo.crates \
     regex-automata                      0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                       0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    reqwest                           0.12.15  d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb \
+    reqwest                           0.12.20  eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813 \
     reqwest-middleware                  0.4.2  57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e \
     ring                              0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rustc-demangle                     0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                          2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustix                              1.0.5  d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf \
     rustls                            0.23.26  df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0 \
-    rustls-pemfile                      2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                   1.11.0  917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c \
     rustls-webpki                     0.103.1  fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03 \
     rustversion                        1.0.20  eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2 \
@@ -300,6 +299,7 @@ cargo.crates \
     toml_edit                         0.22.26  310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e \
     toml_write                          0.1.1  bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076 \
     tower                               0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
+    tower-http                          0.6.5  5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2 \
     tower-layer                         0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                       0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                            0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
@@ -308,10 +308,10 @@ cargo.crates \
     tracing-indicatif                   0.3.9  8201ca430e0cd893ef978226fd3516c06d9c494181c8bf4e5b32e30ed4b40aa1 \
     tracing-log                         0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber                 0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
-    tree-sitter                        0.25.4  69aff09fea9a41fb061ae6b206cb87cac1b8db07df31be3ba271fbc26760f213 \
+    tree-sitter                        0.25.6  a7cf18d43cbf0bfca51f657132cc616a5097edc4424d538bae6fa60142eaf9f0 \
     tree-sitter-bash                   0.23.3  329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e \
     tree-sitter-language                0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
-    tree-sitter-powershell             0.25.2  377974a9bbd11ef11aa298d60def669f78b579d11745066a59bc4167e53d360b \
+    tree-sitter-powershell             0.25.6  e265a36be4ab388c842629bef61fb719c83f9be3241db92288d064ed425758ba \
     tree-sitter-yaml                    0.7.1  3d5893f2a05e57c86a2338aa3aed167a1e5c68b8fdff3bf4a460941f2d8fc944 \
     try-lock                            0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     typed-builder                      0.21.0  ce63bcaf7e9806c206f7d7b9c1f38e0dce8bb165a80af0898161058b19248534 \
@@ -350,6 +350,7 @@ cargo.crates \
     web-sys                            0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                            1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                       0.26.9  29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b \
+    webpki-roots                        1.0.0  2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb \
     winapi                              0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu          0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                         0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
@@ -362,30 +363,19 @@ cargo.crates \
     windows-interface                  0.59.1  bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8 \
     windows-link                        0.1.1  76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38 \
     windows-numerics                    0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
-    windows-registry                    0.4.0  4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3 \
     windows-result                      0.3.2  c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252 \
-    windows-strings                     0.3.1  87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319 \
     windows-strings                     0.4.0  7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97 \
     windows-sys                        0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                        0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-targets                    0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
-    windows-targets                    0.53.0  b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b \
     windows_aarch64_gnullvm            0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
-    windows_aarch64_gnullvm            0.53.0  86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
     windows_aarch64_msvc               0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
-    windows_aarch64_msvc               0.53.0  c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c \
     windows_i686_gnu                   0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
-    windows_i686_gnu                   0.53.0  c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3 \
     windows_i686_gnullvm               0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
-    windows_i686_gnullvm               0.53.0  9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11 \
     windows_i686_msvc                  0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
-    windows_i686_msvc                  0.53.0  581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d \
     windows_x86_64_gnu                 0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
-    windows_x86_64_gnu                 0.53.0  2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba \
     windows_x86_64_gnullvm             0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
-    windows_x86_64_gnullvm             0.53.0  0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
     windows_x86_64_msvc                0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    windows_x86_64_msvc                0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
     wit-bindgen-rt                     0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
     write16                             1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                           0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.10.0

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
