### PR TITLE
py-elasticsearch and py-elastic-transport: update to 9.1.0

### DIFF
--- a/python/py-elastic-transport/Portfile
+++ b/python/py-elastic-transport/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-elastic-transport
-version             8.4.0
+version             9.1.0
 revision            0
 
 platforms           {darwin any}
@@ -17,12 +17,13 @@ long_description    Transport classes and utilities shared among \
                     Python Elastic client libraries
 
 homepage            https://github.com/elastic/elastic-transport-python
+distname            elastic_transport-${version}
 
-checksums           rmd160  596d34fa58674a47e6ff6140ad80688a4d9764e2 \
-                    sha256  b9ad708ceb7fcdbc6b30a96f886609a109f042c0b9d9f2e44403b3133ba7ff10 \
-                    size    44528
+checksums           rmd160  6b8195124247bec279500c9e3af69525c9fc4e36 \
+                    sha256  1590e44a25b0fe208107d5e8d7dea15c070525f3ac9baafbe4cb659cd14f073d \
+                    size    76483
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     depends_run-append \

--- a/python/py-elasticsearch/Portfile
+++ b/python/py-elasticsearch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-elasticsearch
-version             8.9.0
+version             9.1.0
 revision            0
 
 platforms           {darwin any}
@@ -17,11 +17,12 @@ long_description    {*}${description}
 
 homepage            https://github.com/elastic/elasticsearch-py
 
-checksums           rmd160  3f197083f5c342bd41aeab0e990f35f59c4320cc \
-                    sha256  d3367fc013e04fc7aad349a6de9fad1ee04fb6d627b0e7896aa505c12fde5e04 \
-                    size    313760
+checksums           rmd160  aa5ebaaa8d89c8d786c03802eb4d8a3cb68ffbde \
+                    sha256  764d2f724eac94f6bf9903e4feae07112643a9efcfdc5c868c1b69bd48c52e09 \
+                    size    848897
 
-python.versions     39 310 311
+python.versions     39 310 311 312 313
+python.pep517_backend hatch
 
 if {${name} ne ${subport}} {
     depends_run-append \


### PR DESCRIPTION
#### Description

The ports py-elasticsearch and it's accompanying dependency py-elastic-transport are very outdated. This updates both to the latest version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.6.1 24G90 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
