### PR TITLE
openjdk11-zulu: update to 11.82.19

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -15,10 +15,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.80.21
+version      ${feature}.82.19
 revision     0
 
-set openjdk_version ${feature}.0.27
+set openjdk_version ${feature}.0.28
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -30,14 +30,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  2bd1c85ce3bfbe243207113d3add408a8f1cd486 \
-                 sha256  5b2cbab1cede1290a0cd30dfdac3687a1443ef08157f9a393671ca51e78c43aa \
-                 size    195072241
+    checksums    rmd160  ddd36449cd86c361740d22491b3e9432f6927455 \
+                 sha256  11c3a142f82ad10cd9e2bfc0884c36ee66de0ac1b3ed9c018e746345813f80c8 \
+                 size    195129168
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  822c0ee6e96648b7041103264fd1b1c66dcf596f \
-                 sha256  f24b8c06b586efbde158200e764e89d7437f2916f934616ca8bb14c307603624 \
-                 size    193066941
+    checksums    rmd160  593c24cdc4ae14146d1d21af32544c699d6d715d \
+                 sha256  5b104e96bb41dc38b1605d701e4482003acffbe48e25e15ba0cb7a1611821aa7 \
+                 size    193117149
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.82.19.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?