### PR TITLE
gnupg2: update to version 2.4.8

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 
 set my_name         gnupg
 name                ${my_name}2
-version             2.4.7
+version             2.4.8
 revision            0
 
 # Putting the SHA1 hash because that is published on the website
-checksums           rmd160  bdc1884629c651e74bdd02d8f2cb8e746f030e83 \
-                    sha1    2d510a1a7294f2f9ef3f2e280c93c3ad9b0cdb68 \
-                    sha256  7b24706e4da7e0e3b06ca068231027401f238102c41c909631349dcc3b85eb46 \
-                    size    8010244
+checksums           rmd160  a9626023371d2d19fe5b668944967e1e64fea281 \
+                    sha1    c704085aa7cc131a67edd0b7c0c90e5c35ee4adb \
+                    sha256  b58c80d79b04d3243ff49c1c3fc6b5f83138eb3784689563bcdd060595318616 \
+                    size    8017685
 
 # https://trac.macports.org/ticket/63552
 epoch               1


### PR DESCRIPTION
#### Description
Update to version 2.4.8
 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
