### PR TITLE
pytorch: Adding sympy as a dependency

### DIFF
--- a/python/py-pytorch/Portfile
+++ b/python/py-pytorch/Portfile
@@ -8,7 +8,7 @@ PortGroup           python 1.0
 github.setup        pytorch pytorch 2.3.0 v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            0
+revision            1
 name                py-${github.project}
 license             BSD
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description

Adding sympy to dependencies of Pytorch.

See https://github.com/pytorch/pytorch/blob/main/requirements.txt for the list of pytorch dependencies (which include `sympy`)

Encountered a crash when (because sympy was not found) running a pytorch example which imported sympy down the call stack.

May fix https://trac.macports.org/ticket/67176

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vs install`? (-t for some reason does not work but it looks unrelated to this pull request)
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
