### PR TITLE
openjdk11-microsoft: update to 11.0.28

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.27
+version      ${feature}.0.28
 set build    6
 revision     0
 
@@ -32,14 +32,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  4a6ee09a7abfaddc53e4b16e5f494046a9c031cb \
-                 sha256  d5547c30f914d60be45db0ea9807da30931e82855b805e8d49b5d6d08923c4c0 \
-                 size    191555664
+    checksums    rmd160  6c831737ae814dba207ed78625429ed45c561e2c \
+                 sha256  0be18d1119f69d923bb32cd2a991879b522390e15b1fb9dbd70ff04f7c6f5c4a \
+                 size    191624476
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  dd623250b3c48102fd527d77cfbc8c63b5dc82ed \
-                 sha256  f6cbe6d6f3602dcc04828f96a8baad165c572633e727fa7ccd4ec326cf1804cd \
-                 size    185642575
+    checksums    rmd160  5d81a237655d0bab4bd36b38ef7edf0ea39add85 \
+                 sha256  f71f33fccb7a0f565cf9d53f874223abd4f65f0c9ca086cea4924e364b70c3d5 \
+                 size    185703268
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.28.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?