### PR TITLE
kermit-devel: update to 10.0-beta12

### DIFF
--- a/comms/kermit-devel/Portfile
+++ b/comms/kermit-devel/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                kermit-devel
 conflicts           kermit
 # don't forget to update distname too
-version             10.0-beta09
+version             10.0-beta12
 categories          comms
 platforms           darwin
 license             BSD
@@ -22,11 +22,11 @@ long_description    C-Kermit is a combined serial and network \
 homepage            https://www.kermitproject.org/ck90.html
 master_sites        https://www.kermitproject.org/ftp/kermit/test/tar/
 
-distname            cku404-beta09
+distname            cku416-beta12
 
-checksums           rmd160  11af8e4e356b562e0d406f88cfdd88f1f06fe440 \
-                    sha256  855375b61d650b4b489dc1ec945fd38510af4e2bd5d08e45cd03fdaf3c95ace3 \
-                    size    2323021
+checksums           rmd160  901a776b91e8cb7f4731e73a439d4cf09b0e03bb \
+                    sha256  1e38f6f813a8d97ec46bc1002c1bc389a3a3412b1188ace5027143d5c561c5ab \
+                    size    2353340
 
 extract.mkdir       yes
 build.target


### PR DESCRIPTION
#### Description

Update kermit-devel from @10.0-beta09_0 to @10.0-beta12_0.

Version @10.0-beta12_0 supports non standard UART speeds such as 1500000 used in Radxa Rock 3a board.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 x86_64
Command Line Tools 16.4.0.0.1.1747106510

macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
