### PR TITLE
mise: Update to 2025.7.0

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.6.8 v
+github.setup        jdx mise 2025.7.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  52a33bca1379f49ce309f84f1e21ab3aa7944c9b \
-                    sha256  e51ef65a03e8da03ee1d2b75bd2a3715318a33ecef1223216761f6eaecad2cf0 \
-                    size    4190088
+                    rmd160  ae9c24722d3725b223b05f7f683f5e37d470a9a1 \
+                    sha256  ddbb548d2f4e5d27bffa11f61747b377e029939d62f49601cf291409f1d84d8c \
+                    size    4191360
 
 patchfiles          patch-src_cli_self_update.diff
 


### PR DESCRIPTION
#### Description

mise: Update to 2025.7.0

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
