### PR TITLE
mqttui: update to 0.22.1

### DIFF
--- a/net/mqttui/Portfile
+++ b/net/mqttui/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo  1.0
 
-github.setup        EdJoPaTo mqttui 0.22.0 v
+github.setup        EdJoPaTo mqttui 0.22.1 v
 github.tarball_from archive
 revision            0
 
@@ -16,9 +16,9 @@ description         Simple lightweight terminal based MQTT monitor and publisher
 long_description    {*}${description}
 
 checksums           ${distfiles} \
-                    rmd160  62c3ae5d58213c3174f6b06f9687e15c9879effd \
-                    sha256  49bb8839b8c27d2a879c73bd3a26231c1a69263eca8af0b469365b115fadb3ad \
-                    size    223677
+                    rmd160  6cb2ea31481bf1a342780451deb9be92ed112cb5 \
+                    sha256  c8a65a1aef2e96484e09972de50fb6150a868cd30ce16d26df1466fdac1a6c75 \
+                    size    223079
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/target/[option triplet.${muniversal.build_arch}]/release/${name} ${destroot}${prefix}/bin/
@@ -26,8 +26,11 @@ destroot {
 
 cargo.crates_github \
     ratatui-binary-data-widget EdJoPaTo/ratatui-binary-data-widget main \
-    4405e4547d25917f217a810920813bf1a00de1fc \
-    1561bbbe009ad0c45aa18661bb7f87c209de147e8dcc6615ff56ebc8c08a34d6
+    84d5714ea44c98dea255b1264780da15e3b657a7 \
+    ccb9252fcb44dccca1f28cc26987549e4be3390e55a2a9b51049181d810ea696 \
+    ratatui-logline-table EdJoPaTo/ratatui-logline-table main \
+    fda5ce9afad6115289f81ed5c2720e516efa5459 \
+    009d350b52810bccd7f590e33f2b04525ceec1d04e4210dccc62ac3452c8a8d1
 
 cargo.crates \
     addr2line                       0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
@@ -40,7 +43,7 @@ cargo.crates \
     anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                   3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
-    anyhow                          1.0.96  6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4 \
+    anyhow                          1.0.97  dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f \
     async-tungstenite               0.25.1  2cca750b12e02c389c1694d35c16539f88b8bbaa5945934fdc1b41a776688589 \
     async_io_stream                  0.3.3  b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
@@ -49,16 +52,16 @@ cargo.crates \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     bumpalo                         3.17.0  1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                           1.10.0  f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9 \
+    bytes                           1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     castaway                         0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
-    cc                              1.2.16  be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c \
+    cc                              1.2.18  525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chrono                          0.4.40  1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c \
-    clap                            4.5.31  027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767 \
-    clap_builder                    4.5.31  5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863 \
-    clap_complete                   4.5.46  f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98 \
-    clap_derive                     4.5.28  bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed \
+    clap                            4.5.35  d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944 \
+    clap_builder                    4.5.35  2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9 \
+    clap_complete                   4.5.47  c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6 \
+    clap_derive                     4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     clap_mangen                     0.2.26  724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
@@ -74,12 +77,12 @@ cargo.crates \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     ego-tree                        0.10.0  b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8 \
-    either                          1.14.0  b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d \
+    either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
-    errno                           0.3.10  33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d \
+    errno                           0.3.11  976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e \
     flume                           0.11.1  da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    foldhash                         0.1.4  a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f \
+    foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
     futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
@@ -92,22 +95,22 @@ cargo.crates \
     futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
-    getrandom                        0.3.1  43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8 \
+    getrandom                        0.3.2  73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0 \
     gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     hashbrown                       0.15.2  bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
-    http                             1.2.0  f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea \
-    httparse                        1.10.0  f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a \
-    iana-time-zone                  0.1.61  235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220 \
+    http                             1.3.1  f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565 \
+    httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
+    iana-time-zone                  0.1.63  b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
     icu_locid                        1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
     icu_locid_transform              1.5.0  01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e \
-    icu_locid_transform_data         1.5.0  fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e \
+    icu_locid_transform_data         1.5.1  7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d \
     icu_normalizer                   1.5.0  19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f \
-    icu_normalizer_data              1.5.0  f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516 \
+    icu_normalizer_data              1.5.1  c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7 \
     icu_properties                   1.5.1  93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5 \
-    icu_properties_data              1.5.0  67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569 \
+    icu_properties_data              1.5.1  85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2 \
     icu_provider                     1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
     icu_provider_macros              1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
     idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
@@ -115,21 +118,21 @@ cargo.crates \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
-    itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
+    itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
     js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
-    libc                           0.2.170  875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828 \
-    linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
+    libc                           0.2.171  c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6 \
+    linux-raw-sys                    0.9.3  fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413 \
     litemap                          0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
-    log                             0.4.26  30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e \
+    log                             0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
     lru                             0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
-    miniz_oxide                      0.8.5  8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5 \
+    miniz_oxide                      0.8.7  ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430 \
     mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
     mio                              1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     object                          0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
-    once_cell                       1.20.3  945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e \
+    once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
     openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
@@ -138,9 +141,10 @@ cargo.crates \
     pharos                           0.5.3  e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414 \
     pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
-    proc-macro2                     1.0.93  60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99 \
-    quote                           1.0.38  0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc \
+    ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
+    proc-macro2                     1.0.94  a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84 \
+    quote                           1.0.40  1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
+    r-efi                            5.2.0  74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand                             0.9.0  3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
@@ -148,41 +152,41 @@ cargo.crates \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
     ratatui                         0.26.3  f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef \
-    redox_syscall                    0.5.9  82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f \
-    ring                           0.17.11  da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73 \
+    redox_syscall                   0.5.11  d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3 \
+    ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rmp                             0.8.14  228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4 \
     rmpv                             1.3.0  58450723cd9ee93273ce44a20b6ec4efe17f8ed2e3631474387bfdecf18bb2a9 \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     rumqttc                         0.24.0  e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
-    rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
+    rustix                           1.0.5  d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf \
     rustls                          0.22.4  bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432 \
     rustls-native-certs              0.7.3  e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5 \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
     rustls-pki-types                1.11.0  917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c \
     rustls-webpki                  0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
-    rustversion                     1.0.19  f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4 \
-    ryu                             1.0.19  6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd \
+    rustversion                     1.0.20  eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2 \
+    ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
     security-framework               3.2.0  271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316 \
     security-framework-sys          2.14.0  49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32 \
-    semver                          1.0.25  f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03 \
-    serde                          1.0.218  e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60 \
-    serde_bytes                    0.11.15  387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a \
-    serde_derive                   1.0.218  f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b \
-    serde_json                     1.0.139  44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6 \
+    semver                          1.0.26  56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0 \
+    serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
+    serde_bytes                    0.11.17  8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96 \
+    serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
+    serde_json                     1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
     signal-hook-mio                  0.2.4  34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd \
     signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
     slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
-    smallvec                        1.14.0  7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd \
-    socket2                          0.5.8  c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8 \
+    smallvec                        1.15.0  8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9 \
+    socket2                          0.5.9  4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     stability                        0.2.1  d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
@@ -191,13 +195,13 @@ cargo.crates \
     strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
-    syn                             2.0.98  36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1 \
+    syn                            2.0.100  b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
-    terminal_size                    0.4.1  5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9 \
+    terminal_size                    0.4.2  45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
-    tokio                           1.43.0  3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e \
+    tokio                           1.44.2  e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48 \
     tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-rustls                    0.25.0  775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f \
     tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
@@ -206,7 +210,7 @@ cargo.crates \
     tui-tree-widget                 0.20.0  a6201de8ad8d88cb6cac4cfe3436d9a1ea31c0732a7aec4c2cc3b23186ad7dcc \
     tungstenite                     0.21.0  9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1 \
     typenum                         1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
-    unicode-ident                   1.0.17  00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe \
+    unicode-ident                   1.0.18  5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512 \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-truncate                 1.1.0  b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf \
     unicode-width                   0.1.12  68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6 \
@@ -218,7 +222,7 @@ cargo.crates \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasi                          0.13.3+wasi-0.2.2  26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2 \
+    wasi                          0.14.2+wasi-0.2.4  9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3 \
     wasm-bindgen                   0.2.100  1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
     wasm-bindgen-backend           0.2.100  2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
     wasm-bindgen-macro             0.2.100  7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407 \
@@ -227,8 +231,12 @@ cargo.crates \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
-    windows-link                     0.1.0  6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3 \
+    windows-core                    0.61.0  4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980 \
+    windows-implement               0.60.0  a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836 \
+    windows-interface               0.59.1  bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8 \
+    windows-link                     0.1.1  76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38 \
+    windows-result                   0.3.2  c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252 \
+    windows-strings                  0.4.0  7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
@@ -249,16 +257,14 @@ cargo.crates \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    wit-bindgen-rt                  0.33.0  3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c \
+    wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
     write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
     writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
     ws_stream_tungstenite           0.13.0  a198f414f083fb19fcc1bffcb0fa0cf46d33ccfa229adf248cac12c180e91609 \
     yoke                             0.7.5  120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40 \
     yoke-derive                      0.7.5  2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154 \
-    zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
-    zerocopy                        0.8.21  dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478 \
-    zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
-    zerocopy-derive                 0.8.21  712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2 \
+    zerocopy                        0.8.24  2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879 \
+    zerocopy-derive                 0.8.24  a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be \
     zerofrom                         0.1.5  cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e \
     zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \


### PR DESCRIPTION
#### Description
https://github.com/EdJoPaTo/mqttui/releases/tag/v0.22.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
