### PR TITLE
py-isodate: add py-setuptools_scm, py-packaging deps

### DIFF
--- a/python/py-isodate/Portfile
+++ b/python/py-isodate/Portfile
@@ -10,7 +10,7 @@ revision            0
 supported_archs     noarch
 platforms           {darwin any}
 license             BSD
-maintainers         {gmail.com:esafak @esafak}
+maintainers         {@esafak gmail.com:esafak} openmaintainer
 
 description         An ISO 8601 date/time/duration parser and formatter
 long_description    This module implements ISO 8601 date, time and duration \
@@ -24,6 +24,9 @@ homepage            https://pypi.python.org/pypi/${python.rootname}
 checksums           rmd160  97bfafc2a4e0e65fb89d4dee4bf50768c5f2c880 \
                     sha256  4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6 \
                     size    29705
+
+depends_lib-append  port:py${python.version}-packaging \
+                    port:py${python.version}-setuptools_scm
 
 python.versions     39 310 311 312 313
 


### PR DESCRIPTION
#### Description

I received [a notice](https://trac.macports.org/ticket/72750) that the port was missing a dependency, `py-setuptools_scm`. It was also missing `py-packaging`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

Installing does not work yet -- for me, at least. It can't locate `packaging.requirements`, which is part of `py-packaging`. I can in fact import it after installing it so I don't know how to fix it.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
