### PR TITLE
openjdk24-graalvm: update to 24.0.2

### DIFF
--- a/java/openjdk24-graalvm/Portfile
+++ b/java/openjdk24-graalvm/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem       1.0
 
+set feature 24
 name             openjdk24-graalvm
 categories       java devel
 maintainers      {breun.nl:nils @breun} {mascguy @mascguy} openmaintainer
@@ -14,12 +15,11 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version          24.0.1
-set build        9
+version          ${feature}.0.2
+set build        11
 revision         0
-set port_ver_major [lindex [split ${version} .] 0]
 
-description      GraalVM Community Edition based on OpenJDK ${port_ver_major}
+description      GraalVM Community Edition based on OpenJDK ${feature} (Short Term Support until September 2025)
 long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
                  JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
 
@@ -27,14 +27,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-community-jdk-${version}_macos-x64_bin
-    checksums    rmd160  b7d1d45d3bb1f05e2eeeea6ebc94419b3255cc37 \
-                 sha256  452615d870ac9a6bf0fac09ff859d6c1a78e14d6f2a1937d610e7c6e470359e2 \
-                 size    304963827
+    checksums    rmd160  f480e328801692703b96bebcab8afdf6c8a7f956 \
+                 sha256  c59ed856d18dab156c54b2312e24668406050496670842864180ced31a1a76d3 \
+                 size    305002792
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  183b2c921258a5190591c518614b542826171c49 \
-                 sha256  0e18661fb350d76c7d4905484b72b90ecda38a0910b3a9a2856573086678cead \
-                 size    318629584
+    checksums    rmd160  52c2e94ac525a00731c396745ea736e50e571a4b \
+                 sha256  1f5068d07746fe472963189692922a1db58115b6ceaa5d9105a7433b81c6d587 \
+                 size    318680930
 }
 
 worksrcdir   graalvm-community-openjdk-${version}+${build}.1
@@ -75,7 +75,7 @@ test.args   -version
 destroot.violate_mtree yes
 
 set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-${port_ver_major}-oracle-graalvm-community.jdk
+set jdk ${jvms}/jdk-${feature}-oracle-graalvm-community.jdk
 
 destroot {
     xinstall -d ${destroot}${prefix}${jdk}


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 24.0.2.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?