### PR TITLE
openssl3: Update to 3.5.2

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            24
+revision            25
 
 categories          devel security
 license             MIT

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -11,14 +11,14 @@ legacysupport.newest_darwin_requires_legacy 8
 set major_v         3
 # For former rollback to 3.1.x release where needed. Must now stay.
 epoch               1
-github.setup        openssl openssl ${major_v}.5.1 openssl-
+github.setup        openssl openssl ${major_v}.5.2 openssl-
 name                openssl3
 revision            0
 
 github.tarball_from releases
-checksums           rmd160  5a38de494318fcb67193f62c03937ffc65156e65 \
-                    sha256  529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f \
-                    size    53158817
+checksums           rmd160  3641f10527e769fa3cf5751f9e91f9f5824e59bd \
+                    sha256  c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec \
+                    size    53180161
 
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                openssh
 version             10.0p2
 distname            openssh-10.0p1
-revision            2
+revision            3
 categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                27
+revision                28
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588


### PR DESCRIPTION
#### Description

See upstream release notes at https://github.com/openssl/openssl/releases/tag/openssl-3.5.2

Revbump the openssl, openssh, and freeradius ports to rebuild against the new OpenSSL as documented in the Portfile.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
