### PR TITLE
dagger: update to 0.18.13

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.12 v
+github.setup        dagger dagger 0.18.13 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  72ea5cba36d93475ce14aad59221504c91c58243 \
-                            sha256  ffc2e99631c26af9e079fa98bf318ed86b414e297aa800d5361bff141bc5eeab \
-                            size    19184021
+        checksums           rmd160  9b4250de1f68fdde40127ba0f0db389c0fdcf4bc \
+                            sha256  79ecd5d0efdfd13e97a275e846715f609b7866515334fa4ba56cd15d036e6597 \
+                            size    19501487
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  65ba64baa6b4284361b02c89af81a1ec95e59957 \
-                            sha256  8a18828fe4ff5bc31a968429b146a271e1cc4b65e9496fb508fbf10a49a8bfc2 \
-                            size    18291113
+        checksums           rmd160  bb8629308a4d4629f38efae489f7e867c9491692 \
+                            sha256  c21cecd8767dce86c38c0e9d0cd278cbc46bdc7fe4f562a98dc3fd8871a61b33 \
+                            size    18606458
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Released a few minutes ago.

###### Tested on

macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?