### PR TITLE
hamclock: Fix livecheck

### DIFF
--- a/x11/hamclock/Portfile
+++ b/x11/hamclock/Portfile
@@ -68,3 +68,5 @@ destroot {
 post-activate {
     system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
 }
+
+livecheck.regex     Version \(\[0-9.\]+\):


### PR DESCRIPTION
#### Description

Fix livecheck.

###### Type(s)

- [x] enhancement

###### Tested on

 CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?