### PR TITLE
paho.mqtt.c: update to 1.3.15

### DIFF
--- a/net/paho.mqtt.c/Portfile
+++ b/net/paho.mqtt.c/Portfile
@@ -6,9 +6,8 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
-github.setup        eclipse paho.mqtt.c 1.3.14 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        eclipse paho.mqtt.c 1.3.15 v
+github.tarball_from archive
 revision            0
 categories          net
 maintainers         nomaintainer
@@ -37,24 +36,13 @@ configure.args-append \
                     -DPAHO_ENABLE_TESTING=ON \
                     -DPAHO_WITH_SSL=ON
 
-checksums           rmd160  efef65d164aba2da6e879ce84bbaf776224e89ea \
-                    sha256  d1b4731354fd437b5cde8efab4ff85e86afd6f094349c231524e041e723810ad \
-                    size    1198284
+checksums           rmd160  f66d54bd4712445bb9da6ac4f85a858be516f640 \
+                    sha256  60ce2cfdc146fcb81c621cb8b45874d2eb1d4693105d048f60e31b8f3468be90 \
+                    size    1163925
 
 configure.pre_args-replace \
                     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
                     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
-
-if {${os.platform} eq "darwin" && ${configure.build_arch} in [list ppc ppc64]} {
-    variant legacy_dispatch description "Use dispatch via libdispatch-legacy port" {
-        depends_lib-append \
-                    port:libdispatch-legacy
-        configure.cppflags-append \
-                    -DHAS_DISPATCH -I${prefix}/libexec/dispatch/usr/include
-        configure.ldflags-append \
-                    ${prefix}/libexec/dispatch/usr/lib/libdispatch.a
-    }
-}
 
 # FIXME: https://github.com/eclipse/paho.mqtt.c/issues/1524
 test.run            yes

--- a/net/paho.mqtt.c/files/0001-Thread-fix-dispatch-usage-on-macOS.patch
+++ b/net/paho.mqtt.c/files/0001-Thread-fix-dispatch-usage-on-macOS.patch
@@ -12,7 +12,7 @@ diff --git src/Thread.c src/Thread.c
 index f4d43fb..e2964b2 100644
 --- src/Thread.c
 +++ src/Thread.c
-@@ -234,7 +234,7 @@ sem_type Thread_create_sem(int *rc)
+@@ -238,7 +238,7 @@ sem_type Thread_create_sem(int *rc)
  		        NULL                /* object name */
  		        );
  		*rc = (sem == NULL) ? GetLastError() : 0;
@@ -21,16 +21,16 @@ index f4d43fb..e2964b2 100644
  		sem = dispatch_semaphore_create(0L);
  		*rc = (sem == NULL) ? -1 : 0;
  	#else
-@@ -259,7 +259,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
+@@ -263,7 +263,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
   * so I've used trywait in a loop instead. Ian Craggs 23/7/2010
   */
  	int rc = -1;
--#if !defined(_WIN32) && !defined(_WIN64) && !defined(OSX)
-+#if !defined(_WIN32) && !defined(_WIN64) && !(defined(OSX) && defined(HAS_DISPATCH))
+-#if !defined(_WIN32) && !defined(OSX)
++#if !defined(_WIN32) && !(defined(OSX) && defined(HAS_DISPATCH))
  #define USE_TRYWAIT
  #if defined(USE_TRYWAIT)
  	int i = 0;
-@@ -276,7 +276,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
+@@ -280,7 +280,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
  		rc = WaitForSingleObject(sem, timeout < 0 ? 0 : timeout);
  		if (rc == WAIT_TIMEOUT)
  			rc = ETIMEDOUT;
@@ -39,8 +39,8 @@ index f4d43fb..e2964b2 100644
  		/* returns 0 on success, non-zero if timeout occurred */
  		rc = (int)dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout*1000000L));
  		if (rc != 0)
-@@ -320,7 +320,7 @@ int Thread_check_sem(sem_type sem)
- #if defined(_WIN32) || defined(_WIN64)
+@@ -324,7 +324,7 @@ int Thread_check_sem(sem_type sem)
+ #if defined(_WIN32)
  	/* if the return value is not 0, the semaphore will not have been decremented */
  	return WaitForSingleObject(sem, 0) == WAIT_OBJECT_0;
 -#elif defined(OSX)
@@ -48,8 +48,8 @@ index f4d43fb..e2964b2 100644
  	/* if the return value is not 0, the semaphore will not have been decremented */
  	return dispatch_semaphore_wait(sem, DISPATCH_TIME_NOW) == 0;
  #else
-@@ -344,7 +344,7 @@ int Thread_post_sem(sem_type sem)
- 	#if defined(_WIN32) || defined(_WIN64)
+@@ -348,7 +348,7 @@ int Thread_post_sem(sem_type sem)
+ 	#if defined(_WIN32)
  		if (SetEvent(sem) == 0)
  			rc = GetLastError();
 -	#elif defined(OSX)
@@ -57,9 +57,9 @@ index f4d43fb..e2964b2 100644
  		rc = (int)dispatch_semaphore_signal(sem);
  	#else
  		int val;
-@@ -371,7 +371,7 @@ int Thread_destroy_sem(sem_type sem)
+@@ -375,7 +375,7 @@ int Thread_destroy_sem(sem_type sem)
  	FUNC_ENTRY;
- 	#if defined(_WIN32) || defined(_WIN64)
+ 	#if defined(_WIN32)
  		rc = CloseHandle(sem);
 -	#elif defined(OSX)
 +	#elif defined(OSX) && defined(HAS_DISPATCH)
@@ -76,7 +76,7 @@ index b0c823b..721b027 100644
  
 +#ifdef __APPLE__
 +	#include <AvailabilityMacros.h>
-+	#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && !defined(__ppc__)
++	#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
 +	  #define HAS_DISPATCH
 +	#endif
 +#endif

--- a/net/paho.mqtt.c/files/0002-Thread.c-fix-Availability-macros.patch
+++ b/net/paho.mqtt.c/files/0002-Thread.c-fix-Availability-macros.patch
@@ -11,7 +11,7 @@ diff --git src/Thread.c src/Thread.c
 index e2964b2..83ef267 100644
 --- src/Thread.c
 +++ src/Thread.c
-@@ -98,7 +98,7 @@ int Thread_set_name(const char* thread_name)
+@@ -102,7 +102,7 @@ int Thread_set_name(const char* thread_name)
  #endif*/
  #elif defined(OSX)
  	/* pthread_setname_np __API_AVAILABLE(macos(10.6), ios(3.2)) */
@@ -21,9 +21,9 @@ index e2964b2..83ef267 100644
  #endif
  #else
 @@ -449,7 +449,7 @@ int Thread_wait_cond(cond_type condvar, int timeout_ms)
- 	interval.tv_sec = timeout_ms / 1000;
- 	interval.tv_nsec = (timeout_ms % 1000) * 1000000L;
+ 	struct timespec cond_timeout;
  
+ 	FUNC_ENTRY;
 -#if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 /* for older versions of MacOS */
 +#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < 101200 /* for older versions of MacOS */
  	struct timeval cur_time;


### PR DESCRIPTION
#### Description
https://github.com/eclipse-paho/paho.mqtt.c/releases/tag/v1.3.15

cc @barracuda156 

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
