### PR TITLE
mise: Update to 2025.8.10

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.8.8 v
+github.setup        jdx mise 2025.8.10 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2112d562f174230ed8a4958251a192c83e8cb166 \
-                    sha256  ea25f6880b525c4a8444b69b7380f2f7d863784877b469c8257900ea48b37cb6 \
-                    size    4417355
+                    rmd160  64bcd973fedd4aa3dc17f7063cab9c6cd5a2a082 \
+                    sha256  cc113c02147c52a222c504c10da3e136a65e21725a536fd419448bee2922c1dd \
+                    size    4436768
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -100,12 +100,12 @@ cargo.crates \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     ansi-str                         0.9.0  060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d \
     ansitok                          0.3.0  c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee \
-    anstream                        0.6.19  301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933 \
+    anstream                        0.6.20  3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192 \
     anstyle                         1.0.11  862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd \
     anstyle-parse                    0.2.7  4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2 \
-    anstyle-query                    1.1.3  6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9 \
-    anstyle-wincon                   3.0.9  403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882 \
-    anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
+    anstyle-query                    1.1.4  9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2 \
+    anstyle-wincon                  3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
+    anyhow                          1.0.99  b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100 \
     arbitrary                        1.4.1  dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     arrayref                         0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
@@ -142,7 +142,7 @@ cargo.crates \
     bzip2-sys                 0.1.13+1.0.8  225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14 \
     calm_io                          0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                   0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
-    cc                              1.2.30  deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7 \
+    cc                              1.2.32  2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e \
     cfg-if                           1.0.1  9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
@@ -152,11 +152,11 @@ cargo.crates \
     chrono-tz-build                  0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                        0.14.14  840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
-    clap                            4.5.41  be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9 \
-    clap_builder                    4.5.41  707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d \
+    clap                            4.5.44  1c1f056bae57e3e54c3375c41ff79619ddd13460a17d7438712bd0d83fda4ff8 \
+    clap_builder                    4.5.44  b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8 \
     clap_derive                     4.5.41  ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491 \
     clap_lex                         0.7.5  b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675 \
-    clap_mangen                     0.2.28  e2fb6d3f935bbb9819391528b0e7cf655e78a0bc7a7c3d227211a1d24fc11db1 \
+    clap_mangen                     0.2.29  27b4c3c54b30f0d9adcb47f25f61fcce35c4dd8916638c6b82fbd5f4fb4179e2 \
     clru                             0.6.2  cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59 \
     color-eyre                       0.6.5  e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d \
     color-print                      0.3.7  3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4 \
@@ -165,8 +165,8 @@ cargo.crates \
     colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
     colored                          3.0.0  fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e \
     comfy-table                      7.1.4  4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a \
-    confique                         0.3.0  d011f79ecb68498e94453e133c67cc5c35ab847684c59fa58b9ce0698e272e7b \
-    confique-macro                  0.0.11  df20583fae327154743356c4896906bda1aa9b7df30c5aed73a54cf27fede9de \
+    confique                         0.3.1  33cbbbdc4e7bec8bd8a61bc21159fc79fa22004754feb0a83f78119b3918e0b3 \
+    confique-macro                  0.0.12  85d58122c074ab6431418377f20b74cac2d37be215a94784f1aa319e89200aab \
     console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
     console                         0.16.0  2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
@@ -188,17 +188,17 @@ cargo.crates \
     crossterm                       0.28.1  829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6 \
     crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
-    ctor                             0.4.2  a4735f265ba6a1188052ca32d461028a7d1125868be18e287e756019da7607b5 \
-    ctor-proc-macro                  0.0.5  4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d \
+    ctor                             0.4.3  ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6 \
+    ctor-proc-macro                  0.0.6  e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2 \
     ctr                              0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
     darling                        0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
-    darling                         0.21.0  a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9 \
+    darling                         0.21.1  d6b136475da5ef7b6ac596c0e956e37bad51b85b987ff3d5e230e964936736b2 \
     darling_core                   0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
-    darling_core                    0.21.0  74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d \
+    darling_core                    0.21.1  b44ad32f92b75fb438b04b68547e521a548be8acc339a6dacc4a7121488f53e6 \
     darling_macro                  0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
-    darling_macro                   0.21.0  e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146 \
+    darling_macro                   0.21.1  2b5be8a7a562d315a5b92a630c30cec6bcf663e6673f00fbb69cca66a6f521b9 \
     dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     dashmap                          6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
     deflate64                        0.1.9  da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b \
@@ -219,9 +219,9 @@ cargo.crates \
     dtor                             0.0.6  97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8 \
     dtor-proc-macro                  0.0.5  7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055 \
     duct                            0.13.7  e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c \
-    duct                             1.0.0  b6ce170a0e8454fa0f9b0e5ca38a6ba17ed76a50916839d217eb5357e05cdfde \
+    duct                             1.1.0  d7478638a31d1f1f3d6c9f5e57c76b906a04ac4879d6fd0fb6245bc88f73fd0b \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
-    dyn-clone                       1.0.19  1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005 \
+    dyn-clone                       1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
     ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                    2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
     either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
@@ -275,7 +275,7 @@ cargo.crates \
     ghash                            0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     gix                             0.73.0  514c29cc879bdc0286b0cbc205585a49b252809eb86c69df4ce4f855ee75f635 \
-    gix-actor                       0.35.2  58ebbb8f41071c7cf318a0b1db667c34e1df49db7bf387d282a4e61a3b97882c \
+    gix-actor                       0.35.3  d1b1ec302f8dc059df125ed46dfdc7e9d33fe7724df19843aea53b5ffd32d5bb \
     gix-archive                     0.22.0  7be088a0e1b30abe15572ffafb3409172a3d88148e13959734f24f52112a19d6 \
     gix-attributes                  0.27.0  45442188216d08a5959af195f659cb1f244a50d7d2d0c3873633b1cd7135f638 \
     gix-bitmap                      0.2.14  b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540 \
@@ -285,11 +285,11 @@ cargo.crates \
     gix-config                      0.46.0  5dfb898c5b695fd4acfc3c0ab638525a65545d47706064dcf7b5ead6cdb136c0 \
     gix-config-value                0.15.1  9f012703eb67e263c6c1fc96649fec47694dd3e5d2a91abfc65e4a6a6dc85309 \
     gix-credentials                 0.30.0  0039dd3ac606dd80b16353a41b61fc237ca5cb8b612f67a9f880adfad4be4e05 \
-    gix-date                        0.10.3  d7235bdf4d9d54a6901928e3a37f91c16f419e6957f520ed929c3d292b84226e \
+    gix-date                        0.10.5  996b6b90bafb287330af92b274c3e64309dc78359221d8612d11cd10c8b9fe1c \
     gix-diff                        0.53.0  de854852010d44a317f30c92d67a983e691c9478c8a3fb4117c1f48626bcdea8 \
     gix-dir                         0.15.0  dad34e4f373f94902df1ba1d2a1df3a1b29eacd15e316ac5972d842e31422dd7 \
     gix-discover                    0.41.0  ffb180c91ca1a2cf53e828bb63d8d8f8fa7526f49b83b33d7f46cbeb5d79d30a \
-    gix-features                    0.43.0  9a92748623c201568785ee69a561f4eec06f745b4fac67dab1d44ca9891a57ee \
+    gix-features                    0.43.1  cd1543cd9b8abcbcebaa1a666a5c168ee2cda4dea50d3961ee0e6d1c42f81e5b \
     gix-filter                      0.20.0  aa6571a3927e7ab10f64279a088e0dae08e8da05547771796d7389bbe28ad9ff \
     gix-fs                          0.16.0  d793f71e955d18f228d20ec433dcce6d0e8577efcdfd11d72d09d7cc2758dfd1 \
     gix-glob                        0.21.0  b947db8366823e7a750c254f6bb29e27e17f27e457bf336ba79b32423db62cd5 \
@@ -300,12 +300,12 @@ cargo.crates \
     gix-lock                        18.0.0  b9fa71da90365668a621e184eb5b979904471af1b3b09b943a84bc50e8ad42ed \
     gix-mailmap                     0.27.2  9a8982e1874a2034d7dd481bcdd6a05579ba444bcda748511eb0f8e50eb10487 \
     gix-negotiate                   0.21.0  1d58d4c9118885233be971e0d7a589f5cfb1a8bd6cb6e2ecfb0fc6b1b293c83b \
-    gix-object                      0.50.0  49664e3e212bc34f7060f5738ce7022247e4afd959b68a4f666b1fd29c00b23c \
+    gix-object                      0.50.1  aff2047f96d57bcc721426e11ec0f9efeb432d5e6ef5f1aa84cfc55198971dca \
     gix-odb                         0.70.0  9c9d7af10fda9df0bb4f7f9bd507963560b3c66cb15a5b825caf752e0eb109ac \
     gix-pack                        0.60.0  d8571df89bfca5abb49c3e3372393f7af7e6f8b8dbe2b96303593cef5b263019 \
     gix-packetline                  0.19.1  2592fbd36249a2fea11056f7055cc376301ef38d903d157de41998335bbf1f93 \
     gix-packetline-blocking         0.19.1  fc4e706f328cd494cc8f932172e123a72b9a4711b0db5e411681432a89bd4c94 \
-    gix-path                       0.10.19  c6279d323d925ad4790602105ae27df4b915e7a7d81e4cdba2603121c03ad111 \
+    gix-path                       0.10.20  06d37034a4c67bbdda76f7bcd037b2f7bc0fba0c09a6662b19697a5716e7b2fd \
     gix-pathspec                    0.12.0  daedead611c9bd1f3640dc90a9012b45f790201788af4d659f28d94071da7fba \
     gix-prompt                      0.11.1  6ffa1a7a34c81710aaa666a428c142b6c5d640492fcd41267db0740d923c7906 \
     gix-protocol                    0.51.0  12b4b807c47ffcf7c1e5b8119585368a56449f3493da93b931e1d4239364e922 \
@@ -328,14 +328,14 @@ cargo.crates \
     gix-worktree                    0.42.0  55f625ac9126c19bef06dbc6d2703cdd7987e21e35b497bb265ac37d383877b1 \
     gix-worktree-state              0.20.0  06ba9b17cbacc02b25801197b20100f7f9bd621db1e7fce9d3c8ab3175207bf8 \
     gix-worktree-stream             0.22.0  f56a737cefbcd90b573cb5393d636f6dc5e0d08a8086356d8c4fcc623b49a0e8 \
-    glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
+    glob                             0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     globset                         0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
-    h2                              0.4.11  17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785 \
+    h2                              0.4.12  f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386 \
     hash32                           0.3.1  47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashbrown                       0.15.4  5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5 \
+    hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     heapless                         0.8.0  0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
@@ -375,7 +375,7 @@ cargo.crates \
     imara-diff                       0.1.8  17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2 \
     impl-tools                      0.10.3  0ae95c9095c2f1126d7db785955c73cdc5fc33e7c3fa911bd4a42931672029a7 \
     impl-tools-lib                  0.11.3  cc6a9b65dadb575faa21065e8464e88ec3e991b3d6745972dec69d1be6cffcfe \
-    indenter                         0.3.3  ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683 \
+    indenter                         0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
     indexmap                        2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
     indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
@@ -407,15 +407,15 @@ cargo.crates \
     lazy-regex                       3.4.1  60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126 \
     lazy-regex-proc_macros           3.4.1  4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libbz2-rs-sys                    0.2.1  775bf80d5878ab7c2b1080b5351a48b2f737d9f6f8b383574eebcc22be0dfccb \
-    libc                           0.2.174  1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776 \
+    libbz2-rs-sys                    0.2.2  2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7 \
+    libc                           0.2.175  6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543 \
     libm                            0.2.15  f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de \
-    libredox                         0.1.6  4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0 \
+    libredox                         0.1.9  391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3 \
     libz-rs-sys                      0.5.1  172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221 \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                    0.9.4  cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
     litemap                          0.8.0  241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956 \
-    litrs                            0.4.1  b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5 \
+    litrs                            0.4.2  f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed \
     lock_api                        0.4.13  96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765 \
     log                             0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
     logos                           0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
@@ -426,12 +426,14 @@ cargo.crates \
     luajit-src             210.6.1+f9140a6  813bd31f2759443affa687c0d9c5eb5cf6cb0e898810ab197408431d746054bf \
     lzma-rs                          0.3.0  297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e \
     lzma-rust                        0.1.7  5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661 \
+    lzma-rust2                       0.6.1  26175dd096dfaab9f4fbf577a668842ebc48374d4d06b154bffb49918e242261 \
     lzma-sys                        0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
     maybe-async                     0.2.10  5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11 \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     memchr                           2.7.5  32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0 \
     memmap2                          0.9.7  483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28 \
+    memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     miette                           7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
     miette-derive                    7.6.0  db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
@@ -439,8 +441,8 @@ cargo.crates \
     minisign-verify                  0.2.4  e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43 \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                              1.0.4  78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c \
-    mlua                            0.11.1  de25fc513588ac1273aa8c6dc0fffee6d32c12f38dc75f5cdc74547121a107ef \
-    mlua-sys                         0.8.2  bcdf7c9e260ca82aaa32ac11148941952b856bb8c69aa5a9e65962f21fcb8637 \
+    mlua                            0.11.2  ab2fea92b2adabd51808311b101551d6e3f8602b65e9fae51f7ad5b3d500f4cd \
+    mlua-sys                         0.8.3  3d4dc9cfc5a7698899802e97480617d9726f7da78c910db989d4d0fd4991d900 \
     mlua_derive                     0.11.0  465bddde514c4eb3b50b543250e97c1d4b284fa3ef7dc0ba2992c77545dbceb2 \
     mockito                          1.7.0  7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48 \
     native-tls                      0.2.14  87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e \
@@ -508,7 +510,7 @@ cargo.crates \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
-    proc-macro2                     1.0.95  02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778 \
+    proc-macro2                     1.0.97  d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1 \
     prodash                         30.0.1  5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139 \
     quick-xml                       0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
     quinn                           0.11.8  626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8 \
@@ -522,8 +524,8 @@ cargo.crates \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
-    redox_syscall                   0.5.15  7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec \
-    redox_users                      0.5.0  dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b \
+    redox_syscall                   0.5.17  5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77 \
+    redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
     ref-cast                        1.0.24  4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf \
     ref-cast-impl                   1.0.24  1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7 \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
@@ -539,21 +541,21 @@ cargo.crates \
     rmp-serde                        1.3.0  52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
     rops                             0.1.5  5c830d8ae5c50ef149e290235ef564ac84d97181dce248ae30706cfaf1d3e7cc \
-    rowan                          0.15.16  0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d \
+    rowan                          0.15.17  d4f1e4a001f863f41ea8d0e6a0c34b356d5b733db50dadab3efef640bafb779b \
     rust-embed                       8.7.2  025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a \
     rust-embed-impl                  8.7.2  6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c \
     rust-embed-utils                 8.7.2  f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594 \
-    rustc-demangle                  0.1.25  989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f \
+    rustc-demangle                  0.1.26  56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                           1.0.8  11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8 \
-    rustls                         0.23.29  2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1 \
+    rustls                         0.23.31  c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc \
     rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pki-types                1.12.0  229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79 \
     rustls-webpki                  0.103.4  0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc \
-    rustversion                     1.0.21  8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d \
+    rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     salsa20                         0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
@@ -568,7 +570,7 @@ cargo.crates \
     sdd                             3.0.10  490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca \
     secrecy                         0.10.3  e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
-    security-framework               3.2.0  271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316 \
+    security-framework               3.3.0  80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c \
     security-framework-sys          2.14.0  49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     self_cell                       0.10.3  e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d \
@@ -580,7 +582,7 @@ cargo.crates \
     serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
     serde_ignored                   0.1.12  b516445dac1e3535b6d658a7b528d771153dfb272ed4180ca4617a20550365ff \
-    serde_json                     1.0.141  30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3 \
+    serde_json                     1.0.142  030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7 \
     serde_regex                      1.1.0  a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf \
     serde_spanned                    0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
@@ -590,23 +592,24 @@ cargo.crates \
     serial_test                      3.2.0  1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9 \
     serial_test_derive               3.2.0  5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef \
     sevenz-rust                      0.6.1  26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef \
+    sevenz-rust2                    0.17.1  98644326f9145490e4c194dd775a9a2ed7e84f8254415eb709a7924f52fcd7a1 \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha1-checked                    0.10.0  89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423 \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shared_child                     1.1.1  1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7 \
-    shared_thread                    0.1.0  c7a6f98357c6bb0ebace19b22220e5543801d9de90ffe77f8abb27c056bac064 \
+    shared_thread                    0.2.0  52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0 \
     shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
     shell-words                      1.1.0  24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     sigchld                          0.2.4  47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1 \
     signal-hook                     0.3.18  d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
-    signal-hook-registry             1.4.5  9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410 \
+    signal-hook-registry             1.4.6  b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b \
     signature                        2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
     simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \
     similar                          2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
     siphasher                        1.0.1  56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d \
-    slab                            0.4.10  04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d \
+    slab                            0.4.11  7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589 \
     slug                             0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
     smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     socket2                         0.5.10  e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678 \
@@ -632,15 +635,15 @@ cargo.crates \
     tempfile                        3.20.0  e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1 \
     tera                            1.20.0  ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
-    terminal_size                    0.4.2  45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed \
+    terminal_size                    0.4.3  60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0 \
     test-log                        0.2.18  1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b \
     test-log-macros                 0.2.18  451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36 \
     testing_table                    0.3.0  0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc \
     text-size                        1.1.1  f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
+    thiserror                       2.0.14  0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
+    thiserror-impl                  2.0.14  cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227 \
     thread_local                     1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
     time                            0.3.41  8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40 \
     time-core                        0.1.4  c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c \
@@ -648,11 +651,11 @@ cargo.crates \
     tinystr                          0.8.1  5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b \
     tinyvec                          1.9.0  09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.46.1  0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17 \
+    tokio                           1.47.1  89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038 \
     tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                    0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
-    tokio-util                      0.7.15  66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df \
+    tokio-util                      0.7.16  14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5 \
     toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
     toml                            0.8.23  dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362 \
     toml_datetime                   0.6.11  22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
@@ -672,7 +675,7 @@ cargo.crates \
     type-map                         0.5.1  cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90 \
     typeid                           1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
     typenum                         1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
-    ubi                              0.7.2  38280fcdc420d9a0e910c9f8e83566b5d3ef3d53a1020013847ce5e5e1b37bf4 \
+    ubi                              0.7.3  0ba01598cd03e5cf73c25ffd69cb72469d9a4e74b9339c17fa3e95964511c999 \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     uluru                            3.1.0  7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da \
     unic-char-property               0.9.0  a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221 \
@@ -704,7 +707,7 @@ cargo.crates \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
     versions                         7.0.0  80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f \
-    vfox                          2025.8.8  c8254b901f65e248517561c36547429441f0cc6950047d93ebf93f994503b3e4 \
+    vfox                         2025.8.10  1e59923b1bb514c7f947fc8e94ce7ada03a21452a484be92f16f409c694b257d \
     vte                             0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
@@ -743,7 +746,7 @@ cargo.crates \
     windows-sys                     0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
     windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
-    windows-targets                 0.53.2  c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef \
+    windows-targets                 0.53.3  d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91 \
     windows-threading                0.1.0  b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6 \
     windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
     windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
@@ -787,7 +790,7 @@ cargo.crates \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
     zeroize_derive                   1.4.2  ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69 \
     zerotrie                         0.2.2  36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595 \
-    zerovec                         0.11.2  4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428 \
+    zerovec                         0.11.4  e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b \
     zerovec-derive                  0.11.1  5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f \
     zip                              2.4.2  fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50 \
     zip                              3.0.0  12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308 \


### PR DESCRIPTION
#### Description

mise: Update to 2025.8.10

##### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
