### PR TITLE
jdk21-graalvm: update to 21.0.8

### DIFF
--- a/java/jdk21-graalvm/Portfile
+++ b/java/jdk21-graalvm/Portfile
@@ -21,8 +21,8 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava21-mac
 supported_archs  x86_64 arm64
 
-version     ${feature}.0.7
-set build 8
+version     ${feature}.0.8
+set build 12
 revision    0
 
 master_sites https://download.oracle.com/graalvm/${feature}/archive/
@@ -40,14 +40,14 @@ long_description Oracle GraalVM for JDK ${feature} compiles your Java applicatio
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  fc7502e289c33ff1abd4ea88a43bcb5fde0cb201 \
-                 sha256  24094515078a83158bc7b76f73497d52127fdfe32a96665803a52285edd2c08c \
-                 size    315691454
+    checksums    rmd160  0d51077f9e193c177e1a58239baf96aa46c1809d \
+                 sha256  1a63681c9042f92f27da535c3b0fada62aae094da1f705ecb0ef0270b80f873b \
+                 size    314518262
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  cdbb4202dcea71b908da25616fe69951f32b59de \
-                 sha256  5c665f8c4a9c10352023fdbee367784cd8dfc22ffda0e625cd8c823c83b4345d \
-                 size    328232365
+    checksums    rmd160  c30db96351c9c44953378548e82b06f6c1f1a55f \
+                 sha256  3de4049d254dd3c04fd65a66be904d6cf490dca4ece2e2b5fcdfa91d34760f4f \
+                 size    327463597
 }
 
 worksrcdir   graalvm-jdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM for JDK 21.0.8.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?