### PR TITLE
google-cloud-sdk: update to 531.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             530.0.0
+version             531.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  6c42e1c30eadf6f94b8d0d62e81b18feb192563e \
-                    sha256  befb5fbc4d325db4fba5900706eed7fafc474cc287b7621db75c579650f570f1 \
-                    size    54898529
+    checksums       rmd160  a4270e1ebdd6e488dd0f73c8b429e58ee1315212 \
+                    sha256  2f1adf5022d96166bc384bded6b765e23ad2678c991048a0218f7075cca7cdcd \
+                    size    54957433
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  274bea0f065fdf86430f2c8a33982d1917a77a45 \
-                    sha256  b2a15c6fecc7437371f8ea79725d7ffcc007589f7688f691e00baa21f52832d7 \
-                    size    56429889
+    checksums       rmd160  8c18f09c098c20bd8034d302e48deba5c0573a24 \
+                    sha256  7fa65dba7930466f045f05acef70b82d927d29b28cf64aef6e1f1ae0237e3210 \
+                    size    56488131
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  b5e1095cc9039519bb3fa8520f0d744cf95e6564 \
-                    sha256  f39f5b5954baea352bb59dc2e216932b19efdd392d7540bb2133c496a0c6cd10 \
-                    size    56361549
+    checksums       rmd160  c0cae2d65c6c33ebe346e9744c51a04bb114778a \
+                    sha256  f55362e7e48ee9834c93624ba73aec0741368f5c98691b48ad404d6cb4ce98f4 \
+                    size    56421157
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -41,7 +41,7 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 
 worksrcdir          ${name}
 
-# Most recent Python version that supports to both
+# Most recent Python version that supports both
 # glcoud (https://cloud.google.com/sdk/docs/install#mac) and
 # gsutil (https://cloud.google.com/storage/docs/gsutil_install#before_you_begin)
 python.default_version 313


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 531.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?