### PR TITLE
yt-dlp: update to 2025.06.25

### DIFF
--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -37,11 +37,11 @@ if {${subport} eq ${name}} {
 }
 
 subport yt-dlp {
-    github.setup    yt-dlp ${subport} 2025.06.09
+    github.setup    yt-dlp ${subport} 2025.06.25
     revision        0
-    checksums       rmd160  965859495ccd18f8aecb8442d27d2dba35aec211 \
-                    sha256  46497ade23be173595d0bbdb41553873733696e0272fec5918cdcaebe17549aa \
-                    size    6025016
+    checksums       rmd160  1c2bc87519fb1bf37f84210869dde6067a74bdb7 \
+                    sha256  9416b3891b49f8929ed57789914256ce26930c9bf44980742e838db2100bbbf8 \
+                    size    6039215
     dist_subdir     ${subport}/${version}
     distname        ${subport}
 


### PR DESCRIPTION
#### Description

yt-dlp: update to 2025.06.25

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
