### PR TITLE
rclone: 1.70.2

### DIFF
--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/rclone/rclone 1.70.1 v
+go.setup            github.com/rclone/rclone 1.70.2 v
 go.offline_build    no
 revision            0
 
@@ -18,9 +18,9 @@ long_description \
     Backblaze B2, Yandex Disk, SFTP, and the local filesystem.
 
 checksums \
-    rmd160  1ac44f252e37f2375a73cb49eb4e078df3bb9d3c \
-    sha256  d3d31bdf271a374748b0b1611d82d1a868e87471c31ed9715055b2ae36de7282 \
-    size    17212768
+    rmd160  6fbc14a280b547489d088e7f172740352c077897 \
+    sha256  dc6b1eabbe35cfde3b9db2a25567ed6d4f4e65b5c71e52da7d6ff5f987ba86dc \
+    size    17216963
 
 categories          net
 installs_libs       no


### PR DESCRIPTION
Maintainer update.

Upstream changelog: https://rclone.org/changelog/#v1-70-2-2025-06-27