### PR TITLE
openjdk17: update to 17.0.16

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 set feature 17
 name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk17/ for the version and build number that matches the latest '-ga' version
-version             ${feature}.0.15
-set build 6
+version             ${feature}.0.16
+set build 8
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -21,9 +21,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  815a4bf32aa6f4113f71eff5ae976ab871ed385a \
-                    sha256  0ead550ff5abe15df9c2c8b3656198e6e6679186b544e1fa329436e90eb46b31 \
-                    size    66554460
+checksums           rmd160  2476a325a78b3d25737a9a8237bceef2c64d62df \
+                    sha256  0e9b096352ca5e087cbb1447c914c55b60d8e17cc07bd90d8dcfbb271e8fed09 \
+                    size    66771860
 
 set port_jdk_build  openjdk${feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.16.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?