### PR TITLE
openjdk8-temurin: update to 8u462

### DIFF
--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64
 
-version      ${feature}u452
-set build    09
+version      ${feature}u462
+set build    08
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least November 2026)
@@ -31,9 +31,9 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}b${build}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  9121408de9443e09de315004a41fdf0969fbae92 \
-             sha256  2df9adf6f68ea9768a7c38ab6cccc85a018739f47f65fb102b1da5f74f6794f9 \
-             size    109566787
+checksums    rmd160  194c44630e865bced271192c02b77d539e170360 \
+             sha256  026001d776b9e692e9c79b7de975f7a1d819def42bd12e7d655ab16136b7dcf6 \
+             size    109572785
 
 homepage     https://adoptium.net
 


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u462.

###### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?