### PR TITLE
miniflux: update to 2.2.10

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.2.8
+go.setup            github.com/miniflux/v2 2.2.10
 go.package          miniflux.app/v2
 go.offline_build    no
 name                miniflux
@@ -18,9 +18,9 @@ description         Minimalist and opinionated feed reader
 long_description    {*}${description}
 homepage            https://miniflux.app
 
-checksums           rmd160  fa84b7222a2a87f29bf97292efcd27bb8117dc29 \
-                    sha256  1c360012c3dd0202601db26755c511969b6c527f96d6829861a74095633a35c2 \
-                    size    815761
+checksums           rmd160  14ebfd2cc9cd5181f5aab857027b42fccd724e86 \
+                    sha256  a216b93a32d14a7a6ca48fd7f5e86b8a4e8c58b1bf5d83fc4d3aacaaaf4e6a48 \
+                    size    835514
 
 build.args-append   \
     -ldflags=\"-s -w -X \


### PR DESCRIPTION
#### Description
https://github.com/miniflux/v2/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
