### PR TITLE
direnv: Update to 2.37.0

### DIFF
--- a/devel/direnv/Portfile
+++ b/devel/direnv/Portfile
@@ -19,39 +19,39 @@ long_description    \
 
 homepage            https://direnv.net/
 
-go.setup            github.com/direnv/direnv 2.36.0 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+go.setup            github.com/direnv/direnv 2.37.0 v
 revision            0
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
 
-checksums           ${distname}${extract.suffix} \
-                        rmd160  2eb3b2eccdb8ff502156ee2c204065f54de5bfe3 \
-                        sha256  1538d5453a4bd49b9d08b9eb1b2a1c4dec8c7e408d4a6d540822d353e72a9379 \
-                        size    97213
+checksums           direnv-2.37.0.tar.gz \
+                    rmd160  60d20a871210f8349a4c1ad623fe6157670157ea \
+                    sha256  6302f3eb824ae5f7d33475c6e9ac0ec46a228e282fca7dba881f3536575a25c8 \
+                    size    102538
 
 # see ${WORKSRCPATH}/gopath/src/github.com/direnv/direnv/go.sum
 # pick the most recent version of each and verify downloading and building
+
 go.vendors          golang.org/x/sys \
-                        lock    v0.6.0 \
-                        rmd160  eed022d31d3cd2b2a5c7d1bad325b6667db1d831 \
-                        sha256  28b3d661c0b094ccb133bb2f30a2db8fcd64be036f4fc42ee6c2ab4b00867bd3 \
-                        size    1435230 \
+                        lock    v0.30.0 \
+                        rmd160  4cd711df5da2e159b6efbb7fa42ae0a3a3f6eb53 \
+                        sha256  76cfe40018bfa5418c1d19d47d8353c3375594013e2b2feea49f06018d2a3102 \
+                        size    1523466 \
                     golang.org/x/mod \
-                        lock    v0.19.0 \
-                        rmd160  c7151bc570da6418102a9522a17f08ec42e4d120 \
-                        sha256  7a83a550982587f064f5f4f377fec2eb7c22496b495590edf634272437865352 \
-                        size    123358 \
+                        lock    v0.25.0 \
+                        rmd160  5936bc27463b64e63518d170478bd0725f2772f7 \
+                        sha256  b1f05d8f05987cdcc622ff2c8a5c12a4161563ee793ad07527a0cc718b8ce4f3 \
+                        size    126567 \
                     github.com/mattn/go-isatty \
                         lock    v0.0.20 \
                         rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
                         sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
                         size    4717 \
                     github.com/BurntSushi/toml \
-                        lock    v1.4.0 \
-                        rmd160  61fb91ac7b8b358e229a361c615a3cf3ea1fbd14 \
-                        sha256  45692255b59b4dbe0045a088a20eba0efafdca83446accf65847a3184686eff9 \
-                        size    117687
+                        lock    v1.5.0 \
+                        rmd160  49d05b71280b608decff341422e418dde7d3eb5a \
+                        sha256  fa1ef74a26dbc3ffa82643fa9b51e99f54a19dd42a97d39e0ee20c2750bd2d94 \
+                        size    118627
+


### PR DESCRIPTION
#### Description

direnv: Update to 2.37.0

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
