### PR TITLE
openjdk24-temurin: update to 24.0.2

### DIFF
--- a/java/openjdk24-temurin/Portfile
+++ b/java/openjdk24-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.1
-set build    9
+version      ${feature}.0.2
+set build    12
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Short Term Support until September 2025)
@@ -28,14 +28,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e74adf5247f1a291310544bfc4423bba85984834 \
-                 sha256  181593f79dd278e0f44712cd87fd9874fd191e211810a0712450963370badb0a \
-                 size    120245031
+    checksums    rmd160  b506ebb2fe84e1c2595f6f89cc939d23cd590807 \
+                 sha256  4f63497563f6f0eb109f6898bb2e45e6cb428a6e4abe0772698493e373e8f0c7 \
+                 size    120239215
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  f2cb000ff7942f6bcb52ee0c237df9961588267a \
-                 sha256  e3b1fe4cd3da335d07d62f335ae958f5a43c594be1ba333a06a03a49d2212cd4 \
-                 size    135757102
+    checksums    rmd160  f8acd65aca462fb707d33bba6437b06bbae8f682 \
+                 sha256  db2ba6f72c19ad8b742303a504f58474bceeb94174a185de5f095c1d45577f1c \
+                 size    135764495
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 24.0.2.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?