### PR TITLE
mise: update to 2025.8.4

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.7.32 v
+github.setup        jdx mise 2025.8.4 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d2715ab566b39db8cc3f7fd05c142c730b27bddc \
-                    sha256  e3b9e9883ba1fdb765246a3e6a6be24641f827dfa55e5f816ff98551b2460790 \
-                    size    4391804
+                    rmd160  14533cc85731e5220e316613454249a9d7c972fd \
+                    sha256  20fd1c91376305b0854f27f8cf180d3b0891e95da6b9967b6f5409b7ac9df6db \
+                    size    4400068
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua


### PR DESCRIPTION
#### Description

Update mise from 2025.7.32 to 2025.8.4

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Xcode 16.4 16F6

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?