### PR TITLE
openjdk11: update to 11.0.28

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 set feature 11
 name                openjdk${feature}
 # See https://openjdk-sources.osci.io/openjdk11/ for the version and build number that matches the latest '-ga' version
-version             ${feature}.0.27
+version             ${feature}.0.28
 set build 6
 revision            0
 categories          java devel
@@ -21,9 +21,9 @@ distname            openjdk-${version}-ga
 use_xz              yes
 worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  15e931172743e26cf8a0c1807e4dc1606d51e418 \
-                    sha256  b5860fb5202d60530273a57a1a2a9b18af90bfd836705cd562963f2d41436578 \
-                    size    72315888
+checksums           rmd160  e1d4a0fcd64978c022f8ba2798f8320288c0e948 \
+                    sha256  712334ebfe8ad2acb8befee7ec7e57aec7205356b3696e7f181e342a771dbaa9 \
+                    size    72419936
 
 depends_lib         port:freetype \
                     port:libiconv


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.28.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?