### PR TITLE
openjdk24-sap: update to 24.0.2

### DIFF
--- a/java/openjdk24-sap/Portfile
+++ b/java/openjdk24-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/24
-version      ${feature}.0.1
+version      ${feature}.0.2
 revision     0
 
 description  SAP Machine ${feature} (Short Term Support until September 2025)
@@ -31,14 +31,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  c243321b5e4df4e711ba9a577df8dc0cac65eaef \
-                 sha256  df7443d4691ba478eab1a2180a2c37e51dffdb719d4db47e5a6fc28264ab2b1d \
-                 size    219674569
+    checksums    rmd160  d2a5ab6e4c6d20a34a0be14e8d93a83171c8e413 \
+                 sha256  9009da7da2b4b71e360e555de6a710a3c0c0b179eb3417d9abea1302ef6d3690 \
+                 size    219678374
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  ea8f42c3c2620d11e4b0c08871239d87d0708162 \
-                 sha256  771ecd30dde8f48257fcebfbeaab23a31fc4302ca45186c9e6682b9b5154813a \
-                 size    217338502
+    checksums    rmd160  471e3fa1bf2b0d2b792f61c4d3eca7f6e73ce52a \
+                 sha256  50a90420e5dc6675ce553bbc8167f0fdad50550f4240a746aaa3154c47b574fd \
+                 size    217343877
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 24.0.2.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?