### PR TITLE
auto-multiple-choice-devel: update to version 1.7.0-git 20250704122834

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -39,12 +39,12 @@ if {${subport} eq ${name}} {
 } else {
     # devel
     set amc.version.main        1.7.0
-    set amc.version.secondary   20250417073838
-    set amc.version         ${amc.version.main}
-    version                 ${amc.version.main}
-    checksums               rmd160  8886151969ace9a3693b840cd9fcb3aa3678ba28 \
-                            sha256  95c08477ae41f1b2a98881b677b0dce03f70c4a7ab5ac440311091175d9c98f6 \
-                            size    15449580
+    set amc.version.secondary   20250704122834
+    set amc.version         ${amc.version.main}+git${amc.version.secondary}
+    version                 ${amc.version.main}-git${amc.version.secondary}
+    checksums               rmd160  0a1888c9d6af8f5053406f3d4ee2565cd66a873a \
+                            sha256  ced16989fe2246d0bbc092792c3e09f5f2a38e72e4eab91e207503c3e0092370 \
+                            size    15530591
 
     conflicts               auto-multiple-choice
 }


### PR DESCRIPTION
#### Description
Update auto-multiple-choice-devel to version 1.7.0-git 20250704122834

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.5 24F74 arm64
Xcode 16.4 16F6 
MacPorts 2.10.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
