### PR TITLE
carapace: new port (submission)

### DIFF
--- a/sysutils/carapace/Portfile
+++ b/sysutils/carapace/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+name                carapace
+version             1.3.3
+revision            0
+
+go.setup            github.com/carapace-sh/carapace-bin ${version} v
+
+categories          sysutils
+maintainers         {gmail.com:esafak @esafak} openmaintainer
+license             MIT
+description         Command-line interface completion framework
+long_description    Carapace provides multi-shell (bash, zsh, fish, powershell) \
+                    completions for CLI programs.
+
+homepage            https://rsteube.github.io/carapace/
+
+# Update with `port checksum carapace`
+checksums           rmd160  9609c29805089919e19a093353d4153cb5355104 \
+                    sha256  0de73fc9338eb034a0c2bdbda72880f1de12ac0bc686d814beb1975a310264fc \
+                    size    17418650
+
+build {
+    system -W ${worksrcpath} "${go.bin} generate ./..."
+    system -W ${worksrcpath} "${go.bin} build -v -o ${worksrcpath}/carapace -ldflags '-s -w -X main.version=${version}' -tags release ./cmd/carapace"
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/carapace ${destroot}${prefix}/bin/carapace
+
+    # Create directories for completions
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${destroot}${prefix}/share/nushell/completions
+
+    # Generate and install shell completion scripts
+    system "${destroot}${prefix}/bin/carapace completion bash > ${destroot}${prefix}/share/bash-completion/completions/carapace"
+    system "${destroot}${prefix}/bin/carapace completion fish > ${destroot}${prefix}/share/fish/vendor_completions.d/carapace.fish"
+    system "${destroot}${prefix}/bin/carapace completion zsh > ${destroot}${prefix}/share/zsh/site-functions/_carapace"
+    system "${destroot}${prefix}/bin/carapace completion nushell > ${destroot}${prefix}/share/nushell/completions/carapace.nu"
+}
+
+livecheck.type      github


### PR DESCRIPTION
#### Description

A multi-shell completion [library](https://github.com/carapace-sh/carapace) and [binary](https://github.com/carapace-sh/carapace-bin).

###### Type(s)
submission

###### Tested on
macOS 15.5 24F74
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?