### PR TITLE
Rev bumps for fltk update

### DIFF
--- a/graphics/openexr2/Portfile
+++ b/graphics/openexr2/Portfile
@@ -13,7 +13,7 @@ subport ilmbase {
     revision                    0
 }
 subport openexr_viewers {
-    revision                    0
+    revision                    1
 }
 
 categories                      graphics

--- a/math/mathgl/Portfile
+++ b/math/mathgl/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                mathgl
 version             8.0.3
-revision            0
+revision            1
 categories          math
 license             GPL-3
 maintainers         {mps @Schamschula} openmaintainer

--- a/multimedia/lmms/Portfile
+++ b/multimedia/lmms/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 14
 
 github.setup        LMMS lmms 1.2.2 v
-revision            1
+revision            2
 categories          multimedia audio
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-2+

--- a/science/RigCtldGUI/Portfile
+++ b/science/RigCtldGUI/Portfile
@@ -23,7 +23,7 @@ version             20220406-[string range ${github.version} 0 7]
 checksums           rmd160  b639bc162c54e274d1677346a87d36796e929ca1 \
                     sha256  c632fb071caaf6c4a18860058fd59423c3c1c9ea0038a3f8b02d04aaba79664e \
                     size    2492605
-revision            0
+revision            1
 
 # is using clang++ to link but isn't using MacPorts CXXFLAGS
 # therefore we need to add -stdlib manually

--- a/science/fldigi/Portfile
+++ b/science/fldigi/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                fldigi
 version             4.2.06
-revision            0
+revision            1
 # same sources but with different version
 set version_flarq   4.3.9
 categories          science

--- a/science/flrig/Portfile
+++ b/science/flrig/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                flrig
 version             2.0.0
+revision            1
 categories          science
 platforms           darwin macosx
 license             GPL-3

--- a/science/playerstage-stage/Portfile
+++ b/science/playerstage-stage/Portfile
@@ -3,7 +3,7 @@ PortGroup         cmake 1.0
 
 name              playerstage-stage
 version           3.2.2
-revision          7
+revision          8
 categories        science
 platforms         darwin
 maintainers       nomaintainer

--- a/x11/xdiskusage/Portfile
+++ b/x11/xdiskusage/Portfile
@@ -5,7 +5,7 @@ PortGroup           app 1.0
 
 name                xdiskusage
 version             1.60
-revision            0
+revision            1
 checksums           rmd160  e7f7d3626d9c11b9a4a1068be7b1f3033e51e4d4 \
                     sha256  7b536dc6f1bdc6d9bec7c29b9435c23d9d32bff8a0ebee26b9966b273dc9f67e \
                     size    54990


### PR DESCRIPTION
#### Description

Closes https://trac.macports.org/ticket/72758

Skipping gmsh, other PR in progress.
Skipping tigervnc, handled by other PR.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  In progress.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?