### PR TITLE
openjdk21-corretto: update to 21.0.8.9.1

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      ${feature}.0.7.6.1
+version      ${feature}.0.8.9.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  b80c261eb2fa6f61ebc2860c99b8b616e8712fc1 \
-                 sha256  162c8d39c77c15e1b522ab640951e691ea0951d7aaa48c7efec690cc0bdd6c31 \
-                 size    202443249
+    checksums    rmd160  b3bc4c35431f6ab61058b9cfb7a1ab9f89ccc67e \
+                 sha256  20c3e35d7c0f252e2f5426377591c2966538e58e176697190b2ad1d3ee122e93 \
+                 size    202544585
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  f0263122cb37987447f3c55e15124082e7d34b9b \
-                 sha256  911f8dc963a23a9ab417b5270662c7152ab99bb1634f75893a863c6eca91958c \
-                 size    200308124
+    checksums    rmd160  164597c7415612d1ab43156b4f26c5972eb8703f \
+                 sha256  046be4919537c3389b6a1785f992dc1fcba0b2b3b86a88b0ab08563c67ba0ec0 \
+                 size    200432492
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 21.0.8.9.1.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?