### PR TITLE
carapace: update to 1.4.1

### DIFF
--- a/sysutils/carapace/Portfile
+++ b/sysutils/carapace/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 name                carapace
-version             1.3.3
+version             1.4.1
 revision            0
 
 go.setup            github.com/carapace-sh/carapace-bin ${version} v
@@ -19,9 +19,9 @@ long_description    Carapace provides multi-shell (bash, zsh, fish, powershell) 
 homepage            https://carapace.sh/
 
 # Update with `port checksum carapace`
-checksums           rmd160  9609c29805089919e19a093353d4153cb5355104 \
-                    sha256  0de73fc9338eb034a0c2bdbda72880f1de12ac0bc686d814beb1975a310264fc \
-                    size    17418650
+checksums           rmd160  59701f436ebbf0bf2b0ffa1a9369d969a009a86b \
+                    sha256  7460eef0ea7d19e5d0082e425fbef08f506d926d995701c7a8c3c6e90c9e61c5 \
+                    size    18185679
 
 build {
     system -W ${worksrcpath} "${go.bin} generate ./..."


### PR DESCRIPTION
#### Description

###### Tested on

macOS 15.6 24G84 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
