### PR TITLE
openjdk8-zulu: update to 8.88.0.19

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      ${feature}.86.0.25
+version      ${feature}.88.0.19
 revision     0
 
-set openjdk_version ${feature}.0.452
+set openjdk_version ${feature}.0.462
 
 description  Azul Zulu Community OpenJDK ${feature} (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -35,14 +35,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  32bb7f4a0d582cfaca0c9f0d191ac7cf5289a0e1 \
-                 sha256  0cb3d9b8c4285cd7e518e047975ec8eded90f61cd6ea0dea2d499ed4402e2ca0 \
-                 size    106917218
+    checksums    rmd160  1efb7d631a5e30c42132d33c51451375fffcf30e \
+                 sha256  e39adde0283ff1cb5c82193654c15688ea5ea4e6f38336d001c43d81d26c102c \
+                 size    106951722
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  75a96cd46062164fb0e4175498ef9c7c6d02e21e \
-                 sha256  796dbb0d13ac1bea1198e53e52ac576df25a1c5c43449a563fc0b7d7759935fc \
-                 size    104723196
+    checksums    rmd160  7487c9e88a74bd5a46aa4b6453cd63a89221c0c8 \
+                 sha256  abfb45c587b80646eedc679f5fd1c47f1851fd682a043adf5c46c0f55e4d2321 \
+                 size    104668047
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.88.0.19.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?