### PR TITLE
minipro: update to version 0.7.4

### DIFF
--- a/devel/minipro/Portfile
+++ b/devel/minipro/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           gitlab 1.0
 
-gitlab.setup        DavidGriffith minipro 0.7.2
+gitlab.setup        DavidGriffith minipro 0.7.4
 revision            0
-checksums           rmd160  2c3d835658590cdf3784b79479ffd9e2f17a7c91 \
-                    sha256  41eefd44bb405ef89806983bea5d7bd02aba9f4619d23f2085aab056e048fcfc \
-                    size    287826
+checksums           rmd160  6a84e261bbd7ed4cf13e1290310a1be8bcbbd4d3 \
+                    sha256  cac2f3239f50aea70a54fb4f8a5de3c87caba7f377c3cd51a417c1bc7a042921 \
+                    size    346583
 
 categories          devel
 maintainers         openmaintainer {krischik @krischik}
 license             GPL-3
-description         Utility for the MiniPRO TL866CS and TL866A universal programmers
+description         Utility for the MiniPRO TL866CS, TL866A and T56 universal programmers
 long_description    Opensource tool that aims to create a complete cross-platform \
                     replacement for the proprietary utility from autoelectric.cn. \
                     Currently it supports more than 13000 of target devices including \


### PR DESCRIPTION
#### Description

Updates minipro to version 0.7.4

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4.1 24E263 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

