### PR TITLE
dosbox: fix build where it breaks due to invalid suffix

### DIFF
--- a/emulators/dosbox/Portfile
+++ b/emulators/dosbox/Portfile
@@ -35,6 +35,7 @@ post-extract {
 # src__cpu__core_dynrec__risc_x64.h.diff: http://www.freebsd.org/cgi/query-pr.cgi?pr=164243
 patchfiles          3689.diff 3694.diff 3776.diff 3777.diff \
                     patch-src-fpu-fpu_instructions_x86.h.diff \
+                    patch-invalid-literal-int10_vesa.cpp.diff \
                     src__cpu__core_dynrec__risc_x64.h.diff \
                     clang-4.diff
 

--- a/emulators/dosbox/files/patch-invalid-literal-int10_vesa.cpp.diff
+++ b/emulators/dosbox/files/patch-invalid-literal-int10_vesa.cpp.diff
@@ -1,0 +1,11 @@
+--- src/ints/int10_vesa.cpp	2025-07-16 02:53:09.000000000 -0300
++++ src/ints/int10_vesa.cpp	2025-07-16 02:53:31.000000000 -0300
+@@ -39,7 +39,7 @@
+ static char string_oem[]="S3 Incorporated. Trio64";
+ static char string_vendorname[]="DOSBox Development Team";
+ static char string_productname[]="DOSBox - The DOS Emulator";
+-static char string_productrev[]="DOSBox "VERSION;
++static char string_productrev[]="DOSBox " VERSION;
+ 
+ #ifdef _MSC_VER
+ #pragma pack (1)


### PR DESCRIPTION
+ Adding a small patch to fix the dosbox emulator build, where it breaks with: `error: invalid suffix on literal; C++11 requires a space between literal and identifier`
+ This small patch will add the space to address C++11 requirement, an alternative fix could be change the build flag `-Wreserved-user-defined-literal`

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
MaxOSX 10.11.6
Xcode none / Command Line Tools 8.2.0.0.1.1480973914

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->