### PR TITLE
gmsh: Legacy support for 10.9-10.11

### DIFF
--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -6,6 +6,11 @@ PortGroup               mpi            1.0
 PortGroup               linear_algebra 1.0
 PortGroup               muniversal     1.1
 
+# Need clock_gettime with CLOCK_MONOTONIC
+PortGroup               legacysupport 1.1
+
+legacysupport.newest_darwin_requires_legacy 15
+
 name                    gmsh
 version                 4.14.0
 revision                0

--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -80,6 +80,11 @@ configure.args-append   -DENABLE_ACIS=OFF \
 
 configure.env-append    CASROOT=${prefix}/libexec/opencascade
 
+# hxt_tetRefine.c: error: passing argument 1 of 'scanbsearch'
+# from incompatible pointer type [-Wincompatible-pointer-types]
+configure.cflags-append \
+                        -Wno-error=incompatible-pointer-types
+
 pre-configure {
     configure.args-append \
                         -DBLAS_LAPACK_LIBRARIES="-L${prefix}/lib ${linalglib}"

--- a/science/gmsh/Portfile
+++ b/science/gmsh/Portfile
@@ -80,11 +80,6 @@ configure.args-append   -DENABLE_ACIS=OFF \
 
 configure.env-append    CASROOT=${prefix}/libexec/opencascade
 
-# hxt_tetRefine.c: error: passing argument 1 of 'scanbsearch'
-# from incompatible pointer type [-Wincompatible-pointer-types]
-configure.cflags-append \
-                        -Wno-error=incompatible-pointer-types
-
 pre-configure {
     configure.args-append \
                         -DBLAS_LAPACK_LIBRARIES="-L${prefix}/lib ${linalglib}"


### PR DESCRIPTION
#### Description

* Add legacy support for Darwin <= 15.
* Fixes builds for 10.9-10.11.
* Provide clock_gettime with CLOCK_MONOTONIC.
* No rev bump.  Build fixes only.

###### Type(s)

- [x] bugfix

###### Tested on

* CI only.  OS 13, 14, 15 only.
* Waiting for merge to check legacy build results.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?