### PR TITLE
openjdk25-zulu: update to 25.0.45

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.41
-set build    28
+version      ${feature}.0.45
+set build    33
 revision     0
 
 set openjdk_version ${feature}.0.0
@@ -37,14 +37,14 @@ use_zip yes
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_x64
-    checksums    rmd160  d3f87ec4fd89b0113e18bf8aa436f37a8b9a8956 \
-                 sha256  8639f8b3224049e88cd10600420adcc220dbbb35a5c4996eadcf4ec9da706e10 \
-                 size    229901810
+    checksums    rmd160  185eb5144336949ced5be9cc2aad8acff8d53372 \
+                 sha256  abbabc6271f6d867f7f7bdfc5d7d7e79e511b8e3a226ea14ea897c929e3712b5 \
+                 size    229986097
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_aarch64
-    checksums    rmd160  087ec402df5c69653c7a0ca76c5b60755b59c285 \
-                 sha256  0ce786dddb3580ea11eaac4d369f3cf0a5205a48c0be0447b74979e8443d9c4a \
-                 size    227380991
+    checksums    rmd160  fd1eaaaba21961500f679a53c07a545601a3e2e3 \
+                 sha256  d4fe968859b2e5b733327648681dfa2cfe6182533f6c7b117dcc85d8a2642d79 \
+                 size    227463392
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.0.45.

###### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?