### PR TITLE
uv: Update to 0.7.20

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -10,7 +10,7 @@ PortGroup               github 1.0
 #
 # See: https://github.com/macports/macports-ports/pull/27661#issuecomment-2660783907
 
-github.setup            astral-sh uv 0.7.11
+github.setup            astral-sh uv 0.7.20
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -22,9 +22,9 @@ description             Extremely fast Python package and project manager
 long_description        {*}${description}, written in Rust.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  b3e3eeedc759aa3776e0b2c8738e9d857cb5883e \
-                        sha256  6c0c23f99adf51164a83f8b4155a1f7fa16e01c6cb2deaaa68e60e531e8076c0 \
-                        size    4035420
+                        rmd160  b64e1a53d44e51699c34797389556e1e42648cd7 \
+                        sha256  c07afb70c926715b4280815393770350b2cfc63c899bc171f508c74de7fc3f5e \
+                        size    4127300
 
 # Fix opportunistic linking with libiconv and xz
 #
@@ -99,12 +99,13 @@ cargo.crates \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
-    anstream                        0.6.18  8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b \
+    anstream                        0.6.19  301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933 \
     anstyle                         1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
     anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                   3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
     anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
+    approx                           0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
     arbitrary                        1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arcstr                           1.2.0  03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d \
     arrayref                         0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
@@ -113,7 +114,7 @@ cargo.crates \
     assert_cmd                      2.0.17  2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66 \
     assert_fs                        1.1.3  a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9 \
     astral-tokio-tar                 0.5.2  1abb2bfba199d9ec4759b797115ba6ae435bdd920ce99783bb53aeff57ba919b \
-    async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
+    async-channel                    2.5.0  924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2 \
     async-compression               0.4.18  df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522 \
     async-trait                     0.1.88  e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
     async_http_range_reader          0.9.1  2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197 \
@@ -127,12 +128,13 @@ cargo.crates \
     backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
+    bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
     bisection                        0.1.0  021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                         2.9.1  1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967 \
     blake2                          0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    boxcar                          0.2.12  66bb12751a83493ef4b8da1120451a262554e216a247f14b48cb5e8fe7ed8bdf \
+    boxcar                          0.2.13  26c4925bc979b677330a8c7fe7a8c94af2dbb4a2d37b4a20a80d884400f46baa \
     bstr                            1.11.3  531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0 \
     bumpalo                         3.17.0  1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf \
     bytecheck                        0.8.1  50690fb3370fb9fe3550372746084c46f2ac8c9685c583d2be10eefd89d3d1a3 \
@@ -145,7 +147,7 @@ cargo.crates \
     bzip2                            0.5.0  bafdbf26611df8c14810e268ddceda071c297570a5fb360ceddf617fe417ef58 \
     bzip2-sys                 0.1.11+1.0.8  736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc \
     camino                           1.1.9  8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3 \
-    cargo-util                      0.2.20  d767bc85f367f6483a6072430b56f5c0d6ee7636751a21a800526d0711753d76 \
+    cargo-util                      0.2.21  c95ec8b2485b20aed818bd7460f8eecc6c87c35c84191b353a3aba9aa1736c36 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     cc                              1.2.11  e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
@@ -154,16 +156,16 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.39  fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f \
-    clap_builder                    4.5.39  89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51 \
+    clap                            4.5.40  40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f \
+    clap_builder                    4.5.40  e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e \
     clap_complete                   4.5.44  375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6 \
     clap_complete_command            0.6.1  da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62 \
     clap_complete_nushell            4.5.5  c6a8b1593457dfc2fe539002b795710d022dc62a65bf15023f039f9760c7b18a \
-    clap_derive                     4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
+    clap_derive                     4.5.40  d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
-    codspeed                        2.10.1  93f4cce9c27c49c4f101fffeebb1826f41a9df2e7498b7cd4d95c0658b796c6c \
-    codspeed-criterion-compat       2.10.1  c3c23d880a28a2aab52d38ca8481dd7a3187157d0a952196b6db1db3c8499725 \
-    codspeed-criterion-compat-walltime 2.10.1 7b0a2f7365e347f4f22a67e9ea689bf7bc89900a354e22e26cf8a531a42c8fbb \
+    codspeed                         3.0.2  922018102595f6668cdd09c03f4bff2d951ce2318c6dca4fe11bdcb24b65b2bf \
+    codspeed-criterion-compat        3.0.2  24d8ad82d2383cb74995f58993cbdd2914aed57b2f91f46580310dd81dc3d05a \
+    codspeed-criterion-compat-walltime 3.0.2 61badaa6c452d192a29f8387147888f0ab358553597c3fe9bf8a162ef7c2fa64 \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     colored                          2.2.0  117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c \
@@ -212,12 +214,12 @@ cargo.crates \
     errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
     etcetera                        0.10.0  26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6 \
     event-listener                   5.4.0  3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae \
-    event-listener-strategy          0.5.3  3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2 \
+    event-listener-strategy          0.5.4  8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93 \
     fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     fdeflate                         0.3.7  1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c \
     filetime                        0.2.25  35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586 \
     fixedbitset                      0.5.7  1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99 \
-    flate2                           1.1.1  7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece \
+    flate2                           1.1.2  4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d \
     float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
     float-cmp                       0.10.0  b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
@@ -226,7 +228,7 @@ cargo.crates \
     fontdb                          0.12.0  ff20bef7942a72af07104346154a70a70b089c572e454b41bef6eb6cb10e9c06 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fs-err                          2.11.0  88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41 \
-    fs-err                           3.1.0  1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa \
+    fs-err                           3.1.1  88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683 \
     fs2                              0.4.3  9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
     futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
     futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
@@ -251,7 +253,7 @@ cargo.crates \
     h2                               0.4.7  ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e \
     half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashbrown                       0.15.3  84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3 \
+    hashbrown                       0.15.4  5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
@@ -267,7 +269,7 @@ cargo.crates \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     hyper                            1.6.0  cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80 \
     hyper-rustls                    0.27.5  2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2 \
-    hyper-util                      0.1.12  cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710 \
+    hyper-util                      0.1.14  dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb \
     icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
     icu_locid                        1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
     icu_locid_transform              1.5.0  01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e \
@@ -283,12 +285,12 @@ cargo.crates \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
     image                           0.25.5  cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b \
     imagesize                       0.11.0  b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf \
-    indexmap                         2.9.0  cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e \
+    indexmap                        2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
     indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
     indoc                            2.0.6  f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
     insta                           1.43.1  154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371 \
-    instant                         0.1.13  e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222 \
     ipnet                           2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
+    iri-string                       0.7.8  dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2 \
     is-terminal                     0.4.15  e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37 \
     is_ci                            1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
@@ -296,8 +298,8 @@ cargo.crates \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
-    jiff                            0.2.14  a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93 \
-    jiff-static                     0.2.14  6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442 \
+    jiff                            0.2.15  be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49 \
+    jiff-static                     0.2.15  03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4 \
     jiff-tzdb                        0.1.4  c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524 \
     jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jobserver                       0.1.32  48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0 \
@@ -310,7 +312,7 @@ cargo.crates \
     libc                           0.2.171  c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6 \
     libmimalloc-sys                 0.1.39  23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    libz-rs-sys                      0.5.0  6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a \
+    libz-rs-sys                      0.5.1  172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221 \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                    0.9.2  6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9 \
     litemap                          0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
@@ -323,7 +325,7 @@ cargo.crates \
     markdown                         1.0.0  a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
-    memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
+    memchr                           2.7.5  32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0 \
     memmap2                         0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
     memmap2                          0.9.5  fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f \
     miette                           7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
@@ -352,11 +354,9 @@ cargo.crates \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     os_str_bytes                     6.6.1  e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
-    owo-colors                       4.2.1  26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec \
+    owo-colors                       4.2.2  48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e \
     parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
-    parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
-    parking_lot_core                 0.8.6  60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc \
     parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
     path-slash                       0.2.1  1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42 \
@@ -366,7 +366,7 @@ cargo.crates \
     pest_derive                     2.7.15  816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e \
     pest_generator                  2.7.15  7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b \
     pest_meta                       2.7.15  e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea \
-    petgraph                         0.8.1  7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06 \
+    petgraph                         0.8.2  54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca \
     pico-args                        0.5.0  5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315 \
     pin-project                      1.1.8  1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916 \
     pin-project-internal             1.1.8  d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb \
@@ -401,7 +401,6 @@ cargo.crates \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     rctree                           0.5.0  3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f \
-    redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
     redox_syscall                    0.5.8  03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834 \
     redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
     ref-cast                        1.0.24  4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf \
@@ -413,9 +412,7 @@ cargo.crates \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     rend                             0.5.2  a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215 \
-    reqwest                        0.12.15  d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb \
-    reqwest-middleware               0.4.2  57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e \
-    reqwest-retry                    0.7.0  29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178 \
+    reqwest                        0.12.22  cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531 \
     resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
     retry-policies                   0.4.0  5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c \
     rgb                             0.8.50  57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a \
@@ -434,7 +431,6 @@ cargo.crates \
     rustix                           1.0.7  c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266 \
     rustls                         0.23.22  9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
-    rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.11.0  917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c \
     rustls-webpki                  0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
     rustversion                     1.0.19  f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4 \
@@ -442,8 +438,8 @@ cargo.crates \
     ryu                             1.0.19  6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
-    schemars                        0.8.22  3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615 \
-    schemars_derive                 0.8.22  32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d \
+    schemars                         1.0.4  82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0 \
+    schemars_derive                  1.0.4  33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scroll                          0.13.0  c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add \
     scroll_derive                   0.13.0  22fc4f90c27b57691bbaf11d8ecc7cfbfe98a4da6dbe60226115d322aa80c06e \
@@ -457,7 +453,7 @@ cargo.crates \
     serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
     serde_json                     1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
-    serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
+    serde_spanned                    0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     serde_yaml           0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
@@ -472,11 +468,12 @@ cargo.crates \
     simplecss                        0.2.2  7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c \
     siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
-    smallvec                        1.15.0  8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9 \
+    smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     smawk                            0.3.2  b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c \
     socket2                          0.5.9  4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef \
     spdx                            0.10.8  58b69356da67e2fc1f542c71ea7e654a361a79c938e4424392ecf4fa065d2193 \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
+    statrs                          0.18.0  2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e \
     strict-num                       0.1.1  6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
@@ -487,7 +484,7 @@ cargo.crates \
     svgfilters                       0.4.0  639abcebc15fdc2df179f37d6f5463d660c1c79cd552c12343a4600827a04bce \
     svgtypes                         0.9.0  c9ee29c1407a5b18ccfe5f6ac82ac11bab3b14407e09c209a6c1a32098b19734 \
     svgtypes                        0.10.0  98ffacedcdcf1da6579c907279b4f3c5492fbce99fbbf227f5ed270a589c2765 \
-    syn                            2.0.101  8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf \
+    syn                            2.0.104  17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
@@ -501,8 +498,8 @@ cargo.crates \
     test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
     test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
-    test-log                        0.2.17  e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f \
-    test-log-macros                 0.2.17  888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f \
+    test-log                        0.2.18  1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b \
+    test-log-macros                 0.2.18  451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36 \
     textwrap                        0.16.2  c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
     thiserror                       2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
@@ -520,14 +517,14 @@ cargo.crates \
     tokio                           1.45.1  75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779 \
     tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-rustls                    0.26.1  5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37 \
-    tokio-socks                      0.5.2  0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f \
     tokio-stream                    0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
     tokio-util                      0.7.15  66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df \
-    toml                            0.8.22  05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae \
-    toml_datetime                    0.6.9  3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3 \
-    toml_edit                      0.22.26  310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e \
-    toml_write                       0.1.1  bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076 \
+    toml                            0.8.23  dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362 \
+    toml_datetime                   0.6.11  22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
+    toml_edit                      0.22.27  41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
+    toml_write                       0.1.2  5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801 \
     tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
+    tower-http                       0.6.6  adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
@@ -556,7 +553,7 @@ cargo.crates \
     unicode-script                   0.5.7  9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f \
     unicode-vo                       0.1.0  b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94 \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
-    unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
+    unicode-width                    0.2.1  4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c \
     unsafe-libyaml                  0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     unscanny                         0.1.0  e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
@@ -583,12 +580,13 @@ cargo.crates \
     wasm-bindgen-macro-support     0.2.100  8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de \
     wasm-bindgen-shared            0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
     wasm-streams                     0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
-    wasm-timer                       0.2.5  be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f \
+    wasmtimer                        0.4.1  0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23 \
     web-sys                         0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                    0.26.8  2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9 \
+    webpki-roots                     1.0.1  8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502 \
     weezl                            0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
-    which                            7.0.3  24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762 \
+    which                            8.0.0  d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d \
     whoami                           1.6.0  6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7 \
     widestring                       1.1.0  7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
@@ -608,14 +606,13 @@ cargo.crates \
     windows-implement               0.60.0  a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836 \
     windows-interface               0.57.0  29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7 \
     windows-interface               0.59.1  bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8 \
-    windows-link                     0.1.1  76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38 \
+    windows-link                     0.1.3  5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a \
     windows-numerics                 0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
-    windows-registry                 0.4.0  4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3 \
-    windows-registry                 0.5.2  b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820 \
+    windows-registry                 0.5.3  5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e \
     windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
     windows-result                   0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
     windows-strings                  0.3.1  87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319 \
-    windows-strings                  0.4.1  2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a \
+    windows-strings                  0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
@@ -645,9 +642,9 @@ cargo.crates \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
-    winnow                           0.7.7  6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5 \
+    winnow                          0.7.11  74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
-    wiremock                         0.6.3  101681b74cd87b5899e87bcf5a64e83334dd313fcd3053ea72e6dba18928e301 \
+    wiremock                         0.6.4  a2b8b99d4cdbf36b239a9532e31fe4fb8acc38d1897c1761e161550a7dc78e6a \
     wit-bindgen-rt                  0.33.0  3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
@@ -665,7 +662,7 @@ cargo.crates \
     zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
     zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
     zip                              2.3.0  84e9a772a54b54236b9b744aaaf8d7be01b4d6e99725523cb82cb32d1c81b1d7 \
-    zlib-rs                          0.5.0  868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8 \
+    zlib-rs                          0.5.1  626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a \
     zopfli                           0.8.1  e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946 \
     zstd                            0.13.2  fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9 \
     zstd-safe                        7.2.1  54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.7.20

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
