### PR TITLE
k9s: stealth update for 0.50.9

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -5,7 +5,10 @@ PortGroup           golang 1.0
 
 go.setup            github.com/derailed/k9s 0.50.9 v
 go.offline_build    no
-revision            0
+revision            1
+
+# 0.50.9 had a stealth update, remove again with next update -- https://trac.macports.org/ticket/72837
+dist_subdir         ${name}/${version}_1
 
 homepage            https://k9scli.io
 
@@ -25,9 +28,9 @@ maintainers         {breun.nl:nils @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  5659e543e5ee98d8464656bb4467c79b95a40388 \
-                    sha256  e3da6cb1788118ba47233910b3c0aaaca1a0e1b87116b68c65bd1140dbbe8c5a \
-                    size    6834722
+checksums           rmd160  16752367856b46bb073f7f06d0ddc58b9ab13887 \
+                    sha256  7496cfc6da6da5d91ef2ad5ea61eae15186effabb77adf904c896213ca6ff810 \
+                    size    6834765
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

Stealth update for 0.50.9: https://trac.macports.org/ticket/72837

###### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?