### PR TITLE
QtPBFImagePlugin: update to 4.4

### DIFF
--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 QtPBFImagePlugin 4.2
+github.setup        tumic0 QtPBFImagePlugin 4.4
 github.tarball_from archive
 revision            0
 categories          graphics
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
 
-checksums           rmd160  5cc8d22f928beb0a699ec0f50cc2f7abb10e7a26 \
-                    sha256  335ca81fcc4f49ae98c962444739da451545a7c5395f87f64a45c04c26c0f51d \
-                    size    198821
+checksums           rmd160  0f2c48ea737014f1e8e45587cc4fdf7eead669ed \
+                    sha256  12ba988d46f5627b2c2a2bb7081a5699851723e533558dbcf80f1af82973c866 \
+                    size    198924
 
 depends_lib-append  port:zlib
 


### PR DESCRIPTION
#### Description
https://github.com/tumic0/QtPBFImagePlugin/compare/4.2...4.4

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
