### PR TITLE
mysql8: fix for XCode < 15 -no_warn_duplicate_libraries

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -13,7 +13,7 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     0
+set revision_client     1
 set revision_server     0
 
 set name_mysql          ${name}
@@ -163,7 +163,8 @@ if {$subport eq $name} {
     patch.pre_args-replace  -p0 -p1
     patchfiles      patch-cmake-install_layout.cmake.diff \
                     patch-readline.cmake.diff \
-                    patch-scripts-cmakelists.diff
+                    patch-scripts-cmakelists.diff \
+                    patch-no_warn_duplicate_libraries.diff
 
     post-extract {
         file mkdir ${cmake.build_dir}/macports

--- a/databases/mysql8/files/patch-no_warn_duplicate_libraries.diff
+++ b/databases/mysql8/files/patch-no_warn_duplicate_libraries.diff
@@ -1,0 +1,115 @@
+--- ./extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake	2025-08-20 18:06:20
++++ ./extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake	2025-08-20 18:10:56
+@@ -57,10 +57,12 @@
+     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+     )
+ 
+-  IF(APPLE)
+-    TARGET_LINK_OPTIONS(libprotobuf-lite
+-      PRIVATE LINKER:-no_warn_duplicate_libraries)
++  IF(APPLE AND XCODE_VERSION VERSION_LESS 15)
++    TARGET_LINK_OPTIONS(libprotobuf-lite)
+   ENDIF()
++  IF(APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
++    TARGET_LINK_OPTIONS(libprotobuf-lite PRIVATE LINKER:-no_warn_duplicate_libraries)
++  ENDIF()
+ 
+   IF(WIN32)
+     ADD_CUSTOM_COMMAND(TARGET libprotobuf-lite POST_BUILD
+--- ./extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake	2025-08-20 18:06:20
++++ ./extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake	2025-08-20 18:17:15
+@@ -61,7 +61,7 @@
+     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+     )
+ 
+-  IF(APPLE)
++  IF(APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
+     TARGET_LINK_OPTIONS(libprotobuf PRIVATE LINKER:-no_warn_duplicate_libraries)
+   ENDIF()
+ 
+--- ./extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake	2025-08-20 18:06:20
++++ ./extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake	2025-08-20 18:14:45
+@@ -48,7 +48,7 @@
+     DEBUG_POSTFIX ""
+     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory)
+-  IF(APPLE)
++  IF(APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
+     TARGET_LINK_OPTIONS(libprotoc PRIVATE LINKER:-no_warn_duplicate_libraries)
+   ENDIF()
+   IF(WIN32)
+--- ./extra/protobuf/protobuf-24.4/cmake/protoc.cmake	2025-08-20 18:06:20
++++ ./extra/protobuf/protobuf-24.4/cmake/protoc.cmake	2025-08-20 18:19:28
+@@ -15,7 +15,7 @@
+ 
+ ################################################################
+ 
+-IF(APPLE)
++IF(APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
+   TARGET_LINK_OPTIONS(protoc PRIVATE LINKER:-no_warn_duplicate_libraries)
+ ENDIF()
+ 
+--- ./router/cmake/Plugin.cmake	2025-08-20 18:06:20
++++ ./router/cmake/Plugin.cmake	2025-08-20 18:19:11
+@@ -89,7 +89,7 @@
+   # .dylib, which we do not want, so we reset it here.
+   ADD_LIBRARY(${NAME} SHARED ${_option_SOURCES})
+   TARGET_COMPILE_FEATURES(${NAME} PUBLIC cxx_std_20)
+-  IF(APPLE)
++  IF(APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
+     TARGET_LINK_OPTIONS(${NAME} PRIVATE LINKER:-no_warn_duplicate_libraries)
+   ENDIF()
+ 
+--- ./cmake/mysql_add_executable.cmake	2025-08-20 18:06:20
++++ ./cmake/mysql_add_executable.cmake	2025-08-20 18:17:54
+@@ -212,7 +212,7 @@
+     MACOS_ADD_DEVELOPER_ENTITLEMENTS(${target})
+   ENDIF()
+ 
+-  IF(APPLE)
++  IF(APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
+     TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+   ENDIF()
+ 
+--- ./cmake/plugin.cmake	2025-08-20 18:06:20
++++ ./cmake/plugin.cmake	2025-08-20 18:18:50
+@@ -328,7 +328,7 @@
+       DEPENDS ${target})
+   ENDIF()
+ 
+-  IF(BUILD_PLUGIN AND ARG_MODULE_ONLY AND APPLE)
++  IF(BUILD_PLUGIN AND ARG_MODULE_ONLY AND APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
+     TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+   ENDIF()
+ 
+--- ./cmake/component.cmake	2025-08-20 18:06:20
++++ ./cmake/component.cmake	2025-08-20 18:08:46
+@@ -99,7 +99,7 @@
+     # For APPLE: adjust path dependecy for SSL shared libraries.
+     SET_PATH_TO_CUSTOM_SSL_FOR_APPLE(${target})
+ 
+-    IF(APPLE)
++    IF(APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
+       TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+     ENDIF()
+ 
+--- ./cmake/libutils.cmake	2025-08-20 18:06:20
++++ ./cmake/libutils.cmake	2025-08-20 18:16:22
+@@ -358,6 +358,8 @@
+ 
+   IF(APPLE)
+     SET_TARGET_PROPERTIES(${TARGET} PROPERTIES MACOSX_RPATH ON)
++  ENDIF()
++  IF(APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
+     TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
+   ENDIF()
+ 
+@@ -703,7 +705,7 @@
+     ENDIF()
+   ENDIF()
+ 
+-  IF(APPLE)
++  IF(APPLE AND XCODE_VERSION VERSION_GREATER_EQUAL 15)
+     TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
+   ENDIF()
+ 


### PR DESCRIPTION
```
Changes to be committed:
	modified:   databases/mysql8/Portfile
	new file:   databases/mysql8/files/patch-no_warn_duplicate_libraries.diff
```
#### Description
8.4.6 sets a parameter to ld : -no_warn_duplicate_libraries that's XCode >= 15 only.
Thus compiling w/ XCode < 15 fails because there's no check for which XCode is used.
See https://trac.macports.org/ticket/72831 for references and in-depth discussion.

###### Type(s)
- [x] bugfix https://trac.macports.org/ticket/72831

###### Tested on
```
Model Identifier: Macmini6,1               Model Identifier: MacPro5,1
macOS 10.15.7 19H2026 x86_64               macOS 14.7.7 23H723 x86_64
Xcode 12.4 12D4e                           Xcode 16.2 16C5032a
Command Line Tools 12.4.0.0.1.1610135815   Command Line Tools 16.2.0.0.1.1733547573
```
