### PR TITLE
google-cloud-sdk: update to 533.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             532.0.0
+version             533.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  efc2e495f432d01fa8ce30ad3572ea39b4f2e64a \
-                    sha256  f3ad6237bac2351851f5a78ee27d5b6058b5b07d7cc19d20a8255ef4ac1ff814 \
-                    size    55022568
+    checksums       rmd160  f11bfdafb8a4911223ff5f5b0b1a5979719ffb52 \
+                    sha256  15b2d77ec8c7962675513bf0fecf9e9f8729d2f09c5f00d478ca6e9b53846b24 \
+                    size    55046139
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  554aed322903390c89c56c517895763c88058ae1 \
-                    sha256  90aed88a3ddfbde9544691cfd34e1ff93b3963df89d038cb77bdbae436447d6b \
-                    size    56552306
+    checksums       rmd160  a4802f07195582afa140346f76dd0ecf49b37598 \
+                    sha256  2ef770746a10f334c38d8e4f7d71a9a5513240e7f840b242729ecd2361e68b20 \
+                    size    56578286
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  b0d53a45afd7a661916c6c9cdd377253a5ba6602 \
-                    sha256  c41d326154303c2574e5e7abad972d803b0b73bf35fbd8290b642d44e53d1144 \
-                    size    56486027
+    checksums       rmd160  b82fe7c759b9a6aa82a2ed29203efe2c1019a862 \
+                    sha256  37189900ed6b31ecf6efa122b812b9bf21a01c226d9bdfd0891e4ca3d190a611 \
+                    size    56510957
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 533.0.0.

###### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?