### PR TITLE
diffoscope: update to 302

### DIFF
--- a/sysutils/diffoscope/Portfile
+++ b/sysutils/diffoscope/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                diffoscope
-version             296
+version             302
 revision            0
 
 categories          sysutils python
@@ -25,10 +25,10 @@ long_description    diffoscope will try to get to the bottom of what makes \
 
 homepage            https://diffoscope.org/
 
-checksums           md5 4690da0d2e6012c4a70cd19a7adcd458 \
-                    rmd160 64c95d22c461de1fb041c3665800e786e9038de0 \
-                    sha256 a1e9f43052a8b99984ba0bb13649ba0b18fd7da65a359e4f87170c89f8da325e \
-                    size   3188222
+checksums           md5 bae6f418516758910f3d38df45fee699 \
+                    rmd160 b720836e412fd76e9013bb06a5538a4c52c03d10 \
+                    sha256 7b5802d55a81dee59034d398cc6e0ee83b176281c1209d33df5bde29b586b328 \
+                    size   3188946
 
 python.default_version 313
 


### PR DESCRIPTION
#### Description
- update to latest upstream version

###### Tested on
macOS 15.5 24F74 x86_64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
