### PR TITLE
jdk24: update to 24.0.2

### DIFF
--- a/java/jdk24/Portfile
+++ b/java/jdk24/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk24-mac
-version      ${feature}.0.1
+version      ${feature}.0.2
 revision     0
 
 description  Oracle Java SE Development Kit ${feature} (Short Term Support until September 2025)
@@ -29,14 +29,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  aef9f2ccf17cf594caa403681628741a183e20f4 \
-                 sha256  cf77c1d143c94b8e0594822da608594c15f88749db808eaa36ebd6bd8b71a835 \
-                 size    239198871
+    checksums    rmd160  f3e68c01ca78fb0786eea1b4989fde69c0cd5ae0 \
+                 sha256  230b9d15b816206ae6773bd5ac6928abe3051bb4a5c0024075f40c69ac48e614 \
+                 size    239130736
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  e95cb3a692d063bf2083f7063a19a6c0768694e8 \
-                 sha256  692b4f8e7655a87a0a9c8f217c11d4d56995dfb114851fea8451759a5788a9fa \
-                 size    236087227
+    checksums    rmd160  8b016ed542545296db33bf62dfb013f73601672d \
+                 sha256  100c5088cce9a61e0879b06cb040302aa50afeeaa1475db63b5b78a99b0d8cf8 \
+                 size    236026759
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle Java SE 24.0.2.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?