### PR TITLE
openjdk24-zulu: update to 24.32.13

### DIFF
--- a/java/openjdk24-zulu/Portfile
+++ b/java/openjdk24-zulu/Portfile
@@ -15,10 +15,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-24&os=macos&package=jdk#zulu
-version      ${feature}.30.11
+version      ${feature}.32.13
 revision     0
 
-set openjdk_version ${feature}.0.1
+set openjdk_version ${feature}.0.2
 
 description  Azul Zulu Community OpenJDK ${feature} (Short Term Support until September 2025)
 long_description {*}${description}\
@@ -33,14 +33,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  d8d38ccefd02424776c98a47711331ff1c8e22f2 \
-                 sha256  56118e8996aca5779554b129d0c2595f18fffa8bc6826cbe8116f6059f4eba16 \
-                 size    225389420
+    checksums    rmd160  ee02fc2a23e840acd49255059b95e3921793fc81 \
+                 sha256  50763e3b2ea0f7c6d59390537ddfccc77393e477bd4a75944742fe2d9b28dcba \
+                 size    225377318
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  48b4990db9db7a5231fa02dc956c5dba33934be0 \
-                 sha256  a49b2ada029c4f2e38cdb15b4808fa29de55662d3de63286919a9df1c788cfb1 \
-                 size    222919508
+    checksums    rmd160  6877c6f3495c4ffb9e6d1e21c8e7903023267b23 \
+                 sha256  8c31e83c6e0da4d5d52b7e723477b924192668a3408b19a63041343fd8dc7e75 \
+                 size    222905249
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 24.32.13.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?