### PR TITLE
mise: Update to 2025.7.17

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.7.10 v
+github.setup        jdx mise 2025.7.17 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2628ba09ace8bcc37b60abdc7167731e80848b74 \
-                    sha256  bc86c543a313c5cef7a23c8887c751f7ec3e56eb5916523052ad71df3ba686ee \
-                    size    4323146
+                    rmd160  9db893f918c8933a8b4478981e6c3245b6fe648e \
+                    sha256  a9280eb979701be5f6e14a2b60db273d089a6c6d7e9cfc22040e3694dd226378 \
+                    size    4334551
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -112,7 +112,7 @@ cargo.crates \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     async-backtrace                  0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
     async-backtrace-attributes       0.2.7  affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7 \
-    async-compression               0.4.25  40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4 \
+    async-compression               0.4.27  ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8 \
     async-trait                     0.1.88  e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
@@ -167,6 +167,7 @@ cargo.crates \
     confique                         0.3.0  d011f79ecb68498e94453e133c67cc5c35ab847684c59fa58b9ce0698e272e7b \
     confique-macro                  0.0.11  df20583fae327154743356c4896906bda1aa9b7df30c5aed73a54cf27fede9de \
     console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
+    console                         0.16.0  2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     constant_time_eq                 0.3.1  7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6 \
     contracts                        0.6.6  dc486fc59d4d0e52ea0b4461a12720c8617338c9ee955cc4013fb7319d264abd \
@@ -178,7 +179,7 @@ cargo.crates \
     cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
     crc                              3.3.0  9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675 \
     crc-catalog                      2.4.0  19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5 \
-    crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
+    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crossbeam-channel               0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
     crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
@@ -218,7 +219,7 @@ cargo.crates \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.19  1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005 \
     ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
-    ed25519-dalek                    2.1.1  4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871 \
+    ed25519-dalek                    2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
     either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
@@ -269,60 +270,60 @@ cargo.crates \
     getrandom                        0.3.3  26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4 \
     ghash                            0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
-    gix                             0.72.1  01237e8d3d78581f71642be8b0c2ae8c0b2b5c251c9c5d9ebbea3c1ea280dce8 \
-    gix-actor                       0.35.1  6b300e6e4f31f3f6bd2de5e2b0caab192ced00dc0fcd0f7cc56e28c575c8e1ff \
-    gix-archive                     0.21.2  8826f20d84822a9abd9e81d001c61763a25f4ec96caa073fb0b5457fe766af21 \
-    gix-attributes                  0.26.1  6f50d813d5c2ce9463ba0c29eea90060df08e38ad8f34b8a192259f8bce5c078 \
+    gix                             0.73.0  514c29cc879bdc0286b0cbc205585a49b252809eb86c69df4ce4f855ee75f635 \
+    gix-actor                       0.35.2  58ebbb8f41071c7cf318a0b1db667c34e1df49db7bf387d282a4e61a3b97882c \
+    gix-archive                     0.22.0  7be088a0e1b30abe15572ffafb3409172a3d88148e13959734f24f52112a19d6 \
+    gix-attributes                  0.27.0  45442188216d08a5959af195f659cb1f244a50d7d2d0c3873633b1cd7135f638 \
     gix-bitmap                      0.2.14  b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540 \
     gix-chunk                       0.4.11  0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f \
-    gix-command                      0.6.1  d05dd813ef6bb798570308aa7f1245cefa350ec9f30dc53308335eb22b9d0f8b \
-    gix-commitgraph                 0.28.0  e05050fd6caa6c731fe3bd7f9485b3b520be062d3d139cb2626e052d6c127951 \
-    gix-config                      0.45.1  48f3c8f357ae049bfb77493c2ec9010f58cfc924ae485e1116c3718fc0f0d881 \
-    gix-config-value                0.15.0  439d62e241dae2dffd55bfeeabe551275cf9d9f084c5ebc6b48bad49d03285b7 \
-    gix-credentials                 0.29.0  ce1c7307e36026b6088e5b12014ffe6d4f509c911ee453e22a7be4003a159c9b \
-    gix-date                        0.10.2  139d1d52b21741e3f0c72b0fc65e1ff34d4eaceb100ef529d182725d2e09b8cb \
-    gix-diff                        0.52.1  5e9b43e95fe352da82a969f0c84ff860c2de3e724d93f6681fedbcd6c917f252 \
-    gix-dir                         0.14.1  01e6e2dc5b8917142d0ffe272209d1671e45b771e433f90186bc71c016792e87 \
-    gix-discover                    0.40.1  dccfe3e25b4ea46083916c56db3ba9d1e6ef6dce54da485f0463f9fc0fe1837c \
-    gix-features                    0.42.1  56f4399af6ec4fd9db84dd4cf9656c5c785ab492ab40a7c27ea92b4241923fed \
-    gix-filter                      0.19.2  ecf004912949bbcf308d71aac4458321748ecb59f4d046830d25214208c471f1 \
-    gix-fs                          0.15.0  67a0637149b4ef24d3ea55f81f77231401c8463fae6da27331c987957eb597c7 \
-    gix-glob                        0.20.1  90181472925b587f6079698f79065ff64786e6d6c14089517a1972bca99fb6e9 \
-    gix-hash                        0.18.0  8d4900562c662852a6b42e2ef03442eccebf24f047d8eab4f23bc12ef0d785d8 \
-    gix-hashtable                    0.8.1  b5b5cb3c308b4144f2612ff64e32130e641279fcf1a84d8d40dad843b4f64904 \
-    gix-ignore                      0.15.0  ae358c3c96660b10abc7da63c06788dfded603e717edbd19e38c6477911b71c8 \
-    gix-index                       0.40.1  b38e919efd59cb8275d23ad2394b2ab9d002007b27620e145d866d546403b665 \
-    gix-lock                        17.1.0  570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796 \
-    gix-mailmap                     0.27.1  5e7c52eb13d84ad26030d07a2c2975ba639dd1400a7996e6966c5aef617ed829 \
-    gix-negotiate                   0.20.1  2e1ea901acc4d5b44553132a29e8697210cb0e739b2d9752d713072e9391e3c9 \
-    gix-object                      0.49.1  d957ca3640c555d48bb27f8278c67169fa1380ed94f6452c5590742524c40fbb \
-    gix-odb                         0.69.1  868f703905fdbcfc1bd750942f82419903ecb7039f5288adb5206d6de405e0c9 \
-    gix-pack                        0.59.1  9d49c55d69c8449f2a0a5a77eb9cbacfebb6b0e2f1215f0fc23a4cb60528a450 \
-    gix-packetline                  0.19.0  8ddc034bc67c848e4ef7596ab5528cd8fd439d310858dbe1ce8b324f25deb91c \
-    gix-packetline-blocking         0.19.0  c44880f028ba46d6cf37a66d27a300310c6b51b8ed0e44918f93df061168e2f3 \
-    gix-path                       0.10.18  567f65fec4ef10dfab97ae71f26a27fd4d7fe7b8e3f90c8a58551c41ff3fb65b \
-    gix-pathspec                    0.11.0  ce061c50e5f8f7c830cacb3da3e999ae935e283ce8522249f0ce2256d110979d \
-    gix-prompt                      0.11.0  d024a3fe3993bbc17733396d2cefb169c7a9d14b5b71dafb7f96e3962b7c3128 \
-    gix-protocol                    0.50.1  f5c17d78bb0414f8d60b5f952196dc2e47ec320dca885de9128ecdb4a0e38401 \
+    gix-command                      0.6.2  6b31b65ca48a352ae86312b27a514a0c661935f96b481ac8b4371f65815eb196 \
+    gix-commitgraph                 0.29.0  6bb23121e952f43a5b07e3e80890336cb847297467a410475036242732980d06 \
+    gix-config                      0.46.0  5dfb898c5b695fd4acfc3c0ab638525a65545d47706064dcf7b5ead6cdb136c0 \
+    gix-config-value                0.15.1  9f012703eb67e263c6c1fc96649fec47694dd3e5d2a91abfc65e4a6a6dc85309 \
+    gix-credentials                 0.30.0  0039dd3ac606dd80b16353a41b61fc237ca5cb8b612f67a9f880adfad4be4e05 \
+    gix-date                        0.10.3  d7235bdf4d9d54a6901928e3a37f91c16f419e6957f520ed929c3d292b84226e \
+    gix-diff                        0.53.0  de854852010d44a317f30c92d67a983e691c9478c8a3fb4117c1f48626bcdea8 \
+    gix-dir                         0.15.0  dad34e4f373f94902df1ba1d2a1df3a1b29eacd15e316ac5972d842e31422dd7 \
+    gix-discover                    0.41.0  ffb180c91ca1a2cf53e828bb63d8d8f8fa7526f49b83b33d7f46cbeb5d79d30a \
+    gix-features                    0.43.0  9a92748623c201568785ee69a561f4eec06f745b4fac67dab1d44ca9891a57ee \
+    gix-filter                      0.20.0  aa6571a3927e7ab10f64279a088e0dae08e8da05547771796d7389bbe28ad9ff \
+    gix-fs                          0.16.0  d793f71e955d18f228d20ec433dcce6d0e8577efcdfd11d72d09d7cc2758dfd1 \
+    gix-glob                        0.21.0  b947db8366823e7a750c254f6bb29e27e17f27e457bf336ba79b32423db62cd5 \
+    gix-hash                        0.19.0  251fad79796a731a2a7664d9ea95ee29a9e99474de2769e152238d4fdb69d50e \
+    gix-hashtable                    0.9.0  c35300b54896153e55d53f4180460931ccd69b7e8d2f6b9d6401122cdedc4f07 \
+    gix-ignore                      0.16.0  564d6fddf46e2c981f571b23d6ad40cb08bddcaf6fc7458b1d49727ad23c2870 \
+    gix-index                       0.41.0  2af39fde3ce4ce11371d9ce826f2936ec347318f2d1972fe98c2e7134e267e25 \
+    gix-lock                        18.0.0  b9fa71da90365668a621e184eb5b979904471af1b3b09b943a84bc50e8ad42ed \
+    gix-mailmap                     0.27.2  9a8982e1874a2034d7dd481bcdd6a05579ba444bcda748511eb0f8e50eb10487 \
+    gix-negotiate                   0.21.0  1d58d4c9118885233be971e0d7a589f5cfb1a8bd6cb6e2ecfb0fc6b1b293c83b \
+    gix-object                      0.50.0  49664e3e212bc34f7060f5738ce7022247e4afd959b68a4f666b1fd29c00b23c \
+    gix-odb                         0.70.0  9c9d7af10fda9df0bb4f7f9bd507963560b3c66cb15a5b825caf752e0eb109ac \
+    gix-pack                        0.60.0  d8571df89bfca5abb49c3e3372393f7af7e6f8b8dbe2b96303593cef5b263019 \
+    gix-packetline                  0.19.1  2592fbd36249a2fea11056f7055cc376301ef38d903d157de41998335bbf1f93 \
+    gix-packetline-blocking         0.19.1  fc4e706f328cd494cc8f932172e123a72b9a4711b0db5e411681432a89bd4c94 \
+    gix-path                       0.10.19  c6279d323d925ad4790602105ae27df4b915e7a7d81e4cdba2603121c03ad111 \
+    gix-pathspec                    0.12.0  daedead611c9bd1f3640dc90a9012b45f790201788af4d659f28d94071da7fba \
+    gix-prompt                      0.11.1  6ffa1a7a34c81710aaa666a428c142b6c5d640492fcd41267db0740d923c7906 \
+    gix-protocol                    0.51.0  12b4b807c47ffcf7c1e5b8119585368a56449f3493da93b931e1d4239364e922 \
     gix-quote                        0.6.0  4a375a75b4d663e8bafe3bf4940a18a23755644c13582fa326e99f8f987d83fd \
-    gix-ref                         0.52.1  d1b7985657029684d759f656b09abc3e2c73085596d5cdb494428823970a7762 \
-    gix-refspec                     0.30.1  445ed14e3db78e8e79980085e3723df94e1c8163b3ae5bc8ed6a8fe6cf983b42 \
-    gix-revision                    0.34.1  78d0b8e5cbd1c329e25383e088cb8f17439414021a643b30afa5146b71e3c65d \
-    gix-revwalk                     0.20.1  1bc756b73225bf005ddeb871d1ca7b3c33e2417d0d53e56effa5a36765b52b28 \
-    gix-sec                         0.11.0  d0dabbc78c759ecc006b970339394951b2c8e1e38a37b072c105b80b84c308fd \
-    gix-shallow                      0.4.0  6b9a6f6e34d6ede08f522d89e5c7990b4f60524b8ae6ebf8e850963828119ad4 \
-    gix-status                      0.19.1  072099c2415cfa5397df7d47eacbcb6016d2cd17e0d674c74965e6ad1b17289f \
-    gix-submodule                   0.19.1  5f51472f05a450cc61bc91ed2f62fb06e31e2bbb31c420bc4be8793f26c8b0c1 \
-    gix-tempfile                    17.1.0  c750e8c008453a2dba67a2b0d928b7716e05da31173a3f5e351d5457ad4470aa \
-    gix-trace                       0.1.12  7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7 \
-    gix-transport                   0.47.0  edfe22ba26d4b65c17879f12b9882eafe65d3c8611c933b272fce2c10f546f59 \
-    gix-traverse                    0.46.2  b8648172f85aca3d6e919c06504b7ac26baef54e04c55eb0100fa588c102cc33 \
-    gix-url                         0.31.0  42a1ad0b04a5718b5cb233e6888e52a9b627846296161d81dcc5eb9203ec84b8 \
+    gix-ref                         0.53.0  4b7a23209d4e4cbdc2086d294f5f3f8707ac6286768847024d952d8cd3278c5b \
+    gix-refspec                     0.31.0  7d29cae1ae31108826e7156a5e60bffacab405f4413f5bc0375e19772cce0055 \
+    gix-revision                    0.35.0  f651f2b1742f760bb8161d6743229206e962b73d9c33c41f4e4aefa6586cbd3d \
+    gix-revwalk                     0.21.0  06e74f91709729e099af6721bd0fa7d62f243f2005085152301ca5cdd86ec02c \
+    gix-sec                         0.12.0  09f7053ed7c66633b56c57bc6ed3377be3166eaf3dc2df9f1c5ec446df6fdf2c \
+    gix-shallow                      0.5.0  d936745103243ae4c510f19e0760ce73fb0f08096588fdbe0f0d7fb7ce8944b7 \
+    gix-status                      0.20.0  2a4afff9b34eeececa8bdc32b42fb318434b6b1391d9f8d45fe455af08dc2d35 \
+    gix-submodule                   0.20.0  657cc5dd43cbc7a14d9c5aaf02cfbe9c2a15d077cded3f304adb30ef78852d3e \
+    gix-tempfile                    18.0.0  666c0041bcdedf5fa05e9bef663c897debab24b7dc1741605742412d1d47da57 \
+    gix-trace                       0.1.13  e2ccaf54b0b1743a695b482ca0ab9d7603744d8d10b2e5d1a332fef337bee658 \
+    gix-transport                   0.48.0  12f7cc0179fc89d53c54e1f9ce51229494864ab4bf136132d69db1b011741ca3 \
+    gix-traverse                    0.47.0  c7cdc82509d792ba0ad815f86f6b469c7afe10f94362e96c4494525a6601bdd5 \
+    gix-url                         0.32.0  1b76a9d266254ad287ffd44467cd88e7868799b08f4d52e02d942b93e514d16f \
     gix-utils                        0.3.0  5351af2b172caf41a3728eb4455326d84e0d70fe26fc4de74ab0bd37df4191c5 \
     gix-validate                    0.10.0  77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d \
-    gix-worktree                    0.41.0  54f1916f8d928268300c977d773dd70a8746b646873b77add0a34876a8c847e9 \
-    gix-worktree-state              0.19.0  f81e31496d034dbdac87535b0b9d4659dbbeabaae1045a0dce7c69b5d16ea7d6 \
-    gix-worktree-stream             0.21.2  5acc0f942392e0cae6607bfd5fe39e56e751591271bdc8795c6ec34847d17948 \
+    gix-worktree                    0.42.0  55f625ac9126c19bef06dbc6d2703cdd7987e21e35b497bb265ac37d383877b1 \
+    gix-worktree-state              0.20.0  06ba9b17cbacc02b25801197b20100f7f9bd621db1e7fce9d3c8ab3175207bf8 \
+    gix-worktree-stream             0.22.0  f56a737cefbcd90b573cb5393d636f6dc5e0d08a8086356d8c4fcc623b49a0e8 \
     glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
     globset                         0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
@@ -374,6 +375,7 @@ cargo.crates \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
     indexmap                        2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
     indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
+    indicatif                       0.18.0  70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd \
     indoc                            2.0.6  f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
     inout                            0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
     insta                           1.43.1  154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371 \
@@ -425,7 +427,7 @@ cargo.crates \
     maybe-async                     0.2.10  5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11 \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     memchr                           2.7.5  32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0 \
-    memmap2                          0.9.5  fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f \
+    memmap2                          0.9.7  483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28 \
     miette                           7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
     miette-derive                    7.6.0  db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
@@ -433,9 +435,9 @@ cargo.crates \
     minisign-verify                  0.2.4  e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43 \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                              1.0.4  78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c \
-    mlua                     0.11.0-beta.3  20b35ffb9c638eaa0992057934110c0964fc14a6e033d7d70070fdfcbd2e4c62 \
-    mlua-sys                         0.8.1  0f2443fccee1fa88a880b371d9a0af28ff56b76ff52d9ff679559388cdcfc776 \
-    mlua_derive              0.11.0-beta.2  66b452b6259da19a715eb4f174d6856ddaf9b0582d4cc769536fdd319d794b9a \
+    mlua                            0.11.1  de25fc513588ac1273aa8c6dc0fffee6d32c12f38dc75f5cdc74547121a107ef \
+    mlua-sys                         0.8.2  bcdf7c9e260ca82aaa32ac11148941952b856bb8c69aa5a9e65962f21fcb8637 \
+    mlua_derive                     0.11.0  465bddde514c4eb3b50b543250e97c1d4b284fa3ef7dc0ba2992c77545dbceb2 \
     mockito                          1.7.0  7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48 \
     native-tls                      0.2.14  87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e \
     nix                             0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
@@ -467,7 +469,7 @@ cargo.crates \
     os_pipe                          1.2.2  db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224 \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     owo-colors                       4.2.2  48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e \
-    papergrid                       0.15.0  30268a8d20c2c0d126b2b6610ab405f16517f6ba9f244d8c59ac2c512a8a1ce7 \
+    papergrid                       0.17.0  6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1 \
     parking_lot                     0.12.4  70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13 \
     parking_lot_core                0.9.11  bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5 \
     parse-zoneinfo                   0.3.1  1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24 \
@@ -503,7 +505,7 @@ cargo.crates \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro2                     1.0.95  02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778 \
-    prodash                         29.0.2  f04bb108f648884c23b98a0e940ebc2c93c0c3b89f04dbaf7eb8256ce617d1bc \
+    prodash                         30.0.1  5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139 \
     quick-xml                       0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
     quinn                           0.11.8  626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8 \
     quinn-proto                    0.11.12  49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e \
@@ -540,11 +542,11 @@ cargo.crates \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
-    rustix                           1.0.7  c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266 \
-    rustls                         0.23.28  7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643 \
+    rustix                           1.0.8  11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8 \
+    rustls                         0.23.29  2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pki-types                1.12.0  229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79 \
-    rustls-webpki                  0.103.3  e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435 \
+    rustls-webpki                  0.103.4  0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc \
     rustversion                     1.0.21  8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d \
     ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     salsa20                         0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
@@ -556,7 +558,7 @@ cargo.crates \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scrypt                          0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
-    sdd                              3.0.8  584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21 \
+    sdd                              3.0.9  62f5557d2bbddd5afd236ba7856b0e494f5acc7ce805bb0774cc5674b20a06b4 \
     secrecy                         0.10.3  e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework               3.2.0  271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316 \
@@ -614,7 +616,7 @@ cargo.crates \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
     system-configuration             0.6.1  3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b \
     system-configuration-sys         0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
-    tabled                          0.19.0  228d124371171cd39f0f454b58f73ddebeeef3cef3207a82ffea1c29465aea43 \
+    tabled                          0.20.0  e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d \
     tabled_derive                   0.11.0  0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846 \
     taplo                           0.14.0  c221a50eef1a5493074f11ca1ed62bef28c05a4d925002944cc686b2e783a5b3 \
     tar                             0.4.44  1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a \
@@ -679,12 +681,13 @@ cargo.crates \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                    0.2.1  4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
+    unit-prefix                      0.5.1  323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817 \
     universal-hash                   0.5.1  fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea \
     unsafe-libyaml                  0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                        2.1.1  f5fa05e330e8533a1b7899b89fc7096f48378c49e7cdfdc3472ce32bb38860b3 \
+    usage-lib                        2.2.2  a10ea46630ad25b371a9f1c849e4a07217385cf2d908b1bebe324689d33c68b2 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
@@ -692,7 +695,7 @@ cargo.crates \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
     versions                         7.0.0  80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f \
-    vfox                         2025.7.10  575a47680f1c1c1215f2bdc627eb94c2d2cc09e66553573c529c34c46de4512f \
+    vfox                         2025.7.17  050005ca8a06b5fd1903de8f859d73f49916b77c52fdc4d43e81f653e0946875 \
     vte                             0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
@@ -757,7 +760,7 @@ cargo.crates \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
     winnow                          0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
-    winnow                          0.7.11  74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd \
+    winnow                          0.7.12  f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95 \
     winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
     wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
     writeable                        0.6.1  ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb \


### PR DESCRIPTION
#### Description

mise: Update to 2025.7.17

##### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
