### PR TITLE
borgmatic: Update to 2.0.7, use Python 3.13

### DIFF
--- a/sysutils/borgmatic/Portfile
+++ b/sysutils/borgmatic/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                borgmatic
-version             1.9.13
+version             2.0.7
 revision            0
 
-checksums           rmd160  d446a45a8ee9ae4bf1bfc40a907dcd68aaea49b9 \
-                    sha256  a30cfa47dae10cd04592f68d9d7fd46d10235e62aeb5195877fb326e0fc89bf9 \
-                    size    655690
+checksums           rmd160  2fd34155e3932c10bd72b4548f02907bf9b6850f \
+                    sha256  1ee9ca5d5b83193747f82cc841bb64374a11328710ee0561e8c7fa2fbc258406 \
+                    size    684455
 
 categories          sysutils
 platforms           {darwin any}
@@ -25,7 +25,7 @@ long_description    \
 
 homepage            https://torsion.org/borgmatic/
 
-python.default_version  312
+python.default_version  313
 
 depends_build-append \
                     port:py${python.version}-setuptools
@@ -48,3 +48,20 @@ post-destroot {
         ${worksrcpath}/LICENSE \
         ${docdir}
 }
+
+notes "If you are upgrading from borgmatic < 2.0, there are few breaking changes:
+- BREAKING: For both new and deprecated command hooks, run a configured 'after'\
+hook even if an error occurs first. This allows you to perform cleanup steps\
+that correspond to 'before' preparation commands—even when something goes\
+wrong.
+- BREAKING: Run all command hooks (both new and deprecated) respecting the\
+'working_directory' option if configured, meaning that hook commands are run\
+in that directory.
+
+Additionally, the configuration format changed, especially around before_*,\
+after_* and on_error hooks. See \[1] for the current docs. \[2] has\
+instructions to upgrade your current configuration file to match the new format\
+(use borgmatic config generate --source oldconfig.yaml).
+
+\[1]: https://torsion.org/borgmatic/docs/how-to/add-preparation-and-cleanup-steps-to-backups/
+\[2]: https://torsion.org/borgmatic/docs/how-to/upgrade/#upgrading-your-configuration"


### PR DESCRIPTION
#### Description

Upstream changelog at
https://projects.torsion.org/borgmatic-collective/borgmatic/releases. Note that there are a few breaking changes:

- BREAKING: For both new and deprecated command hooks, run a configured "after" hook even if an error occurs first. This allows you to perform cleanup steps that correspond to "before" preparation commands—even when something goes wrong.
- BREAKING: Run all command hooks (both new and deprecated) respecting the "working_directory" option if configured, meaning that hook commands are run in that directory.

Additionally, the configuration format changed, especially around before_*, after_* and on_error hooks. See [1] for the current docs. [2] has instructions to upgrade your current configuration file to match the new format (use borgmatic config generate --source oldconfig.yaml).

[1]: https://torsion.org/borgmatic/docs/how-to/add-preparation-and-cleanup-steps-to-backups/
[2]: https://torsion.org/borgmatic/docs/how-to/upgrade/#upgrading-your-configuration

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
