### PR TITLE
giza: Update to 1.5.0

### DIFF
--- a/science/giza/Portfile
+++ b/science/giza/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup compilers 1.0
 PortGroup github    1.0
 
-github.setup        danieljprice giza 1.4.1 v
+github.setup        danieljprice giza 1.5.0 v
 revision            0
 categories          science graphics fortran
 maintainers         {monash.edu:daniel.price @danieljprice}
@@ -19,9 +19,9 @@ homepage            https://danieljprice.github.io/giza/
 github.tarball_from releases
 license             GPL-2+
 distname            ${name}-v${version}
-checksums           rmd160  ec66c59c2663f9d9f4a2e36ff702c191e3b318a7 \
-                    sha256  9d77e0f7bc500d918fb67d5a95acaf6eab9688e71cfb3784f9b77238f5232d78 \
-                    size    1175428
+checksums           rmd160  fb909f9224949a930ac0eb64269106b5ec5d5346 \
+                    sha256  dfd9f257c620b22ebe9177e068f194ace7887d55ec5207e7cffec46115dc3a59 \
+                    size    1204040
 extract.rename      yes
 
 conflicts           pgplot


### PR DESCRIPTION
#### Description

Update giza 1.4.1 --> 1.5.0

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?