### PR TITLE
Remove jnb.za.*.macports.org mirror

### DIFF
--- a/_resources/port1.0/fetch/archive_sites.tcl
+++ b/_resources/port1.0/fetch/archive_sites.tcl
@@ -24,7 +24,6 @@ set cjj.kr      http
 #set fco.it      ${letsencrypt_https_or_http}
 set fco.it      http
 set fra.de      ${letsencrypt_https_or_http}
-set jnb.za      ${letsencrypt_https_only}
 set jog.id      http
 set kmq.jp      ${letsencrypt_https_or_http}
 set lis.pt      ${letsencrypt_https_or_http}
@@ -50,7 +49,6 @@ set portfetch::mirror_sites::sites(macports_archives) [lsearch -all -glob -inlin
     ${cph.dk}://cph.dk.packages.macports.org/:nosubdir
     ${fco.it}://fco.it.packages.macports.org/:nosubdir
     ${fra.de}://fra.de.packages.macports.org/:nosubdir
-    ${jnb.za}://jnb.za.packages.macports.org/packages/:nosubdir
     ${jog.id}://jog.id.packages.macports.org/macports/packages/:nosubdir
     ${kmq.jp}://kmq.jp.packages.macports.org/:nosubdir
     ${lis.pt}://lis.pt.packages.macports.org/:nosubdir

--- a/_resources/port1.0/fetch/mirror_sites.tcl
+++ b/_resources/port1.0/fetch/mirror_sites.tcl
@@ -428,7 +428,6 @@ set cjj.kr      http
 #set fco.it      ${letsencrypt_https_or_http}
 set fco.it      http
 set fra.de      ${letsencrypt_https_or_http}
-set jnb.za      ${letsencrypt_https_only}
 set jog.id      http
 set kmq.jp      ${letsencrypt_https_or_http}
 set lis.pt      ${letsencrypt_https_or_http}
@@ -454,7 +453,6 @@ set portfetch::mirror_sites::sites(macports_distfiles) [lsearch -all -glob -inli
     ${cph.dk}://cph.dk.distfiles.macports.org/:mirror
     ${fco.it}://fco.it.distfiles.macports.org/:mirror
     ${fra.de}://fra.de.distfiles.macports.org/:mirror
-    ${jnb.za}://jnb.za.distfiles.macports.org/distfiles/:mirror
     ${jog.id}://jog.id.distfiles.macports.org/macports/distfiles/:mirror
     ${kmq.jp}://kmq.jp.distfiles.macports.org/:mirror
     ${lis.pt}://lis.pt.distfiles.macports.org/:mirror


### PR DESCRIPTION
#### Description

The Johannesburg, South Africa mirror will stop working on September 10, 2025.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
