### PR TITLE
gnucash: update to 5.12

### DIFF
--- a/gnome/gnucash/Portfile
+++ b/gnome/gnucash/Portfile
@@ -12,7 +12,7 @@ legacysupport.use_mp_libcxx                 yes
 name              gnucash
 conflicts         gnucash gnucash-devel
 conflicts-delete  ${subport}
-version           5.11
+version           5.12
 perl5.branches    5.34
 categories        gnome x11
 license           GPL-2+
@@ -39,9 +39,9 @@ use_bzip2         yes
 distname          ${name}-${version}
 worksrcdir        ${name}-${version}
 
-checksums         rmd160  1aa170b4dc154ce83aeaf21223a0cf53b3bb7de4 \
-                  sha256  6ba42313aaaa99b5f07ff6e4dbc58b33fbf5f4be6e911376701d65c26fd4debe \
-                  size    15165344
+checksums         rmd160  9f12ff14010b5df4ffad42ccbfe949d2773654de \
+                  sha256  b35b4756be12bcfdbed54468f30443fa53f238520a9cead5bde2e6c4773fbf39 \
+                  size    15209384
 
 patchfiles-append   macintegration_4-files.patch
 patchfiles-append   patch-CMakeLists.txt.diff


### PR DESCRIPTION
#### Description

Update gnucash to upstream version 5.12.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.6 23H626 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`? (N.B. `port -t install` fails on Apple Silicon machines.)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
