### PR TITLE
ImageMagick7: Update to 7.1.2-0

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -21,13 +21,13 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-github.setup        ImageMagick ImageMagick 7.1.1-47
+github.setup        ImageMagick ImageMagick 7.1.2-0
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  19c1d6251f48053782bd2507c9dd2df2d5bd1ffc \
-                    sha256  818e21a248986f15a6ba0221ab3ccbaed3d3abee4a6feb4609c6f2432a30d7ed \
-                    size    15675207
+checksums           rmd160  4af8092f371de9c44bcfac7d46632fbd869bd901 \
+                    sha256  03fe29e376b5938255b3fdb8d1f50515caa48055c0c2743faaeea52fc673a38b \
+                    size    15689645
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \


### PR DESCRIPTION
#### Description

Update 7.1.1-47 --> 7.1.2-0

###### Type(s)

###### Tested on

macOS 15.5
Xcode 16.2
Command Line Tools 16.2.0.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ **`port -vs install`**?
- [x] tested basic functionality of ~~all binary files~~ **main executables**?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?