### PR TITLE
google-cloud-sdk: update to 535.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             534.0.0
+version             535.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  ffd9f1bfdf4897b4a45452087345a0b9ffbd6ccf \
-                    sha256  2d1b72d767949f8a512de11b1c3786de177014f7cb58c607dfc142a2e85421fc \
-                    size    55074147
+    checksums       rmd160  cf4c94e59276e18a8ea4e7e0a52118f58bfc8a8b \
+                    sha256  3bd08ac3746337267378d8f514e12aeb850192b54eabdbb592f78c0cf65cf5f8 \
+                    size    55103517
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a52db618a037e7a1aa6dac7734d53454e52e208a \
-                    sha256  7540683cd31ed0de3566df66a3f939d2960d77663f6129ef5f3e757e7dc4a40c \
-                    size    56606541
+    checksums       rmd160  d876c6c4b64cdf7e8ff4be168acd3ab3f703a091 \
+                    sha256  9c911d51f60f39796a4eeb0eff56a5cbb5f16d36df60beb1e3f2bfdfb48f5cdc \
+                    size    56636239
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  98421782dfd851ff60ae7a61b19cf82fe89d785f \
-                    sha256  04f7f9452d955f4e64fd6730e0fbd83060b0caf7a4673e8c198b6152ffc81835 \
-                    size    56538945
+    checksums       rmd160  7a5ab278c32b9442506890c465a40e93f10aaa98 \
+                    sha256  f7162d25a1189c67aeed6ad11cdd5f342ce3815ddda22f2ca3121572b5f4d974 \
+                    size    56569124
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -103,6 +103,7 @@ variant nomos description {Add Nomos CLI} { dict set variant_to_component nomos 
 variant package_go_module description {Add Artifact Registry Go Module Package Helper} { dict set variant_to_component package_go_module package-go-module }
 variant pkg description {Add pkg} { dict set variant_to_component pkg pkg }
 variant pubsub_emulator description {Add Cloud Pub/Sub Emulator} { dict set variant_to_component pubsub_emulator pubsub-emulator }
+variant spanner_cli description {Add Spanner CLI} { dict set variant_to_component spanner_cli spanner-cli }
 variant skaffold description {Add Skaffold} { dict set variant_to_component skaffold skaffold }
 variant terraform_tools description {Add Terraform Tools} { dict set variant_to_component terraform_tools terraform-tools }
 


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 535.0.0.

###### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?