### PR TITLE
pgplot: Enable longer fortran lines

### DIFF
--- a/graphics/pgplot/Portfile
+++ b/graphics/pgplot/Portfile
@@ -9,7 +9,6 @@ version             5.2.2
 revision            14
 categories          graphics devel
 license             Noncommercial
-platforms           darwin
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 
 description         C/Fortran graphics library
@@ -66,6 +65,10 @@ if { [string match *64 ${build_arch}] } {
 
 # Tell the compiler not to treat backslash characters as C-style escape sequences.
 configure.fcflags-append -fno-backslash
+
+# Allow long fortran lines because of unpredictable expansion from patches,
+# such as inserting $prefix.
+configure.fcflags-append -ffixed-line-length-none
 
 # see https://trac.macports.org/ticket/60442
 compilers.allow_arguments_mismatch yes


### PR DESCRIPTION
#### Description

* Fix builds on systems with long custom $prefix.
* Insertion of $prefix can expand fixed-format fortran lines past standard 72-character limit.
* Remove obsolete platforms line.
* No rev bump.  Build fix only.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 15.5
Xcode 16.2
Command Line Tools 16.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -vs install` ?
- [x] tested basic functionality of all ~~binary files~~ executables?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?