### PR TITLE
dante: Update to 1.4.4

### DIFF
--- a/net/dante/Portfile
+++ b/net/dante/Portfile
@@ -1,10 +1,15 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem              1.0
+PortGroup               legacysupport 1.1
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 name                    dante
-version                 1.4.2
-revision                1
+version                 1.4.4
+revision                0
 categories              net
-platforms               darwin
 license                 BSD
 maintainers             nomaintainer
 
@@ -24,11 +29,11 @@ master_sites            ${homepage}files/ \
                         ftp://ftp.inet.no/pub/socks/ \
                         ftp://ftp.inet.no/pub/socks/old/
 
-dist_subdir             ${name}/${version}_1
-checksums               rmd160 d2e01bf899b0df74ef441926c497385ab8040a7c \
-                        sha256 4c97cff23e5c9b00ca1ec8a95ab22972813921d7fbf60fc453e3e06382fc38a7
+checksums               rmd160  ef9cee6b5267e174dfc91571dedf79c151a4ff32 \
+                        sha256  1973c7732f1f9f0a4c0ccf2c1ce462c7c25060b25643ea90f9b98f53a813faec \
+                        size    1378352
 
-configure.args          --mandir=${prefix}/share/man \
+configure.args-append   --mandir=${prefix}/share/man \
                         --without-gssapi \
                         --with-socks-conf=${prefix}/etc/dante/socks.conf \
                         --with-sockd-conf=${prefix}/etc/dante/sockd.conf \
@@ -42,5 +47,5 @@ post-destroot {
 }
 
 livecheck.type          regex
-livecheck.url           [lindex ${master_sites} 0]
-livecheck.regex         ${name}-(\[0-9.\]+)\\.tar
+livecheck.url           ${homepage}download.html
+livecheck.regex         ${name}-(\[0-9.\]+)\\.tar.gz


### PR DESCRIPTION
#### Description

Update `dante` to its latest released version, 1.4.4

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
