### PR TITLE
1password-cli: fix variable substitution in notes

### DIFF
--- a/security/1password-cli/Portfile
+++ b/security/1password-cli/Portfile
@@ -82,11 +82,11 @@ livecheck.type      regex
 livecheck.url       https://app-updates.agilebits.com/product_history/CLI2
 livecheck.regex     ${archive}_v(\\d+(\\.\\d+)+)${extract.suffix}
 
-notes {
-  1Password CLI has been installed as ${bin_name}
+notes "
+  1Password CLI has been installed as '${bin_name}'
 
   For instructions on getting started, see:
   https://support.1password.com/command-line-getting-started/#get-started-with-the-command-line-tool
 
   Completion scripts have been installed for Bash, Fish, and Zsh.
-}
+"


### PR DESCRIPTION
#### Description

Fix variable substitution in the notes section.

Old:

```
--->  1password-cli has the following notes:
  1Password CLI has been installed as ${bin_name}
(...)
```

New:

```
--->  1password-cli has the following notes:
  1Password CLI has been installed as 'op'
(...)
```

###### Tested on

macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?