### PR TITLE
openjdk24: update to 24.0.2

### DIFF
--- a/java/openjdk24/Portfile
+++ b/java/openjdk24/Portfile
@@ -9,8 +9,8 @@ set boot_feature 23
 
 name                openjdk${feature}
 # See https://github.com/openjdk/jdk24u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             ${feature}.0.1
-set build 9
+version             ${feature}.0.2
+set build 12
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -25,9 +25,9 @@ master_sites        https://github.com/openjdk/jdk${feature}u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk${feature}u-${distname}
 
-checksums           rmd160  e4d431355090cdb11fe445cb8839541d89bb83ab \
-                    sha256  2ccaaf7c5f03b6f689347df99e6e34cd6d3b30bc56af815c8c152a6eeb6a6c25 \
-                    size    120717798
+checksums           rmd160  c31440c7579b1a69d3ff328d588a2ff7901cfc69 \
+                    sha256  d5a1b364de4335d86590d2e91eb8fce0560ade28759734c531915b8293e502e8 \
+                    size    120792603
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 24.0.2.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?