### PR TITLE
GPXSee: update to 13.45

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.43
+github.setup        tumic0 GPXSee 13.45
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  05bb183802b19fb57d2168dc132daacc6dff00d8 \
-                    sha256  6ff815a376042eb5d2db174c897fab2948ce1ba57293a71c50d7f54b7ed96f4b \
-                    size    5903063
+checksums           rmd160  f59df46f73f56ee4afbdd62b97f4b35f9cc7f603 \
+                    sha256  e4a6bebe97c21b989dfa6be2dfcc2c20b8f17590b234fee57932662e82d50557 \
+                    size    5914049
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
