### PR TITLE
llvm-3.4: Fix build on macOS 15

### DIFF
--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -15,7 +15,6 @@ set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
 categories              lang
-platforms               darwin
 license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
@@ -126,6 +125,7 @@ patchfiles \
         0006-Fix-dylib-install-name-when-building-on-Tiger.patch \
         0007-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.patch \
         llvm-skip-unittests.patch \
+        regex_impl.h.patch \
         patch-macports-flags.diff
 
 if {${subport} eq "clang-${llvm_version}"} {

--- a/lang/llvm-3.4/files/regex_impl.h.patch
+++ b/lang/llvm-3.4/files/regex_impl.h.patch
@@ -1,0 +1,30 @@
+From b86c249691a7973a451bc6a586b39da64778d219 Mon Sep 17 00:00:00 2001
+From: Hans Wennborg <hans@chromium.org>
+Date: Mon, 8 May 2023 15:51:52 +0200
+Subject: [PATCH] Use LLVM-style include guard in regex_impl.h
+
+The previous include guard (_REGEX_H_) is also used in a macOS SDK
+header (xlocale.h), causing potential for trouble. This was previously
+addressed in 2b8b90a7686858b1d22cae6fcfbd0904135112aa, but renaming the
+macro in line with LLVM's other include guards seems like a better fix.
+
+Differential revision: https://reviews.llvm.org/D150117
+--- a/lib/Support/regex_impl.h
++++ b/lib/Support/regex_impl.h
+@@ -35,8 +35,8 @@
+  *	@(#)regex.h	8.1 (Berkeley) 6/2/93
+  */
+ 
+-#ifndef _REGEX_H_
+-#define	_REGEX_H_
++#ifndef LLVM_SUPPORT_REGEX_IMPL_H
++#define LLVM_SUPPORT_REGEX_IMPL_H
+ 
+ #include <sys/types.h>
+ typedef off_t llvm_regoff_t;
+@@ -105,4 +105,4 @@ size_t  llvm_strlcpy(char *dst, const char *src, size_t siz);
+ }
+ #endif
+ 
+-#endif /* !_REGEX_H_ */
++#endif /* LLVM_SUPPORT_REGEX_IMPL_H */


### PR DESCRIPTION
#### Description

This is intended to fix the build on macOS 15 by applying an upstream patch that renames an include guard to avoid a conflict with the macOS SDK.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
I haven't tested it locally besides verifying the patch applies. CI results are unlikely to be useful since the issue only affects macOS 15 and later and the port doesn't build on arm64 but CI only has arm64 runners for macOS 15.

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
