### PR TITLE
yt-dlp: update to 2025.07.21

### DIFF
--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -37,11 +37,11 @@ if {${subport} eq ${name}} {
 }
 
 subport yt-dlp {
-    github.setup    yt-dlp ${subport} 2025.06.30
+    github.setup    yt-dlp ${subport} 2025.07.21
     revision        0
-    checksums       rmd160  9ab7985301b90f1a6c78b360e7641dfbddbdcc6a \
-                    sha256  606f3e3e431839998d1f377de615a9792e77e5968ad929c2c6ba1a17774bbf1b \
-                    size    6029721
+    checksums       rmd160  5be56bf963ab717002d7f2e3e6db1c781e998ff7 \
+                    sha256  36cbd8a36c30c8a17c13faf452118c1ee8ba1aeb8516aa4ead6f17d8a6e4a10a \
+                    size    6055710
     dist_subdir     ${subport}/${version}
     distname        ${subport}
 


### PR DESCRIPTION
#### Description

yt-dlp: update to 2025.07.21

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
