### PR TITLE
legacy-support-devel: Update to latest master - v20250720.

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
-PortGroup           muniversal 1.1
 
 name                legacy-support
 categories          devel
@@ -28,6 +27,8 @@ set release_ver     1.5.0
 set compat_ver      1.0.0
 
 subport ${name} {
+    PortGroup           muniversal 1.1
+
     conflicts           ${name}-devel
     github.setup        macports macports-legacy-support ${release_ver} v
     # Change github.tarball_from to 'releases' or 'archive' next update
@@ -42,19 +43,44 @@ subport ${name} {
 subport ${name}-devel {
     conflicts           ${name}
     github.setup        macports macports-legacy-support \
-                        fa7afdfd63b58d6ca21c5e1908b179f811f8d1cd
+                        1b7bf5ec237c91367d5d58f05fbc0428f0145414
     # Change github.tarball_from to 'releases' or 'archive' next update
     # N.B.: That's a nice theory, but neither choice works correctly
     github.tarball_from tarball
-    version             20250711
+    version             20250720
     revision            0
     livecheck.type      none
-    checksums           rmd160  f37a1c1a2f0b5cc0c8f59c97e04da8f81456a107 \
-                        sha256  de66c3eca95e8e591a23dcf916f81b588ea2b83970a1d0c0506fcde76393386a \
-                        size    228977
+    checksums           rmd160  29518415d298480ca045ab103d499b0604f3ea21 \
+                        sha256  b55fa17f568428e060fecc26347858a25ea1a4696a71ed670825fa9e36b45193 \
+                        size    227547
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
 
+    # Set up proper arch list for build and test
+    if {![variant_isset universal]} {
+        set archs       ${configure.build_arch}
+    } else {
+        set archs       ${configure.universal_archs}
+    }
+
+    # Let the Makefile handle the archs setup
+    configure.cc_archflags
+    configure.cxx_archflags
+    configure.ld_archflags
+    configure.universal_cflags
+    configure.universal_cxxflags
+    configure.universal_ldflags
+
+    # Pass the arch list to the Makefile
+    build.env-append        ARCHS=${archs}
+    destroot.env-append     ARCHS=${archs}
+    test.env-append         ARCHS=${archs}
+
+    # Set test target for optional universal handling
+    # For some reason, setting test.target doesn't work.
+    test.pre_args       test_unv
+
+    # Enable parallel tests
     default test.jobs   ${build.jobs}
     test.post_args      -j${test.jobs}
 }


### PR DESCRIPTION
Notable changes since last -devel:

- Fixes 64-bit packet timestamps with unusual 10.4 SDK.
- Implements multiarch test runner.

Earlier notable -devel changes since v1.5.0:

- Fixes boottime sysctls for 64-bit <10.6
- Consequently undisables sleep offset on ppc64

- Fixes fcntl() F_GETPATH for 10.4 ppc64
- Fixes stat() et al tv_nsec for 10.4 ppc64
- Adds missing address validation for 10.4 stat64() calls.
- Makes all tests parallelizable.
- Fixes (Apple) [f]setattrlist() bug in 10.5-10.7.

Switches to built-in universal support for the -devel subport, while continuing to use muniversal for the main port.

TESTED:
Tested both normal and -devel versions -/+universal on 10.4-10.5 ppc, 10.4-10.5 ppc64, 10.4-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-15.x arm64.
Builds and passes all tests on all tested platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S165, ppc64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, ppc (i386 Rosetta), Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, ppc (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.6 22H625, arm64, Xcode 15.2 15C500b
macOS 14.7.6 23H626, arm64, Xcode 16.2 16C5032a
macOS 15.5 24F74, arm64, Xcode 16.4 16F6
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
