### PR TITLE
Enforce C++14 for libmodplug

### DIFF
--- a/audio/libmodplug/Portfile
+++ b/audio/libmodplug/Portfile
@@ -18,6 +18,11 @@ master_sites    sourceforge:modplug-xmms
 checksums       rmd160  81eae38506cfba344af9b01c2336de643adbbbe3 \
                 sha256  457ca5a6c179656d66c01505c0d95fafaead4329b9dbaa0f997d00a3508ad9de
 
+
+# Use C++14 (libmodplug uses the register keyword which is not supported in C++17 and higher)
+compiler.cxx_standard 2014
+configure.cxxflags-append -std=c++14
+
 # Teach glibtool about -stdlib=libc++
 use_autoreconf  yes
 autoreconf.args -fvi


### PR DESCRIPTION
#### Description

libmodplug no longer compiles with Clang by default, as it uses the register keyword in its source code, which isn't supported in C++17 and higher. This patch to the port file enforces C++14, in which the register keyword is still supported, and allows it to compile once again.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A5316i arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
