### PR TITLE
pinact: Update to 3.4.1

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.3.1 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.4.1 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,11 +16,11 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2dfe60222e7652078dc5e513c00a7e1c46a32b47 \
-                    sha256  f4b34a86afd43d0ddd7df833e7755e131dd06cdbb057d549a52a707a7eee9184 \
-                    size    39497
+                    rmd160  b842cbb5ab423a417c8696742d178cf47482373c \
+                    sha256  0df5b888045092abcef4d12ef043d63eaaa12c7254f843441443b8c12fc805ce \
+                    size    39917
 
-livecheck.regex     "v(\\d+\\.\\d+\\.\\d+)\$"
+livecheck.regex     {v(\d+\.\d+\.\d+)$}
 
 build.args-append   -ldflags \"-X main.version=${version} -X main.commit=MacPorts \" \
                     ./cmd/pinact
@@ -36,12 +36,6 @@ notes {
   If you have an existing .pinact.yaml file, you will need to use pinact 2.2 and run
   'pinact migrate' to fix the pinact configuration file for pinact 3.0.
 }
-
-
-
-
-
-
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
@@ -84,10 +78,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  c7caff4ba164feeebdcc568d6598931a20719827e05dfa18ac7d7c495d36b883 \
                         size    20797 \
                     github.com/urfave/cli \
-                        lock    v3.3.8 \
-                        rmd160  bb887122013f6f342e79338b6df7f4c2b319f84a \
-                        sha256  28f885c2b0e6e1e0ac4f7605741e9fc39e0401f1f5af648e029af046a69a1099 \
-                        size    6801980 \
+                        lock    v3.3.9 \
+                        rmd160  4e7c86feee9a52c1277bf0b9aa4fc20a4a2f58f4 \
+                        sha256  d074614536bae2855a68d8e95d484275f317e1470d0cbb32584ef1c84308e4db \
+                        size    6802003 \
                     github.com/suzuki-shunsuke/urfave-cli-v3-util \
                         lock    v0.0.7 \
                         rmd160  b3ca107c8c1430c04f335a7bed3166299f380a65 \
@@ -179,10 +173,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  95f52c816370b06a38bb827367c1acb5b1a0aa2e8d425f94ce2d32afe0c57510 \
                         size    10418 \
                     github.com/google/go-github \
-                        lock    v73.0.0 \
-                        rmd160  e2e0312eb2bc91d7cf88b4b0f34dd3a7ad0ec2cc \
-                        sha256  916c7feb96e4940e7e4289d16a64cd4fbaffb21db801fcf7566b960b1c207349 \
-                        size    818435 \
+                        lock    v74.0.0 \
+                        rmd160  e703994f7ec535b5c00e10e560ab50b2661f3264 \
+                        sha256  81f346b8adf4fe05c454304b12dbb84543c538d77cfa0a4a38cc609f61e4fd86 \
+                        size    822125 \
                     github.com/google/go-cmp \
                         lock    v0.7.0 \
                         rmd160  3f04a79c291d786f9c69c2944bdd521402052a5c \


### PR DESCRIPTION
#### Description

pinact: Update to 3.4.1

##### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
