### PR TITLE
zizmor: Update to 1.11.0

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.10.0 v
+github.setup        zizmorcore zizmor 1.11.0 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6b20262b29ed01f78fa1af06cb54ffc131274d2b \
-                    sha256  f87f6298325b980f5b5415ac2d381302e00cd624528d6b858ed54487655ef1ce \
-                    size    529006
+                    rmd160  439c161a96b0dbb9f417fa1092c0c5828fb2ed18 \
+                    sha256  e60c8c280bee3b3a7eba32a961f6aa23d229f7a9db754715b7c98362a7c6dc7f \
+                    size    466819
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -45,6 +45,7 @@ cargo.crates \
     arrayvec                            0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert_cmd                         2.0.17  2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66 \
     async-trait                        0.1.88  e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
+    auto_impl                           1.3.0  ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7 \
     autocfg                             1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     backtrace                          0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
     base64                             0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
@@ -52,6 +53,7 @@ cargo.crates \
     bincode                             1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
     bit-set                             0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                             0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
+    bitflags                            1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                            2.9.0  5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd \
     block-buffer                       0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     borrow-or-share                     0.2.2  3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32 \
@@ -73,6 +75,7 @@ cargo.crates \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     colorchoice                         1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     console                           0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
+    console                            0.16.0  2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d \
     cpufeatures                        0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
     crc32fast                           1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
     crossbeam-deque                     0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
@@ -81,6 +84,7 @@ cargo.crates \
     crypto-common                       0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     csv                                 1.3.1  acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf \
     csv-core                           0.1.12  7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d \
+    dashmap                             5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     deranged                            0.4.0  9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e \
     diff                               0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     difflib                             0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
@@ -116,6 +120,7 @@ cargo.crates \
     getrandom                           0.3.2  73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0 \
     gimli                              0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     globset                            0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
+    hashbrown                          0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                          0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                                0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                                 0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
@@ -123,8 +128,8 @@ cargo.crates \
     http                                1.3.1  f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565 \
     http-body                           1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                      0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
-    http-cache                         0.20.1  7e883defacf53960c7717d9e928dc8667be9501d9f54e6a8b7703d7a30320e9c \
-    http-cache-reqwest                 0.15.1  e076afd9d376f09073b515ce95071b29393687d98ed521948edb899195595ddf \
+    http-cache                         0.21.0  1437561a949a2168929d7559aecd2f0ecb18b9e676080396388cdc399ddb723a \
+    http-cache-reqwest                 0.16.0  8ccca775a066b2a65da33611921e078ebdcfc27065c8bee96794703541101886 \
     http-cache-semantics                2.1.0  92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c \
     http-serde                          2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
     httparse                           1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
@@ -146,8 +151,8 @@ cargo.crates \
     idna                                1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                        1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                             0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
-    indexmap                            2.9.0  cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e \
-    indicatif                         0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
+    indexmap                           2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
+    indicatif                         0.17.12  4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056 \
     insta                              1.43.1  154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371 \
     inventory                          0.3.20  ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83 \
     ipnet                              2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
@@ -165,8 +170,9 @@ cargo.crates \
     litemap                             0.7.5  23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856 \
     lock_api                           0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
     log                                0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
+    lsp-types                          0.94.1  c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1 \
     matchers                            0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
-    memchr                              2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
+    memchr                              2.7.5  32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0 \
     memmap2                            0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
     miette                             5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
     miette-derive                      5.10.0  49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c \
@@ -185,13 +191,12 @@ cargo.crates \
     num-iter                           0.1.45  1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
     num-rational                        0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
     num-traits                         0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
-    number_prefix                       0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     object                             0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
     once_cell                          1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
     os_info                            3.10.0  2a604e53c24761286860eba4e2c8b23a0161526476b1de520139d69cdb85a6b5 \
     outref                              0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
     overload                            0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
-    owo-colors                          4.2.1  26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec \
+    owo-colors                          4.2.2  48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e \
     parking_lot                        0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                   0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     percent-encoding                    2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
@@ -199,6 +204,8 @@ cargo.crates \
     pest_derive                         2.8.1  bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc \
     pest_generator                      2.8.1  87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966 \
     pest_meta                           2.8.1  edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5 \
+    pin-project                        1.1.10  677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a \
+    pin-project-internal               1.1.10  6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861 \
     pin-project-lite                   0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                           0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     portable-atomic                    1.11.0  350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e \
@@ -251,6 +258,7 @@ cargo.crates \
     serde_json_path_core                0.2.2  dde67d8dfe7d4967b5a95e247d4148368ddd1e753e500adb34b3ffe40c6bc1bc \
     serde_json_path_macros              0.1.6  517acfa7f77ddaf5c43d5f119c44a683774e130b4247b7d3210f8924506cfac8 \
     serde_json_path_macros_internal     0.1.2  aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90 \
+    serde_repr                         0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
     serde_spanned                       0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
     serde_urlencoded                    0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     serde_yaml              0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
@@ -294,13 +302,17 @@ cargo.crates \
     tokio-macros                        2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-rustls                       0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
     tokio-stream                       0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
+    tokio-util                         0.7.15  66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df \
     toml                               0.8.22  05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae \
     toml_datetime                       0.6.9  3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3 \
     toml_edit                         0.22.26  310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e \
     toml_write                          0.1.1  bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076 \
+    tower                              0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
     tower                               0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
     tower-http                          0.6.5  5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2 \
     tower-layer                         0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
+    tower-lsp                          0.20.0  d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508 \
+    tower-lsp-macros                    0.9.0  84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa \
     tower-service                       0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                            0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-attributes                 0.1.28  395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d \
@@ -321,6 +333,7 @@ cargo.crates \
     unicode-ident                      1.0.18  5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512 \
     unicode-width                      0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                       0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
+    unit-prefix                         0.5.1  323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817 \
     unsafe-libyaml                     0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     untrusted                           0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     uriparse                            0.6.4  0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff \
@@ -367,15 +380,25 @@ cargo.crates \
     windows-strings                     0.4.0  7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97 \
     windows-sys                        0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                        0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
+    windows-sys                        0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
     windows-targets                    0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-targets                    0.53.2  c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef \
     windows_aarch64_gnullvm            0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_gnullvm            0.53.0  86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
     windows_aarch64_msvc               0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_aarch64_msvc               0.53.0  c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c \
     windows_i686_gnu                   0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnu                   0.53.0  c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3 \
     windows_i686_gnullvm               0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_gnullvm               0.53.0  9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11 \
     windows_i686_msvc                  0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_i686_msvc                  0.53.0  581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d \
     windows_x86_64_gnu                 0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnu                 0.53.0  2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba \
     windows_x86_64_gnullvm             0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_gnullvm             0.53.0  0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
     windows_x86_64_msvc                0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
+    windows_x86_64_msvc                0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
     wit-bindgen-rt                     0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
     write16                             1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                           0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.11.0

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
