### PR TITLE
steampipe: update to 2.1.0

### DIFF
--- a/net/steampipe/Portfile
+++ b/net/steampipe/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/turbot/steampipe 1.0.1 v
+go.setup            github.com/turbot/steampipe 2.1.0 v
 go.offline_build    no
 revision            0
 
@@ -22,9 +22,11 @@ license             AGPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  c2434a2fd06182cf7b959d672a680f21f6507358 \
-                    sha256  adb3427982bd950b821b0e67837e3770af787458cbaadb786cdac29ccfd454f8 \
-                    size    463172
+checksums           rmd160  11aaa5700661018b99043948345fda31c2df0864 \
+                    sha256  e6c364e3fa5d537fd274e6c87bd249413ad77f3e97fda51eef13e160c5416af4 \
+                    size    489142
+
+build.args          -ldflags '-X main.version=${version}'
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Update to the latest version of steampipe.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.7.5 23H527 x86_64
Xcode 15.4 15F31d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
