### PR TITLE
openjdk24-corretto: update to 24.0.2.12.1

### DIFF
--- a/java/openjdk24-corretto/Portfile
+++ b/java/openjdk24-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-24/releases
-version      ${feature}.0.1.9.1
+version      ${feature}.0.2.12.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Short Term Support until September 2025)
@@ -32,14 +32,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  fa98b3e93e903a60178f9c9ceb34e66042cfb92b \
-                 sha256  be0dcec5e8a67d17d34206f31b31a3da5c2c757318660b8a221a6f5593b45e9a \
-                 size    220044690
+    checksums    rmd160  f112525c8ea0ee52d4643671fc65fe33f2b27e8a \
+                 sha256  4ac3714d9b384cc0b966639c145c963222013fde19252c39abda8fb237d984ff \
+                 size    220029511
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  25f01ebe1fbb90ffbe335f1cbbde5844cc49dc58 \
-                 sha256  cdbf70570a0a9bfbee3524021e4b61ee3b1a8615162dfbb7edf80c1b6da5ff3b \
-                 size    217651724
+    checksums    rmd160  ac90feb426fb5a2bab4c321a44593ec92feef46f \
+                 sha256  ac4e961dbb047740d1e2de141dd739da9fee4b6b2d62151e33b3bbbdb0b592dc \
+                 size    217635696
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 24.0.2.12.1.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?