### PR TITLE
esmf: Fix builds for 10.6

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -35,6 +35,14 @@ long_description    ESMF defines an architecture for composing complex, coupled 
 homepage            https://earthsystemmodeling.org
 github.tarball_from archive
 
+# Fix builds for 10.6.
+# Fixes "error: missing terminating ' character".
+# This is a preprocessor bug that breaks only in early clang versions
+# such as clang 11.  More recent clang versions give warnings only.
+# Upstream PR: https://github.com/esmf-org/esmf/pull/481
+# Remove this patch on next release after 8.9.0.
+patchfiles-append   patch.ESMF_FieldBundle_cppF90.diff
+
 depends_build       bin:ranlib:cctools
 
 depends_lib         port:netcdf \

--- a/science/esmf/files/patch.ESMF_FieldBundle_cppF90.diff
+++ b/science/esmf/files/patch.ESMF_FieldBundle_cppF90.diff
@@ -1,0 +1,11 @@
+--- src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90.orig	2025-08-11 16:33:46
++++ src/Infrastructure/FieldBundle/src/ESMF_FieldBundle.cppF90	2025-08-19 07:57:04
+@@ -1739,7 +1739,7 @@
+ ! \item[8.8.0] Added argument {\tt vm} in order to offer information about the
+ !              VM on which the FieldBundle was created.
+ ! \item[8.9.0] Added argument {\tt geom} to allow the user to retrieve a generic representation of
+-!              the FieldBundle's geometry.
++!              the geometry of the FieldBundle.
+ ! \end{description}
+ ! \end{itemize}
+ !


### PR DESCRIPTION
#### Description

* Yet another fix for preprocessor bug, "missing terminating ' character".
* Caused by new code added between ESMF 8.8.1 and 8.9.0 releases.
* No rev bump.  Build fix only, for 10.6 only.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?