### PR TITLE
vtk: Use MacPorts libraries HDF5, proj9.

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -25,7 +25,7 @@ compiler.blacklist-append {clang < 900}
 
 gitlab.instance     https://gitlab.kitware.com
 gitlab.setup        vtk vtk 9.5.0 v
-revision            0
+revision            1
 categories          graphics devel
 license             BSD
 
@@ -45,10 +45,22 @@ checksums           rmd160  71620582086344c5117bb9aea908ba151412950c \
 
 mpi.setup
 
-depends_lib-append  port:libxml2
+set proj_version    proj9
+
+depends_lib-append  port:hdf5 \
+                    port:libxml2 \
+                    port:${proj_version}
 
 configure.args-append \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_hdf5:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_libproj:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_libxml2:BOOL=ON
+
+mpi.enforce_variant hdf5
+
+# PROJ needs extra help for multiple versioned subdirectories.
+configure.args-append \
+                    -DLibPROJ_ROOT=${prefix}/lib/${proj_version}
 
 # Re restoring support for legacy macOS, see:
 # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11171
@@ -66,6 +78,10 @@ configure.args-append \
                     -DVTK_WRAP_PYTHON:BOOL=OFF \
                     -DVTK_WRAP_JAVA:BOOL=OFF \
                     -DVTK_USE_COCOA:BOOL=ON
+
+# Do not allow any remote downloads of code or test data.
+configure.args-append \
+                    -DVTK_FORBID_DOWNLOADS:BOOL=ON
 
 # Support for Cocoa of 10.6 has been dropped in
 # https://github.com/Kitware/VTK/commit/f2e249c0a6a93f12808822cc5e5dddda35a09a35


### PR DESCRIPTION
#### Description

* Avoid out-of-date bundled libraries for HDF5 and proj.
* Fix builds for 10.7-10.12 for "undeclared identifier PTHREAD_MUTEX_RECURSIVE_NP".
* Was caused by down-level proj8 library.
* Block unwanted VTK auto-downloads.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.5
Xcode 16.2
Command Line Tools 16.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -vst install`?
- [x] tested basic functionality of all ~~binary files~~ executables?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?