### PR TITLE
gobject_introspection: Fix meson universal builds

### DIFF
--- a/_resources/port1.0/group/gobject_introspection-1.0.tcl
+++ b/_resources/port1.0/group/gobject_introspection-1.0.tcl
@@ -100,7 +100,11 @@ proc gobject_introspection_pg::gobject_introspection_setup {} {
             foreach arch [option muniversal.architectures] {
                 foreach tool {cc ld} {
                     set env_var [gobject_introspection_pg::map_tool_to_environment_variable $tool]
-                    build.args.${arch}-append ${env_var}+="[muniversal::get_archflag ${tool} ${arch}]"
+                    if {[string match *meson* [option configure.cmd]]} {
+                        build.env.${arch}-append ${env_var}=[muniversal::get_archflag ${tool} ${arch}]
+                    } else {
+                        build.args.${arch}-append ${env_var}+="[muniversal::get_archflag ${tool} ${arch}]"
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
#### Description

Fixes universal builds of meson-based projects that depend on gobject-introspection

Note: The fix sets env variables instead of appending to the command line for meson, since ninja doesn't support `VAR+=append` syntax.  This overwrites the environment variable if it already existed, but hopefully overriding cflags/ldflags for builds isn't too common.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.5 24F74 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (tested harfbuzz)
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
