### PR TITLE
nccmp: Update to 1.10.0.0

### DIFF
--- a/science/nccmp/Portfile
+++ b/science/nccmp/Portfile
@@ -6,11 +6,11 @@ PortGroup           gitlab 1.0
 # this port can optionally be built with cmake (but then tests are run in a different way)
 #PortGroup          cmake 1.1
 
-gitlab.setup        remikz nccmp 1.9.1.0
-revision            1
-checksums           rmd160  d3eb0a8d2b55c93f42832e74dedab358f42fa243 \
-                    sha256  44768ebdc5633207fbf1a7e087767782c6811f600c6a6c91b5829fb7787064ae \
-                    size    312482
+gitlab.setup        remikz nccmp 1.10.0.0
+revision            0
+checksums           rmd160  b65c81e56a0112e6675469b9b04b7c0ce57a12cb \
+                    sha256  cc3b5bb1331b08529e076fc9c007907320d2248dd5f4fd3feb99461644a9bfe8 \
+                    size    318500
 
 categories          science
 maintainers         {noaa.gov:dave.allured @Dave-Allured} openmaintainer


### PR DESCRIPTION
#### Description

Update nccmp 1.9.1.0 --> 1.10.0.0

###### Type(s)

###### Tested on

macOS 15.5
Xcode 16.2
Command Line Tools 16.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `port -s install`?
- [x] tested basic functionality of all binary files?