### PR TITLE
Enforce C++14 on libLASi

### DIFF
--- a/print/libLASi/Portfile
+++ b/print/libLASi/Portfile
@@ -37,6 +37,11 @@ depends_lib             port:fontconfig \
                         path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                         path:lib/pkgconfig/pango.pc:pango
 
+# Enforce C++14 to resolve error below:
+# error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
+compiler.cxx_standard 2014
+configure.cxxflags-append -std=c++14
+
 cmake.build_type        Release
 
 build.target            LASi/fast


### PR DESCRIPTION
#### Description

As of C++17, dynamic exception specifications are no longer supported, and libLASi uses them. As such, enforce C++14 to allow it to build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.0 25A5316i arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
