### PR TITLE
Remove use of compiler_blacklist_versions PortGroup

### DIFF
--- a/aqua/FScript/Portfile
+++ b/aqua/FScript/Portfile
@@ -3,7 +3,6 @@
 PortSystem              1.0
 PortGroup               xcode 1.0
 PortGroup               github 1.0
-PortGroup               compiler_blacklist_versions 1.0
 
 github.setup            pmougin F-Script e9aa94f2a5ec3409423f907c9423f7d1d845b893
 # Change github.tarball_from to 'releases' or 'archive' next update

--- a/databases/mongodb-devel/Portfile
+++ b/databases/mongodb-devel/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           muniversal 1.0
 

--- a/databases/mongodb/Portfile
+++ b/databases/mongodb/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           muniversal 1.0
 

--- a/databases/postgresql10/Portfile
+++ b/databases/postgresql10/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
 PortGroup deprecated 1.0
 

--- a/databases/postgresql11/Portfile
+++ b/databases/postgresql11/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem 1.0
 PortGroup compilers 1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
 PortGroup deprecated 1.0
 

--- a/databases/postgresql93/Portfile
+++ b/databases/postgresql93/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
 PortGroup deprecated 1.0
 

--- a/databases/postgresql94/Portfile
+++ b/databases/postgresql94/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
 PortGroup deprecated 1.0
 

--- a/databases/postgresql95/Portfile
+++ b/databases/postgresql95/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
 PortGroup deprecated 1.0
 

--- a/databases/postgresql96/Portfile
+++ b/databases/postgresql96/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
 PortGroup deprecated 1.0
 

--- a/devel/GASNet/Portfile
+++ b/devel/GASNet/Portfile
@@ -6,7 +6,6 @@ PortGroup           mpi 1.0
 compilers.choose    cc cxx
 mpi.setup           require -clang -g95 -gfortran
 
-PortGroup           compiler_blacklist_versions 1.0
 compiler.blacklist  {clang < 421} *llvm-gcc-4.2 *gcc-4.0 gcc-3.3
 
 name                GASNet

--- a/devel/gettext/Portfile
+++ b/devel/gettext/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               clang_dependency 1.0
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               gnulib 1.0
 PortGroup               muniversal 1.0
 

--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 
 name                    ld64
 epoch                   2

--- a/devel/libsdl2-powerpc/Portfile
+++ b/devel/libsdl2-powerpc/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 name                libsdl2-powerpc

--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           python 1.0
 
 if {${subport} eq "mercurial-rustext"} {

--- a/devel/streamlog/Portfile
+++ b/devel/streamlog/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           bitbucket 1.0
 PortGroup           cmake 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 bitbucket.setup     nwehr streamlog 1.0 v
 revision            1

--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 # The vim port should always follow the patch level used in the MacVim port. This
 # is because they both share the same set of configuration files and ensures

--- a/emulators/wine-devel/Portfile
+++ b/emulators/wine-devel/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
-PortGroup                   compiler_blacklist_versions 1.0
 PortGroup                   github 1.0
 PortGroup                   muniversal 1.1
 

--- a/emulators/wine-stable/Portfile
+++ b/emulators/wine-stable/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
-PortGroup                   compiler_blacklist_versions 1.0
 PortGroup                   github 1.0
 PortGroup                   muniversal 1.1
 

--- a/games/godot/Portfile
+++ b/games/godot/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 name                godot
 categories          games graphics multimedia

--- a/graphics/cairo/Portfile
+++ b/graphics/cairo/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
-PortGroup                   compiler_blacklist_versions 1.0
 PortGroup                   debug 1.0
 PortGroup                   legacysupport 1.1
 PortGroup                   muniversal 1.0

--- a/graphics/charls/Portfile
+++ b/graphics/charls/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           cmake   1.1
 PortGroup           github  1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        team-charls charls 2.4.2 
 # Change github.tarball_from to 'releases' or 'archive' next update

--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           perl5 1.0
 
 name                gimp2

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           active_variants 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           debug 1.0
 PortGroup           meson 1.0
 PortGroup           perl5 1.0

--- a/graphics/libpixman-devel/Portfile
+++ b/graphics/libpixman-devel/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               legacysupport 1.1
 PortGroup               meson 1.0
 PortGroup               muniversal 1.0

--- a/graphics/libpixman/Portfile
+++ b/graphics/libpixman/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               legacysupport 1.1
 PortGroup               meson 1.0
 PortGroup               muniversal 1.0

--- a/graphics/materialx/Portfile
+++ b/graphics/materialx/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cmake 1.1
 
 github.setup        materialx MaterialX 1.38.2 v

--- a/graphics/opencv3-devel/Portfile
+++ b/graphics/opencv3-devel/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
 
 #==============================================================================

--- a/graphics/opencv3/Portfile
+++ b/graphics/opencv3/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
 
 #==============================================================================

--- a/graphics/opencv4-devel/Portfile
+++ b/graphics/opencv4-devel/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 #==============================================================================

--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 #==============================================================================

--- a/graphics/usd/Portfile
+++ b/graphics/usd/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cmake 1.1
 PortGroup           active_variants 1.1
 PortGroup           legacysupport 1.0

--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 
 PortGroup           active_variants 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0

--- a/lang/llvm-10/Portfile
+++ b/lang/llvm-10/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup select        1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
 

--- a/lang/llvm-11/Portfile
+++ b/lang/llvm-11/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup select        1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
 PortGroup legacysupport 1.0

--- a/lang/llvm-12/Portfile
+++ b/lang/llvm-12/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem                            1.0
 PortGroup select                      1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants             1.1
 PortGroup cmake                       1.1
 PortGroup legacysupport               1.0

--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -4,7 +4,6 @@
 
 PortSystem              1.0
 PortGroup select        1.0
-PortGroup compiler_blacklist_versions 1.0
 
 set llvm_version        3.4
 set llvm_version_no_dot 34

--- a/lang/llvm-3.7/Portfile
+++ b/lang/llvm-3.7/Portfile
@@ -10,7 +10,6 @@
 
 PortSystem              1.0
 PortGroup select        1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 
 set llvm_version        3.7

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup select        1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
 

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -5,7 +5,6 @@
 
 PortSystem              1.0
 PortGroup select        1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
 

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -6,7 +6,6 @@
 
 PortSystem              1.0
 PortGroup select        1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
 

--- a/lang/llvm-8.0/Portfile
+++ b/lang/llvm-8.0/Portfile
@@ -5,7 +5,6 @@
 
 PortSystem              1.0
 PortGroup select        1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
 

--- a/lang/llvm-9.0/Portfile
+++ b/lang/llvm-9.0/Portfile
@@ -5,7 +5,6 @@
 
 PortSystem              1.0
 PortGroup select        1.0
-PortGroup compiler_blacklist_versions 1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
 

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               php 1.1
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               openssl 1.0
 
 # Disable by default adding openssl support.

--- a/lang/ruby/Portfile
+++ b/lang/ruby/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem      1.0
 PortGroup       muniversal 1.0
-PortGroup       compiler_blacklist_versions 1.0
 PortGroup       select 1.0
 PortGroup       openssl 1.0
 PortGroup       deprecated 1.0

--- a/math/wxMaxima/Portfile
+++ b/math/wxMaxima/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 
 PortGroup           active_variants 1.1
 PortGroup           cmake 1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           wxWidgets 1.0
 PortGroup           github 1.0
 

--- a/net/aria2/Portfile
+++ b/net/aria2/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 github.setup        aria2 aria2 1.37.0 release-

--- a/print/freetype/Portfile
+++ b/print/freetype/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 PortGroup               muniversal 1.0
 
 name                    freetype

--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           compilers 1.0
 PortGroup           mpiutil 1.0
 

--- a/science/root6/Portfile
+++ b/science/root6/Portfile
@@ -5,7 +5,6 @@ PortSystem          1.0
 PortGroup           active_variants               1.1
 PortGroup           cmake                         1.1
 PortGroup           compilers                     1.0
-PortGroup           compiler_blacklist_versions   1.0
 PortGroup           github                        1.0
 PortGroup           select                        1.0
 PortGroup           legacysupport                 1.1

--- a/science/volk/Portfile
+++ b/science/volk/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           muniversal 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           boost 1.0
 
 # Volk requires C/C++11 as of release 2.0.0

--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 name                bash
 set bash_version    5.2

--- a/sysutils/cfm/Portfile
+++ b/sysutils/cfm/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 PortGroup           makefile 1.0

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       compiler_blacklist_versions 1.0
 PortGroup       texlive 1.0
 
 # luajittex requires muniversal (and some patches to configure

--- a/textproc/libetonyek/Portfile
+++ b/textproc/libetonyek/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       compiler_blacklist_versions 1.0
 PortGroup       boost 1.0
 
 name            libetonyek

--- a/textproc/stardict/Portfile
+++ b/textproc/stardict/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               compiler_blacklist_versions 1.0
 
 name                    stardict
 version                 3.0.7


### PR DESCRIPTION
This PortGroup is no longer needed as of MacPorts 2.11.

###### Type(s)

- [x] enhancement
