### PR TITLE
sshuttle: update to 1.3.2

### DIFF
--- a/net/sshuttle/Portfile
+++ b/net/sshuttle/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                sshuttle
-version             1.3.1
+version             1.3.2
 revision            0
 
 homepage            https://sshuttle.readthedocs.io/en/stable
@@ -21,9 +21,9 @@ supported_archs     noarch
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  3c40bdb321f6265abfc0e0d84f20accbf2bf375b \
-                    sha256  04c2b16164b4b2b5945ff17c4556a8a2f0d63fb1ea2ca032748f047852ff2fcb \
-                    size    166795
+checksums           rmd160  62d16b379f04cf567ed2c2c3e03361a15aa0a0f0 \
+                    sha256  eeb2eee300a7de16117a86bbb9adb7b0647158edccfb8076f260e0535a439448 \
+                    size    172292
 
 python.default_version \
                     313


### PR DESCRIPTION
#### Description
https://github.com/sshuttle/sshuttle/releases/tag/v1.3.2

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
