### PR TITLE
newsraft: update to 0.32

### DIFF
--- a/net/newsraft/Portfile
+++ b/net/newsraft/Portfile
@@ -5,7 +5,7 @@ PortGroup           codeberg 1.0
 PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
-codeberg.setup      newsraft newsraft 0.31 newsraft-
+codeberg.setup      newsraft newsraft 0.32 newsraft-
 revision            0
 
 categories          net
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Feed reader for terminal
 long_description    {*}${description}
 
-checksums           rmd160  0eca28d379a5b0833daaf214dae86f16659eb2e4 \
-                    sha256  de0d96664d9a276dbe58cf4b44a6861bc18b6fd4c0f41a97450c5b3509904ae8 \
-                    size    224575
+checksums           rmd160  bb458ef55e92ec6ae283bb6b994dd7af1364f2d5 \
+                    sha256  a3b5f4935189316b5962658f29669472798a3e40d62b4f60d66644af3f04d2d3 \
+                    size    225800
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
#### Description
https://codeberg.org/newsraft/newsraft/releases/tag/newsraft-0.32

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
