### PR TITLE
openjdk21-microsoft: update to 21.0.8

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.7
-set build    6
+version      ${feature}.0.8
+set build    9
 revision     0
 
 description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  e3e04f9382a4e66a91bfecc32ec69ce5187bf249 \
-                 sha256  862435de8c6ecd10ddce544ff2cbc7f6d95f41476b5536757554c806568b7522 \
-                 size    202080910
+    checksums    rmd160  972b6298bf54f23df9ead90e8ac1b130c2b44767 \
+                 sha256  9e8ad632305401c2fd2d1af90a4bd23ae2c817dc599b23ea85c5b703ec4a749e \
+                 size    202216447
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  27e6df7dfa6fcae887c17b6fae62ad8a06653da2 \
-                 sha256  dfc5ed1e8ef5042bba8aaa780fafa835da88f40bb7f9b9192b4bfeb22efc363d \
-                 size    199691887
+    checksums    rmd160  e63b280a5ba3e47719b2cd1647b11cac8f0e6514 \
+                 sha256  b6b54d72a76c16cef488ba0b3179e3d9af0dfbb573d7283e8c573dd43c400e34 \
+                 size    199806252
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 21.0.8.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?