### PR TITLE
tomcat-native: update to 1.3.1

### DIFF
--- a/java/tomcat-native/Portfile
+++ b/java/tomcat-native/Portfile
@@ -4,12 +4,11 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                tomcat-native
-version             1.3.0
+version             1.3.1
 revision            0
 categories          java www
 maintainers         {thebishops.org:matt @mattbishop} openmaintainer
 license             Apache-2
-platforms           darwin
 
 description         Tomcat 7+ HTTP Server native library support.
 long_description    This port provides access to native apr and other \
@@ -18,9 +17,9 @@ long_description    This port provides access to native apr and other \
 homepage            https://tomcat.apache.org/
 master_sites        apache:tomcat/tomcat-connectors/native/${version}/source/
 
-checksums           rmd160  a4fd6aa40d2ef947ec117254cf31d6565c03b6bd \
-                    sha256  cd849ac0040fe979f96ce089b091c4055952cc3313c1aad452d48ad53ec36867 \
-                    size    345276
+checksums           rmd160  34aedc26eb546d663d687eb42c1f4ab95922bd8b \
+                    sha256  dd7f4c8a9dbc2391a2aeb6068e42dfce5c912bf3cdcb262892b3dfc188f565f5 \
+                    size    346588
 
 distname            ${name}-${version}-src
 worksrcdir          ${distname}/native


### PR DESCRIPTION
#### Description

Update Tomcat Native to version 1.3.1

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->

Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
