### PR TITLE
openjdk8-openj9: update to 8u462

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -20,11 +20,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
-version      ${feature}u452
+version      ${feature}u462
 revision     0
 
-set build    09
-set openj9_version 0.51.0
+set build    08
+set openj9_version 0.53.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -35,9 +35,9 @@ master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/d
 distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  1bc27eada9d15e1d287156345379539e35496aa3 \
-             sha256  04ce03f6b8f914821425a1c118bd20d4d9f014346efe1592f78fd91ff4345de4 \
-             size    129528649
+checksums    rmd160  d6325865a604a695715963b26718f8cdfe4e2c90 \
+             sha256  9ea9098514a47a44dfa083b2fb82395bace0751314488618bd5e098ff120d6d7 \
+             size    129898129
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8u462.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
