### PR TITLE
py-llfuse: update to 1.5.1, add python 3.13 variant

### DIFF
--- a/python/py-llfuse/Portfile
+++ b/python/py-llfuse/Portfile
@@ -5,11 +5,11 @@ PortGroup           python 1.0
 PortGroup           fuse 1.0
 
 name                py-llfuse
-version             1.5.0
+version             1.5.1
 revision            0
-checksums           rmd160  81cd43b01454815baaf97ddc920099c8315a20c9 \
-                    sha256  d094448bb4eb20099537be53dc2b5b2c0369d36bde09207a9bb228cc3cd58ee1 \
-                    size    869259
+checksums           rmd160  ce88eb01bde3fcda708160c6f38349d8773c7799 \
+                    sha256  7c9be52289cf647e3d735104531cc23a1a89fd1be3a621613a1cc0991f1b2699 \
+                    size    959557
 
 categories-append   devel fuse
 license             LGPL-2+
@@ -21,7 +21,7 @@ long_description    Python-LLFUSE is a set of Python bindings for the low \
 
 homepage            https://github.com/python-llfuse/python-llfuse/
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_build-append    port:pkgconfig


### PR DESCRIPTION
#### Description

update to 1.5.1 adds a python 3.13 variant. This will be necessary for #28848 since there was no 3.13 variant and thus `port install borgbackup +fuse` would fail.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
