### PR TITLE
Rev bump dependents for opencascade update

### DIFF
--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -8,7 +8,7 @@ PortGroup               muniversal     1.1
 
 name                    gmsh
 version                 4.11.1
-revision                6
+revision                7
 categories              science
 license                 GPL-2+
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/kicad/Portfile
+++ b/science/kicad/Portfile
@@ -29,7 +29,7 @@ if {${name} eq ${subport}} {
     master_sites        macports_distfiles
 
     gitlab.setup        kicad/code kicad ${version}
-    revision            0
+    revision            1
     checksums           rmd160  05936277e09b18f03f773d7e8ffdd7fbb54e3376 \
                         sha256  24feb0747ee8d767c903fac5254c314a5012f4aee7016e961da845765764cf73 \
                         size    44083805
@@ -138,7 +138,7 @@ if {${name} eq ${subport}} {
 }
 
 subport kicad-docs {
-    revision            0
+    revision            1
     checksums           rmd160  9b5c9570129336d2cf603e91cbcc29f7668da69c \
                         sha256  0ecf3c1b748a1a2d07cc3f8e74e3ffcca948ee997b1eed2ef371ae4d7992ab9a \
                         size    602194906
@@ -163,7 +163,7 @@ subport kicad-docs {
 
 subport kicad-symbols {
     gitlab.setup        kicad/libraries kicad-symbols ${version}
-    revision            0
+    revision            1
     checksums           rmd160  dd69fdc2cf17e0574508663285024e6369348d43 \
                         sha256  666acf1ef282430721e64b651672d5a0b6896b3db7d8854f6035de767bf9b21b \
                         size    3369887
@@ -174,7 +174,7 @@ subport kicad-symbols {
 
 subport kicad-footprints {
     gitlab.setup        kicad/libraries kicad-footprints ${version}
-    revision            0
+    revision            1
     checksums           rmd160  e9f5b60f98f393c0d78b20e82bef74bb36fecc2f \
                         sha256  c07a5886023793efc4e697bd49b07c7e13d5ec6eb18db8bf62b849add219b48f \
                         size    22722611
@@ -185,7 +185,7 @@ subport kicad-footprints {
 
 subport kicad-packages3D {
     gitlab.setup        kicad/libraries kicad-packages3D ${version}
-    revision            0
+    revision            1
     checksums           rmd160  36f02b35321c7e203fb6308d8d9912bfe28d343f \
                         sha256  11361137f3604d11b12a1f5c132e939f6fed806bb2675d9990a985c967fae2f9 \
                         size    774735333
@@ -196,7 +196,7 @@ subport kicad-packages3D {
 
 subport kicad-templates {
     gitlab.setup        kicad/libraries kicad-templates ${version}
-    revision            0
+    revision            1
     checksums           rmd160  10be23bfa01d8b1e617197774b1e2768797a6e12 \
                         sha256  df708e2ac2a81cbe1fb8b655b0d29694dc8c530616d244330f4cd70a9e463fd2 \
                         size    1348043

--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -12,7 +12,7 @@ gitlab.setup            nektar nektar 5.6.0 v
 boost.version           1.76
 
 name                    nektarpp
-revision                1
+revision                2
 
 categories              science
 license                 MIT


### PR DESCRIPTION
#### Description

Bump 3 dependents.
Skip deal.ii, currently does not build and needs update.

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?