### PR TITLE
openjdk11-temurin: update to 11.0.28

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?os=mac&version=11
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.27
+version      ${feature}.0.28
 set build    6
 revision     0
 
@@ -32,14 +32,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  306d2fad65baf21067a6fae1b7a4f7d3a0c7f811 \
-                 sha256  805d225d46eab5702bf2f654856d846f426bebf6f143e5f06c8b1397855252e5 \
-                 size    187806165
+    checksums    rmd160  b889ea4ff01d70e772ff5ca56d72cb496e4d1615 \
+                 sha256  4683f3b751310bfd228a5a64e6ee643e9f1ccadd38b4bac3d74597dbf6d5d57a \
+                 size    187862376
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e25d8872549d7f3e331f741f474db550d805cab2 \
-                 sha256  780ae402dcd93fea0fee10d02dcd0a0b72cb7298f2ef4dddbad4d54c31a40a4d \
-                 size    185102522
+    checksums    rmd160  ced8aa4f7306cb1caf276a3fef508f56daac3ba2 \
+                 sha256  b5b46eb84aa2f301e739178aef0209c6843d6ad45b33f19dd39df4decdd29e9e \
+                 size    185148017
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.28.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?