### PR TITLE
openjdk21: update to 21.0.8

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 set feature 21
 name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk21/ for the version and build number that matches the latest '-ga' version
-version             ${feature}.0.7
-set build 6
+version             ${feature}.0.8
+set build 9
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -26,9 +26,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  29b2690fb3f49dd19810de98ca609c6c5a1317c2 \
-                    sha256  18809fec2b348bd28ce7bdb4de27112431fdfef8e224f31e0beb0b79ce1ab5b1 \
-                    size    70334524
+checksums           rmd160  bcb7ca26a71c74cbec71f270f54f3e92d0b7538d \
+                    sha256  ad794448f9eac0e4c3637ec7a3c15a1384659500eb676ad768a381eeff2a9f10 \
+                    size    70692760
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.8.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?