### PR TITLE
openjdk17-openj9: update to 17.0.16

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -20,11 +20,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.15
+version      ${feature}.0.16
 revision     0
 
-set build    6
-set openj9_version 0.51.0
+set build    8
+set openj9_version 0.53.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -34,14 +34,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  cc7cccb5578552d4b5f3076bb6c65ec3a025259a \
-                 sha256  f52976bb35df541e396337d5b0b68c61c8a2f1e03ed643ba393831091f42bbf6 \
-                 size    213534650
+    checksums    rmd160  a95b28ffe7e2f4381edcc97226608b2ab2f1adb2 \
+                 sha256  0f650ef3c4c442ba21da7f2ad0d4382434af91dc7894ca9da4ef79f25110ff51 \
+                 size    218453781
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  84728f446bd6555777fa3eed7f9833a25816f853 \
-                 sha256  0a2a57c97c01e9fda2ac6c128702efa856371dac991b0260d1dc9cedf69d4bad \
-                 size    207256732
+    checksums    rmd160  3228bcb93c1d51793a3751981710bbb36aeba2cb \
+                 sha256  aed4e6351d142cab02fbf3f6c6275e828071254d611ec7c022c7a1718df65e4d \
+                 size    212947941
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.16.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?