### PR TITLE
lagrange: update to 1.18.6

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.18.5 v
+gitea.setup         gemini lagrange 1.18.6 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  ca5d92843f0149e635638cb9e0400eff6bd63370 \
-                    sha256  10625a712255f2fb18ff704b53c4b1aec8d551044a14ba70ac86b64df039a542 \
-                    size    8859504
+checksums           rmd160  d76a313b6ffd46671b2cac146ab17674d442f201 \
+                    sha256  4466d9f19d05f427d55a7c12111365d08cf352612d3a57173cca49663a124c8d \
+                    size    8894577
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://github.com/skyjake/lagrange/releases/tag/v1.18.6

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
