### PR TITLE
groovy: update to 4.0.28

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         4.0.27
+version         4.0.28
 revision        0
 
 categories      lang java
@@ -30,9 +30,9 @@ master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zi
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  e5aed16cde54af47c6b32aa9beed6907dac8ff9d \
-                sha256  bc917c8bb01b2832f124a7bd63a3c72ba5e83ef7f056650dfd9a2f7944960685 \
-                size    30200400
+checksums       rmd160  1281a6a21b18795b6fdcbb0a5eea99d832cb3c4d \
+                sha256  6a052bfd2ca77d57e0db304a313dd9a729945c5a31420e6d48505be4840bfc54 \
+                size    30311613
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Apache Groovy 4.0.28.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?