### PR TITLE
audacious: update to 4.5

### DIFF
--- a/audio/audacious-core/Portfile
+++ b/audio/audacious-core/Portfile
@@ -7,7 +7,7 @@ name                audacious-core
 set real_name       audacious
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
-version             4.4.2
+version             4.5
 revision            0
 
 license             BSD
@@ -30,9 +30,9 @@ long_description    ${description} It is free, lightweight, based on GTK3, \
 master_sites        https://distfiles.audacious-media-player.org
 distname            ${real_name}-${version}
 use_bzip2           yes
-checksums           rmd160  7a195d96a2b4f8d449c2e182a964059ff862f65a \
-                    sha256  34509504f8c93b370420d827703519f0681136672e42d56335f26f7baec95005 \
-                    size    636838
+checksums           rmd160  8add4931af87ad8fbab135916c1b44fc85d9d878 \
+                    sha256  1ea5e0f871c6a8b2318e09a9d58fc573fe3f117ae0d8d163b60cc05b2ce7c405 \
+                    size    642198
 
 universal_variant   no
 

--- a/audio/audacious-core/files/patch-big-endian.diff
+++ b/audio/audacious-core/files/patch-big-endian.diff
@@ -1,7 +1,7 @@
 Reverts https://github.com/audacious-media-player/audacious/commit/9e51ffa0c0ec79b537cc970158d51557273970ea
 
---- src/config.h.meson	2024-11-04 04:00:44.000000000 +0800
-+++ src/config.h.meson	2024-11-11 02:05:46.000000000 +0800
+--- config.h.meson	2024-11-04 04:00:44.000000000 +0800
++++ config.h.meson	2024-11-11 02:05:46.000000000 +0800
 @@ -5,7 +5,6 @@
  #mesondefine EXPORT
  #mesondefine PLUGIN_SUFFIX

--- a/audio/audacious-plugins/Portfile
+++ b/audio/audacious-plugins/Portfile
@@ -7,8 +7,8 @@ PortGroup           active_variants 1.1
 name                audacious-plugins
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
-version             4.4.2
-revision            2
+version             4.5
+revision            0
 
 # FIXME: probably more licenses involved here...
 license             BSD GPL-2+
@@ -27,9 +27,9 @@ long_description    This ports bundles most of the functionality for audacious. 
 
 master_sites        https://distfiles.audacious-media-player.org
 use_bzip2           yes
-checksums           rmd160  3ce31585b2721e32d219f987864b7369c7bbcc93 \
-                    sha256  50f494693b6b316380fa718c667c128aa353c01e954cd77a65c9d8aedf18d4bd \
-                    size    1816431
+checksums           rmd160  bd4d5651a589e5461863755ba8ff0a718b6a032d \
+                    sha256  36c19940ee7227f67df4f0c7fd98a5f60c60257a1a47ecd014c9e2a26d7846dd \
+                    size    1907160
 
 universal_variant   no
 
@@ -125,10 +125,6 @@ configure.args-append \
 configure.args-append \
                     -Dgl-spectrum=false \
                     -Dvumeter=false \
-
-# interface
-configure.args-append \
-                    -Dmoonstone=false
 
 # This issue was supposed to be fixed, but it did not work as intended.
 # Temporarily revert upstream commit and restore our patch. This is tested.

--- a/audio/audacious-plugins/files/patch-big-endian.diff
+++ b/audio/audacious-plugins/files/patch-big-endian.diff
@@ -1,7 +1,7 @@
 Reverts https://github.com/audacious-media-player/audacious-plugins/commit/c175d8b9cece8a53d86ce54fc252454287814e9e
 
---- src/config.h.meson	2024-11-04 04:02:39.000000000 +0800
-+++ src/config.h.meson	2024-11-11 02:06:51.000000000 +0800
+--- config.h.meson	2024-11-04 04:02:39.000000000 +0800
++++ config.h.meson	2024-11-11 02:06:51.000000000 +0800
 @@ -3,7 +3,6 @@
  #mesondefine COPYRIGHT
  #mesondefine EXPORT

--- a/audio/audacious/Portfile
+++ b/audio/audacious/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                audacious
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
-version             4.4.2
+version             4.5
 revision            0
 
 license             BSD GPL-2+


### PR DESCRIPTION
###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?