### PR TITLE
libgphoto2: Add portfile developer note

### DIFF
--- a/devel/libgphoto2/Portfile
+++ b/devel/libgphoto2/Portfile
@@ -38,6 +38,7 @@ depends_lib         port:curl \
 patchfiles          static_assert.patch
 
 # Was fixed upstream.  Remove this patch on next update after 2.5.32.
+# See https://github.com/gphoto/libgphoto2/commit/6670f88e7470b28e7fb345e2c7c2beba5d3427d7
 patchfiles-append   qtk-thumbnail-decoder.c.patch
 
 configure.args      --disable-silent-rules \

--- a/devel/libgphoto2/Portfile
+++ b/devel/libgphoto2/Portfile
@@ -36,6 +36,8 @@ depends_lib         port:curl \
                     port:gd2
 
 patchfiles          static_assert.patch
+
+# Was fixed upstream.  Remove this patch on next update after 2.5.32.
 patchfiles-append   qtk-thumbnail-decoder.c.patch
 
 configure.args      --disable-silent-rules \


### PR DESCRIPTION
#### Description

* Comment update only.  No rev bump or testing.
* Anticipate upstream fix:  https://github.com/gphoto/libgphoto2/pull/1151

###### Type(s)

- [x] enhancement

###### Tested on

* Comment update only.  No testing needed.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?