### PR TITLE
cgal5: Update to 5.6.2

### DIFF
--- a/gis/cgal5/Portfile
+++ b/gis/cgal5/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem              1.0
 PortGroup               github  1.0
-PortGroup               cmake   1.0
+PortGroup               cmake   1.1
 PortGroup               boost   1.0
 
 description             Computational Geometry Algorithm Library
@@ -15,7 +15,7 @@ long_description        The goal of the ${description} is to provide easy access
                         molecular biology, medical imaging, robotics and\
                         motion planning, mesh generation, numerical methods...
 
-github.setup            CGAL cgal 5.6.1 v
+github.setup            CGAL cgal 5.6.2 v
 revision                0
 conflicts               cgal4 cgal6
 github.tarball_from     releases
@@ -30,9 +30,9 @@ distname                CGAL-${version}
 
 homepage                http://www.cgal.org/
 
-checksums               rmd160  54c3b5255cf24f88eec75b2f98fcbeaf0f28602e \
-                        sha256  cdb15e7ee31e0663589d3107a79988a37b7b1719df3d24f2058545d1bcdd5837 \
-                        size    24893904
+checksums               rmd160  5ee29dc52f2ec401edff16dc03ae462903d3acc0 \
+                        sha256  458f60df8e8f1f2fdad93c8f24e1aa8f4b095cc61a14fac81b90680d7306a42e \
+                        size    24489156
 
 boost.version           1.81
 
@@ -44,4 +44,4 @@ depends_lib-append      port:mpfr \
 compiler.cxx_standard   2014
 compiler.thread_local_storage yes
 
-github.livecheck.regex  {([0-9.]+)}
+github.livecheck.regex  {(5[0-9.]+)}


### PR DESCRIPTION
#### Description

* cgal5: Update 5.61 --> 5.6.2.
* Constrain livecheck top version 5 only.
* Update to cmake 1.1 portgroup.
* See https://trac.macports.org/ticket/47197 (update cmake portgroup).

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?