### PR TITLE
buf: update to 1.55.1

### DIFF
--- a/devel/buf/Portfile
+++ b/devel/buf/Portfile
@@ -2,7 +2,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/bufbuild/buf 1.54.0 v
+go.setup            github.com/bufbuild/buf 1.55.1 v
 go.offline_build    no
 revision            0
 
@@ -16,9 +16,9 @@ long_description    The Buf CLI is a helpful tool for managing Protobuf schemas.
                     It works with your choice of plugins and languages and gives you access to a vast library of certified plugins in the Buf Schema Registry.
 homepage            https://buf.build/
 
-checksums           rmd160  3f1b388fb703faf9463e89c5570f914c93839018 \
-                    sha256  e64786bd2f17dc3731dd30280cf1ba24e0781300ea0f781251ce98ce13142f49 \
-                    size    1550634
+checksums           rmd160  c2008ef6d8bf503419cb5af2b7c0edf256c93368 \
+                    sha256  01663475792aa851d4b3af16be9ec19d808cead673f986902343beed1a0063dd \
+                    size    1565778
 
 build.args-append   -ldflags="-s -w" -trimpath ./cmd/buf
 


### PR DESCRIPTION
#### Description
Update buf to version 1.55.1

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?