### PR TITLE
nim: update to 2.2.4

### DIFF
--- a/lang/nim/Portfile
+++ b/lang/nim/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                nim
-version             2.2.2
+version             2.2.4
 revision            0
 license             MIT
 categories          lang
@@ -20,9 +20,9 @@ long_description    Nim is a statically typed compiled systems programming \
 homepage            https://nim-lang.org
 
 master_sites        ${homepage}/download/
-checksums           rmd160  96b6c4297d9474d519ac5c8188f57b0d885a9841 \
-                    sha256  7fcc9b87ac9c0ba5a489fdc26e2d8480ce96a3ca622100d6267ef92135fd8a1f \
-                    size    8188616
+checksums           rmd160  3f66546c376a3eda4af8879db139d7562bc41fbb \
+                    sha256  f82b419750fcce561f3f897a0486b180186845d76fb5d99f248ce166108189c7 \
+                    size    8168916
 
 use_configure       no
 use_xz              yes
@@ -36,9 +36,7 @@ build {
         # nim looks for aarch64 and not arm/arm64
         set nim_build_arch "aarch64"
     }
-    system -W ${worksrcpath} \
-        "./build.sh --os ${os.platform} --cpu ${nim_build_arch}"
-
+    system -W ${worksrcpath} "./build.sh --os ${os.platform} --cpu ${nim_build_arch}"
     system -W ${worksrcpath} "./bin/nim c koch"
     system -W ${worksrcpath} "./koch boot -d:release"
     system -W ${worksrcpath} "./koch tools -d:release"


### PR DESCRIPTION
#### Description

Update to current version

###### Tested on
macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
