### PR TITLE
google-cloud-sdk: update to 529.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             528.0.0
+version             529.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  643c942b9491135f0db3c18f5cf570167f6fdf2f \
-                    sha256  02278f8b051b5b11ae0b5c31abdf5ba7d3c0acba35ba5cc1ddfc50aabf2afe36 \
-                    size    54202327
+    checksums       rmd160  79413fd2726ad634e8a133ac87bfcef8235e27ab \
+                    sha256  405aa63130b4db786471764444af19281e0cbf595466c9b98c6d24ef68684254 \
+                    size    54813095
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a6c5029be140c0861c75512c6c7fa09ff985c094 \
-                    sha256  96d0d697ba970057a155cc6cb54b3bb3daa3ad02ae79e93ab53933c6cfd436ee \
-                    size    55735355
+    checksums       rmd160  a0a27d9942e11ff9e95dfb1878d26c875d6fe9f7 \
+                    sha256  d2244db22ffd1bae9713e1d0ef5661befd2301a79203ebae9f29e995fe01d3e9 \
+                    size    56342082
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  38a15d051098217d666e0944ae4bdd077954256f \
-                    sha256  c8a175347e4a99d3f834c54ab922ba6a5276f6403f7a70c42e77dd3a0cfcf48e \
-                    size    55670081
+    checksums       rmd160  3ca449d70cb4a9645f37311d5b4eb707f7eafeb7 \
+                    sha256  75fc98465297923aa412cd6cb3476adaa9312e2c6fd0c2dec9f652ad19b89fce \
+                    size    56275074
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -44,7 +44,7 @@ worksrcdir          ${name}
 # Most recent Python version that supports to both
 # glcoud (https://cloud.google.com/sdk/docs/install#mac) and
 # gsutil (https://cloud.google.com/storage/docs/gsutil_install#before_you_begin)
-python.default_version 312
+python.default_version 313
 
 post-patch {
     # Default to the MacPorts Python binary


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 529.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?