### PR TITLE
git: Quote path to TKEXECUTABLE

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -12,7 +12,7 @@ name                git
 # NOTE: Update the DEVEL version first before updating this RELEASE version,
 #       to verify that the intended version builds on all platforms.
 version             2.50.1
-revision            0
+revision            1
 
 description         A fast version control system
 
@@ -25,7 +25,7 @@ subport ${name}-devel {
 
     github.setup        git git 2.50.1 v
     github.tarball_from archive
-    revision            0
+    revision            1
 
     description     \
         {*}${description} (Development Version)
@@ -127,6 +127,7 @@ depends_lib-append  port:curl \
 depends_run-append  path:bin/rsync:rsync
 
 patchfiles-append   patch-Makefile.diff \
+                    patch-git-gui-GIT-GUI-BUILD-OPTIONS.in.diff \
                     patch-git-subtree.1.diff \
                     patch-sha1dc-older-apple-gcc-versions.diff
 

--- a/devel/git/files/patch-git-gui-GIT-GUI-BUILD-OPTIONS.in.diff
+++ b/devel/git/files/patch-git-gui-GIT-GUI-BUILD-OPTIONS.in.diff
@@ -1,0 +1,10 @@
+Quote TKEXECUTABLE for Mac OS X 10.5 and earlier where the path contains spaces
+(/System/Library/Frameworks/Tk.framework/Resources/Wish Shell.app/Contents/MacOS/Wish Shell)
+--- a/git-gui/GIT-GUI-BUILD-OPTIONS.in.orig	2025-06-16 00:11:33.000000000 -0500
++++ b/git-gui/GIT-GUI-BUILD-OPTIONS.in	2025-07-27 15:44:43.000000000 -0500
+@@ -4,4 +4,4 @@
+ SHELL_PATH=@SHELL_PATH@
+ TCLTK_PATH=@TCLTK_PATH@
+ TCL_PATH=@TCL_PATH@
+-TKEXECUTABLE=@TKEXECUTABLE@
++TKEXECUTABLE="@TKEXECUTABLE@"


### PR DESCRIPTION
#### Description

Fixes build failure on Mac OS X 10.5 and earlier where that path contains spaces.

Closes: https://trac.macports.org/ticket/72706

I *didn't* test this on 10.5. I hope someone on 10.5 will test this before merging.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
