### PR TITLE
perl5: Resolve symlinks in dylib install name

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -133,6 +133,11 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
             patchfiles-append \
                             ${perl5.major}/adjust-dependency-paths-PR126706.patch
         }
+        if {${perl5.major} >= 5.24} {
+            # Fix the library path fix
+            patchfiles-append \
+                            ${perl5.major}/resolve-install_name-symlink.patch
+        }
         if {${perl5.major} == 5.26} {
             # Avoid rebuilding DB_File in the destroot phase
             patchfiles-append \

--- a/lang/perl5/files/5.24/resolve-install_name-symlink.patch
+++ b/lang/perl5/files/5.24/resolve-install_name-symlink.patch
@@ -1,0 +1,13 @@
+Resolve any symlinks to cwd in dylib install name
+https://github.com/Perl/perl5/pull/23461
+--- Makefile.SH.orig	2025-07-21 23:27:01.000000000 -0500
++++ Makefile.SH	2025-07-22 00:12:10.000000000 -0500
+@@ -70,7 +70,7 @@
+ 				${revision}.${patchlevel}.${subversion}"
+ 		case "$osvers" in
+ 	        1[5-9]*|[2-9]*)
+-			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
++			shrpldflags="$shrpldflags -install_name `pwd -P`/\$@ -Xlinker -headerpad_max_install_names"
+ 			exeldflags="-Xlinker -headerpad_max_install_names"
+ 			;;
+ 		*)

--- a/lang/perl5/files/5.26/resolve-install_name-symlink.patch
+++ b/lang/perl5/files/5.26/resolve-install_name-symlink.patch
@@ -1,0 +1,13 @@
+Resolve any symlinks to cwd in dylib install name
+https://github.com/Perl/perl5/pull/23461
+--- Makefile.SH.orig	2025-07-21 23:27:01.000000000 -0500
++++ Makefile.SH	2025-07-22 00:12:10.000000000 -0500
+@@ -70,7 +70,7 @@
+ 				${revision}.${patchlevel}.${subversion}"
+ 		case "$osvers" in
+ 	        1[5-9]*|[2-9]*)
+-			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
++			shrpldflags="$shrpldflags -install_name `pwd -P`/\$@ -Xlinker -headerpad_max_install_names"
+ 			exeldflags="-Xlinker -headerpad_max_install_names"
+ 			;;
+ 		*)

--- a/lang/perl5/files/5.28/resolve-install_name-symlink.patch
+++ b/lang/perl5/files/5.28/resolve-install_name-symlink.patch
@@ -1,0 +1,13 @@
+Resolve any symlinks to cwd in dylib install name
+https://github.com/Perl/perl5/pull/23461
+--- Makefile.SH.orig	2025-07-21 23:27:01.000000000 -0500
++++ Makefile.SH	2025-07-22 00:12:10.000000000 -0500
+@@ -70,7 +70,7 @@
+ 				${revision}.${patchlevel}.${subversion}"
+ 		case "$osvers" in
+ 	        1[5-9]*|[2-9]*)
+-			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
++			shrpldflags="$shrpldflags -install_name `pwd -P`/\$@ -Xlinker -headerpad_max_install_names"
+ 			exeldflags="-Xlinker -headerpad_max_install_names"
+ 			;;
+ 		*)

--- a/lang/perl5/files/5.30/resolve-install_name-symlink.patch
+++ b/lang/perl5/files/5.30/resolve-install_name-symlink.patch
@@ -1,0 +1,13 @@
+Resolve any symlinks to cwd in dylib install name
+https://github.com/Perl/perl5/pull/23461
+--- Makefile.SH.orig	2025-07-21 23:27:01.000000000 -0500
++++ Makefile.SH	2025-07-22 00:12:10.000000000 -0500
+@@ -70,7 +70,7 @@
+ 				${revision}.${patchlevel}.${subversion}"
+ 		case "$osvers" in
+ 	        1[5-9]*|[2-9]*)
+-			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
++			shrpldflags="$shrpldflags -install_name `pwd -P`/\$@ -Xlinker -headerpad_max_install_names"
+ 			exeldflags="-Xlinker -headerpad_max_install_names"
+ 			;;
+ 		*)

--- a/lang/perl5/files/5.32/resolve-install_name-symlink.patch
+++ b/lang/perl5/files/5.32/resolve-install_name-symlink.patch
@@ -1,0 +1,13 @@
+Resolve any symlinks to cwd in dylib install name
+https://github.com/Perl/perl5/pull/23461
+--- Makefile.SH.orig	2025-07-21 23:27:01.000000000 -0500
++++ Makefile.SH	2025-07-22 00:12:10.000000000 -0500
+@@ -70,7 +70,7 @@
+ 				${revision}.${patchlevel}.${subversion}"
+ 		case "$osvers" in
+ 	        1[5-9]*|[2-9]*)
+-			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
++			shrpldflags="$shrpldflags -install_name `pwd -P`/\$@ -Xlinker -headerpad_max_install_names"
+ 			exeldflags="-Xlinker -headerpad_max_install_names"
+ 			;;
+ 		*)

--- a/lang/perl5/files/5.34/resolve-install_name-symlink.patch
+++ b/lang/perl5/files/5.34/resolve-install_name-symlink.patch
@@ -1,0 +1,13 @@
+Resolve any symlinks to cwd in dylib install name
+https://github.com/Perl/perl5/pull/23461
+--- Makefile.SH.orig	2025-07-21 23:27:01.000000000 -0500
++++ Makefile.SH	2025-07-22 00:12:10.000000000 -0500
+@@ -70,7 +70,7 @@
+ 				${revision}.${patchlevel}.${subversion}"
+ 		case "$osvers" in
+ 	        1[5-9]*|[2-9]*)
+-			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
++			shrpldflags="$shrpldflags -install_name `pwd -P`/\$@ -Xlinker -headerpad_max_install_names"
+ 			exeldflags="-Xlinker -headerpad_max_install_names"
+ 			;;
+ 		*)

--- a/lang/perl5/files/5.36/resolve-install_name-symlink.patch
+++ b/lang/perl5/files/5.36/resolve-install_name-symlink.patch
@@ -1,0 +1,13 @@
+Resolve any symlinks to cwd in dylib install name
+https://github.com/Perl/perl5/pull/23461
+--- Makefile.SH.orig	2025-07-22 00:55:36.000000000 -0500
++++ Makefile.SH	2025-07-22 00:55:37.000000000 -0500
+@@ -64,7 +64,7 @@
+ 				${revision}.${patchlevel}.${subversion}"
+ 		case "$osvers" in
+ 	        1[5-9]*|[2-9]*)
+-			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
++			shrpldflags="$shrpldflags -install_name `pwd -P`/\$@ -Xlinker -headerpad_max_install_names"
+ 			exeldflags="-Xlinker -headerpad_max_install_names"
+ 			;;
+ 		*)


### PR DESCRIPTION
#### Description

perl5: Resolve symlinks in dylib install name

Fixes build with MacPorts 2.11.2

Closes: https://trac.macports.org/ticket/72715

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
