### PR TITLE
lagrange: update to 1.18.7

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           gitea 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.18.6 v
+gitea.setup         gemini lagrange 1.18.7 v
 revision            0
 categories          net gemini
 license             BSD
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  d76a313b6ffd46671b2cac146ab17674d442f201 \
-                    sha256  4466d9f19d05f427d55a7c12111365d08cf352612d3a57173cca49663a124c8d \
-                    size    8894577
+checksums           rmd160  deeb3551942e7c09e2f2b2f3baac0008bdd15fb5 \
+                    sha256  6dfc6a1d25c5c62a5ab64d7560dd590339654a7ada882d19a9eced6e870a5b04 \
+                    size    8894632
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://github.com/skyjake/lagrange/releases/tag/v1.18.7

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
