### PR TITLE
tcl: use zlib from MacPorts

### DIFF
--- a/lang/tcl/Portfile
+++ b/lang/tcl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tcl
 version             8.6.16
-revision            0
+revision            1
 # Tk (x11/tk) port depends on this version
 categories          lang
 license             Tcl/Tk
@@ -28,6 +28,8 @@ checksums           md5 eaef5d0a27239fb840f04af8ec608242 \
 
 distname            ${name}${version}-src
 worksrcdir          ${name}${version}/unix
+
+depends_lib         port:zlib
 
 configure.args      --mandir=${prefix}/share/man \
                     --disable-corefoundation \


### PR DESCRIPTION
Avoid linking to MacPorts zlib opportunistically
Closes: https://trac.macports.org/ticket/71893

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
