### PR TITLE
Revert "x264: improve livecheck"

### DIFF
--- a/multimedia/x264/Portfile
+++ b/multimedia/x264/Portfile
@@ -7,10 +7,11 @@ PortGroup           muniversal 1.1
 epoch               1
 
 gitlab.instance     https://code.videolan.org
+# Get latest stable commit id from
+# https://code.videolan.org/videolan/x264/-/tree/stable
 # Get minor version (X264_BUILD) from
 # https://code.videolan.org/videolan/x264/-/blob/stable/x264.h
-# Get patch version using commit id from
-# https://artifacts.videolan.org/x264/release-macos-arm64/
+# Run port livecheck to get patch version
 # Change in minor version requires rev-bumping dependents
 gitlab.setup        videolan x264 31e19f92f00c7003fa115047ce50978bc98c3a0d
 version             0.164.3108
@@ -66,6 +67,8 @@ platform darwin 8 {
 # sets its own optflags
 configure.optflags
 
-livecheck.url       ${git.url}
-livecheck.type      git
-livecheck.branch    stable
+# Can't livecheck stable branch but use it to validate version matches commit
+livecheck.url       https://artifacts.videolan.org/x264/release-macos-arm64/
+livecheck.type      regex
+livecheck.version   $rev
+livecheck.regex     "r(\[0-9]+)-$sha"


### PR DESCRIPTION
#### Description

This is causing build failures:

      Failed to parse file multimedia/x264/Portfile: invalid command name "livecheck.branch"

This reverts commit a9e6773b171a4ec6aafe738d9bfc35c1e2c8afb2.

**/cc** @mohd-akram 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.6 23H626 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
