### PR TITLE
zizmor: Update to 1.12.1

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.11.0 v
+github.setup        zizmorcore zizmor 1.12.1 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  439c161a96b0dbb9f417fa1092c0c5828fb2ed18 \
-                    sha256  e60c8c280bee3b3a7eba32a961f6aa23d229f7a9db754715b7c98362a7c6dc7f \
-                    size    466819
+                    rmd160  96621a47df00e9f468c95521091325962802220c \
+                    sha256  1caa4b9884d7755cd5679f629ecbfe7d028cbb508fae9ed423129b48f7f3dbaf \
+                    size    491933
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -36,7 +36,7 @@ cargo.crates \
     ahash                              0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                        1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     annotate-snippets                  0.11.5  710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4 \
-    anstream                           0.6.19  301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933 \
+    anstream                           0.6.20  3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192 \
     anstyle                            1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
     anstyle-parse                       0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                       1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
@@ -62,16 +62,16 @@ cargo.crates \
     bytecount                           0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
     bytes                              1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
     cacache                            13.1.0  5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b \
-    camino                             1.1.10  0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab \
+    camino                             1.1.11  5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0 \
     cc                                 1.2.20  04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a \
     cfg-if                              1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                         0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    clap                               4.5.40  40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f \
+    clap                               4.5.43  50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f \
     clap-verbosity-flag                 3.0.3  eeab6a5cdfc795a05538422012f20a5496f050223c91be4e5420bfd13c641fb1 \
-    clap_builder                       4.5.40  e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e \
-    clap_complete                      4.5.54  aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677 \
-    clap_complete_nushell               4.5.7  cdb8335b398d197fb3176efe9400c6c053a41733c26794316c73423d212b2f3d \
-    clap_derive                        4.5.40  d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce \
+    clap_builder                       4.5.43  c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65 \
+    clap_complete                      4.5.56  67e4efcbb5da11a92e8a609233aa1e8a7d91e38de0be865f016d14700d45a7fd \
+    clap_complete_nushell               4.5.8  0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce \
+    clap_derive                        4.5.41  ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491 \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     colorchoice                         1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     console                           0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
@@ -134,7 +134,7 @@ cargo.crates \
     http-serde                          2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
     httparse                           1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                            1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    human-panic                         2.0.2  80b84a66a325082740043a6c28bbea400c129eac0d3a27673a1de971e44bf1f7 \
+    human-panic                         2.0.3  ac63a746b187e95d51fe16850eb04d1cfef203f6af98e6c405a6f262ad3df00a \
     hyper                               1.6.0  cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80 \
     hyper-rustls                       0.27.5  2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2 \
     hyper-util                         0.1.13  b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8 \
@@ -152,9 +152,10 @@ cargo.crates \
     idna_adapter                        1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                             0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
     indexmap                           2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
-    indicatif                         0.17.12  4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056 \
+    indicatif                          0.18.0  70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd \
     insta                              1.43.1  154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371 \
     inventory                          0.3.20  ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83 \
+    io-uring                            0.7.8  b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013 \
     ipnet                              2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
     iri-string                          0.7.8  dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2 \
     is_terminal_polyfill               1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
@@ -235,7 +236,7 @@ cargo.crates \
     regex-automata                      0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                       0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    reqwest                           0.12.20  eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813 \
+    reqwest                           0.12.22  cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531 \
     reqwest-middleware                  0.4.2  57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e \
     ring                              0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rustc-demangle                     0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
@@ -253,13 +254,13 @@ cargo.crates \
     serde                             1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
     serde-sarif                         0.8.0  a053c46f18a8043570d4e32fefc4c6377f82bf29ec310a33e93f273048e3b0be \
     serde_derive                      1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
-    serde_json                        1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
+    serde_json                        1.0.142  030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7 \
     serde_json_path                     0.7.2  b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33 \
     serde_json_path_core                0.2.2  dde67d8dfe7d4967b5a95e247d4148368ddd1e753e500adb34b3ffe40c6bc1bc \
     serde_json_path_macros              0.1.6  517acfa7f77ddaf5c43d5f119c44a683774e130b4247b7d3210f8924506cfac8 \
     serde_json_path_macros_internal     0.1.2  aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90 \
     serde_repr                         0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
-    serde_spanned                       0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
+    serde_spanned                       1.0.0  40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83 \
     serde_urlencoded                    0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     serde_yaml              0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     sha-1                              0.10.1  f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c \
@@ -271,6 +272,7 @@ cargo.crates \
     slab                                0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
     smallvec                           1.15.0  8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9 \
     socket2                             0.5.9  4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef \
+    socket2                             0.6.0  233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807 \
     ssri                                9.2.0  da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082 \
     stable_deref_trait                  1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     streaming-iterator                  0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
@@ -298,15 +300,14 @@ cargo.crates \
     tinystr                             0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
     tinyvec                             1.9.0  09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71 \
     tinyvec_macros                      0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                              1.45.1  75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779 \
+    tokio                              1.47.1  89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038 \
     tokio-macros                        2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-rustls                       0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
     tokio-stream                       0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
     tokio-util                         0.7.15  66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df \
-    toml                               0.8.22  05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae \
-    toml_datetime                       0.6.9  3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3 \
-    toml_edit                         0.22.26  310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e \
-    toml_write                          0.1.1  bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076 \
+    toml                                0.9.2  ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac \
+    toml_datetime                       0.7.0  bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3 \
+    toml_writer                         1.0.2  fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64 \
     tower                              0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
     tower                               0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
     tower-http                          0.6.5  5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2 \
@@ -316,14 +317,14 @@ cargo.crates \
     tower-service                       0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                            0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-attributes                 0.1.28  395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d \
-    tracing-core                       0.1.33  e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c \
-    tracing-indicatif                   0.3.9  8201ca430e0cd893ef978226fd3516c06d9c494181c8bf4e5b32e30ed4b40aa1 \
+    tracing-core                       0.1.34  b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678 \
+    tracing-indicatif                  0.3.12  e1983afead46ff13a3c93581e0cec31d20b29efdd22cbdaa8b9f850eccf2c352 \
     tracing-log                         0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber                 0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
-    tree-sitter                        0.25.6  a7cf18d43cbf0bfca51f657132cc616a5097edc4424d538bae6fa60142eaf9f0 \
+    tree-sitter                        0.25.8  6d7b8994f367f16e6fa14b5aebbcb350de5d7cbea82dc5b00ae997dd71680dd2 \
     tree-sitter-bash                   0.23.3  329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e \
     tree-sitter-language                0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
-    tree-sitter-powershell             0.25.6  e265a36be4ab388c842629bef61fb719c83f9be3241db92288d064ed425758ba \
+    tree-sitter-powershell             0.25.8  d76347b6c5300ae20622847aa53c88005d13b6999708ffbe4618b509ddb45178 \
     tree-sitter-yaml                    0.7.1  3d5893f2a05e57c86a2338aa3aed167a1e5c68b8fdff3bf4a460941f2d8fc944 \
     try-lock                            0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     typed-builder                      0.21.0  ce63bcaf7e9806c206f7d7b9c1f38e0dce8bb165a80af0898161058b19248534 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.12.1

##### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
