### PR TITLE
mockery: update to 3.5.0

### DIFF
--- a/devel/mockery/Portfile
+++ b/devel/mockery/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/vektra/mockery 3.3.2 v
+go.setup            github.com/vektra/mockery 3.5.0 v
 go.offline_build    no
 revision            0
 
@@ -18,9 +18,9 @@ installs_libs       no
 license             BSD
 maintainers         nomaintainer
 
-checksums           rmd160  3f293797c019752e4ba9354137dd701a2ac4473d \
-                    sha256  479b93d6699b3d62141c3629330af52733545d0040d0c3b8cb594fd5a3e8f576 \
-                    size    2895981
+checksums           rmd160  18c077e9d0ea91d7c74187a5f368f5d1f784c14d \
+                    sha256  02586a2dcd30de1ab48106224cfbba4306f7d16e9e552bb5202c57c24610e5c8 \
+                    size    2902927
 
 build.args-append   -ldflags="-s -w -X github.com/vektra/mockery/v3/internal/logging.SemVer=v${version}" -trimpath
 


### PR DESCRIPTION
#### Description
Update mockery to version 3.5.0

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?