### PR TITLE
docker-credential-helper-osxkeychain: update to 0.9.3

### DIFF
--- a/devel/docker-credential-helper-osxkeychain/Portfile
+++ b/devel/docker-credential-helper-osxkeychain/Portfile
@@ -3,13 +3,10 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/docker/docker-credential-helpers 0.8.2 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+go.setup            github.com/docker/docker-credential-helpers 0.9.3 v
 revision            0
 name                docker-credential-helper-osxkeychain
 categories          devel
-platforms           darwin
 license             Apache-2
 maintainers         {emcrisostomo @emcrisostomo} \
                     openmaintainer
@@ -18,9 +15,9 @@ long_description    docker-credential-helpers is a suite of programs to use \
                     native stores to keep Docker credentials safe.  This \
                     port installs the macOS keychain credential helper.
 
-checksums           rmd160  d54db845f3de7c2420361b04b3c6a7a6e2baeb52 \
-                    sha256  23bb43aafa143ea49ce5728b1647938668dd92ddbece2168dcd5529d8b50ccc6 \
-                    size    283861
+checksums           rmd160  cc36f2f77bceb6074df1c12387cbfca48db5c08b \
+                    sha256  1111c403d50fc26bee310db8bed4fb7d98a43e88850e2ad47403e8f2e9109860 \
+                    size    295607
 
 set docker.helper   docker-credential-osxkeychain
 set credentials.Version ${version}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
