### PR TITLE
openjdk17-sap: update to 17.0.16

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.15
+version      ${feature}.0.16
 revision     0
 
 description  OpenJDK ${feature} builds (Long Term Support) maintained and supported by SAP
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  de91b50ef3293cbbcf262d7b6281070836fe1ce2 \
-                 sha256  5dc0076b8c278080f9afb29b401c7736279a6722828ca822e1e70db941fa7052 \
-                 size    188400677
+    checksums    rmd160  738ac68319484b25694e12fac85c0484d09ad0eb \
+                 sha256  18b69fd17e5e05ebcc70d7ff16eb2e422681e8bf956c6c6d097038a61d1d2098 \
+                 size    188462400
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  c62632f3a464d853f439c414acf758bd429f9219 \
-                 sha256  4262936d6e098551166ab7902c4cf8897201004a9728ef86ad2401ab6cf30321 \
-                 size    186355877
+    checksums    rmd160  d6c3ab06508e388f6a46e270613b4f406b1acde5 \
+                 sha256  a76863317bf85282f82d0759c306f6d64df800bc57a21a84de305d31b0fd1b22 \
+                 size    186422566
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.16.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?