### PR TITLE
libomp: 20.1.8

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -27,8 +27,8 @@ epoch                   1
 
 if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
 
-    version             20.1.6
-    revision            1
+    version             20.1.8
+    revision            0
 
     livecheck.regex {"llvmorg-([0-9.]+)".*}
 
@@ -36,14 +36,14 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
     distfiles       ${distname}.tar.xz cmake-${version}.src.tar.xz
 
     checksums \
-        openmp-20.1.6.src.tar.xz \
-        rmd160  60f8defe957f7b5a4d56ce585a6caa3902ae065a \
-        sha256  ff8dabd89212cd41b4fc5c26433bcde368873e4f10ea0331792e6b6e7707eff9 \
-        size    1093988 \
-        cmake-20.1.6.src.tar.xz \
-        rmd160  64eee290f5fe98fe397f416886ac0ac3099cf67d \
-        sha256  b4b3efa5d5b01b3f211f1ba326bb6f0c318331f828202d332c95b7f30fca5f8c \
-        size    8644
+        openmp-20.1.8.src.tar.xz \
+        rmd160  38affbfcb416e8ae4272b552013715b38cb67dcf \
+        sha256  b21c04ee9cbe56e200c5d83823765a443ee6389bbc3f64154c96e94016e6cee9 \
+        size    1093976 \
+        cmake-20.1.8.src.tar.xz \
+        rmd160  a8f2663e84d840c15158f5d7dd090efab0f876c6 \
+        sha256  3319203cfd1172bbac50f06fa68e318af84dcb5d65353310c0586354069d6634 \
+        size    8652 
 
     if {${os.major} <= 12} {
         # kmp_alloc.c includes <atomic> but libc++ is not the default on


### PR DESCRIPTION
Maintainer update. Primarily to silence livecheck; no changes to libomp within clang 20.1.6 .. 20.1.8.