### PR TITLE
netdata: update to 2.5.4

### DIFF
--- a/sysutils/netdata/Portfile
+++ b/sysutils/netdata/Portfile
@@ -9,7 +9,7 @@ PortGroup               compiler_blacklist_versions 1.0
 # clock_gettime, utimensat
 legacysupport.newest_darwin_requires_legacy 16
 
-github.setup            netdata netdata 2.5.3 v
+github.setup            netdata netdata 2.5.4 v
 github.tarball_from     releases
 revision                0
 
@@ -54,9 +54,9 @@ depends_lib-append      bin:curl:curl \
 
 distname                ${name}-v${version}
 
-checksums               rmd160  a041f69abe9bce8cd18aecaf2c993fe3b3c8384b \
-                        sha256  d0d17d5e6c64b520241371bcf60b5859ad482463327fcfbe5a6e0069415c58c6 \
-                        size    31858932
+checksums               rmd160  95efb2d301a7852626db6bf8ee7f0c1918889bf7 \
+                        sha256  acfbda16c7c5786f4b0feb1c8e195d6489c727010739797a04cc5f71d5ede041 \
+                        size    31861211
 
 set netdata_user        netdata
 set netdata_group       netdata


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
