### PR TITLE
pdal: update to 2.9.0; saga: update to 9.8.1

### DIFF
--- a/gis/pdal/Portfile
+++ b/gis/pdal/Portfile
@@ -128,7 +128,7 @@ subport pdal-pgpointcloud {
                         -DBUILD_PLUGIN_PGPOINTCLOUD=ON
 
     # PostgreSQL variants
-    set postgresql_suffixes {16 15 14 13 12}
+    set postgresql_suffixes {17 16 15 14 13 12}
     set def_psql_var "if {"
 
     set postgresql_variants {}
@@ -139,7 +139,7 @@ subport pdal-pgpointcloud {
 
     # Set default variant
     set def_psql_var [string range ${def_psql_var} 0 end-4]
-    set def_psql_var "${def_psql_var}} {default_variants +postgresql16}"
+    set def_psql_var "${def_psql_var}} {default_variants +postgresql17}"
     eval ${def_psql_var}
 
     foreach suffix ${postgresql_suffixes} {
@@ -153,7 +153,7 @@ subport pdal-pgpointcloud {
             configure.args-append   -DPostgreSQL_ROOT=${prefix}/lib/${vrt} \
                                     -DPostgreSQL_INCLUDE_DIR=${prefix}/include/${vrt} \
                                     -DBUILD_PLUGIN_PGPOINTCLOUD=ON
-            configure.env-append    PostgreSQL_ADDITIONAL_VERSIONS=15,16
+            configure.env-append    PostgreSQL_ADDITIONAL_VERSIONS=15,16,17
         "
     }
 

--- a/gis/pdal/Portfile
+++ b/gis/pdal/Portfile
@@ -5,8 +5,8 @@ PortGroup           cmake         1.1
 PortGroup           github        1.0
 PortGroup           legacysupport 1.1
 
-github.setup        PDAL PDAL 2.8.4
-revision            1
+github.setup        PDAL PDAL 2.9.0
+revision            0
 
 name                pdal
 categories          gis
@@ -32,9 +32,9 @@ compiler.thread_local_storage yes
 
 github.tarball_from releases
 
-checksums           rmd160  173a599ef11c3fb77ce74ee78b446b33c2f709c5 \
-                    sha256  8f3e364db21294b35aa43ad9042443a78e05f8135789d3b9e8a2fce70c91134a \
-                    size    89478184
+checksums           rmd160  3249c4c5775632b660e224af65c6bf0eaf2401f3 \
+                    sha256  9fd3cffd9cf84b36f83e599ea2c41147032832f91d1efdf01fd8142d5bfe6b8e \
+                    size    99401139
 
 depends_build-append \
                     port:pkgconfig \

--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -10,8 +10,8 @@ wxWidgets.use       wxWidgets-3.2
 name                saga
 categories          gis
 license             GPL
-version             9.7.2
-revision            1
+version             9.8.1
+revision            0
 maintainers         {yahoo.com:n_larsson @nilason} {vince @Veence} openmaintainer
 
 description         SAGA is a GIS oriented towards statistics and analysis
@@ -26,9 +26,9 @@ homepage            https://saga-gis.sourceforge.io/en/index.html
 set master_sites_in sourceforge:project/saga-gis/SAGA%20-%20[lindex [split ${version} "."] 0]/SAGA%20-%20${version}
 master_sites        ${master_sites_in}
 
-checksums           rmd160  740cceb31b2959595d4a2e99de881754b4f140d5 \
-                    sha256  d675a91464414b8f6ecca97b9bfe1858523ede5be6db3281c98a51f65971b206 \
-                    size    9852216
+checksums           rmd160  2078567b291e1c0ce44b30f4c78b28d84b3d2c60 \
+                    sha256  34235e4f1478796309dce1dc044436319932f578841313ec70686b883bd761ff \
+                    size    9959164
 
 cmake.source_dir    ${worksrcpath}/saga-gis
 
@@ -138,7 +138,7 @@ if {${subport} eq ${name}} {
     }
 
     # Set PostgreSQL variant
-    set postgresql_suffixes {12 13 14 15 16}
+    set postgresql_suffixes {12 13 14 15 16 17}
     set postgresql_variants {}
     foreach suffix ${postgresql_suffixes} {
         lappend postgresql_variants postgresql${suffix}
@@ -159,7 +159,7 @@ if {${subport} eq ${name}} {
         set pgdefault "${pgdefault}!\[variant_isset postgresql${suffix}\] && "
     }
     set pgdefault [string range ${pgdefault} 0 end-4]
-    set pgdefault "${pgdefault}} { default_variants +postgresql16 }"
+    set pgdefault "${pgdefault}} { default_variants +postgresql17 }"
     eval ${pgdefault}
 }
 

--- a/gis/saga/files/patch-findpostgres-cmake.diff
+++ b/gis/saga/files/patch-findpostgres-cmake.diff
@@ -1,5 +1,5 @@
---- saga-gis/cmake/modules/FindPostgres.cmake.orig	2024-04-15 12:03:58
-+++ saga-gis/cmake/modules/FindPostgres.cmake	2024-04-16 13:26:18
+--- saga-gis/cmake/modules/FindPostgres.cmake.orig	2025-05-12 14:20:06
++++ saga-gis/cmake/modules/FindPostgres.cmake	2025-07-08 19:10:32
 @@ -61,13 +61,7 @@
    IF(UNIX) 
  
@@ -15,12 +15,3 @@
      
      IF (POSTGRES_CONFIG) 
        # set INCLUDE_DIR
-@@ -77,7 +71,7 @@
-       SET(POSTGRES_INCLUDE_DIR ${PG_TMP} CACHE STRING INTERNAL)
- 
-       # set LIBRARY_DIR
--      execute_process(COMMAND ${POSTGRES_CONFIG} --includedir
-+      execute_process(COMMAND ${POSTGRES_CONFIG} --libdir
-         OUTPUT_VARIABLE PG_TMP
-         OUTPUT_STRIP_TRAILING_WHITESPACE)
-       IF (APPLE)

--- a/python/py-pdal-plugins/Portfile
+++ b/python/py-pdal-plugins/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pdal-plugins
-version             1.6.2
+version             1.6.5
 revision            0
 
 categories-append   gis
@@ -20,9 +20,9 @@ homepage            https://www.pdal.io
 
 distname            [string map {- _} ${python.rootname}]-${version}
 
-checksums           rmd160  acecaafe5847e2af10b69ccdd9094f6546ebd3ce \
-                    sha256  aa868401f2595e739b420a902ac1f63dfc38f0e4da77fcfd088a7fb4c4e4e342 \
-                    size    575594
+checksums           rmd160  91162507ec118282eb3f79c6b574070e72e4e84b \
+                    sha256  a423508bd43037e92e1c93cac3de177c8aee8a8376c25f167813ad8d534596f1 \
+                    size    539021
 
 python.versions     39 310 311 312 313
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- `pdal`: update to 2.9.0
- `pdal-pgpointcloud`: add postgresql17 (default) variant
- `py-pdal-plugins`: update to 1.6.5
- `saga`: update to 9.8.1




###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
