### PR TITLE
mani: Update to 0.31.0

### DIFF
--- a/devel/mani/Portfile
+++ b/devel/mani/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/alajmo/mani 0.30.1 v
+go.setup            github.com/alajmo/mani 0.31.0 v
 revision            0
 
 homepage            https://manicli.com
@@ -24,9 +24,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  bdbd0ffbafb6235b36da2c2781575c25ea46ecdc \
-                    sha256  a75984fda15ac431424964fe0a1d2c936e123583f2482eb3147c1ef20ba85c80 \
-                    size    924900
+checksums           rmd160  f20f4720156a7ce2bd6e7a32e2bd23e04a4739fa \
+                    sha256  dd44bd7f409c5b2a755beca45229cbc9be02712be55c099bd6a01f6cc3441df2 \
+                    size    925425
 
 # Allow Go to fetch deps at build time
 go.offline_build no


### PR DESCRIPTION
#### Description

mani: Update to 0.31.0

##### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
