### PR TITLE
redka: update to 0.6.0

### DIFF
--- a/databases/redka/Portfile
+++ b/databases/redka/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/nalgeon/redka 0.5.3 v
+go.setup            github.com/nalgeon/redka 0.6.0 v
 revision            0
 categories          databases
 maintainers         {@sikmir disroot.org:sikmir} \
@@ -17,18 +17,16 @@ set go_ldflags      "-s -w -X main.version=${version}"
 
 build.args-append   -ldflags \"${go_ldflags}\" \
                     -o bin/ \
-                    ./cmd/redka \
-                    ./cmd/cli
+                    ./cmd/redka
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/bin/redka ${destroot}${prefix}/bin
-    xinstall -m 0755 ${worksrcpath}/bin/cli ${destroot}${prefix}/bin/redka-cli
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  fb957a1facf5aa8b16a2d21c3b16e6429415f537 \
-                        sha256  c5b1746f5c1af905d79247b1e3d808c0da14fd8caf1115023a4d12fe3ad8ebe4 \
-                        size    121584
+                        rmd160  89b6092ea0c09a72a0d8ac58cf9455c8b19a189c \
+                        sha256  cfccbfc5b4887211146352426efe0c3fcc2adbcfe71ef6b58da3d29cba867bde \
+                        size    130315
 
 go.vendors          github.com/tidwall/redcon \
                         lock    v1.6.2 \
@@ -45,8 +43,18 @@ go.vendors          github.com/tidwall/redcon \
                         rmd160  59017aac6c4fc24d16e2efffacf61f0d4d91e3e7 \
                         sha256  da5041373bcd1b0da101ec3cc26eeba68f778633a4611ad1165d1dd549a547aa \
                         size    31444 \
+                    github.com/nalgeon/be \
+                        lock    v0.2.0 \
+                        rmd160  e12cc4a67ca36f633df2dc385302ecc5a8c6a7a1 \
+                        sha256  6af905a7d7ace81d2970161d758ee2483254d317db413b77fd5fa87ba97936db \
+                        size    6844 \
                     github.com/mattn/go-sqlite3 \
-                        lock    v1.14.22 \
-                        rmd160  51cca4f09f23a404613e3eb48b77a44f4d98814e \
-                        sha256  02c8bc2780ff6f0b845e01efe0cfa006d8f85e48a06cd6c8566c21c3b88a644e \
-                        size    2602371
+                        lock    v1.14.28 \
+                        rmd160  911be9e03d227fbe5270191063d416a5fdf3bc70 \
+                        sha256  84d71a61cd24d6828c21be2e4b01908185480853fa8dc68d7c2dbfa59910f9f6 \
+                        size    2660019 \
+                    github.com/lib/pq \
+                        lock    v1.10.9 \
+                        rmd160  beb0e233773f49d8d08ee991abf23bc8febf69d0 \
+                        sha256  08610bf0370b202bee369b7303c3085e02c7f6fdfd42a3f58e8f033088151eea \
+                        size    114528


### PR DESCRIPTION
#### Description
https://github.com/nalgeon/redka/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
