### PR TITLE
cgal6: Update to 6.0.1

### DIFF
--- a/gis/cgal6/Portfile
+++ b/gis/cgal6/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem              1.0
 PortGroup               github  1.0
-PortGroup               cmake   1.0
+PortGroup               cmake   1.1
 PortGroup               boost   1.0
 
 description             Computational Geometry Algorithm Library
@@ -15,7 +15,7 @@ long_description        The goal of the ${description} is to provide easy access
                         molecular biology, medical imaging, robotics and\
                         motion planning, mesh generation, numerical methods...
 
-github.setup            CGAL cgal 6.0 v
+github.setup            CGAL cgal 6.0.1 v
 revision                0
 conflicts               cgal4 cgal5
 github.tarball_from     releases
@@ -30,9 +30,9 @@ distname                CGAL-${version}
 
 homepage                http://www.cgal.org/
 
-checksums               rmd160  9ca4f096aac2c60a222dbbc7960d48864bc231ad \
-                        sha256  6b0c9b47c7735a2462ff34a6c3c749d1ff4addc1454924b76263dc60ab119268 \
-                        size    25979696
+checksums               rmd160  7320dc2c942925d3ae2af0c473ea3fc6c6feb729 \
+                        sha256  0acdfbf317c556630dd526f3253780f29b6ec9713ee92903e81b5c93c0f59b7f \
+                        size    25659212
 
 boost.version           1.81
 


### PR DESCRIPTION
#### Description

* Update CGAL 6.0 --> 6.0.1 (bugfix release).
* Update to cmake portgroup 1.1.

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?