### PR TITLE
vtk: Livecheck avoid release candidates

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -212,3 +212,6 @@ if {[mpi_variant_isset]} {
     configure.args-append \
         -DVTK_Group_MPI:BOOL=ON
 }
+
+# Avoid release candidates
+gitlab.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

* Livecheck: Avoid release candidates.

###### Type(s)

- [x] enhancement

###### Tested on

* Tested livecheck change only.  No other portfile changes.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?