### PR TITLE
google-cloud-sdk: update to 534.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             533.0.0
+version             534.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  f11bfdafb8a4911223ff5f5b0b1a5979719ffb52 \
-                    sha256  15b2d77ec8c7962675513bf0fecf9e9f8729d2f09c5f00d478ca6e9b53846b24 \
-                    size    55046139
+    checksums       rmd160  ffd9f1bfdf4897b4a45452087345a0b9ffbd6ccf \
+                    sha256  2d1b72d767949f8a512de11b1c3786de177014f7cb58c607dfc142a2e85421fc \
+                    size    55074147
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a4802f07195582afa140346f76dd0ecf49b37598 \
-                    sha256  2ef770746a10f334c38d8e4f7d71a9a5513240e7f840b242729ecd2361e68b20 \
-                    size    56578286
+    checksums       rmd160  a52db618a037e7a1aa6dac7734d53454e52e208a \
+                    sha256  7540683cd31ed0de3566df66a3f939d2960d77663f6129ef5f3e757e7dc4a40c \
+                    size    56606541
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  b82fe7c759b9a6aa82a2ed29203efe2c1019a862 \
-                    sha256  37189900ed6b31ecf6efa122b812b9bf21a01c226d9bdfd0891e4ca3d190a611 \
-                    size    56510957
+    checksums       rmd160  98421782dfd851ff60ae7a61b19cf82fe89d785f \
+                    sha256  04f7f9452d955f4e64fd6730e0fbd83060b0caf7a4673e8c198b6152ffc81835 \
+                    size    56538945
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -41,7 +41,7 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 
 worksrcdir          ${name}
 
-# Most recent Python version that supports both
+# Most recent Python version that is compatible with both
 # glcoud (https://cloud.google.com/sdk/docs/install#mac) and
 # gsutil (https://cloud.google.com/storage/docs/gsutil_install#before_you_begin)
 python.default_version 313


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 534.0.0.

###### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?