### PR TITLE
snappy: Complete the patch-no-disable-rtti and bump revision

### DIFF
--- a/archivers/snappy/Portfile
+++ b/archivers/snappy/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        google snappy 1.2.2
 github.tarball_from archive
-revision            1
+revision            2
 categories          archivers
 maintainers         nomaintainer
 license             BSD

--- a/archivers/snappy/files/patch-no-disable-rtti.diff
+++ b/archivers/snappy/files/patch-no-disable-rtti.diff
@@ -1,5 +1,5 @@
 --- CMakeLists.txt	2025-03-26 23:19:22.000000000 +0800
-+++ CMakeLists.txt	2025-04-30 06:00:15.000000000 +0800
++++ CMakeLists.txt	2025-04-30 06:23:14.000000000 +0800
 @@ -52,9 +52,6 @@
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c-")
    add_definitions(-D_HAS_EXCEPTIONS=0)
@@ -10,3 +10,14 @@
  else(MSVC)
    # Use -Wall for clang and gcc.
    if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+@@ -81,10 +78,6 @@
+   # Disable C++ exceptions.
+   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+-
+-  # Disable RTTI.
+-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+ endif(MSVC)
+ 
+ # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make


### PR DESCRIPTION
It seems that when the patch was re-inroduced @ 52395ddce2fa2d922bbbdc0dab69006db891a766 the new snappy 1.2.2 version requires a slightly different patch.

Without that, dependent packages like folly are unable to build from source. Note that they install ok when (old) binaries are downloaded, but consistently fail when building.

So this just picks the patch file from:

https://github.com/macos-powerpc/powerpc-ports/blob/main/archivers/snappy/files/patch-no-disable-rtti.diff

because it has been tested  and then both snappy and folly (and other dependent packages) can build ok locally.

More info: https://github.com/macports/macports-ports/commit/5089ecb79bce3415f4a8be1e7df6562f4a771f87

Credit goes to @barracuda156, I just have applied his recommendations, thanks!

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
