### PR TITLE
jenv: update to 0.5.9

### DIFF
--- a/java/jenv/Portfile
+++ b/java/jenv/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    jenv jenv 0.5.7
+github.setup    jenv jenv 0.5.9
 revision        0
 
 categories      java
@@ -16,12 +16,12 @@ description     Master your Java environment with jEnv
 
 long_description jEnv is a command line tool to help you forget how to set the JAVA_HOME environment variable.
 
-homepage        https://www.jenv.be
+homepage        https://github.com/jenv/jenv
 github.tarball_from archive
 
-checksums       rmd160  8acc65ef031a935ffa40bd64bda82157a0c4aaf9 \
-                sha256  5865f7839eda303467fb1ad3dfb606b31566001beeb05360f653905346c2624f \
-                size    22717
+checksums       rmd160  ca3385f4cb9f0466c9cc5f35d0baa96f09f905ed \
+                sha256  137361c8a25eeabe6f90f435048a698e1c93e5718e0b57069e69f9e2b9ece63c \
+                size    28545
 
 use_configure   no
 
@@ -34,7 +34,7 @@ destroot {
     xinstall -m 755 -d ${target}
 
     # Copy over the files
-    foreach d { LICENSE README.md available-plugins bin completions fish libexec } {
+    foreach d { LICENSE CHANGELOG.md README.md available-plugins bin completions fish libexec } {
         copy ${worksrcpath}/${d} ${target}
     }
 


### PR DESCRIPTION
#### Description

* update jenv to 0.5.9
* include CHANGELOG.md in files
* update homepage to git repo as jenv.be no longer exists

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.6.1 23G93 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
