### PR TITLE
openjdk17-microsoft: update to 17.0.16

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.15
-set build    6
+version      ${feature}.0.16
+set build    8
 revision     0
 
 description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  72bb1e5f125b8782867de4322a9e0ee2a1e342ef \
-                 sha256  72ffaaf9efdb1cbcaa4d0033674f8f589f4d71c67a79396c09960c0e0ecdb509 \
-                 size    187749568
+    checksums    rmd160  8eea281d5b19260e6c2aba7b810f656070f4ddfa \
+                 sha256  2d59937eff1d00b495566c0d39d7ba7a52281b82ed717b8497d04ab7f48a2298 \
+                 size    187783835
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  7f6d87eb0c23fc54d89f1d94c308b8c284e6b853 \
-                 sha256  08f338f2c73a4f19bc43bd2a76e8a5eb7262defc8aa127f8bfc422b95e372a28 \
-                 size    185614487
+    checksums    rmd160  0f7b6f5334e882be18c598ada222b7e941d394ef \
+                 sha256  112b5ef5f4295e78571a70c6d229077512ef584e51c344af7cdbc2aedc9871b3 \
+                 size    185662211
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.16.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?