### PR TITLE
openjdk17-zulu: update to 17.60.17

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -15,10 +15,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.58.21
+version      ${feature}.60.17
 revision     0
 
-set openjdk_version ${feature}.0.15
+set openjdk_version ${feature}.0.16
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -30,14 +30,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  54b5423d131ea6af8e6f0e8721081acdd1ed505c \
-                 sha256  ebaa3d4c1eefd3d612320a5caf3e2b190d1a2524449f02afb0e5374eaadae628 \
-                 size    194285628
+    checksums    rmd160  cd20ad2319b9fdfcd2b9fabe669b9f3e50ae9e82 \
+                 sha256  6578d84c961b23f27bc7d504cb2fc45a47296bce382927d6485d404753a8a51a \
+                 size    194313773
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  8cd696044691cef10a71e9ebc8615b97748334fa \
-                 sha256  e63a2fc063d40945bb849912c38b70f7b18a3bf0c04e3e05b5dbe26938a6f356 \
-                 size    192224762
+    checksums    rmd160  b92f9913fd7649893fcb10617f17d70da98ce59e \
+                 sha256  1e23895f8edddd86dbc20a2820b1bd11695e7a6ac37f1bcee90492341aa5b32d \
+                 size    192274740
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.60.17.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?