### PR TITLE
git-annex: update to 10.20250630

### DIFF
--- a/devel/git-annex/Portfile
+++ b/devel/git-annex/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           haskell_stack 1.0
 
 name                git-annex
-version             10.20230321
-checksums           rmd160  d6ddd3c9ccce684f0d788c1308b6f451aa1a28c7 \
-                    sha256  7f4580835bdaeef8ae8c1c8f61abb43aafc39b986446d13093769aecbe047bd1 \
-                    size    1454067
+version             10.20250630
+checksums           rmd160  a267a6c17b655fc5cc157c8c58fa8094d3dc62e6 \
+                    sha256  03df602f2f72110d5a782a760399b64a57d37661f84aed6612d9d62d727459ed \
+                    size    1560178
 
 description         git-annex allows managing files with git, without checking the file contents into git
 long_description    \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update git-annex to 10.20250630.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
