### PR TITLE
gphoto2: Update to 2.5.32

### DIFF
--- a/graphics/gphoto2/Portfile
+++ b/graphics/gphoto2/Portfile
@@ -1,12 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github         1.0
+PortGroup           github 1.0
 
 github.setup        gphoto gphoto2 2.5.32 v
 revision            0
-github.tarball_from releases
-use_xz              yes
 checksums           rmd160  83258b01868b7a3b0e51c232c9b54e7139e9e9b8 \
                     sha256  be08a449bbed9613bc9db105997c4ba71410d41870496420359a99b37502c406 \
                     size    607452
@@ -21,6 +19,8 @@ long_description    gphoto2 is the command line interface to libgphoto2. It \
                     allows almost everything that libgphoto2 can do.
 
 homepage            http://www.gphoto.org/proj/gphoto2/
+github.tarball_from releases
+use_xz              yes
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description

* Update gphoto2 2.5.28 --> 2.5.32.
* Fix builds for macOS 15.
* Use Github portgroup.
* Switch from Sourceforge to Github source.
* Switch distfile format to XZ.

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?