### PR TITLE
openjdk8-corretto: update to 8.462.08.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.452.09.1
+version      ${feature}.462.08.1
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -31,14 +31,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  2cbb2e2c13b368282f82166982e79bb39e00a9ec \
-                 sha256  a0645f8b5f0f551a7fd521356d1f0e4dc4d9279fe9d23c6bca2c0ce19f3c7ac4 \
-                 size    118516353
+    checksums    rmd160  6466bd32f603b31c2a00cee88a05b72e4332aecc \
+                 sha256  a62f720b599d8f0710b3c82e91900924e58ed00fffe71bdeb37afcf242df54db \
+                 size    118517226
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  bdcab9de758e572cb5abd4b2165d57606f32dba6 \
-                 sha256  66d064185b337bc1f104e7ccfb47644a48ca0c2b8ccbd1fdec308c0f6702078b \
-                 size    102949635
+    checksums    rmd160  92587e5edffd81902bdc8c9caed289dbfded475a \
+                 sha256  a71f369811f93b7aea3475daa79111bd2aea28dd088690621bb3fb5a46d888d1 \
+                 size    102955099
 }
 
 worksrcdir   amazon-corretto-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.462.08.1.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?