### PR TITLE
i2pd: fix build on macOS <10.15 with Clangs

### DIFF
--- a/security/i2pd/Portfile
+++ b/security/i2pd/Portfile
@@ -7,6 +7,12 @@ PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
 
+# on <10.15 built-in libc++ has no support for std::filesystem
+legacysupport.use_mp_libcxx \
+                        yes
+legacysupport.newest_darwin_requires_legacy \
+                        18
+
 github.setup            PurpleI2P i2pd 2.57.0
 revision                0
 categories              security net
@@ -41,8 +47,12 @@ add_users               ${i2pduser} group=${i2pduser} realname=I2PD\ user
 
 cmake.source_dir        ${worksrcpath}/build
 
-# Minimum required is C++11, C++17 used if supported.
-compiler.cxx_standard   2011
+# requires a C++17 compiler
+compiler.cxx_standard   2017
+# error: 'auto' return without trailing return type on
+# macOS <10.15 with Xcode Clang
+compiler.blacklist-append \
+                        {clang < 1200}
 
 platform darwin {
     # https://github.com/PurpleI2P/i2pd/issues/1846
@@ -50,10 +60,6 @@ platform darwin {
         cmake.set_cxx_standard yes
     }
 }
-
-# https://github.com/PurpleI2P/i2pd/issues/1798
-compiler.blacklist-append \
-                        {clang < 600}
 
 # These are defaults, but better have them explicit:
 configure.args-append   -DWITH_LIBRARY=ON \


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
