### PR TITLE
git-annex: update to 10.20250721

### DIFF
--- a/devel/git-annex/Portfile
+++ b/devel/git-annex/Portfile
@@ -4,17 +4,16 @@ PortSystem          1.0
 PortGroup           haskell_stack 1.0
 
 name                git-annex
-version             10.20250630
-checksums           rmd160  a267a6c17b655fc5cc157c8c58fa8094d3dc62e6 \
-                    sha256  03df602f2f72110d5a782a760399b64a57d37661f84aed6612d9d62d727459ed \
-                    size    1560178
+version             10.20250721
+checksums           rmd160  f525ac4da658612fdaf603751e4819038e9a5e69 \
+                    sha256  217fd675dba96fc82734d08b7951ad596f2ba4f99bb01fa848528d9874828aac \
+                    size    1561652
 
 description         git-annex allows managing files with git, without checking the file contents into git
-long_description    \
-	git-annex allows managing files with git, without checking the file \
-	contents into git. While that may seem paradoxical, it is useful when \
-	dealing with files larger than git can currently easily handle, whether due \
-	to limitations in memory, time, or disk space.
+long_description    git-annex allows managing files with git, without checking the file \
+                    contents into git. While that may seem paradoxical, it is useful when \
+                    dealing with files larger than git can currently easily handle, whether due \
+                    to limitations in memory, time, or disk space.
 license             AGPL-3
 homepage            https://git-annex.branchable.com/
 


### PR DESCRIPTION
#### Description

Update git-annex to 10.20250721. Also refactors indentation of long_description to be aligned and use spaces instead of tabs to fix `port lint` warnings.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->