### PR TITLE
gitu: Update to 0.34.0

### DIFF
--- a/devel/gitu/Portfile
+++ b/devel/gitu/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            altsem gitu 0.33.0 v
+github.setup            altsem gitu 0.34.0 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -16,9 +16,9 @@ description             A TUI Git client inspired by Magit
 long_description        {*}${description}, launched straight from the terminal.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  a8505d1480a284d9fd115056480f5571ccaec14f \
-                        sha256  43dea7dae5f9aef9d3edb2f4e6ddd16d21664a6739b2856d53471846a97ded7d \
-                        size    3941447
+                        rmd160  e638e3c07d1f4c62845285d45e6e7d029d5eaf1a \
+                        sha256  65fac3b521fd94bc7a21585df7f8c75930beb1b62e6a1f8760333f51245161f5 \
+                        size    3951051
 
 # Fix opportunistic linking with libiconv
 depends_lib-append      port:libiconv
@@ -29,6 +29,7 @@ destroot {
 }
 
 cargo.crates \
+    ahash                           0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     allocator-api2                  0.2.18  5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
@@ -39,20 +40,29 @@ cargo.crates \
     anstyle-parse                    0.2.5  eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb \
     anstyle-query                    1.1.1  6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a \
     anstyle-wincon                   3.0.4  5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8 \
+    anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
     arboard                          3.4.1  df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4 \
     atomic                           0.6.0  8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
+    base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
+    bit-set                          0.5.3  0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1 \
+    bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
+    block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block2                           0.5.1  2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f \
     bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
     bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
     bytemuck                        1.19.0  8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d \
+    cached                          0.55.1  b0839c297f8783316fcca9d90344424e968395413f0662a5481f79c6648bbc14 \
+    cached_proc_macro               0.24.0  673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603 \
+    cached_proc_macro_types          0.1.1  ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0 \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     castaway                         0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
     cc                              1.2.26  956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chrono                          0.4.40  1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
@@ -66,6 +76,7 @@ cargo.crates \
     compact_str                      0.8.0  6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644 \
     console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
     criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
     criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
     crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
@@ -74,7 +85,16 @@ cargo.crates \
     crossterm                       0.28.1  829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6 \
     crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
+    crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
+    csscolorparser                   0.6.2  eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf \
+    darling                        0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
+    darling_core                   0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
+    darling_macro                  0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
+    deltae                           0.3.2  5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4 \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
+    digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    dirs                             4.0.0  ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059 \
+    dirs-sys                         0.3.7  1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6 \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
     encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
@@ -82,31 +102,32 @@ cargo.crates \
     errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
     error-code                       3.3.1  a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f \
     etcetera                        0.10.0  26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6 \
+    euclid                         0.22.11  ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48 \
+    fancy-regex                     0.11.0  b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2 \
+    fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     figment                        0.10.19  8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3 \
+    filedescriptor                   0.8.3  e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
+    finl_unicode                     1.3.0  94c970b525906eb37d3940083aa65b95e481fc1857d467d13374e1d925cfc163 \
+    fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                         0.1.3  f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fsevent-sys                      4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
-    futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
-    futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
-    futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
-    futures-executor                0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
-    futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
-    futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
-    futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
-    futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
-    futures-timer                    3.0.3  f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24 \
-    futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
+    generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     gethostname                      0.4.3  0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818 \
+    getrandom                       0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
+    getrandom                        0.3.3  26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4 \
     git-version                      0.3.9  1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19 \
     git-version-macro                0.3.9  53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0 \
     git2                            0.20.1  5220b8ba44c68a9a7f7a7659e864dd73692e417ef0211bea133c7b74e031eeb9 \
-    glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
+    hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                       0.15.0  1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
+    hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
     iana-time-zone                  0.1.61  235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
@@ -120,6 +141,7 @@ cargo.crates \
     icu_properties_data              1.5.1  85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2 \
     icu_provider                     1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
     icu_provider_macros              1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
+    ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     indexmap                         2.6.0  707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da \
@@ -136,9 +158,10 @@ cargo.crates \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
-    js-sys                          0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
+    js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
     kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
     kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
+    lab                             0.11.0  bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     libc                           0.2.168  5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d \
     libgit2-sys               0.18.1+1.9.0  e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e \
@@ -146,16 +169,24 @@ cargo.crates \
     libz-sys                        1.1.20  d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472 \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
+    linux-raw-sys                    0.9.4  cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
     litemap                          0.7.5  23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
     log                             0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
     lru                             0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
+    mac_address                      1.1.8  c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303 \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
+    memmem                           0.1.1  a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15 \
+    memoffset                        0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
+    memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
+    nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
+    nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     notify                           7.0.0  c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009 \
     notify-types                     1.0.0  7393c226621f817964ffb3dc5704f9509e107a8b024b489cc2c1b217378785df \
+    num-derive                       0.3.3  876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     objc-sys                         0.3.5  cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310 \
     objc2                            0.5.2  46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804 \
@@ -168,52 +199,63 @@ cargo.crates \
     objc2-quartz-core                0.2.2  e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a \
     once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
     oorandom                        11.1.4  b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9 \
+    ordered-float                    4.6.0  7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951 \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    pest                             2.8.0  198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6 \
+    pest_derive                      2.8.0  d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5 \
+    pest_generator                   2.8.0  db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841 \
+    pest_meta                        2.8.0  7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0 \
+    phf                             0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
+    phf_codegen                     0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
+    phf_generator                   0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
+    phf_macros                      0.11.3  f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216 \
+    phf_shared                      0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
     pin-project                     1.1.10  677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a \
     pin-project-internal            1.1.10  6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861 \
-    pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
     plotters                         0.3.7  5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747 \
     plotters-backend                 0.3.7  df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a \
     plotters-svg                     0.3.7  51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
-    proc-macro-crate                 3.2.0  8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b \
     proc-macro2                     1.0.88  7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9 \
     quote                           1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
+    r-efi                            5.2.0  74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5 \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     ratatui                         0.29.0  eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b \
-    ratatui-macros                   0.6.0  6fef540f80dbe8a0773266fa6077788ceb65ef624cdbf36e131aaf90b4a52df4 \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
     redox_syscall                    0.5.7  9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f \
+    redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                   0.4.8  368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    relative-path                    1.9.3  ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
-    rstest                          0.23.0  0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035 \
-    rstest_macros                   0.23.0  825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a \
-    rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.42  f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85 \
+    rustix                           1.0.7  c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266 \
     rustversion                     1.0.18  0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248 \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
+    semver                          0.11.0  f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6 \
+    semver-parser                   0.10.3  9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2 \
     serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
     serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
     serde_json                     1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
     serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
+    sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
     signal-hook-mio                  0.2.4  34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd \
     signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
     similar                          2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
     simple-logging                   2.0.2  b00d48e85675326bb182a2286ea7c1a0b264333ae10f27a937a72be08628b542 \
-    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
+    siphasher                        1.0.1  56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d \
     smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
@@ -222,10 +264,17 @@ cargo.crates \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
     syn                             2.0.87  25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     temp-dir                        0.1.14  bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72 \
+    tempfile                        3.20.0  e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1 \
+    terminfo                         0.8.0  666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f \
+    termios                          0.3.3  411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b \
+    termwiz                         0.22.0  5a75313e21da5d4406ea31402035b3b97aa74c04356bdfafa5d1043ab4e551d1 \
+    thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
     thiserror                       2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
+    thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                  2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
     thread-id                        3.3.0  c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1 \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
@@ -255,7 +304,8 @@ cargo.crates \
     tree-sitter-scala               0.23.4  efde5e68b4736e9eac17bfa296c6f104a26bffab363b365eb898c40a63c15d2f \
     tree-sitter-toml-ng              0.7.0  e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1 \
     tree-sitter-typescript          0.23.2  6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff \
-    tui-prompts                      0.5.0  eb6e0d8a972545cc209b933a1c06dab8932674b54ae19947834ec854fec2364f \
+    typenum                         1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
+    ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     uncased                         0.9.10  e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697 \
     unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
@@ -266,17 +316,27 @@ cargo.crates \
     utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
+    uuid                            1.17.0  3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     vte                             0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
+    vtparse                          0.6.2  6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.95  128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e \
-    wasm-bindgen-backend            0.2.95  cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358 \
-    wasm-bindgen-macro              0.2.95  e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56 \
-    wasm-bindgen-macro-support      0.2.95  26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68 \
-    wasm-bindgen-shared             0.2.95  65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d \
+    wasi                 0.14.2+wasi-0.2.4  9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3 \
+    wasm-bindgen                   0.2.100  1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
+    wasm-bindgen-backend           0.2.100  2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
+    wasm-bindgen-macro             0.2.100  7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407 \
+    wasm-bindgen-macro-support     0.2.100  8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de \
+    wasm-bindgen-shared            0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
     web-sys                         0.3.72  f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112 \
+    web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
+    wezterm-bidi                     0.2.3  0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec \
+    wezterm-blob-leases              0.1.1  692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7 \
+    wezterm-color-types              0.3.0  7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296 \
+    wezterm-dynamic                  0.2.1  5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac \
+    wezterm-dynamic-derive           0.1.1  46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b \
+    wezterm-input-types              0.1.0  7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
@@ -304,6 +364,7 @@ cargo.crates \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     winnow                           0.7.4  0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36 \
+    wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     x11rb                           0.13.1  5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12 \
@@ -311,6 +372,8 @@ cargo.crates \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
+    zerocopy                        0.8.26  1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f \
+    zerocopy-derive                 0.8.26  9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181 \
     zerofrom                         0.1.6  50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5 \
     zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
     zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \


### PR DESCRIPTION
#### Description

Update `gitu` to its latest released version, 0.34.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
