### PR TITLE
astyle: update to 3.6.11

### DIFF
--- a/devel/astyle/Portfile
+++ b/devel/astyle/Portfile
@@ -3,10 +3,9 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           java 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 name                astyle
-version             3.6.9
+version             3.6.11
 set branch          [join [lrange [split ${version} .] 0 1] .]
 revision            0
 categories          devel
@@ -21,9 +20,9 @@ long_description    Artistic Style is a source code indenter, source code format
 homepage            https://astyle.sourceforge.net
 master_sites        sourceforge:project/astyle/astyle/astyle%20${branch}
 use_bzip2           yes
-checksums           rmd160  45ad83be0e19a58ffe1bcfd19d5385c4f6346caa \
-                    sha256  b644597654df5b40087be4a46723c65040f7ce59f3369f1b8f690f9c10cababc \
-                    size    217232
+checksums           rmd160  4e090bc7f9375fca3e1f7fde84cf1eceb1948dd8 \
+                    sha256  0eabee3fd9d07406772abce93241d62c1f47d456d3f941cbf15af9c23dc74ad6 \
+                    size    217154
 
 patchfiles          dont-force-stdlib.diff
 


### PR DESCRIPTION
 - update to 3.6.11
 - remove PortGroup compiler_blacklist_versions

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
