### PR TITLE
micronaut: update to 4.9.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.9.1 v
+github.setup    micronaut-projects micronaut-starter 4.9.2 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     mn-darwin-amd64-v${version}
-    checksums    rmd160  a25c70d6d3793573bb00127cb60c51e3e8585a9f \
-                 sha256  2a33d40487e69fe6023c6915ce9a8f3dcc1f40194679128b976ddacd34718b04 \
-                 size    28611010
+    checksums    rmd160  4e4ad69e9e471f7290de585763b413caab1b8dcf \
+                 sha256  91287a22424437e814b1a08a66f0154cb58d0869413bf27c75eca8ab9c162a96 \
+                 size    29534209
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     mn-darwin-aarch64-v${version}
-    checksums    rmd160  b0262aa86eb589ebbf4ddaf473afce30b090ec56 \
-                 sha256  70c3f6ee959011bb2eec624308a310bb0d1e2f18a14f6e139e9f2458fd31fc18 \
-                 size    28383606
+    checksums    rmd160  2b5530adcaded043e9b67e97d5ae6c01b70bca77 \
+                 sha256  3dc41d8c2c2f3f986a5fed85e5a116c62ca538b68e9e254079db62c10ab822b3 \
+                 size    29299931
 }
 
 use_zip         yes


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.9.2.

###### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?