### PR TITLE
munge wallet wallet-kdc wallet-server: Unify maintainer info to match lldpd

### DIFF
--- a/net/munge/Portfile
+++ b/net/munge/Portfile
@@ -9,7 +9,7 @@ github.tarball_from tarball
 revision            2
 categories          net security
 license             {GPL-3+ LGPL-3+}
-maintainers         kornel.us:karl openmaintainer
+maintainers         {@akkornel stanford.edu:akkornel} openmaintainer
 description         Creating and validating credentials in HPC clusters.
 long_description    MUNGE (MUNGE Uid 'N' Gid Emporium) is an authentication \
                     service for creating and validating credentials.  It is \

--- a/net/wallet/Portfile
+++ b/net/wallet/Portfile
@@ -14,7 +14,7 @@ version             1.3
 revision            2
 categories          net security
 license             MIT
-maintainers         kornel.us:karl openmaintainer
+maintainers         {@akkornel stanford.edu:akkornel} openmaintainer
 description         Kerberos-authenticated secure data management
 long_description    The wallet is a system for managing secure data, \
                     authorization rules to retrieve or change that data, \


### PR DESCRIPTION
#### Description

Modify the Portfiles for `munge` & `wallet` (which provides the subports `wallet-kdc` `wallet-server`), changing the `maintainers` line to match what I use in the `lldpd` port.

At the same time, I fix an errant tab in `wallet`'s Portfile (which was present in a commented-out portion).

Neither change affects the software that is downloaded & installed, so I'm not changing the version or revision numbers.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

Port metadata (maintainers) update

###### Tested on

macOS 15.6 24G84 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?