### PR TITLE
qemu: Bump version to 10.0.2

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -8,8 +8,8 @@ PortGroup               legacysupport               1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
-version                 10.0.0
-revision                1
+version                 10.0.2
+revision                0
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -26,9 +26,9 @@ homepage                https://www.qemu.org
 master_sites            https://download.qemu.org/
 use_xz                  yes
 
-checksums               rmd160  ec3d3294e2f8e8d84c5e9fcf5ee2ed3138753689 \
-                        sha256  22c075601fdcf8c7b2671a839ebdcef1d4f2973eb6735254fd2e1bd0f30b3896 \
-                        size    135618260
+checksums               rmd160  990f2de50bd7fd7c34547fcd8988862b3572442a \
+                        sha256  ef786f2398cb5184600f69aef4d5d691efd44576a3cff4126d38d4c6fec87759 \
+                        size    135678180
 
 set py_branch           3.13
 set py_version          [string replace ${py_branch} 1 1]


### PR DESCRIPTION
#### Description

Bump version to 10.0.2, see [upstream changes](https://gitlab.com/qemu-project/qemu/-/compare/v10.0.0...v10.0.2?from_project_id=11167699)

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
