### PR TITLE
fzy: update to 1.1

### DIFF
--- a/devel/fzy/Portfile
+++ b/devel/fzy/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           makefile 1.0
 PortGroup           github 1.0
 
-github.setup        jhawthorn fzy 1.0
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-revision            1
+github.setup        jhawthorn fzy 1.1 v
+github.tarball_from archive
+revision            0
 categories          devel
 license             MIT
 maintainers         nomaintainer
@@ -17,8 +17,8 @@ long_description    fzy tries to find the result the user intended. It does \
                     starts of words. This allows matching using acronyms or \
                     different parts of the path.
 
-checksums           rmd160  2ede1ebddd76596fbc49d4b57c9843ad8e192a89 \
-                    sha256  e27f6f65ced83615b95885f85f18af64a86810c98c457acc456a2cffdf0a7809 \
-                    size    47458
+checksums           rmd160  d778a207514c60d08eaa570016b2d5e6720bee9f \
+                    sha256  93d300d9c6c7063b2c6bda4e08a9704a029ec33f609718cd95443d1a890aff4e \
+                    size    49070
 
 test.run            yes


### PR DESCRIPTION
#### Description

update fzy to version 1.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.6 23H626 arm64
Xcode 15.4 15F31d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
