### PR TITLE
google-cloud-sdk: update to 532.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             531.0.0
+version             532.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  a4270e1ebdd6e488dd0f73c8b429e58ee1315212 \
-                    sha256  2f1adf5022d96166bc384bded6b765e23ad2678c991048a0218f7075cca7cdcd \
-                    size    54957433
+    checksums       rmd160  efc2e495f432d01fa8ce30ad3572ea39b4f2e64a \
+                    sha256  f3ad6237bac2351851f5a78ee27d5b6058b5b07d7cc19d20a8255ef4ac1ff814 \
+                    size    55022568
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  8c18f09c098c20bd8034d302e48deba5c0573a24 \
-                    sha256  7fa65dba7930466f045f05acef70b82d927d29b28cf64aef6e1f1ae0237e3210 \
-                    size    56488131
+    checksums       rmd160  554aed322903390c89c56c517895763c88058ae1 \
+                    sha256  90aed88a3ddfbde9544691cfd34e1ff93b3963df89d038cb77bdbae436447d6b \
+                    size    56552306
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  c0cae2d65c6c33ebe346e9744c51a04bb114778a \
-                    sha256  f55362e7e48ee9834c93624ba73aec0741368f5c98691b48ad404d6cb4ce98f4 \
-                    size    56421157
+    checksums       rmd160  b0d53a45afd7a661916c6c9cdd377253a5ba6602 \
+                    sha256  c41d326154303c2574e5e7abad972d803b0b73bf35fbd8290b642d44e53d1144 \
+                    size    56486027
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 532.0.0.

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?