### PR TITLE
openjdk21-sap: update to 21.0.8

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/21
-version      ${feature}.0.7
+version      ${feature}.0.8
 revision     0
 
 description  SAP Machine ${feature}
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  05441ce18b0836fcc7c88dddbc3b07bfc687854b \
-                 sha256  853cc0bc3242645326c47dc46117e8c3c5117202ea1fc711b502ab08bf9829e4 \
-                 size    202669047
+    checksums    rmd160  56a62ddd23c368b99d2fdc2954fed7d8ef5496c0 \
+                 sha256  243a730ec6a64a25239a1b45adc8c755892d3c8b8584c249dd6cb498d36e7773 \
+                 size    202790307
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  b557b2918bbf2b85e6c30bd26a3357a19fcf6344 \
-                 sha256  0c287f26b22f720addd3535de5852934112cbe2a01dfef5d36f0bca33b292d23 \
-                 size    200403831
+    checksums    rmd160  ef3ab9bc50e3ddda4ac60d992684ac09289563db \
+                 sha256  f177c93c35375f7841a243014d896d4931fda1a8d4a1e0570e2de8e5788bc207 \
+                 size    200533691
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 21.0.8.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?