### PR TITLE
hamclock: New port

### DIFF
--- a/x11/x11/Portfile
+++ b/x11/x11/Portfile
@@ -1,0 +1,74 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           legacysupport 1.1
+PortGroup           makefile 1.0
+
+# _faccessat, _clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
+
+name                hamclock
+version             4.19
+revision            0
+categories          x11
+license             MIT
+maintainers         nomaintainer
+description         Handy clock with features for amateur radio operators
+long_description    {*}${description}
+homepage            https://www.clearskyinstitute.com/ham/HamClock
+master_sites        ${homepage}/
+distname            ESPHamClock-V${version}
+extract.suffix      .tgz
+checksums           rmd160  59d0d2a4eb4d28f49315584cdc80033c88eed8b1 \
+                    sha256  1fde1f683a5f2cf748ccc2dfbecb25d30f2c07888e5a2169055432e9fde8fcfd \
+                    size    1966386
+
+worksrcdir          ESPHamClock
+
+variant native description "Build with native cpu optimizations" {}
+
+post-patch {
+    # Respect build environment:
+    reinplace "s|CXXFLAGS =|CXXFLAGS +=|" ${worksrcpath}/Makefile
+    reinplace "s|LIBS =|LIBS +=|" ${worksrcpath}/Makefile
+    reinplace "s|CXX =|CXX ?=|" ${worksrcpath}/ArduinoLib/Makefile
+    # Fix X11 paths:
+    reinplace "s|/opt/X11|${prefix}|g" ${worksrcpath}/Makefile
+
+    # No cpu-specific opts by default:
+    if {![variant_isset native]} {
+        reinplace "s|-march=native||" ${worksrcpath}/Makefile
+    } elseif {${configure.build_arch} in [list ppc ppc64]} {
+        # On PowerPC there is no -march= flag:
+        reinplace "s|-march=native|-mtune=native|" ${worksrcpath}/Makefile
+    }
+}
+
+depends_lib-append  port:curl \
+                    port:xorg-libX11
+
+depends_run-append  port:desktop-file-utils
+
+compiler.cxx_standard   2017
+
+# If desired, there are targets for bigger sizes.
+build.target            hamclock-800x480
+
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    build.env-append    LIBS=-lMacportsLegacySupport
+}
+
+destroot {
+    copy ${worksrcpath}/${build.target} ${destroot}${prefix}/bin
+    # Make a symlink, so that it can be invoked with ${name}
+    ln -s ${build.target} ${destroot}${prefix}/bin/${name}
+    xinstall -d ${destroot}${prefix}/share/applications
+    xinstall -d ${destroot}${prefix}/share/icons/hicolor/48x48/apps
+    copy ${worksrcpath}/${name}.desktop ${destroot}${prefix}/share/applications
+    copy ${worksrcpath}/${name}.png ${destroot}${prefix}/share/icons/hicolor/48x48/apps
+}
+
+# Only run this for applications, not icons, to avoid GTK dependency:
+post-activate {
+    system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
+}


### PR DESCRIPTION
#### Description

HamClock is a kiosk-style application that provides real time space weather, radio propagation models, operating events and other information particularly useful to the radio amateur.

https://clearskyinstitute.com/ham/HamClock/

Closes: https://trac.macports.org/ticket/72625

###### Type(s)

- [x] enhancement

###### Tested on

CI only.  OS 13, 14, 15 only.
More testing in progress.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?