### PR TITLE
liboqs: update to 0.14.0

### DIFF
--- a/devel/liboqs/Portfile
+++ b/devel/liboqs/Portfile
@@ -4,13 +4,12 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           openssl 1.0
 
 # _arc4random_buf
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        open-quantum-safe liboqs 0.13.0
+github.setup        open-quantum-safe liboqs 0.14.0
 revision            0
 categories          devel crypto
 license             MIT
@@ -20,9 +19,9 @@ description         C library for prototyping and experimenting with quantum-res
 long_description    {*}${description}
 homepage            https://openquantumsafe.org
 
-checksums           rmd160  b03e1dac5495f8c6e65052c38a24683104bbf57e \
-                    sha256  789e9b56bcb6b582467ccaf5cdb5ab85236b0c1007d30c606798fa8905152887 \
-                    size    16432953
+checksums           rmd160  e6cd5e0f2b053d5b5e8962e297b3ad73ed8c6a41 \
+                    sha256  5b0df6138763b3fc4e385d58dbb2ee7c7c508a64a413d76a917529e3a9a207ea \
+                    size    17928284
 github.tarball_from archive
 
 compiler.cxx_standard   2011
@@ -34,3 +33,6 @@ compiler.blacklist-append \
 
 configure.args-append \
                     -DBUILD_SHARED_LIBS=ON
+
+github.livecheck.regex \
+                    {([0-9.]+)}


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
