### PR TITLE
update nodejs portfiles, enable ccache, use macports libraries where possible

### DIFF
--- a/lang/nodejs14/Portfile
+++ b/lang/nodejs14/Portfile
@@ -27,10 +27,6 @@ categories              lang net
 license                 {MIT BSD}
 maintainers             {ciserlohn @ci42} openmaintainer
 
-# Attempting to use node on Mac OS X 10.7 causes a kernel panic. libuv could
-# be patched to fix this; see https://trac.macports.org/ticket/71475
-platforms               {darwin != 11.*}
-
 description             Evented I/O for V8 JavaScript
 
 long_description        Node's goal is to provide an easy way to build scalable network programs in JavaScript. \
@@ -56,8 +52,11 @@ set py_ver              3.10
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
-                        port:python${py_ver_nodot} \
-                        port:zlib
+                        path:lib/libz.dylib:zlib \
+                        port:openssl \
+                        port:c-ares \
+                        port:nghttp2 \
+                        port:brotli
 
 use_xcode               yes
 
@@ -90,8 +89,8 @@ post-patch {
 # use the system libuv instead of the bundled version, as it is fixed for older systems
 if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
     depends_lib-append    path:lib/libuv.dylib:libuv
-    configure.args-append --shared-libuv
 
+    configure.args-append --shared-libuv
     if {${configure.cxx_stdlib} eq "libc++"} {
         depends_lib-append        port:macports-libcxx
         configure.cxx-append      -Wl,-L${prefix}/lib/libcxx
@@ -111,27 +110,36 @@ pre-configure {
      # Copy zlib headers here because we do not want to prepend the entire
      # ${prefix}/include to the include path (the build will then attempt to use
      # ICU 67 headers)
-     file mkdir ${workpath}/zlib-inc
-     file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
-         ${workpath}/zlib-inc/
+    file mkdir ${workpath}/zlib-inc ${workpath}/cares-inc
+    file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
+        ${workpath}/zlib-inc/
+    system "cp ${prefix}/include/*ares*.h ${workpath}/cares-inc"
+
 }
 
 configure.args-append   --without-npm
 configure.args-append   --with-intl=system-icu
-configure.args-append   --shared-openssl
-configure.args-append   --shared-openssl-includes=[openssl::include_dir]
-configure.args-append   --shared-openssl-libpath=[openssl::lib_dir]
 configure.args-append   --shared-zlib
 configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
 configure.args-append   --shared-zlib-libpath=${prefix}/lib
+configure.args-append   --shared-openssl
+configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
+configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
+configure.args-append   --shared-nghttp2
+configure.args-append   --shared-nghttp2-includes=${prefix}/include/nghttp2
+configure.args-append   --shared-nghttp2-libpath=${prefix}/lib
+configure.args-append   --shared-cares
+configure.args-append   --shared-cares-includes=${workpath}/cares-inc
+configure.args-append   --shared-cares-libpath=${prefix}/lib
+configure.args-append   --shared-brotli
+configure.args-append   --shared-brotli-libpath=${prefix}/lib
 
 # V8 only supports ARM and IA-32 processors
 supported_archs         i386 x86_64 arm64
 
 universal_variant       no
 
-# "V8 doesn't like cache."
-configure.ccache        no
+configure.ccache        yes 
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}

--- a/lang/nodejs16/Portfile
+++ b/lang/nodejs16/Portfile
@@ -23,10 +23,6 @@ categories              lang net
 license                 {MIT BSD}
 maintainers             {ciserlohn @ci42} openmaintainer
 
-# Attempting to use node on Mac OS X 10.7 causes a kernel panic. libuv could
-# be patched to fix this; see https://trac.macports.org/ticket/71475
-platforms               {darwin != 11.*}
-
 description             Evented I/O for V8 JavaScript
 
 long_description        Node's goal is to provide an easy way to build scalable network programs in JavaScript. \
@@ -52,7 +48,11 @@ set py_ver_nodot        [string map {. {}} ${py_ver}]
 depends_build-append    port:pkgconfig \
                         port:python${py_ver_nodot}
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
-                        port:zlib
+                        path:lib/libz.dylib:zlib \
+                        port:openssl \
+                        port:c-ares \
+                        port:nghttp2 \
+                        port:brotli
 
 if {![variant_isset openssl3]} {
     openssl.branch          1.1
@@ -119,27 +119,36 @@ pre-configure {
     # Copy zlib headers here because we do not want to prepend the entire
     # ${prefix}/include to the include path (the build will then attempt to use
     # ICU headers)
-    file mkdir ${workpath}/zlib-inc
+    file mkdir ${workpath}/zlib-inc ${workpath}/cares-inc
     file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
         ${workpath}/zlib-inc/
+    system "cp ${prefix}/include/*ares*.h ${workpath}/cares-inc"
 }
 
 configure.args-append   --without-npm
 configure.args-append   --with-intl=system-icu
-configure.args-append   --shared-openssl
-configure.args-append   --shared-openssl-includes=[openssl::include_dir]/openssl
-configure.args-append   --shared-openssl-libpath=[openssl::lib_dir]
 configure.args-append   --shared-zlib
 configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
 configure.args-append   --shared-zlib-libpath=${prefix}/lib
+configure.args-append   --shared-openssl
+configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
+configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
+configure.args-append   --shared-nghttp2
+configure.args-append   --shared-nghttp2-includes=${prefix}/include/nghttp2
+configure.args-append   --shared-nghttp2-libpath=${prefix}/lib
+configure.args-append   --shared-cares
+configure.args-append   --shared-cares-includes=${workpath}/cares-inc
+configure.args-append   --shared-cares-libpath=${prefix}/lib
+configure.args-append   --shared-brotli
+configure.args-append   --shared-brotli-libpath=${prefix}/lib
+
 
 # V8 only supports ARM and IA-32 processors
 supported_archs         i386 x86_64 arm64
 
 universal_variant       no
 
-# "V8 doesn't like cache."
-configure.ccache        no
+configure.ccache        yes 
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}

--- a/lang/nodejs18/Portfile
+++ b/lang/nodejs18/Portfile
@@ -15,10 +15,6 @@ categories              lang net
 license                 {MIT BSD}
 maintainers             {ciserlohn @ci42} openmaintainer
 
-# Attempting to use node on Mac OS X 10.7 causes a kernel panic. libuv could
-# be patched to fix this; see https://trac.macports.org/ticket/71475
-platforms               {darwin != 11.*}
-
 description             Evented I/O for V8 JavaScript
 
 long_description        Node's goal is to provide an easy way to build scalable network programs in JavaScript. \
@@ -44,7 +40,11 @@ set py_ver_nodot        [string map {. {}} ${py_ver}]
 depends_build-append    port:pkgconfig \
                         port:python${py_ver_nodot}
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
-                        port:zlib
+                        path:lib/libz.dylib:zlib \
+                        port:openssl \
+                        port:c-ares \
+                        port:nghttp2 \
+                        port:brotli
 
 
 # use the system libuv instead of the bundled version, as it is fixed for older systems
@@ -106,32 +106,35 @@ pre-configure {
     # Copy zlib headers here because we do not want to prepend the entire
     # ${prefix}/include to the include path (the build will then attempt to use
     # ICU headers)
-    file mkdir ${workpath}/zlib-inc
+    file mkdir ${workpath}/zlib-inc ${workpath}/cares-inc 
     file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
         ${workpath}/zlib-inc/
+    system "cp ${prefix}/include/*ares*.h ${workpath}/cares-inc"
 }
 
+
 configure.args-append   --without-npm
-configure.args-append   --with-intl=system-icu
 configure.args-append   --shared-zlib
 configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
 configure.args-append   --shared-zlib-libpath=${prefix}/lib
+configure.args-append   --shared-openssl
+configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
+configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
+configure.args-append   --shared-nghttp2
+configure.args-append   --shared-nghttp2-includes=${prefix}/include/nghttp2
+configure.args-append   --shared-nghttp2-libpath=${prefix}/lib
+configure.args-append   --shared-cares
+configure.args-append   --shared-cares-includes=${workpath}/cares-inc
+configure.args-append   --shared-cares-libpath=${prefix}/lib
+configure.args-append   --shared-brotli
+configure.args-append   --shared-brotli-libpath=${prefix}/lib
 
 # V8 only supports ARM and IA-32 processors
 supported_archs         i386 x86_64 arm64
 
 universal_variant       no
 
-# https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V17.md#openssl-30
-variant no_openssl3_with_quic description {use MacPort's OpenSSL rather than Node.js' provided OpenSSL 3.0 extended with QUIC} {
-    depends_lib-append      port:openssl3
-    configure.args-append   --shared-openssl
-    configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
-    configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
-}
-
-# "V8 doesn't like cache."
-configure.ccache        no
+configure.ccache        yes
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}
@@ -148,9 +151,9 @@ switch $build_arch {
     }
 }
 
-# Node.js 18.x requires Xcode >= 11 (Apple LLVM >= 11)
-# https://github.com/nodejs/node/blob/v18.x/BUILDING.md#supported-toolchains
-compiler.blacklist-append {clang < 1100}
+# Node.js 18.x requires Xcode >= 12 (Apple LLVM >= 12)
+# https://github.com/nodejs/node/pull/42292 
+compiler.blacklist-append {clang < 1200}
 
 build.args-append   CC=${configure.cc} \
                     CXX=${configure.cxx} \

--- a/lang/nodejs20/Portfile
+++ b/lang/nodejs20/Portfile
@@ -15,10 +15,6 @@ categories              lang net
 license                 {MIT BSD}
 maintainers             {ciserlohn @ci42} openmaintainer
 
-# Attempting to use node on Mac OS X 10.7 causes a kernel panic. libuv could
-# be patched to fix this; see https://trac.macports.org/ticket/71475
-platforms               {darwin != 11.*}
-
 description             Evented I/O for V8 JavaScript
 
 long_description        Node's goal is to provide an easy way to build scalable network programs in JavaScript. \
@@ -44,8 +40,11 @@ set py_ver_nodot        [string map {. {}} ${py_ver}]
 depends_build-append    port:pkgconfig \
                         port:python${py_ver_nodot}
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
-                        port:zlib
-
+                        path:lib/libz.dylib:zlib \
+                        port:openssl \
+                        port:c-ares \
+                        port:nghttp2 \
+                        port:brotli
 
 # use the system libuv instead of the bundled version, as it is fixed for older systems
 if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
@@ -110,9 +109,11 @@ pre-configure {
     # Copy zlib headers here because we do not want to prepend the entire
     # ${prefix}/include to the include path (the build will then attempt to use
     # ICU headers)
-    file mkdir ${workpath}/zlib-inc
+    file mkdir ${workpath}/zlib-inc ${workpath}/cares-inc
     file copy ${prefix}/include/zconf.h ${prefix}/include/zlib.h \
         ${workpath}/zlib-inc/
+    system "cp ${prefix}/include/*ares*.h ${workpath}/cares-inc"
+
 }
 
 configure.args-append   --without-npm
@@ -120,22 +121,24 @@ configure.args-append   --with-intl=system-icu
 configure.args-append   --shared-zlib
 configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
 configure.args-append   --shared-zlib-libpath=${prefix}/lib
+configure.args-append   --shared-openssl
+configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
+configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
+configure.args-append   --shared-nghttp2
+configure.args-append   --shared-nghttp2-includes=${prefix}/include/nghttp2
+configure.args-append   --shared-nghttp2-libpath=${prefix}/lib
+configure.args-append   --shared-cares
+configure.args-append   --shared-cares-includes=${workpath}/cares-inc
+configure.args-append   --shared-cares-libpath=${prefix}/lib
+configure.args-append   --shared-brotli
+configure.args-append   --shared-brotli-libpath=${prefix}/lib
 
 # V8 only supports ARM and IA-32 processors
 supported_archs         i386 x86_64 arm64
 
 universal_variant       no
 
-# https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V17.md#openssl-30
-variant no_openssl3_with_quic description {use MacPort's OpenSSL rather than Node.js' provided OpenSSL 3.0 extended with QUIC} {
-    depends_lib-append      port:openssl3
-    configure.args-append   --shared-openssl
-    configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
-    configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
-}
-
-# "V8 doesn't like cache."
-configure.ccache        no
+configure.ccache        yes 
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}
@@ -152,9 +155,9 @@ switch $build_arch {
     }
 }
 
-# Node.js 20.x requires Xcode >= 11 (Apple LLVM >= 11)
-# https://github.com/nodejs/node/blob/v20.x/BUILDING.md#supported-toolchains
-compiler.blacklist-append {clang < 1100}
+# Node.js 20.x requires Xcode >= 12 (Apple LLVM >= 12)
+# https://github.com/nodejs/node/pull/42292  
+compiler.blacklist-append {clang < 1200}
 
 build.args-append   CC=${configure.cc} \
                     CXX=${configure.cxx} \

--- a/lang/nodejs22/Portfile
+++ b/lang/nodejs22/Portfile
@@ -45,7 +45,11 @@ depends_build-append    port:pkgconfig \
                         port:python${py_ver_nodot}
 
 depends_lib-append      path:lib/pkgconfig/icu-uc.pc:icu \
-                        port:zlib
+                        path:lib/libz.dylib:zlib \
+                        port:openssl \
+                        port:c-ares \
+                        port:nghttp2 \
+                        port:brotli
 
 # use the system libuv instead of the bundled version, as it is fixed for older systems
 if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
@@ -123,25 +127,25 @@ pre-configure {
 
 configure.args-append   --without-npm
 configure.args-append   --with-intl=system-icu
-configure.args-append   --shared-zlib
-configure.args-append   --shared-zlib-includes=${workpath}/zlib-inc
-configure.args-append   --shared-zlib-libpath=${prefix}/lib
+configure.args-append   --shared-openssl
+configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
+configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
+configure.args-append   --shared-nghttp2
+configure.args-append   --shared-nghttp2-includes=${prefix}/include/nghttp2
+configure.args-append   --shared-nghttp2-libpath=${prefix}/lib
+configure.args-append   --shared-cares
+configure.args-append   --shared-cares-includes=${workpath}/cares-inc
+configure.args-append   --shared-cares-libpath=${prefix}/lib
+configure.args-append   --shared-brotli
+configure.args-append   --shared-brotli-libpath=${prefix}/lib
 
 # V8 only supports ARM and IA-32 processors
 supported_archs         i386 x86_64 arm64
 
 universal_variant       no
 
-# https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V17.md#openssl-30
-variant no_openssl3_with_quic description {use MacPort's OpenSSL rather than Node.js' provided OpenSSL 3.0 extended with QUIC} {
-    depends_lib-append      port:openssl3
-    configure.args-append   --shared-openssl
-    configure.args-append   --shared-openssl-includes=${prefix}/libexec/openssl3/include/openssl
-    configure.args-append   --shared-openssl-libpath=${prefix}/libexec/openssl3/lib
-}
-
 # "V8 doesn't like cache."
-configure.ccache        no
+configure.ccache        yes 
 
 test.run                yes
 test.cmd                ${build.cmd} -j${build.jobs}


### PR DESCRIPTION
please see my follow-up to @ryandesign's ticket here:

https://trac.macports.org/ticket/71475#comment:17

**as it stands, with the forthcoming pull this is the status:**

   1. nodejs14->nodejs20 will build/run properly on all macs that have a newer libuv (i'm on 10.14, so i dunno where the line is)
   2. nodejs14->nodejs18 will build/run properly on all macs from 10.7 and newer
   3. whilst the logs on the ticket aren't showing ccache, i did test it on nodejs18 on lion (as we speak) and it looks fine. i see no reason why ccache should cause a problem.

**the outstanding issues are now:**

   5. fixing libuv for nodejs20->nodejs22 on older macs
   6. fixing/updating macports-libcxx so more-recent macs (like 10.14 machines) can run nodejs22 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.7.5 11G63 x86_64
Xcode 4.6.2 4H1003

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
