### PR TITLE
spring-boot-cli: update to 3.5.4

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.5.3
+version         3.5.4
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  279d38803855d89eb832b75e5313ed1b1a7d207c \
-                sha256  b389572d77cf7ae521315f8066355a52d92820ecc1f24fddd3fd4bc558fc69e3 \
-                size    7151413
+checksums       rmd160  7231d5468e6e96baac658b5a96b7dddc2cc8d84c \
+                sha256  41f608403e982b25e4384cff287f00be0a307ac25d2f56f1210488a9bcc51627 \
+                size    7152240
 
 worksrcdir      spring-${version}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.5.4.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?