### PR TITLE
openjdk17-temurin: update to 17.0.16

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.15
-set build    6
+version      ${feature}.0.16
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least October 2027)
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e9a4146224ef7eeb9815b5017127e3fa4fc046f9 \
-                 sha256  424d7f758a272718887bd93f4d8b63e560c0797a884e036c4b3dbf5d2cdfa1cd \
-                 size    180100463
+    checksums    rmd160  8451951815ec64b30da1b92d27800b4f67858280 \
+                 sha256  ca5700c5d13124467ae52e1609881d7ce45d974870b18c3382ea8b7ae69d0f00 \
+                 size    180154703
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  982511fb8529d9e8d11f5711c2feeb7edb2befc2 \
-                 sha256  1a2fa2bb9ea059cf2c1ab3e296a98e006fb6fdad2bd19ce52df48794eaa1836a \
-                 size    185382473
+    checksums    rmd160  05c86cb27d2c276e83118edd0f604b90d125e75d \
+                 sha256  f9845abc8403f1d489402201064e7b9f2c57605d8717b85a95a15d94f882eeb7 \
+                 size    185444095
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.16.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?