### PR TITLE
emacs{,-app}-devel: set lexical binding, update to 20250816

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -129,17 +129,17 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs d99354720be8655a58c8a09c5ae110f86ac9fb5d
+    github.setup    emacs-mirror emacs 25380c8e14567894f1e847b5f2ce75f0265293d8
     github.tarball_from archive
     epoch           5
-    version         20250814
+    version         20250816
     revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  1ac90ea0947dc4f965cd2e22d52f11712ad86395 \
-                    sha256  459c5535864ec8212f9f8604baf7675207e86fa40eab60300169354b87a59bb6 \
-                    size    52268769
+    checksums       rmd160  f1d603f1d185c5e1f8fc9fc10a36f219baa16c60 \
+                    sha256  b509a8389090cc59c44797ad19796e4e68d94bded2e3b45fcaa249e5ec8f6a19 \
+                    size    52268149
 
     livecheck.type none
 

--- a/editors/emacs/files/site-start-app.el
+++ b/editors/emacs/files/site-start-app.el
@@ -1,3 +1,5 @@
+;;  -*- lexical-binding: t; -*-
+;;
 ;; load-path contains ${prefix}/share/emacs/site-lisp and its subdirecotries.
 ;; See #12115, #29232, #32146.
 (setq load-path (cons "__PREFIX__/share/emacs/site-lisp" load-path))


### PR DESCRIPTION
#### Description

Set lexical binding cookie in `site-start.el` to prevent a warning (in emacs{,app}-devel) about missing cookie. Also relevant for Emacs 30.x; but here the user does not get the warning about the missing cookie.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

