### PR TITLE
surfraw: Update to 2.3.0

### DIFF
--- a/net/surfraw/Portfile
+++ b/net/surfraw/Portfile
@@ -1,20 +1,27 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               gitlab 1.0
 
+gitlab.setup            surfraw Surfraw 2.3.0 surfraw-
 name                    surfraw
-version                 2.2.9
+revision                0
+
 categories              net
 license                 public-domain
+platforms               any
+supported_archs         noarch
 maintainers             acuityph.com:alistair.isreal
+
 description             Shell Users' Revolutionary Front Rage Against the Web
 long_description        Surfraw provides a fast unix command line interface to \
                         a variety of popular WWW search engines and other artifacts \
                         of power.
-homepage                http://surfraw.alioth.debian.org/
-platforms               any
-supported_archs         noarch
-master_sites            ${homepage}dist/
 
-checksums               rmd160  27bddd2f133a48f9215fc30bdf4891c70751bc5c \
-                        sha256  aa97d9ac24ca4299be39fcde562b98ed556b3bf5ee9a1ae497e0ce040bbcc4bb
+checksums               rmd160  2a1c5504b7884243de20c696b4c335dce7a45510 \
+                        sha256  d63c19c382b0e888e442f4106ee6babb5071ce076ab7834028db070814c42556 \
+                        size    114164
+
+use_autoreconf          yes
+
+configure.args-append   --disable-silent-rules


### PR DESCRIPTION
#### Description

Update surfraw to 2.3.0 and switch to new upstream. Unsure if this should be marked as having no maintainer.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.7 23H124 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
