### PR TITLE
legacy-support: Update to v1.5.1.

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -21,23 +21,21 @@ long_description    {*}${description}
 epoch               1
 
 # Primary release version
-set release_ver     1.5.0
+set release_ver     1.5.1
 
 # Binary compatibility version
 set compat_ver      1.0.0
 
 subport ${name} {
-    PortGroup           muniversal 1.1
-
     conflicts           ${name}-devel
     github.setup        macports macports-legacy-support ${release_ver} v
     # Change github.tarball_from to 'releases' or 'archive' next update
     # N.B.: That's a nice theory, but neither choice works correctly
     github.tarball_from tarball
     revision            0
-    checksums           rmd160  02d6f192a75ffacda4530d82464240f404cc224c \
-                        sha256  18f4df8850aebe64f66ed80eae14b50cc87cbe1d1dabfbdd432ff0aaf87b44f4 \
-                        size    214986
+    checksums           rmd160  80bea072afe759d0aa13bed02205e7165e116b51 \
+                        sha256  aa9f267e7d25a10ea359e571a1fb180440f8d81aca1f250b95df42a4b1a65ddc \
+                        size    227836
 }
 
 subport ${name}-devel {
@@ -55,43 +53,43 @@ subport ${name}-devel {
                         size    227836
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
-
-    # Set up proper arch list for build and test
-    if {![variant_isset universal]} {
-        set archs       ${configure.build_arch}
-    } else {
-        set archs       ${configure.universal_archs}
-    }
-
-    # Let the Makefile handle the archs setup
-    configure.cc_archflags
-    configure.cxx_archflags
-    configure.ld_archflags
-    configure.universal_cflags
-    configure.universal_cxxflags
-    configure.universal_ldflags
-
-    # Pass the arch list to the Makefile
-    build.env-append        ARCHS=${archs}
-    destroot.env-append     ARCHS=${archs}
-    test.env-append         ARCHS=${archs}
-
-    # Set test target for optional universal handling
-    # For some reason, setting test.target doesn't work.
-    test.pre_args       test_unv
-
-    # Enable parallel tests
-    default test.jobs   ${build.jobs}
-    test.post_args      -j${test.jobs}
 }
+
+# Set up proper arch list for build and test
+if {![variant_isset universal]} {
+    set archs       ${configure.build_arch}
+} else {
+    set archs       ${configure.universal_archs}
+}
+
+# Let the Makefile handle the archs setup
+configure.cc_archflags
+configure.cxx_archflags
+configure.ld_archflags
+configure.universal_cflags
+configure.universal_cxxflags
+configure.universal_ldflags
+
+# Pass the arch list to the Makefile
+build.env-append        ARCHS=${archs}
+destroot.env-append     ARCHS=${archs}
+test.env-append         ARCHS=${archs}
+
+# Set test target for optional universal handling
+# For some reason, setting test.target doesn't work.
+test.pre_args       test_unv
+
+# Enable parallel tests
+default test.jobs   ${build.jobs}
+test.post_args      -j${test.jobs}
 
 # The makefile PG brings in the unnecessary compiler_wrapper PG.
 # Disable it to reduce logfile clutter and obfuscation.
 #
 compwrap.compilers_to_wrap
 
-# This port doesn't use C++ at all, except for three obsolete tests that
-# are now manual-only.  Disabling cxx_stdlib avoids unnessary compiler
+# This port doesn't use C++ at all, except for two very limited tests
+# that are manual-only.  Disabling cxx_stdlib avoids unnessary compiler
 # constraints on some platforms.
 #
 configure.cxx_stdlib
@@ -104,13 +102,7 @@ platform darwin 8 {
     build.target-append     tiger-bins
     destroot.target-append  install-tiger
 
-    # The 10.4 compiler selection logic fails to correctly substitute
-    # apple-gcc42 for the Xcode compiler when building +universal for
-    # "ppc ppc64", and blacklisting seems to just result in a different
-    # bad choice.
-    # In this particular circumstance, just setting configure.compiler
-    # directly isn't unreasonable.
-    #
+    # Avoid troublesome Xcode 2.5 linker on 10.4
     configure.compiler      apple-gcc-4.2
 }
 


### PR DESCRIPTION
Notable functional changes since v1.5.0:

- Fixes boottime sysctls for 64-bit <10.6.
- Consequently undisables sleep offset on ppc64.

- Fixes fcntl() F_GETPATH for 10.4 ppc64.
- Fixes stat() et al tv_nsec for 10.4 ppc64.
- Adds missing address validation for 10.4 stat64() calls.
- Fixes (Apple) [f]setattrlist() bug in 10.5-10.7.

- Fixes 64-bit packet timestamps with unusual 10.4 SDK.

- Fixes thread-time bug on 10.10-10.11.

Port improvements:

- Tests now run in parallel.
- Handles universal builds/tests natively, without muniversal.

TESTED:
Tested both normal and -devel versions -/+universal on 10.4-10.5 ppc, 10.4-10.5 ppc64, 10.4-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-15.x arm64.
Builds and passes all tests on all tested platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S165, ppc64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, ppc (i386 Rosetta), Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, ppc (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.6 22H625, arm64, Xcode 15.2 15C500b
macOS 14.7.6 23H626, arm64, Xcode 16.2 16C5032a
macOS 15.5 24F74, arm64, Xcode 16.4 16F6
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
