### PR TITLE
google-cloud-sdk: update to 530.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             529.0.0
+version             530.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  79413fd2726ad634e8a133ac87bfcef8235e27ab \
-                    sha256  405aa63130b4db786471764444af19281e0cbf595466c9b98c6d24ef68684254 \
-                    size    54813095
+    checksums       rmd160  6c42e1c30eadf6f94b8d0d62e81b18feb192563e \
+                    sha256  befb5fbc4d325db4fba5900706eed7fafc474cc287b7621db75c579650f570f1 \
+                    size    54898529
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a0a27d9942e11ff9e95dfb1878d26c875d6fe9f7 \
-                    sha256  d2244db22ffd1bae9713e1d0ef5661befd2301a79203ebae9f29e995fe01d3e9 \
-                    size    56342082
+    checksums       rmd160  274bea0f065fdf86430f2c8a33982d1917a77a45 \
+                    sha256  b2a15c6fecc7437371f8ea79725d7ffcc007589f7688f691e00baa21f52832d7 \
+                    size    56429889
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  3ca449d70cb4a9645f37311d5b4eb707f7eafeb7 \
-                    sha256  75fc98465297923aa412cd6cb3476adaa9312e2c6fd0c2dec9f652ad19b89fce \
-                    size    56275074
+    checksums       rmd160  b5e1095cc9039519bb3fa8520f0d744cf95e6564 \
+                    sha256  f39f5b5954baea352bb59dc2e216932b19efdd392d7540bb2133c496a0c6cd10 \
+                    size    56361549
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 530.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?