### PR TITLE
openjdk21-jetbrains: update to 21.0.7b1038.58

### DIFF
--- a/java/openjdk21-jetbrains/Portfile
+++ b/java/openjdk21-jetbrains/Portfile
@@ -5,7 +5,7 @@ PortGroup        github 1.0
 
 set feature 21
 set openjdk_version ${feature}.0.7
-set jbr_version b982.16
+set jbr_version b1038.58
 github.setup     JetBrains JetBrainsRuntime ${openjdk_version}${jbr_version} jbr-release-
 github.tarball_from archive
 name             openjdk${feature}-jetbrains
@@ -41,14 +41,14 @@ use_bzip2        no
 
 if {${configure.build_arch} eq "x86_64"} {
     set jbr_arch x64
-    checksums    rmd160  588cf91628a8d058ca7931e992ade8df3089f50e \
-                 sha256  4b53fc37039a6ca0c67a4b5cb9cb4cfdea5efcfcbeb85d76853cead464f847d9 \
-                 size    86606463
+    checksums    rmd160  decda335f1fcfb3227e7419472566c72231171b1 \
+                 sha256  e38217fd5390ea9d3ddbd42483d295f60c2411acb6a85bdeb60fd01b3b2a3d18 \
+                 size    95697315
 } else {
     set jbr_arch aarch64
-    checksums    rmd160  54008e782e2edb8cdbaa7bdd788b354fe7e8d9fb \
-                 sha256  5eee11e32591c76a4d6e55cc62713a96f3418f3e657b900177e6bfcc21a039d7 \
-                 size    85503301
+    checksums    rmd160  69841017ced81ea372e5aa3841bac263d7ddb2ca \
+                 sha256  f5a6b817d91b36fa238d278acfb70e18c5134a25c74aa86a6946aeab4df6beeb \
+                 size    94594599
 }
 
 distname         jbr-${openjdk_version}-osx-${jbr_arch}-${jbr_version}


### PR DESCRIPTION
#### Description

Update to JetBrains Runtime 21.0.7b1038.58.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?