### PR TITLE
jdk21: update to 21.0.8

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      ${feature}.0.7
+version      ${feature}.0.8
 revision     0
 
 description  Oracle Java SE Development Kit ${feature}
@@ -27,14 +27,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  c4f4e1b94df111f29563e9c4395e13d20f921370 \
-                 sha256  d876db943926408075f18372240d8b08b4540b10fe3fe602a7a488b91541b886 \
-                 size    193271275
+    checksums    rmd160  c6a5594dc0827a718e1d1f942328b3ea57672dbf \
+                 sha256  43eaf4e0224986087c946c201567fe31b2b6b23dec5a702bcf679276708d0d7e \
+                 size    192568089
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  d397b8e99b1e00f90bceed6b76f5bf92034d6405 \
-                 sha256  d29e6bf91bd7ebd14c289c2daa112a0d613ee568ee5c1a8c5f9e4bb31b09173e \
-                 size    190915097
+    checksums    rmd160  20ab8d1fd69ee6e3120adb15e9dd29a311295fa8 \
+                 sha256  421afea21e96332c40a019846c0c7a211a72c4bcd2b29911dcb50d2f58533ab1 \
+                 size    190272043
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle Java SE 21.0.8.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?