### PR TITLE
cgal5: Fix livecheck

### DIFF
--- a/gis/cgal5/Portfile
+++ b/gis/cgal5/Portfile
@@ -44,4 +44,4 @@ depends_lib-append      port:mpfr \
 compiler.cxx_standard   2014
 compiler.thread_local_storage yes
 
-github.livecheck.regex  {([0-9.]+)}
+github.livecheck.regex  {(5[0-9.]+)}


### PR DESCRIPTION
#### Description

* Constrain livecheck to CGAL version 5 only.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
