### PR TITLE
mise: Update to 2025.7.10

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.7.3 v
+github.setup        jdx mise 2025.7.10 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  410e07b6a4e6882648400aa1d7eca3eb6b0b8ee0 \
-                    sha256  646ada3451e61b4a9fec0133c2f138cfd4af5a8b9fb56a70648f452124221f39 \
-                    size    4208842
+                    rmd160  2628ba09ace8bcc37b60abdc7167731e80848b74 \
+                    sha256  bc86c543a313c5cef7a23c8887c751f7ec3e56eb5916523052ad71df3ba686ee \
+                    size    4323146
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -107,6 +107,7 @@ cargo.crates \
     anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
     arbitrary                        1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
+    arrayref                         0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     async-backtrace                  0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
@@ -126,6 +127,7 @@ cargo.crates \
     bit-set                          0.6.0  f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f \
     bit-vec                          0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
     bitflags                         2.9.1  1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967 \
+    blake3                           1.8.2  3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0 \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     bstr                            1.12.0  234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4 \
     built                            0.8.0  f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64 \
@@ -149,11 +151,11 @@ cargo.crates \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
-    clap                            4.5.40  40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f \
-    clap_builder                    4.5.40  e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e \
-    clap_derive                     4.5.40  d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce \
+    clap                            4.5.41  be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9 \
+    clap_builder                    4.5.41  707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d \
+    clap_derive                     4.5.41  ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491 \
     clap_lex                         0.7.5  b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675 \
-    clap_mangen                     0.2.27  fc33c849748320656a90832f54a5eeecaa598e92557fb5dedebc3355746d31e4 \
+    clap_mangen                     0.2.28  e2fb6d3f935bbb9819391528b0e7cf655e78a0bc7a7c3d227211a1d24fc11db1 \
     clru                             0.6.2  cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59 \
     color-eyre                       0.6.5  e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d \
     color-print                      0.3.7  3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4 \
@@ -414,8 +416,8 @@ cargo.crates \
     logos-derive                    0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
     loom                             0.5.6  ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5 \
     lru-slab                         0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
-    lua-src                        547.0.0  1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42 \
-    luajit-src            210.5.12+a4f56a4  b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671 \
+    lua-src                        548.1.1  00bc4bd1f1d5c65b30717333cbec4fa7aa378978940a1bca62f404498d423233 \
+    luajit-src             210.6.1+f9140a6  813bd31f2759443affa687c0d9c5eb5cf6cb0e898810ab197408431d746054bf \
     lzma-rs                          0.3.0  297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e \
     lzma-rust                        0.1.7  5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661 \
     lzma-sys                        0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
@@ -431,9 +433,9 @@ cargo.crates \
     minisign-verify                  0.2.4  e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43 \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                              1.0.4  78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c \
-    mlua                            0.10.5  c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0 \
-    mlua-sys                         0.6.8  380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93 \
-    mlua_derive                     0.10.1  870d71c172fcf491c6b5fb4c04160619a2ee3e5a42a1402269c66bcbf1dd4deb \
+    mlua                     0.11.0-beta.3  20b35ffb9c638eaa0992057934110c0964fc14a6e033d7d70070fdfcbd2e4c62 \
+    mlua-sys                         0.8.1  0f2443fccee1fa88a880b371d9a0af28ff56b76ff52d9ff679559388cdcfc776 \
+    mlua_derive              0.11.0-beta.2  66b452b6259da19a715eb4f174d6856ddaf9b0582d4cc769536fdd319d794b9a \
     mockito                          1.7.0  7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48 \
     native-tls                      0.2.14  87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e \
     nix                             0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
@@ -614,7 +616,7 @@ cargo.crates \
     system-configuration-sys         0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
     tabled                          0.19.0  228d124371171cd39f0f454b58f73ddebeeef3cef3207a82ffea1c29465aea43 \
     tabled_derive                   0.11.0  0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846 \
-    taplo                           0.13.2  010941ac4171eaf12f1e26dfc11dadaf78619ea2330940fef01fe6bb0442d14d \
+    taplo                           0.14.0  c221a50eef1a5493074f11ca1ed62bef28c05a4d925002944cc686b2e783a5b3 \
     tar                             0.4.44  1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a \
     tempfile                        3.20.0  e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1 \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
@@ -690,7 +692,7 @@ cargo.crates \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
     versions                         7.0.0  80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f \
-    vfox                             1.0.5  ed8b4515b35f86ca1d3ea7c936e704ade91ec9f609000f3de82febdea27406da \
+    vfox                         2025.7.10  575a47680f1c1c1215f2bdc627eb94c2d2cc09e66553573c529c34c46de4512f \
     vte                             0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \


### PR DESCRIPTION
#### Description

mise: Update to 2025.7.10

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
