### PR TITLE
borgbackup: Update to 1.4.1, use Python 3.13, ignore msgpack version

### DIFF
--- a/python/py-msgpack/Portfile
+++ b/python/py-msgpack/Portfile
@@ -5,6 +5,11 @@ PortGroup           python 1.0
 PortGroup           compiler_wrapper 1.0
 
 name                py-msgpack
+
+# Note that borgbackup has an in-code check that starts failing when msgpack is
+# updated to a version it does not allowlist yet. We have removed this check
+# downstream, but to avoid breaking our users' backups, please run `sudo port
+# test borgbackup` with an updated msgpack before committing. Thanks!
 version             1.1.1
 revision            0
 categories-append   devel

--- a/sysutils/borgbackup/Portfile
+++ b/sysutils/borgbackup/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                borgbackup
-version             1.4.0
+version             1.4.1
 revision            0
 
 categories          sysutils
@@ -23,11 +23,14 @@ long_description    BorgBackup (short: Borg) is a deduplicating backup \
 
 homepage            https://www.borgbackup.org/
 
-checksums           rmd160  988cbdc2a5697cb0b10e062644e26575db4e8bdc \
-                    sha256  c54c45155643fa66fed7f9ff2d134ea0a58d0ac197c18781ddc2fb236bf6ed29 \
-                    size    3798511
+checksums           rmd160  51bf968d6242ccb37042809df59dc7fce1937d49 \
+                    sha256  b8fbf8f1c19d900b6b32a5a1dc131c5d8665a7c7eea409e9095209100b903839 \
+                    size    3817197
 
-python.default_version  312
+patchfiles          patch-accept-newer-msgpack.diff \
+                    patch-docs-use-sphinx_rtd_theme.diff
+
+python.default_version  313
 
 depends_build-append \
                     port:py${python.version}-cython \
@@ -45,14 +48,19 @@ depends_lib-append  path:lib/libssl.dylib:openssl \
 depends_run-append  port:py${python.version}-msgpack \
                     port:py${python.version}-packaging
 
+# Run tests, but skip test_unix_socket, since it will fail because the path is
+# longer than the maximum length of a unix socket name when run in a MacPorts
+# build.
+depends_test-append port:py${python.version}-pytest-xdist \
+                    port:py${python.version}-pytest-benchmark
+
+test.run            yes
+test.args-append    -k 'not test_unix_socket' \
+                    -n ${build.jobs} \
+                    --pyargs borg.testsuite
+
 post-build {
-    reinplace "s|sphinx-build|sphinx-build-${python.branch}|g" \
-        ${worksrcpath}/docs/Makefile
-    reinplace "s|guzzle_sphinx_theme|sphinx_rtd_theme|g" \
-        ${worksrcpath}/docs/conf.py
-    reinplace "s|sphinx_rtd_theme.html_theme_path()|sphinx_rtd_theme.get_html_theme_path()|g" \
-        ${worksrcpath}/docs/conf.py
-    system "make -C ${worksrcpath}/docs man singlehtml"
+    system "make -C [shellescape ${worksrcpath}/docs] man singlehtml SPHINXBUILD=[shellescape sphinx-build-${python.branch}]"
 }
 
 post-destroot {

--- a/sysutils/borgbackup/files/patch-accept-newer-msgpack.diff
+++ b/sysutils/borgbackup/files/patch-accept-newer-msgpack.diff
@@ -1,0 +1,98 @@
+borgbackup: Accept newer msgpack versions
+
+Upstream borgbackup added a check in February 2019 that requires
+manually allowlisting new msgpack versions [1]. This was done in
+response to a number of problematic releases of msgpack back then, which
+caused problems for borgbackup [2]. This was around the time that Python
+3.4 to 3.6 were current, and there seemed to have been problems with
+support for 3.4, which msgpack dropped early, as well as a data
+corruption issue in the pure python msgpack when using 0.4.6. [3]
+
+In the 0.5.x series of releases, borgbackup upstream had concerns about
+warnings that broke tests [4], build failures [5], memory leaks [6] and
+other issues based on the msgpack ChangeLog [7].
+
+Since then, upstream has updated the file that checks for the specific
+msgpack version 13 times without major problems in:
+
+- https://github.com/borgbackup/borg/commit/0ebfaa5b61a675c22cda301bc20d0b00372dd181
+- https://github.com/borgbackup/borg/commit/e2ee7fd24b73f560168b89bf8b7d457de58a56ee
+- https://github.com/borgbackup/borg/commit/da6d1ac538827100fc8a546378fb5fd9bca6ca7d
+- https://github.com/borgbackup/borg/commit/0937ae90787b7a42f29818a49197e93e1301114b
+- https://github.com/borgbackup/borg/commit/a970f000b04f808c712eee5e53a32dec66efe803
+- https://github.com/borgbackup/borg/commit/1ab90b339e39535e74695b1f5d7176c90f035164
+- https://github.com/borgbackup/borg/commit/bc9ce99e9b86f964aad6276c8f5d76983193958c
+- https://github.com/borgbackup/borg/commit/95e75b90f1a092bad10e0b93ef065e78dfabb227
+- https://github.com/borgbackup/borg/commit/cdcab4df6851b5d3da6ac5435bcaeb8aa1d632b5
+- https://github.com/borgbackup/borg/commit/a507a2cb3b9fed025743e80971ce1615887a47e4
+- https://github.com/borgbackup/borg/commit/d43892d474499a56460753332748f0653a4d571e
+- https://github.com/borgbackup/borg/commit/862f19aab9780b91424bb7f9319d915751d0024f
+- https://github.com/borgbackup/borg/commit/467d0604dae10b816b3f80d8237f2f0353d8c27f
+
+In once instance, a release (1.0.1) was added to the blocklist:
+
+- https://github.com/borgbackup/borg/commit/12d9110882da6fb72537f243dd6bc09cb96c615f
+
+The commit message says it is unclear whether the (unspecified) issues
+affect borgbackup. The upstream msgpack ChangeLog [8] between the
+blocklisted 1.0.1 release and the allowlisted 1.0.2 refers to a year
+2038 regression tracked in [9], which apparently never affected macOS
+[10].
+
+At the same time, this check for a specific version of msgpack has
+caused no fewer than 5 tickets for MacPorts because the installed
+borgbackup broke on users systems when msgpack was updated, and one
+commit without a ticket for the same problem:
+
+- https://trac.macports.org/ticket/56868
+- https://trac.macports.org/ticket/58215
+- https://trac.macports.org/ticket/68998
+- https://trac.macports.org/ticket/69452
+- https://trac.macports.org/ticket/72682
+- https://github.com/macports/macports-ports/commit/ab8dad0225ef9840744a00588400159fbed976b0
+
+The NetBSD pkgsrc people did ask whether the msgpack check is still
+required in 2024 [11] without a clear answer. Given the churn this check
+causes in MacPorts and the improved track record of the msgpack
+developers in avoiding problems, I think it's time to remove this check.
+I'll also add a comment to the msgpack Portfile to recommend testing
+borgbackup and enable the borgbackup testsuite so we can run some
+downstream tests instead.
+
+[1]: https://github.com/borgbackup/borg/commit/18c9feb7e31d9c3dcf8d70cbf89ad520e35d1848
+[2]: https://github.com/borgbackup/borg/issues/3753
+[3]: https://github.com/borgbackup/borg/issues/3753#issuecomment-380230635
+[4]: https://github.com/borgbackup/borg/issues/3753#issuecomment-380231618
+[5]: https://github.com/borgbackup/borg/issues/3753#issuecomment-380241819
+[6]: https://github.com/borgbackup/borg/issues/3753#issuecomment-380262549
+[7]: https://github.com/borgbackup/borg/issues/3753#issuecomment-380399945
+[8]: https://github.com/msgpack/msgpack-python/blob/main/ChangeLog.rst#102
+[9]: https://github.com/msgpack/msgpack-python/issues/451
+[10]: https://github.com/msgpack/msgpack-python/issues/451#issuecomment-747416323
+[11]: https://github.com/borgbackup/borg/issues/8144
+
+Upstream-Status: Inappropriate
+
+--- pyproject.toml.orig	2025-07-11 22:59:15
++++ pyproject.toml	2025-07-11 23:04:09
+@@ -34,7 +34,7 @@
+     # Please note:
+     # using any other msgpack version is not supported by borg development and
+     # any feedback related to issues caused by this will be ignored.
+-    "msgpack >=1.0.3, <=1.1.0",
++    "msgpack >=1.0.3",
+     "packaging",
+ ]
+ 
+--- src/borg/helpers/msgpack.py.orig	2025-07-11 22:57:44
++++ src/borg/helpers/msgpack.py	2025-07-11 22:58:46
+@@ -137,8 +137,7 @@
+ def is_supported_msgpack():
+     # DO NOT CHANGE OR REMOVE! See also requirements and comments in pyproject.toml.
+     import msgpack
+-    return (1, 0, 3) <= msgpack.version <= (1, 1, 0) and \
+-           msgpack.version not in []  # < add bad releases here to deny list
++    return msgpack.version not in []  # < add bad releases here to deny list
+ 
+ 
+ def get_limited_unpacker(kind):

--- a/sysutils/borgbackup/files/patch-docs-use-sphinx_rtd_theme.diff
+++ b/sysutils/borgbackup/files/patch-docs-use-sphinx_rtd_theme.diff
@@ -1,0 +1,34 @@
+docs: Use sphinx_rtd_theme
+
+Upstream has changed its docs theme, but we don't have this additional
+theme packaged in MacPorts and neither do we want the additional build
+depdendency. Patch the docs config file to switch back to the previous
+theme instead.
+
+Upstream-Status: Inappropriate [configuration]
+
+--- docs/conf.py.orig	2025-07-15 10:27:32
++++ docs/conf.py	2025-07-15 10:28:51
+@@ -99,10 +99,10 @@
+ 
+ # The theme to use for HTML and HTML Help pages.  See the documentation for
+ # a list of builtin themes.
+-import guzzle_sphinx_theme
++import sphinx_rtd_theme
+ 
+-html_theme_path = guzzle_sphinx_theme.html_theme_path()
+-html_theme = 'guzzle_sphinx_theme'
++html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
++html_theme = 'sphinx_rtd_theme'
+ 
+ 
+ def set_rst_settings(app):
+@@ -260,7 +260,7 @@
+     'sphinx.ext.coverage',
+     'sphinx.ext.viewcode',
+     'sphinxcontrib.jquery',  # jquery is not included anymore by default
+-    'guzzle_sphinx_theme',  # register the theme as an extension to generate a sitemap.xml
++    'sphinx_rtd_theme',  # register the theme as an extension to generate a sitemap.xml
+ ]
+ 
+ extlinks = {


### PR DESCRIPTION
#### Description

Update borgbackup to 1.4.1, which now supports Python 3.13, which is currently our preferred version.

Enable running borgbackup tests, since I'm adding a patch to remove the msgpack version check that keeps breaking otherwise working installations and causing churn. See the patch header of the added patchfile for an in-depth look at the situation to determine whether this check is a net benefit for MacPorts.

Change the reinplaces to fix the docs builds to use a patchfile, which is cleaner and allows us to document the rationale in the patch file header. Remove the reinplace that switches the sphinx-build executable by overriding the Makefile variable on the command line instead to fix an interrupted build, see https://trac.macports.org/ticket/72139.

Closes: https://trac.macports.org/ticket/72139
Closes: https://trac.macports.org/ticket/72682
Closes: https://trac.macports.org/ticket/72684

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
