### PR TITLE
clutter: Disable EGL backend

### DIFF
--- a/graphics/clutter/Portfile
+++ b/graphics/clutter/Portfile
@@ -5,7 +5,7 @@ PortGroup           gobject_introspection 1.0
 
 name                clutter
 version             1.26.4
-revision            1
+revision            2
 license             LGPL-2.1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          graphics
@@ -54,6 +54,11 @@ variant x11 conflicts quartz {
                        --disable-examples \
                        --disable-silent-rules \
                        --disable-gtk-doc
+
+    # https://trac.macports.org/ticket/71653
+    configure.args-append \
+                       --enable-egl-backend=no \
+                       --enable-wayland-backend=no
 }
 
 variant quartz conflicts x11 {
@@ -68,6 +73,11 @@ variant quartz conflicts x11 {
                     --enable-quartz-backend=yes \
                     --disable-silent-rules \
                     --disable-gtk-doc
+
+    # https://trac.macports.org/ticket/71653
+    configure.args-append \
+                    --enable-egl-backend=no \
+                    --enable-wayland-backend=no
 }
 
 variant debug description {Enable full debugging} {


### PR DESCRIPTION
#### Description

* Fix recent builds.
* Fixes: error: cogl/cogl-egl.h: No such file or directory
* Closes https://trac.macports.org/ticket/71653.
* Follows recommendation in that ticket.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?