### PR TITLE
racket: Update to version 8.18; Use full Racket source with native apps

### DIFF
--- a/lang/racket/Portfile
+++ b/lang/racket/Portfile
@@ -1,19 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           openssl 1.0
-
-openssl.branch      1.1
 
 name                racket
-version             8.17
+version             8.18
 revision            0
 categories          lang scheme
 license             Apache-2 MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Scheme programming environment
 long_description    Interactive, integrated, graphical {*}${description}.
+
 homepage            https://racket-lang.org
+
 master_sites        https://download.racket-lang.org/releases/${version}/installers/ \
                     https://mirror.racket-lang.org/installers/${version}/ \
                     https://www.cs.utah.edu/plt/installers/${version}/ \
@@ -21,11 +20,14 @@ master_sites        https://download.racket-lang.org/releases/${version}/install
                     https://mirror.csclub.uwaterloo.ca/racket/racket-installers/${version}/ \
                     https://mirror.informatik.uni-tuebingen.de/mirror/racket/${version}/ \
                     https://racket.infogroep.be/${version}/
-distname            ${name}-minimal-${version}-src
+
+distname            ${name}-${version}-src
 extract.suffix      .tgz
-checksums           rmd160  48637c0cbeb240461516a23fb3ba34b51430630d \
-                    sha256  4acb365869290881fa07c69588cfa8b2dc1000bdc69955d70964b0b1e76b71ba \
-                    size    16865194
+
+checksums           rmd160  dbe15517355e52310146dcd1b4712015f32ff942 \
+                    sha256  65477c71ec1a978a6ee4db582b9b47b1a488029d7a42e358906de154a6e5905c \
+                    size    34413405
+
 extract.rename      yes
 
 patch.dir           ${workpath}/${distname}
@@ -35,9 +37,33 @@ patch.dir           ${workpath}/${distname}
 patchfiles-append   paths-to-openssl.diff
 
 post-patch {
+    # patch the @@PREFIX@@ in paths-to-openssl.diff
     foreach rkt {libcrypto.rkt libssl.rkt} {
         reinplace "s|@@PREFIX@@|${prefix}|g" \
-                    ${worksrcpath}/../collects/openssl/${rkt}
+            ${worksrcpath}/../collects/openssl/${rkt}
+    }
+
+    # https://github.com/racket/racket/issues/5055#issuecomment-2321445579
+    # collects/racket/private/so-search.rkt
+    reinplace -E \
+        "s|^#hash\\((.+)\\)$|#hash(\\1 (lib-search-dirs . (\"${prefix}/lib\" \"${frameworks_dir}\" #f)))|" \
+        ${worksrcpath}/../etc/config.rktd
+
+    # use MacPorts-installed libraries
+    # gettext-runtime provides libintl.8
+    # jpeg-turbo provides libjpeg.8
+    # libffi provides libffi.8
+    # mpfr provides libmpfr.6
+    # ossp-uuid provides libuuid.16
+    # poppler provides libpoppler.136
+    foreach rkt [list \
+                    "${worksrcpath}/native-libs/install.rkt" \
+                    "${worksrcpath}/../share/pkgs/draw-lib/racket/draw/unsafe/cairo-lib.rkt" \
+                    "${worksrcpath}/../share/pkgs/draw-lib/racket/draw/unsafe/glib.rkt" \
+                    "${worksrcpath}/../share/pkgs/draw-lib/racket/draw/unsafe/jpeg.rkt" \
+        ] {
+        # regex for (libffi).6, (libpangocairo-1.0.0), (libpng16).6.(.dylib), etc.
+        reinplace -E "s|\"(lib\[\[:alnum:]_]+(-\[\[:alnum:]_]+)*(-\[\[:digit:]]+(\\.\[\[:digit:]]+)+)*)(\\.\[\[:digit:]]+)?(\\.dylib)*\"|\"\\1\\6\"|g" ${rkt}
     }
 }
 
@@ -46,18 +72,22 @@ worksrcdir          ${worksrcpath}/src
 depends_build-append \
                     port:libtool
 
-depends_lib-append  port:ncurses \
+depends_lib-append  path:lib/libcrypto.dylib:openssl \
+                    path:lib/libssl.dylib:openssl \
+                    port:expat \
+                    port:fontconfig \
+                    port:freetype \
                     port:libffi \
                     port:libiconv \
                     port:lz4 \
+                    port:ncurses \
                     port:zlib
 
 configure.args-append \
                     --enable-curses \
                     --enable-liblz4 \
                     --enable-libz \
-                    --enable-pthread \
-                    --enable-xonx
+                    --enable-pthread
 
 if {${configure.build_arch} in [list ppc ppc64]} {
     # Stripping may fail on PowerPC:
@@ -65,6 +95,101 @@ if {${configure.build_arch} in [list ppc ppc64]} {
     configure.args-append \
                     --disable-strip \
                     --enable-bigendian
+}
+
+set Name            [string totitle ${name}]
+set Name_fw         ${Name}.framework/Versions/${version}_CS/${Name}
+set racket_apps_dir "${applications_dir}/${Name} ${version}"
+
+variant x11 \
+    description {Use X11 GUI.} {}
+
+if { [variant_isset "x11"] } {
+    PortGroup       active_variants 1.1
+
+    depends_lib-append \
+                    port:gdk-pixbuf2 \
+                    port:gtk2
+
+    require_active_variants gtk2 x11
+
+    configure.args-append \
+                    --enable-xonx
+} else {
+    depends_build-append \
+                    port:cctools \
+                    port:file \
+                    port:grep \
+                    port:gsed \
+                    path:bin/openssl:openssl
+
+    # https://github.com/racket/libs/tree/master/draw-x86_64-macosx-3/racket/draw
+    # https://github.com/racket/libs/tree/master/gui-x86_64-macosx/racket/gui
+    # https://github.com/racket/libs/tree/master/math-x86_64-macosx/math
+    # https://github.com/racket/libs/tree/master/racket-x86_64-macosx-4/racket
+    depends_lib-append \
+                    port:atk \
+                    port:cairo \
+                    port:fribidi \
+                    port:gettext-runtime \
+                    port:glib2 \
+                    port:harfbuzz \
+                    port:libedit \
+                    port:libjpeg-turbo \
+                    port:libpixman \
+                    port:libpng \
+                    port:MMTabBarView \
+                    port:mpfr \
+                    port:ossp-uuid \
+                    port:pango \
+                    port:poppler
+
+    configure.args-append \
+                    --disable-origtree \
+                    --enable-macprefix \
+                    --enable-nonatipkg \
+                    "--guibindir='${racket_apps_dir}'"
+    
+    pre-destroot {
+        xinstall -d ${racket_apps_dir}
+    }
+
+    post-destroot {
+        # framework
+        xinstall -d ${destroot}${frameworks_dir}
+        move        ${destroot}${prefix}/lib/${name}/${Name}.framework \
+                    ${destroot}${frameworks_dir}
+        system -W ${destroot}${frameworks_dir} \
+                    "install_name_tool -change '${Name_fw}' '@rpath/${Name_fw}' '${Name_fw}'"
+
+        # GRacket.app
+        system -W   ${destroot}${prefix}/lib/${name} \
+                    "install_name_tool -change '${prefix}/lib/${name}/${Name_fw}' '${frameworks_dir}/${Name_fw}' GRacket.app/Contents/MacOS/GRacket"
+
+        # binaries
+        foreach binfile {mzscheme racket} {
+            system -W ${destroot}${prefix}/bin \
+                    "install_name_tool -change '${prefix}/lib/${name}/${Name_fw}' '${frameworks_dir}/${Name_fw}' '${binfile}'"
+            if {${configure.build_arch} eq {arm64}} {
+                system -W ${destroot}${prefix}/bin \
+                    "codesign -f -s - '${binfile}'"
+            }
+        }
+
+        # apps
+        foreach app_name [list \
+                    DrRacket \
+                    "PLT Games" \
+                    "Racket Documentation" \
+                    Slideshow \
+            ] {
+            system -W ${destroot}${racket_apps_dir} \
+                "install_name_tool -change '${prefix}/lib/${name}/${Name_fw}' '${frameworks_dir}/${Name_fw}' '${app_name}.app/Contents/MacOS/${app_name}'"
+            if {${configure.build_arch} eq {arm64}} {
+                system "codesign -f -s - '${destroot}${racket_apps_dir}/${app_name}.app/Contents/MacOS/${app_name}'"
+            }
+        }
+    }
 }
 
 livecheck.type  regex

--- a/lang/racket/files/paths-to-openssl.diff
+++ b/lang/racket/files/paths-to-openssl.diff
@@ -18,7 +18,7 @@ diff -NaurdwB -I ^;;[[:space:]]* ./collects/openssl/libcrypto.rkt ./collects/ope
 -        ;; Version "3" is bundled with Racket
 -        '(so "libcrypto" ("3" #f))])]
 -    [else '(so "libcrypto")]))
-+(define-runtime-path libcrypto-so "@@PREFIX@@/lib/openssl-1.1/libcrypto.1.1.dylib")
++(define-runtime-path libcrypto-so "@@PREFIX@@/lib/libcrypto.dylib")
  
  (define libcrypto
    (cond
@@ -42,7 +42,7 @@ diff -NaurdwB -I ^;;[[:space:]]* ./collects/openssl/libssl.rkt ./collects/openss
 -        ;; Version "3" is bundled with Racket
 -        '(so "libssl" ("3" #f))])]
 -    [else '(so "libssl")]))
-+(define-runtime-path libssl-so "@@PREFIX@@/lib/openssl-1.1/libssl.1.1.dylib")
++(define-runtime-path libssl-so "@@PREFIX@@/lib/libssl.dylib")
  
  (define libssl
    (and libcrypto


### PR DESCRIPTION
This PR builds the full racket system per https://github.com/racket/racket/issues/5055#issuecomment-2321445579, and fixes the issue of unsigned `arm64` binaries.

There is the remaining issue that calling the GUI fails with the cause apparently being uninitialized variables: "`invalid memory reference`").

If anyone knows how to set defaults at compile time or in a config file, please post.

Here's the issue:

> ```sh
> $ drracket -display=0:0
> invalid memory reference.  Some debugging context lost
>   context...:
>    body of "/opt/local/share/racket/pkgs/gui-lib/mred/private/wx/gtk/style.rkt"
>   body of "/opt/local/share/racket/pkgs/gui-lib/mred/private/wx/platform.rkt"
> ```

Using trace with `(require racket/gui)` shows that the variables `has-x-selection?`, `cursor-driver%`, and so forth are uninitialized in `racket/pkgs/xrepl-lib/xrepl/xrepl.rkt` and `racket/pkgs/gui-lib/mred/private/wx/platform.rkt`.
> ```sh
> $ racket -i
> Welcome to Racket v8.17 [cs].
> > (require racket/gui)
> ; invalid memory reference.  Some debugging context lost [,bt for context]
> > ,bt
> ; invalid memory reference.  Some debugging context lost
> ;   context...:
> ;    body of "/opt/local/share/racket/pkgs/gui-lib/mred/private/wx/gtk/style.rkt"
> ;    body of "/opt/local/share/racket/pkgs/gui-lib/mred/private/wx/platform.rkt"
> ;    body of top-level
> ;    /opt/local/share/racket/pkgs/xrepl-lib/xrepl/xrepl.rkt:1573:0
> ;    /opt/local/share/racket/collects/racket/repl.rkt:11:26
> > (require racket/gui)
> ; instantiate-linklet: mismatch;
> ;  reference to a variable that is uninitialized
> ;   name: has-x-selection?
> ;   exporting instance:
> ;     "/opt/local/share/racket/pkgs/gui-lib/mred/private/wx/platform.rkt"
> ;   importing instance:
> ;     "/opt/local/share/racket/pkgs/gui-lib/mred/private/wx/common/clipboard.rkt"
> ;   possible reason: modules need to be recompiled because dependencies changed
> ;   possible solution: running `racket -y`, `raco make`, or `raco setup`
> ; [,bt for context]
> > (require racket/gui)
> ; instantiate-linklet: mismatch;
> ;  reference to a variable that is uninitialized
> ;   name: cursor-driver%
> ;   exporting instance:
> ;     "/opt/local/share/racket/pkgs/gui-lib/mred/private/wx/platform.rkt"
> ;   importing instance:
> ;     "/opt/local/share/racket/pkgs/gui-lib/mred/private/wx/common/cursor.rkt"
> ;   possible reason: modules need to be recompiled because dependencies changed
> ;   possible solution: running `racket -y`, `raco make`, or `raco setup`
> ; [,bt for context]
> ```



#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
