### PR TITLE
openjdk11-openj9: update to 11.0.28

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -15,11 +15,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.27
+version      ${feature}.0.28
 revision     0
 
 set build    6
-set openj9_version 0.51.0
+set openj9_version 0.53.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -29,14 +29,14 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  4900ffb79525e8de7d4004bf3fb8d968a012f40a \
-                 sha256  bfb748db4246d0b78554f461f6e4fe7909c0a4c595ec7a7535a287dc3ab3feaa \
-                 size    207960615
+    checksums    rmd160  7272e4f9844b7edeaadc8ee5432f8a5d5aa3ce74 \
+                 sha256  9df4034690c682bf76a024b04af4716e9fd4a7b20939688fe44a2a01e5fd6c42 \
+                 size    212710773
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  927df8fa8035542e68bb165a28037ef1f6e2709c \
-                 sha256  93bda5ae950cc2fba34803b059ad13db567f50ea2d8b7a635d39c3bc330a4890 \
-                 size    201938561
+    checksums    rmd160  596f44f7301a32f313a5f9592ae3ae842cb7bd91 \
+                 sha256  b5d685f5851f21c9e8eb11644b2bd65659eba46541050c985160956206b62627 \
+                 size    207506284
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.28.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?