### PR TITLE
maven3: update to 3.9.11

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.9.10
+version         3.9.11
 revision        0
 
 categories      java devel
@@ -35,9 +35,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  f933ee9d4ea301e797c0f78feeb55dcb996bfdf7 \
-                sha256  e036059b0ac63cdcc934afffaa125c9bf3f4a4cd2d2b9995e1aee92190a0979c \
-                size    8885210
+checksums       rmd160  0a30b36c6d19c3f2453aa48c99eb5c77d795c7ae \
+                sha256  4b7195b6a4f5c81af4c0212677a32ee8143643401bc6e1e8412e6b06ea82beac \
+                size    9160848
 
 java.version    1.8+
 java.fallback   openjdk21


### PR DESCRIPTION
#### Description

Update to Apache Maven 3.9.11.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?