### PR TITLE
pinact: Update to 3.4.2

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.4.1 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.4.2 v
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
@@ -16,9 +16,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b842cbb5ab423a417c8696742d178cf47482373c \
-                    sha256  0df5b888045092abcef4d12ef043d63eaaa12c7254f843441443b8c12fc805ce \
-                    size    39917
+                    rmd160  8b49bb624d098e8c72876452852120760b298c52 \
+                    sha256  2b47c1d6fee9b41a58e21d1d9452fae7434134637472e80e499490079922f389 \
+                    size    54551
 
 livecheck.regex     {v(\d+\.\d+\.\d+)$}
 
@@ -36,6 +36,7 @@ notes {
   If you have an existing .pinact.yaml file, you will need to use pinact 2.2 and run
   'pinact migrate' to fix the pinact configuration file for pinact 3.0.
 }
+
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
@@ -78,10 +79,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  c7caff4ba164feeebdcc568d6598931a20719827e05dfa18ac7d7c495d36b883 \
                         size    20797 \
                     github.com/urfave/cli \
-                        lock    v3.3.9 \
-                        rmd160  4e7c86feee9a52c1277bf0b9aa4fc20a4a2f58f4 \
-                        sha256  d074614536bae2855a68d8e95d484275f317e1470d0cbb32584ef1c84308e4db \
-                        size    6802003 \
+                        lock    v3.4.1 \
+                        rmd160  b504efdfb46ffdb324dada15de4218398e9e1cc9 \
+                        sha256  daca4c7052f1b7fda8c68703c986436b865d91075de4f967061e95288ecf4740 \
+                        size    6803523 \
                     github.com/suzuki-shunsuke/urfave-cli-v3-util \
                         lock    v0.0.7 \
                         rmd160  b3ca107c8c1430c04f335a7bed3166299f380a65 \


### PR DESCRIPTION
#### Description

pinact: Update to 3.4.2

##### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
