### PR TITLE
cdo: fix for MacOS 10.14

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -6,7 +6,7 @@ PortGroup                   legacysupport 1.0
 
 name                        cdo
 version                     2.5.3
-revision                    0
+revision                    1
 maintainers                 {takeshi @tenomoto} \
                             {me.com:remko.scharroo @remkos} \
                             openmaintainer
@@ -30,6 +30,7 @@ fetch.ignore_sslcert        yes
 
 # Since cdo 2.4.0, we need to select C++20 capable compilers.
 # On MacOS-13 compilation with /usr/bin/clang++ fails, so we blacklist it.
+# https://github.com/macports/macports-ports/pull/24069
 
 compiler.cxx_standard       2020
 compiler.blacklist-append   clang
@@ -59,6 +60,12 @@ configure.args              --with-netcdf=${prefix} \
                             --with-zlib=${prefix}
 configure.cppflags-append   -I${prefix}/include/udunits2
 configure.ldflags-append    -lhdf5
+
+# If cpp is not forced here, configure could select /usr/bin/cpp, which may be either incompatible
+# with the selected clang c-compiler or may be too old, as was found on MacOS 10.14.
+# https://trac.macports.org/ticket/72869
+
+configure.args-append        CPP="\${CC} -E"
 
 # Since cdo 2.2.0, running tests requires the Python 3 interpreter. But since the configure always looks
 # for a recent Python and does not distinguish whether test is requested, it is added here as a build dependency.


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
This PR attempts to address the failure of selecting a proper cpp on MacOS 10.14.
See https://trac.macports.org/ticket/72869

The approach is to set 'CPP="\${CC} -E"' in the `configure` step, so that Macports' `clang` version is selected, instead of that of Xcode.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.6.1 24G90 x86_64
Command Line Tools 16.4.0.0.1.1747106510


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
