### PR TITLE
dvdauthor: add missing build dependency on gettext

### DIFF
--- a/multimedia/dvdauthor/Portfile
+++ b/multimedia/dvdauthor/Portfile
@@ -24,7 +24,8 @@ checksums           rmd160  8e97697cb81d4c3b454961221c8c1aab4ddc7f59 \
                     sha256  3020a92de9f78eb36f48b6f22d5a001c47107826634a785a62dfcd080f612eb7 \
                     size    648305
 
-depends_build       port:pkgconfig
+depends_build       port:pkgconfig \
+                    port:gettext
 
 depends_lib         port:libdvdread \
                     port:fribidi \


### PR DESCRIPTION
Fixes build failure caused by a missing AM_ICONV macro during the
configure step. Adding gettext as a build dependency resolves the
issue.

Closes: https://trac.macports.org/ticket/69651

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Xcode 14.2 / Command Line Tools 14.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open 
a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
