### PR TITLE
ecCodes: update to 2.42.0

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 16
 legacysupport.use_mp_libcxx yes
 
 name                ecCodes
-version             2.41.0
+version             2.42.0
 revision            0
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
@@ -24,9 +24,9 @@ homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
 
-checksums           rmd160  544ce7c163fe85ddb7dd89b03b198cf03c163d96 \
-                    sha256  a1467842e11ed7f62a2f5cc1982e04eec62398f4962e6ba03ace7646f32cf270 \
-                    size    12637191
+checksums           rmd160  093eef2f3a38e9e042e326c74bb869eb6ef8698f \
+                    sha256  60371b357cb011dee546db2eabace5b7e27f0f87d3ea4a5adde7891371b3c128 \
+                    size    12279749
 
 patchfiles          patch-pkg-config.diff
 


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.42.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 x86_64
Command Line Tools 16.4.0.0.1.1747106510


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
