### PR TITLE
openjdk17-corretto: update to 17.0.16.8.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.15.6.1
+version      ${feature}.0.16.8.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  3dcbf66f5cdbab6502caf392a854ed30ddb7f486 \
-                 sha256  b840d10c3b51b4ba3829f7a7bfc230fe366fa1ed9218f46ecac4590be2fb04a7 \
-                 size    188139726
+    checksums    rmd160  b4ad37a4fcc46b5a59231d73a7db4d63b737471d \
+                 sha256  6a273cc8b58e07b42e78ef9fb89a1d421734792ab5bf66927d5ad376219d6ccd \
+                 size    188180365
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  b0e1c9dcf627dbd264bc310e181b3e2f5dd57c68 \
-                 sha256  0102047bbcf897fd66af96c0859d6a552973038a142f36ca64344d1b68f90d68 \
-                 size    186305356
+    checksums    rmd160  ca6130aa6c3a9a673b0c5726d83b9c6b613dcd6c \
+                 sha256  4db8ae4e60eed810e989c27c08df954913cd6b72344bee877c3e28d0557b03e6 \
+                 size    186334817
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.16.8.1.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?