### PR TITLE
libpng: update to 1.6.50

### DIFF
--- a/graphics/libpng/Portfile
+++ b/graphics/libpng/Portfile
@@ -4,11 +4,11 @@ PortSystem              1.0
 PortGroup               muniversal 1.0
 
 name                    libpng
-version                 1.6.49
+version                 1.6.50
 revision                0
-checksums               rmd160  604adf0638e188d142aaf23f67c1e0dd62e7cab9 \
-                        sha256  43182aa48e39d64b1ab4ec6b71ab3e910b67eed3a0fff3777cf8cf40d6ef7024 \
-                        size    1060752
+checksums               rmd160  b1f46dc95ee562df9e87722f8a51e3a574040804 \
+                        sha256  4df396518620a7aa3651443e87d1b2862e4e88cad135a8b93423e01706232307 \
+                        size    1060992
 
 set branch              [join [lrange [split ${version} .] 0 1] ""]
 categories              graphics


### PR DESCRIPTION
Since buildbots are offline there is no need to merge this PR immediately.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
