### PR TITLE
pinact: Update to 3.3.1

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.3.0 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.3.1 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,9 +16,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  68891d967b8db3611935cc71978baf5a1782a982 \
-                    sha256  2646a3857f59accf33812cb926ac8b1eb2d139de487686f08adff56c531eb83b \
-                    size    40237
+                    rmd160  2dfe60222e7652078dc5e513c00a7e1c46a32b47 \
+                    sha256  f4b34a86afd43d0ddd7df833e7755e131dd06cdbb057d549a52a707a7eee9184 \
+                    size    39497
 
 livecheck.regex     "v(\\d+\\.\\d+\\.\\d+)\$"
 
@@ -42,21 +42,22 @@ notes {
 
 
 
+
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
                         rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
                         sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
                         size    91208 \
                     gopkg.in/check.v1 \
-                        lock    20d25e280405 \
-                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
-                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
-                        size    30360 \
+                        lock    10cb98267c6c \
+                        rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
+                        sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
+                        size    32368 \
                     golang.org/x/text \
-                        lock    v0.23.0 \
-                        rmd160  febd99ac1a9d727290c467b44d1e4b6b90cf7c7d \
-                        sha256  fe8e1d49b2c470afa75311e5336594399227ddbb272cb0fb3dbef77efea30d63 \
-                        size    8974449 \
+                        lock    v0.24.0 \
+                        rmd160  b181709ec4248be6a143e2448942748f081b2f50 \
+                        sha256  329c3d21dc0465c090733bdb87cc596776a8492901411be9024028af808903ac \
+                        size    8974645 \
                     golang.org/x/term \
                         lock    v0.32.0 \
                         rmd160  b245db46f202e1df70d376b326aef1afe88b8a7b \
@@ -83,15 +84,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  c7caff4ba164feeebdcc568d6598931a20719827e05dfa18ac7d7c495d36b883 \
                         size    20797 \
                     github.com/urfave/cli \
-                        lock    v3.3.7 \
-                        rmd160  f6db18b3f81861fd9c87eb5cfcd40cd0dc0d6666 \
-                        sha256  130637bbd55c0eb4afa5a6d78b5ca208381d1c447166537aea4d470263dfdbea \
-                        size    6802058 \
+                        lock    v3.3.8 \
+                        rmd160  bb887122013f6f342e79338b6df7f4c2b319f84a \
+                        sha256  28f885c2b0e6e1e0ac4f7605741e9fc39e0401f1f5af648e029af046a69a1099 \
+                        size    6801980 \
                     github.com/suzuki-shunsuke/urfave-cli-v3-util \
-                        lock    v0.0.5 \
-                        rmd160  7790fbae62fea70864b484feb621a785d7b7899e \
-                        sha256  9076093018eba5a9175a63f54a82d0e2889c58e0565e9308c2cc5d8e3adf3cd9 \
-                        size    9236 \
+                        lock    v0.0.7 \
+                        rmd160  b3ca107c8c1430c04f335a7bed3166299f380a65 \
+                        sha256  ffaf37a33a0bd3af529cd3a8547135b3811c7c05553a47033f11242a35521024 \
+                        size    11822 \
                     github.com/suzuki-shunsuke/logrus-error \
                         lock    v0.1.4 \
                         rmd160  d52b0d1f07e0dde083a4deaea70d508880b724ba \
@@ -122,6 +123,11 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  db211aeb52d4a85a7dc8acf83f7475b5f4fa9092 \
                         sha256  36a05391b8c6cef99e9a9c78b598f3a8da8feed318b385eadcdede08ae5cc229 \
                         size    50327 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.9.0 \
+                        rmd160  acb8f644e5634bdae632cdb61ea736422aeb88f0 \
+                        sha256  65b0852e5c78fa920fef2176fa17180bf1f7f32a1163baacb44c2aa480845a16 \
+                        size    133682 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -142,11 +148,21 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  f40deae988781d59d399784445dc89fe84d69e37 \
                         sha256  05481ab8b5f3709d4bd49b5459159b32856f426f021225774db000ec15792f2e \
                         size    81411 \
+                    github.com/kr/text \
+                        lock    v0.2.0 \
+                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
+                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
+                        size    8702 \
+                    github.com/kr/pretty \
+                        lock    v0.3.1 \
+                        rmd160  8c08579b4c56cdc958794e77afe3413e80aa67c3 \
+                        sha256  7fcea475d6280976cf4a838e75d2b3a4105827316e588a80e49e8063d950c999 \
+                        size    10232 \
                     github.com/invopop/jsonschema \
-                        lock    v0.12.0 \
-                        rmd160  7e00a8f7d77808fd32c5718be18fa7963f982563 \
-                        sha256  31186f3d574b69f010532031dfa998c74be6e75935bea4252e4d24e70718a658 \
-                        size    32648 \
+                        lock    v0.13.0 \
+                        rmd160  8524a6c14b6288b502b4d8e481cc07b1141850f9 \
+                        sha256  7098b5e0ff261babbc693210e61c946db68eba2622bb2dc5c0a1426391a558a3 \
+                        size    33788 \
                     github.com/hashicorp/go-version \
                         lock    v1.7.0 \
                         rmd160  f17baae769838015801830335bfd94a0849cd21f \
@@ -163,10 +179,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
                         size    10418 \
                     github.com/google/go-github \
-                        lock    v72.0.0 \
-                        rmd160  ca4ecae25d3837f8c8b445fc8d731653c59649ce \
-                        sha256  a6de1954f2dad7fcaf36ff6191a0696162cab65c5b4cfbc958129a587ee0212f \
-                        size    815113 \
+                        lock    v73.0.0 \
+                        rmd160  e2e0312eb2bc91d7cf88b4b0f34dd3a7ad0ec2cc \
+                        sha256  916c7feb96e4940e7e4289d16a64cd4fbaffb21db801fcf7566b960b1c207349 \
+                        size    818435 \
                     github.com/google/go-cmp \
                         lock    v0.7.0 \
                         rmd160  3f04a79c291d786f9c69c2944bdd521402052a5c \


### PR DESCRIPTION
#### Description

pinact: Update to 3.3.1

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
