### PR TITLE
ddrescueview: use ld-classic on macOS 14 and later

### DIFF
--- a/sysutils/ddrescueview/Portfile
+++ b/sysutils/ddrescueview/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            ddrescueview
 version         0.4.5
-revision        0
+revision        1
 categories      sysutils aqua
 license         GPL-2
 maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
@@ -31,9 +31,21 @@ depends_build   port:lazarus port:makeicns
 set savedsrcdir ${worksrcpath}
 worksrcdir      ${worksrcdir}/source
 
+patchfiles-append \
+                patch-deployment_target.patch
+
+set proj_file   ddrescueview.lpi
 post-patch {
+    reinplace "s|@@DEPLOYMENT_TARGET@@|${macosx_deployment_target}|g" ${proj_file}
     # remove incorrect linux linker options
-    reinplace "s|-z relro --as-needed||g" ddrescueview.lpi
+    if {${os.major} >= 23} {
+        # ld segfaults on macOS 15.4 and later and reports unaligned pointer on 14.x
+        # fall back to classic linker
+        # See https://gitlab.com/freepascal.org/lazarus/lazarus/-/issues/41570
+        reinplace "s|-z relro --as-needed|-ld_classic|g" ${proj_file}
+    } else {
+        reinplace "s|-z relro --as-needed||g" ${proj_file}
+    }
 }
 
 use_configure   no

--- a/sysutils/ddrescueview/files/patch-deployment_target.patch
+++ b/sysutils/ddrescueview/files/patch-deployment_target.patch
@@ -1,0 +1,10 @@
+--- ddrescueview.lpi.old	2022-02-26 02:47:26
++++ ddrescueview.lpi	2025-07-23 09:29:05
+@@ -260,6 +260,7 @@
+       <CompilerMessages>
+         <IgnoredMessages idx5091="True" idx5024="True" idx4080="True" idx4079="True"/>
+       </CompilerMessages>
++      <CustomOptions Value="-WM@@DEPLOYMENT_TARGET@@"/>
+     </Other>
+   </CompilerOptions>
+ </CONFIG>


### PR DESCRIPTION
set deployment target

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
