### PR TITLE
cdo: update to 2.5.3

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,7 +5,7 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.0
 
 name                        cdo
-version                     2.5.2
+version                     2.5.3
 revision                    0
 maintainers                 {takeshi @tenomoto} \
                             {me.com:remko.scharroo @remkos} \
@@ -14,11 +14,11 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/29938
+master_sites                https://code.mpimet.mpg.de/attachments/download/30034
 
-checksums           rmd160  202b6dcac2c7e212b0cc436777d8658c91a516bb \
-                    sha256  3b28da72d75547663b1b9b08332bfe3f884d27742d0eeeb7f3c8b2c70f521fa9 \
-                    size    13966550
+checksums           rmd160  ee1d5a3d3b38cd538330f2957baa8fec36ef5458 \
+                    sha256  0145cdba866a02b3e9b269e2ff7728ce61e21761332888041f05dc033676fa08 \
+                    size    14007141
 
 long_description \
     CDO is a collection of command line Operators               \
@@ -64,8 +64,8 @@ configure.ldflags-append    -lhdf5
 # for a recent Python and does not distinguish whether test is requested, it is added here as a build dependency.
 # To make sure that it works prior to Catalina, it is best to simply require the latest python3 package.
 
-depends_build-append        port:python312
-configure.env-append        PYTHON=${prefix}/bin/python3.12
+depends_build-append        port:python313
+configure.env-append        PYTHON=${prefix}/bin/python3.13
 
 test.run                    yes
 test.args                   -j1


### PR DESCRIPTION
#### Description

Update to upstream version 2.5.3.

Also updated the dependency to Python from version 3.1.2 to 3.1.3.
Note that the dependency only applies to the tests, but the configuration does not distinguish between "build" and "test" runs and looks for Python in either case. Thus it is kept as a build dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.6 24G84 x86_64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
