### PR TITLE
openEMS: Rev bump for VTK-9.5.0 update

### DIFF
--- a/science/openEMS/Portfile
+++ b/science/openEMS/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 
 github.setup        thliebig openEMS 1ccf0942477e9178b27f5e00dddd4d62bff78d29
 version             20240312-[string range ${github.version} 0 7]
-revision            2
+revision            3
 
 checksums           rmd160  c29d96ef9a7c08f6d6295aa6fe5eb0feddcb2362 \
                     sha256  984f5263562bb32d104bffd4f66c148abe2ee57df48c3ac6dd9751a15b83a312 \


### PR DESCRIPTION
#### Description

* Second rev bump, fix VTK linkage.
* The first bump was done too quickly and linked to the previous version of VTK.  My mistake in timing.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?