### PR TITLE
htpdate: Update to 2.0.0

### DIFF
--- a/net/htpdate/Portfile
+++ b/net/htpdate/Portfile
@@ -1,25 +1,27 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			htpdate
-version			0.9.1
-categories		net
-license			GPL-2+
-platforms		darwin
-maintainers		nomaintainer
-description		network time synchronization over http protocol
-long_description	${description}
+PortSystem              1.0
 
-homepage		http://www.clevervest.com/htp/
-master_sites	${homepage}archive/c/
-checksums		sha1 e0b1a3ae9ba755471102f28a2b8a7e2dc77addc7
-use_bzip2		yes
+name                    htpdate
+version                 0.9.1
+categories              net
+license                 GPL-2+
+platforms               darwin
+maintainers             nomaintainer
+description             network time synchronization over http protocol
+long_description        ${description}
 
-use_configure	no
+homepage                http://www.clevervest.com/htp/
+master_sites            ${homepage}archive/c/
+checksums               sha1 e0b1a3ae9ba755471102f28a2b8a7e2dc77addc7
+use_bzip2               yes
 
-build.args		CC=${configure.cc}
+use_configure           no
 
-destroot.destdir	prefix=${destroot}${prefix} STRIP=/usr/bin/strip
+build.args              CC=${configure.cc}
 
-livecheck.type	regex
-livecheck.url	[lindex ${master_sites} 0]
-livecheck.regex	${name}-(\[0-9.\]+)\\.tar
+destroot.destdir        prefix=${destroot}${prefix} STRIP=/usr/bin/strip
+
+livecheck.type          regex
+livecheck.url           [lindex ${master_sites} 0]
+livecheck.regex         ${name}-(\[0-9.\]+)\\.tar

--- a/net/htpdate/Portfile
+++ b/net/htpdate/Portfile
@@ -1,27 +1,35 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               makefile 1.0
+PortGroup               openssl 1.0
 
-name                    htpdate
-version                 0.9.1
+github.setup            twekkel htpdate 2.0.0 v
+github.tarball_from     archive
+revision                0
 categories              net
 license                 GPL-2+
-platforms               darwin
 maintainers             nomaintainer
-description             network time synchronization over http protocol
-long_description        ${description}
 
-homepage                http://www.clevervest.com/htp/
-master_sites            ${homepage}archive/c/
-checksums               sha1 e0b1a3ae9ba755471102f28a2b8a7e2dc77addc7
-use_bzip2               yes
+description             Network time synchronization over remote web servers
+long_description        ${description}.
 
-use_configure           no
+homepage                https://www.vervest.org/htp/
+master_sites-append     ${homepage}archive/c/
 
-build.args              CC=${configure.cc}
+checksums               rmd160  f7a72342824a287451955d8e84e3f24fde66e087 \
+                        sha256  52f25811f00dfe714e0bcf122358ee0ad74e25db3ad230d5a4196e7a62633f27 \
+                        size    17443
 
-destroot.destdir        prefix=${destroot}${prefix} STRIP=/usr/bin/strip
+compiler.c_standard     2011
 
-livecheck.type          regex
-livecheck.url           [lindex ${master_sites} 0]
-livecheck.regex         ${name}-(\[0-9.\]+)\\.tar
+makefile.has_destdir    no
+makefile.prefix_name    prefix
+
+makefile.override-append \
+                        PREFIX
+
+build.target            https
+
+destroot.destdir-append STRIP=/usr/bin/strip


### PR DESCRIPTION
#### Description

Update htpdate to 2.0.0 and switch to new upstream.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.7 23H124 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
