### PR TITLE
dagger: update to 0.18.14

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.13 v
+github.setup        dagger dagger 0.18.14 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  9b4250de1f68fdde40127ba0f0db389c0fdcf4bc \
-                            sha256  79ecd5d0efdfd13e97a275e846715f609b7866515334fa4ba56cd15d036e6597 \
-                            size    19501487
+        checksums           rmd160  3c171f4ed3bc3acf2014103b430ecc7aafe0857d \
+                            sha256  880361e92842400f4b14ef4dc4eb05dd269ee4f7a18059871f1c4411b8ddea4c \
+                            size    19501498
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  bb8629308a4d4629f38efae489f7e867c9491692 \
-                            sha256  c21cecd8767dce86c38c0e9d0cd278cbc46bdc7fe4f562a98dc3fd8871a61b33 \
-                            size    18606458
+        checksums           rmd160  4df6567a11097cab5734535ba34d3b2b40c27304 \
+                            sha256  c8646f662b75caf7226b83d840cf7a31533801514b06c1ea7e35e3e456fc894e \
+                            size    18606440
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Another day, another dagger version

###### Tested on

macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?