### PR TITLE
temporal: new port @1.4.1 (Temporal CLI incl. dev server); temporal-cli: obsolete; replaced_by temporal

### DIFF
--- a/devel/temporal-cli/Portfile
+++ b/devel/temporal-cli/Portfile
@@ -1,11 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           golang 1.0
+PortGroup           obsolete 1.0
+
+name                temporal-cli
+version             1.18.4
+replaced_by         temporal
 
 go.setup            github.com/temporalio/tctl 1.18.1 v
 go.offline_build    no
-name                temporal-cli
 revision            0
 
 homepage            https://temporal.io

--- a/devel/temporal/Portfile
+++ b/devel/temporal/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/temporalio/cli 1.4.1 v
+go.offline_build    no
+name                temporal
+
+homepage            https://temporal.io
+
+description         Command-line interface for Temporal incl. local dev server
+long_description    \
+    {*}${description}. Temporal is the open source microservices \
+    orchestration platform for running mission critical code at any scale.
+
+categories          devel sysutils
+installs_libs       no
+license             MIT
+maintainers         {pardus.de:wrobel @wrobel} openmaintainer
+
+supported_archs     arm64 x86_64
+use_parallel_build  no
+
+
+build.target        ./cmd/temporal
+
+checksums           rmd160  cf3e5d608ab21ec8fecbbd5accf10d7133dd5e81 \
+                    sha256  fcfe2e857b4e03fad8e63f239df03a21685427f88e0a627c8ac5050ea5908974 \
+                    size    249415
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/temporal ${destroot}${prefix}/bin/temporal
+}
+
+notes "Start dev server: 'temporal server start-dev' (UI: http://localhost:8233)"


### PR DESCRIPTION
#### Description

Add new port `temporal` for the current Temporal CLI (`github.com/temporalio/cli`, v1.4.1).  
This CLI supersedes the deprecated `tctl` (`temporal-cli` port), includes the local development server (`temporal server start-dev`), and bundles the Web UI.

Mark the old `temporal-cli` port as obsolete and replaced by `temporal`.

**Note:** When building `temporal` from source locally (instead of installing a prebuilt archive from the buildbots), the large single binary (~181 MB) can trigger a SIGKILL during the install phase on some systems due to `bsdtar --hfsCompression`.  
This does **not** affect normal users who receive prebuilt archives from buildbots.  
For local source builds, using an alternate archive type (e.g. `sudo port -s -v install temporal archive_type=tgz`) avoids the issue.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 15.6 24G93 arm64  
Command Line Tools 16.4.0.0.1.1747106510

###### Verification
- [x] followed [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)
- [x] squashed and minimized commits
- [x] checked there aren't other open PRs for this change
- [x] checked Portfile with `port lint`
- [x] tested full install with `sudo port -s -v install temporal archive_type=tgz`
- [x] tested basic CLI functionality: `temporal version`, `temporal server start-dev`
- [x] verified old `temporal-cli` correctly obsoleted and replaced
