### PR TITLE
cppcheck: update to 2.18.0

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -2,9 +2,8 @@
 
 PortSystem                  1.0
 PortGroup                   github 1.0
-PortGroup                   compiler_blacklist_versions 1.0
 
-github.setup                danmar cppcheck 2.17.1
+github.setup                danmar cppcheck 2.18.0
 revision                    0
 
 categories                  devel
@@ -21,11 +20,11 @@ long_description            Cppcheck is an analysis tool for C and C++ code. Unl
 
 github.tarball_from         archive
 
-checksums                   rmd160  1b761190f2ceb30397f4330d03a6608c9150669e \
-                            sha256  bfd681868248ec03855ca7c2aea7bcb1f39b8b18860d76aec805a92a967b966c \
-                            size    3872633
+checksums                   rmd160  3ef5bd06d13865874e0b6a88aca10917e8ce5665 \
+                            sha256  dc74e300ac59f2ef9f9c05c21d48ae4c8dd1ce17f08914dd30c738ff482e748f \
+                            size    3928107
 
-set python_branch   3.12
+set python_branch   3.13
 set python_version  [string map {"." ""} ${python_branch}]
 set python_bin      ${prefix}/bin/python${python_branch}
 
@@ -64,12 +63,6 @@ build.args                  CXX="${configure.cxx} [get_canonical_archflags cxx] 
                             MATCHCOMPILER=yes \
                             PREFIX=${prefix} \
                             PYTHON_INTERPRETER=${python_bin}
-
-# https://trac.macports.org/ticket/66418
-platform darwin 8 {
-    depends_build-append    port:gmake-apple
-    build.cmd               gmake-apple
-}
 
 test.run                    yes
 test.target                 test


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 4.2 4C199

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
