### PR TITLE
openjdk11-corretto: update to 11.0.28.6.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      ${feature}.0.27.6.1
+version      ${feature}.0.28.6.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  0154ebb4c535c1b7c339215f6552d7ff51cf3128 \
-                 sha256  fdc87869eb29309d3bff60cd32848e5d2a85d52bda78ced5dabdd2e9872bdce1 \
-                 size    187879484
+    checksums    rmd160  ce9d00763d9cff560f5454db7caef5f179d82c2f \
+                 sha256  6df1f9fbd0b14655c727fed04f1dfa5ffa01e8a75e4004e4bf2c3ac4ec801445 \
+                 size    187942806
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  20430703498b69ae0e64b2a9994d7a1801f61f65 \
-                 sha256  da6e1b54afb4f15e949a1e51562e3488afd64218decc063b19cad588602fa9d2 \
-                 size    185492180
+    checksums    rmd160  c28c1f11d0fd500cd565db5ccd110c99ab9783ac \
+                 sha256  5fd69f12b4c961ed2fce17e29c1475f9a7b667cff0fe0a8ba26eb154ee0ede74 \
+                 size    185512031
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.28.6.1.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?