### PR TITLE
jdk24-graalvm: update to 24.0.2

### DIFF
--- a/java/jdk24-graalvm/Portfile
+++ b/java/jdk24-graalvm/Portfile
@@ -16,8 +16,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava24-mac
 supported_archs  x86_64 arm64
 
-version     ${feature}.0.1
-set build 9
+version     ${feature}.0.2
+set build 11
 revision    0
 
 master_sites https://download.oracle.com/graalvm/${feature}/archive/
@@ -37,14 +37,14 @@ long_description {*}${description} \
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  cfdd199e9e006f4e7b8d728ccd238446a22fef65 \
-                 sha256  35852ef7040be5e73d4b8f23481c4f70e4dcb088d302e28f6a88e6a4d47de2b9 \
-                 size    344433795
+    checksums    rmd160  2f7b523cb830111bd77cbcf400857ac89f561d3b \
+                 sha256  df0f9e5d101201c50bfa6baa3c657a81a2883c5b5097a9f5ab93dab86f7e3ba2 \
+                 size    344642438
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  d7d624c2937f6ef05faafb28ef030547efde88c7 \
-                 sha256  875555f6063b4847b617504e8f8a36290a6726770be72388261f6118bcf28f81 \
-                 size    358863647
+    checksums    rmd160  70a9d0f45c08568f2ff7e9824797e299f337a055 \
+                 sha256  2dc7634ed939c725d41a353f73443ff32e70f2fb577367f12a6936107e3494dc \
+                 size    359008057
 }
 
 worksrcdir   graalvm-jdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM for JDK 24.0.2.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?