### PR TITLE
icon: Update to 9.5.25a

### DIFF
--- a/lang/icon/Portfile
+++ b/lang/icon/Portfile
@@ -7,7 +7,7 @@ PortGroup           makefile 1.0
 # The MacPorts tracked "version number" for this port includes the
 # tag suffix, e.g. 9.5.24b.  This matches the upstream tag labeling.
 
-github.setup        gtownsend icon 9.5.24 v b
+github.setup        gtownsend icon 9.5.25 v a
 revision            0
 version             ${github.version}${github.tag_suffix}
 github.tarball_from archive
@@ -26,18 +26,36 @@ long_description    Icon is a high-level, general-purpose programming \
 
 homepage            https://www.cs.arizona.edu/icon/
 
-checksums           rmd160  4aa95dc9816aa174b59629eb1e54123582be840e \
-                    sha256  85d695ab34d62f86d5b08f5bde91200026c1fc5a67f33f47c498f96e72543c62 \
-                    size    3086266
+checksums           rmd160  7dd9f0905694292053a835f3929744abb281c91a \
+                    sha256  ab15b7fc5a96e8b4da1b76cc6c7935400879f8a54b0fcf94a947c02815f21006 \
+                    size    3086255
 
 universal_variant   no
 use_parallel_build  no
 
+# Create a custom MacPorts "Makedefs" file for the Icon build system.
+# Overwrite the original version in icon-source/config/macintosh/Makedefs.
+
+set SYS_NAME        macintosh
+
+post-extract {
+    ui_debug "Create custom config/${SYS_NAME}/Makedefs file for MacPorts."
+    set makedefs [open ${worksrcpath}/config/${SYS_NAME}/Makedefs "w"]
+    puts ${makedefs} "CC     = ${configure.cc}"
+    puts ${makedefs} "CFLAGS = ${configure.cflags}"
+    puts ${makedefs} "CFDYN  ="
+    puts ${makedefs} "RLINK  = ${configure.ldflags}"
+    puts ${makedefs} "RLIBS  ="
+    puts ${makedefs} "TLIBS  ="
+    puts ${makedefs} "XLIBS  = -lXpm -lX11"
+    puts ${makedefs} "SFLAGS ="
+    close ${makedefs}
+}
+
 use_configure       yes
 configure.cmd       make
 configure.pre_args
-
-configure.args      Configure name=macintosh
+configure.args      Configure name=${SYS_NAME}
 
 build.target        All
 
@@ -57,9 +75,14 @@ post-destroot {
     ln -s ../../../libexec/${name}/man/man1/icont.1 ${man1_dir}
 }
 
-#default_variants    +x11
+default_variants    +x11
 
 variant x11 {
-    configure.args X-Configure name=macintosh
-    depends_lib-append    port:xorg-libXt
+    depends_lib-append          port:xorg-libXt \
+                                port:xpm
+    configure.args              X-Configure name=${SYS_NAME}
 }
+
+# Version has a letter suffix, so include letter on both sides of livecheck.
+livecheck.version   ${version}
+livecheck.regex     /tags/v(\[0-9a-z.\]+)\\.tar\\.gz


### PR DESCRIPTION
#### Description

* Update icon 9.5.1 --> 9.5.25a.
* Switch to github portgroup, and github named tags.
* Fix builds for default x11 variant.

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?