### PR TITLE
debianutils: Update to 5.23.2

### DIFF
--- a/sysutils/debianutils/Portfile
+++ b/sysutils/debianutils/Portfile
@@ -1,13 +1,12 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 
 name                debianutils
-version             4.8
-livecheck.version   4.8.4
+version             5.23.2
 categories          sysutils
-platforms           darwin
 license             GPL-2+
-maintainers         {raimue @raimue} \
-                    openmaintainer
+maintainers         {raimue @raimue} openmaintainer
 description         Miscellaneous utilities from Debian
 long_description \
     ${name} is a collection of miscellaneous utilities developed by the Debian \
@@ -23,16 +22,19 @@ long_description \
 #                            see http://packages.debian.org/changelogs/pool/main/d/debianutils/current/debianutils.copyright
 #   which                    Unnecessary, /usr/bin/which is provided by the operating system
 
-homepage            http://packages.qa.debian.org/d/debianutils.html
+homepage            https://tracker.debian.org/pkg/debianutils
 master_sites        debian:d/debianutils
 distname            ${name}_${version}
-worksrcdir          ${name}-${version}
-use_xz yes
+worksrcdir          work
+use_xz              yes
 
-checksums           rmd160  95a3e86b58684b03158b0923c5df3f7c86daed33 \
-                    sha256  afa95bbe6b6fd3ef3c0c838b2d7232f09fabeff593ca4b5583cffa6748567ee2
+checksums           rmd160  6ea9ee976eb90470bd4e9d06008fa5632fa7864f \
+                    sha256  79e524b7526dba2ec5c409d0ee52ebec135815cf5b2907375d444122e0594b69 \
+                    size    82376
 
-build.target run-parts tempfile
+use_autoreconf      yes
+
+build.target        run-parts tempfile
 
 destroot {
     xinstall -W ${worksrcpath} run-parts   ${destroot}${prefix}/sbin
@@ -41,5 +43,5 @@ destroot {
     xinstall -W ${worksrcpath} tempfile.1  ${destroot}${prefix}/share/man/man1
 }
 
-livecheck.type  regex
-livecheck.regex ${name}_(\\d+(?:.\\d+)+).dsc
+livecheck.type      regex
+livecheck.regex     ${name}_(\\d+(?:.\\d+)+).dsc


### PR DESCRIPTION
#### Description

Update `debianutils` to its latest released version, 5.23.2. Apparently, there was a newer version, but `port livecheck` didn't pick it up

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
