### PR TITLE
go-devel: rollback macOS 11 to 1.24.6

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -7,7 +7,6 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 name                go
-epoch               3
 
 # IMPORTANT:
 #
@@ -21,6 +20,9 @@ if {$subport eq $name} {
 # However past 1.11.x everything is broken.
 # FIXME: consider implementing support for PowerPC.
 if {${os.platform} eq "darwin" && ${os.major} < 17} {
+
+    epoch 3
+
     if {${build_arch} eq "i386"} {
         version     1.11.13
         revision    0
@@ -37,16 +39,30 @@ if {${os.platform} eq "darwin" && ${os.major} < 17} {
     set unsupported_macos false
     set unsupported_macos_386 false
     revision        0
+    epoch           3
 }
+
 platforms           {darwin >= 10} freebsd linux
 }
 
 # Subport for Go Unstable Version
 subport ${name}-devel {
-    version         1.25.0
-    revision        0
-    epoch           1
-    platforms       {darwin >= 17} freebsd linux
+
+    # macOS 11's most recently supported Go major version is 1.24
+    if {${os.platform} eq "darwin" && ${os.major} == 20} {
+        version         1.24.6
+        set unsupported_macos false
+        set unsupported_macos_386 false
+        revision        0
+        epoch           2
+
+    # macOS 12 and up - latest version
+    } else {
+        version         1.25.0
+        revision        0
+        epoch           1
+        platforms       {darwin >= 17} freebsd linux
+    }
 }
 
 if {${os.platform} eq "darwin" \
@@ -82,8 +98,25 @@ livecheck.type      regex
 livecheck.url       ${homepage}/dl/
 
 if {$subport eq "${name}-devel"} {
-    # Go (DEVEL / UNSTABLE)
-    checksums       ${go_src_dist} \
+
+    # Go (DEVEL / UNSTABLE) - macOS 11
+    if {${os.platform} eq "darwin" && ${os.major} == 20} {
+        checksums   ${go_src_dist} \
+                    rmd160  7015227465326c4feb4f86371cd209b159a2b76b \
+                    sha256  e1cb5582aab588668bc04c07de18688070f6b8c9b2aaf361f821e19bd47cfdbd \
+                    size    30794139 \
+                    ${go_armbin_dist} \
+                    rmd160  7dd60961b2e2e851364743836e970be80a839a17 \
+                    sha256  4e29202c49573b953be7cc3500e1f8d9e66ddd12faa8cf0939a4951411e09a2a \
+                    size    76293244 \
+                    ${go_amdbin_dist} \
+                    rmd160  79910d8795a22d3dd02bf6ffee4413c840325b38 \
+                    sha256  4a8d7a32052f223e71faab424a69430455b27b3fff5f4e651f9d97c3e51a8746 \
+                    size    79994594
+
+    # Go (DEVEL / UNSTABLE) - LATEST
+     } else {
+         checksums  ${go_src_dist} \
                     rmd160  db4ac2f1bd023c5a4be42236c1d35fc1644e495c \
                     sha256  4bd01e91297207bfa450ea40d4d5a93b1b531a5e438473b2a06e18e077227225 \
                     size    31974753 \
@@ -95,6 +128,7 @@ if {$subport eq "${name}-devel"} {
                     rmd160  2356e113c52466b4f4cb07732d43aaffad29552a \
                     sha256  5bd60e823037062c2307c71e8111809865116714d6f6b410597cf5075dfd80ef \
                     size    60370925
+     }
 
     livecheck.regex {go([0-9.A-z]+)\.src\.tar\.gz}
 } else {


### PR DESCRIPTION
Test rolling back Go for macOS 11 to 1.24.6 using `go-devel`

See: https://trac.macports.org/ticket/72828

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
