### PR TITLE
minicom: Update to 2.10

### DIFF
--- a/comms/minicom/Portfile
+++ b/comms/minicom/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 PortGroup           gitlab 1.0
 
 gitlab.instance     https://salsa.debian.org
-gitlab.setup        minicom-team minicom 2.9
-revision            1
+gitlab.setup        minicom-team minicom 2.10
+revision            0
 categories          comms
 maintainers         nomaintainer
 license             GPL-2+
@@ -17,22 +17,25 @@ long_description    Minicom is a menu driven communications program. It \
                     emulates ANSI and VT102 terminals. It has a dialing \
                     directory and auto zmodem download.
 
-checksums           rmd160  671b178a62b62c360b053baab943fdba9bacdcd9 \
-                    sha256  9efbb6458140e5a0de445613f0e76bcf12cbf7a9892b2f53e075c2e7beaba86c \
-                    size    681585
+checksums           rmd160  e54c29554c42197f1d9fc6a629874245a8b7868f \
+                    sha256  90e7ce2856b3eaaa3f452354d17981c49d32c426a255b6f0d3063a227c101538 \
+                    size    556661
 
 # cc1: error: unrecognized command line option "-Wno-format-truncation"
 # Undefined symbols: "__Static_assert"
 compiler.blacklist-append \
                     *gcc-4.0 *gcc-4.2
 
-depends_build       port:pkgconfig
+# See: https://lists.macports.org/pipermail/macports-dev/2021-December/044042.html
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig \
+                    port:gettext
 
-depends_lib         port:gettext \
+depends_lib-append  port:gettext-runtime \
                     port:libiconv \
                     port:ncurses
 
-depends_run         port:lrzsz
+depends_run-append  port:lrzsz
 
 configure.args      --enable-lock-dir=/tmp
 


### PR DESCRIPTION
#### Description

Update minicom to 2.10

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.7 23H124 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
