### PR TITLE
colima: update to 0.8.3

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.8.2 v
+go.setup            github.com/abiosoft/colima 0.8.3 v
 revision            0
 
 description         Run Kubernetes and Docker containers with minimal setup
@@ -21,9 +21,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  3d6ea38546924260b54afb348e870cba6bf06694 \
-                    sha256  c076bc9bf984f42d7f3b47b09cec9859f5fc715a0410d5e2e8263cc9cb05b864 \
-                    size    618128
+checksums           rmd160  0bbed158de0877d60e0d23a15ad16f3e6fcc3b24 \
+                    sha256  2c0f670f2e3124d1e81894bc3c0bea90f25cc675bb293e70e8ff25f47c8db35e \
+                    size    619003
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

Update to colima 0.8.3.

###### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?