### PR TITLE
micronaut: update to 4.9.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.8.3 v
+github.setup    micronaut-projects micronaut-starter 4.9.1 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  2afc6bc53bd45ed17e2fe221aa4868ae68abbf8a \
-                 sha256  c736ead04c1e51e498d7d1e8a10ce5a0add07070734982deaa3f8a7ce644a337 \
-                 size    28162348
+    checksums    rmd160  a25c70d6d3793573bb00127cb60c51e3e8585a9f \
+                 sha256  2a33d40487e69fe6023c6915ce9a8f3dcc1f40194679128b976ddacd34718b04 \
+                 size    28611010
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  3ebd24540d737224222e43366381b764f9d29a33 \
-                 sha256  d45387ab3a1849d02d94ed81411b9126a103288be098b58580dfe227d3a6d7e2 \
-                 size    27925161
+    checksums    rmd160  b0262aa86eb589ebbf4ddaf473afce30b090ec56 \
+                 sha256  70c3f6ee959011bb2eec624308a310bb0d1e2f18a14f6e139e9f2458fd31fc18 \
+                 size    28383606
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.9.1.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?