### PR TITLE
ImageMagick7: Update to 7.1.2-1

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -21,13 +21,13 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-github.setup        ImageMagick ImageMagick 7.1.2-0
+github.setup        ImageMagick ImageMagick 7.1.2-1
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  4af8092f371de9c44bcfac7d46632fbd869bd901 \
-                    sha256  03fe29e376b5938255b3fdb8d1f50515caa48055c0c2743faaeea52fc673a38b \
-                    size    15689645
+checksums           rmd160  cc3af690ecc67010629f4e5f5bb06309571c7d90 \
+                    sha256  9306407381a7bf0ac5d97074eca3ce9dfaac65ced4d44f6a47bc24fbfc693e9a \
+                    size    15704122
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \


### PR DESCRIPTION
#### Description

Update ImageMagick7, 7.1.2-0 --> 7.1.2-1

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?