### PR TITLE
gemget: update to 1.9.0

### DIFF
--- a/net/gemget/Portfile
+++ b/net/gemget/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/makeworld-the-better-one/gemget 1.8.0 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+go.setup            github.com/makew0rld/gemget 1.9.0 v
+go.package          github.com/makeworld-the-better-one/gemget
 revision            0
 categories          net gemini
 maintainers         {@sikmir gmail.com:sikmir} openmaintainer
@@ -14,21 +13,23 @@ license             MIT
 description         Command line downloader for the Gemini protocol
 long_description    ${description}
 
+build.args          -ldflags '-X main.version=${version}'
+
 checksums           ${distname}${extract.suffix} \
-                        rmd160  c43dfd2307c6c3ad4da37671438266313efa864e \
-                        sha256  ce0dcc04c220aee8faf692d08d43627ea3fd40c3d56fd7ea889f7fb7aaea35e2 \
-                        size    10457
+                        rmd160  ababb335f2444063d09d33050cdc3a7cb24c012a \
+                        sha256  ded2b0d86e24d0a35a35ea412d08ebff636698fa5114e0da80b5b4c1b003e431 \
+                        size    11883
 
 go.vendors          golang.org/x/text \
-                        lock    v0.3.3 \
-                        rmd160  babfa547ba9a9dab7fe08fa5543f1d8e7ae00301 \
-                        sha256  1c4a8c12295d484e0360d8e010ebc4b8a9a05aa2a07c10c3d3e5b17aa063f0db \
-                        size    7745597 \
+                        lock    v0.7.0 \
+                        rmd160  bd2aafec6ceb2ea04c3904d2f7308916ca2b7a87 \
+                        sha256  9f3c2fc2967a7a81586f0af894f2a60ddcad5e7acda9713cd6b9cf2b39df010d \
+                        size    8361394 \
                     golang.org/x/net \
-                        lock    986b41b23924 \
-                        rmd160  83029228f5946c63337ea000b5123ccd20245004 \
-                        sha256  384b8c1e750469fe62d9280126a8218bf1f4eb13734ebaf4f856ae6dc18060a3 \
-                        size    1251258 \
+                        lock    v0.7.0 \
+                        rmd160  e2907c7257546564c6b2eb97189d65da022bc6dc \
+                        sha256  aa9701a779a24fa615009ab3f177145c2a39a0e5366de39a08b84a0f952587b6 \
+                        size    1241181 \
                     github.com/stretchr/testify \
                         lock    v1.3.0 \
                         rmd160  80582370443047a1d7020211865d85d54c036eea \
@@ -59,11 +60,18 @@ go.vendors          golang.org/x/text \
                         rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
                         sha256  4f0f4a22257ccecfb6beae88052d850380ecc0e806d6bcc92d3656ebcac3b638 \
                         size    16716 \
+                    github.com/makeworld-the-better-one/go-gemini-socks5 \
+                        repo    github.com/makew0rld/go-gemini-socks5 \
+                        lock    v1.0.0 \
+                        rmd160  cf1475937df982aca8dc0ad214b6a46b522c1b18 \
+                        sha256  aa7c78414140524a8d045489620dc9c16ce277475b8f438852ab8beb03af5833 \
+                        size    2505 \
                     github.com/makeworld-the-better-one/go-gemini \
-                        lock    v0.11.0 \
-                        rmd160  8b52426f5ed2718c7e1d637de4e2dd2da0053dc3 \
-                        sha256  297368c8e482401448132cc6b04b41b87ff213111119861653aa7cd77f0e4391 \
-                        size    11863 \
+                        repo    github.com/makew0rld/go-gemini \
+                        lock    v0.13.1 \
+                        rmd160  116fe228eed7d54efffb2d8922640a5f45ac3aea \
+                        sha256  f92569261a9d68003bee707d8bfa2ae66843d9bcd62f3673c428d5424fff9313 \
+                        size    13990 \
                     github.com/google/go-cmp \
                         lock    v0.3.1 \
                         rmd160  66e42f672a5a40561c388b78b3644abd926e7bef \
@@ -79,8 +87,6 @@ go.vendors          golang.org/x/text \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171
-
-build.args          -ldflags '-X main.version=${version}'
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description
https://github.com/makew0rld/gemget/releases/tag/v1.9.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
