### PR TITLE
fx: update to 39.0.1

### DIFF
--- a/sysutils/fx/Portfile
+++ b/sysutils/fx/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/antonmedv/fx 38.0.0
+go.setup            github.com/antonmedv/fx 39.0.1
 go.offline_build    no
 github.tarball_from archive
 revision            0
@@ -22,9 +22,9 @@ long_description    {*}${description}
 
 conflicts           felix
 
-checksums           rmd160  641292c7a5f1c71c5777151f4a3745dfe058b3bf \
-                    sha256  b9c4b935852cb9c3bae39b1c1293a8bfb010c5d79ce71a1ea6197002a5291613 \
-                    size    2689735
+checksums           rmd160  de19da294d9014bd010555387c500add0717d9a6 \
+                    sha256  0ddbef45762a3a2b4b13afb03093139121422b6f73aecbf2b6655598bd98575f \
+                    size    2702212
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description
https://github.com/antonmedv/fx/releases/tag/39.0.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
