### PR TITLE
wb32-dfu-updater: new port

### DIFF
--- a/cross/wb32-dfu-updater/Portfile
+++ b/cross/wb32-dfu-updater/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+PortGroup           cmake 1.0
+
+github.setup        WestberryTech wb32-dfu-updater 1.0.0
+checksums           rmd160  ad14277c6934c65279e44ffd82fd305f69167362 \
+                    sha256  2b1c5b5627723067168af9740cb25c5c179634e133e4ced06028462096de5699 \
+                    size    338940
+github.tarball_from archive
+
+description         USB programmer for downloading and uploading firmware to/from USB devices with the WestberryTech WB32 chips.
+long_description    ${description}
+license             Apache-2.0
+
+maintainers         {cal @neverpanic} openmaintainer
+categories          cross devel
+
+depends_lib         port:libusb


### PR DESCRIPTION
#### Description

A flashing tool for WestberryTech WB32 chips.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
