### PR TITLE
lychee: Update to 0.20.0

### DIFF
--- a/devel/lychee/Portfile
+++ b/devel/lychee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo  1.0
 PortGroup           github 1.0
 
-github.setup        lycheeverse lychee 0.18.1 lychee-v
+github.setup        lycheeverse lychee 0.20.0 lychee-v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ long_description    {*}${description} \
     reStructuredText, or any other text file or website!
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6df1d60645ee35c4684b3e98c2de0561a2a19199 \
-                    sha256  f04f4cd3dc2ac190a5d28134362e9ea44409013ab372086dbe2c73792dc4b462 \
-                    size    847306
+                    rmd160  6aaa72424c7353dab55a49ba513df2a66afc015c \
+                    sha256  defb37caebeddc0fdfa7205c0d69d58ed55fabb0cbfa5b48954b2442ec90c170 \
+                    size    900490
 
 depends_lib         path:lib/libssl.dylib:openssl
 
@@ -32,254 +32,258 @@ destroot {
 
 cargo.crates \
     addr2line                       0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
-    adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
-    ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
+    adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
+    ahash                           0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
-    allocator-api2                  0.2.20  45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9 \
+    allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
-    anstream                        0.6.18  8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b \
-    anstyle                         1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
-    anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
-    anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
-    anstyle-wincon                   3.0.6  2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125 \
-    anyhow                          1.0.95  34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04 \
+    anstream                        0.6.20  3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192 \
+    anstyle                         1.0.11  862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd \
+    anstyle-parse                    0.2.7  4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2 \
+    anstyle-query                    1.1.4  9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2 \
+    anstyle-wincon                  3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
+    anyhow                          1.0.99  b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100 \
     arc-swap                         1.7.1  69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457 \
     ascii_utils                      0.9.3  71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a \
     assert-json-diff                 2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
-    assert_cmd                      2.0.16  dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d \
+    assert_cmd                      2.0.17  2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66 \
     async-channel                    1.9.0  81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35 \
-    async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
-    async-compression               0.4.17  0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857 \
-    async-executor                  1.13.1  30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec \
+    async-channel                    2.5.0  924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2 \
+    async-compression               0.4.27  ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8 \
+    async-executor                  1.13.2  bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa \
     async-global-executor            2.4.1  05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c \
-    async-io                         2.4.0  43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059 \
-    async-lock                       3.4.0  ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18 \
+    async-io                         2.5.0  19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca \
+    async-lock                       3.4.1  5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc \
     async-native-tls                 0.4.0  d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe \
-    async-process                    2.3.0  63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb \
+    async-process                    2.4.0  65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00 \
     async-recursion                  1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
-    async-signal                    0.2.10  637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3 \
+    async-signal                    0.2.12  f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1 \
     async-smtp                       0.6.0  2ade89127f9e0d44f9e83cf574d499060005cd45b7dc76be89c0167487fe8edd \
-    async-std                       1.13.0  c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615 \
+    async-std                       1.13.2  2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b \
     async-std-resolver              0.21.2  0f2f8a4a203be3325981310ab243a28e6e4ea55b6519bffce05d41ab60e09ad8 \
     async-stream                     0.3.6  0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476 \
     async-stream-impl                0.3.6  c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d \
     async-task                       4.7.1  8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de \
-    async-trait                     0.1.84  1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0 \
+    async-trait                     0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
-    backtrace                       0.3.74  8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a \
+    autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
+    backtrace                       0.3.75  6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002 \
     base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                         2.6.0  b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de \
+    bitflags                         2.9.2  6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29 \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    blocking                         1.6.1  703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea \
-    bstr                            1.10.0  40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c \
+    blocking                         1.6.2  e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21 \
+    bstr                            1.12.0  234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4 \
     bufstream                        0.1.4  40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8 \
-    bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
+    bumpalo                         3.19.0  46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43 \
     by_address                       1.2.1  64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06 \
-    bytecount                        0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
-    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                            1.8.0  9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da \
-    cached                          0.54.0  9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae \
-    cached_proc_macro               0.23.0  2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa \
+    bytecount                        0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
+    bytes                           1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
+    cached                          0.56.0  801927ee168e17809ab8901d9f01f700cd7d8d6a6527997fee44e4b0327a253c \
+    cached_proc_macro               0.25.0  9225bdcf4e4a9a4c08bf16607908eb2fbf746828d5e0b5e019726dbf6571f201 \
     cached_proc_macro_types          0.1.1  ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
-    cc                               1.2.0  1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8 \
-    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    cc                              1.2.33  3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f \
+    cfg-if                           1.0.3  2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     check-if-email-exists            0.9.1  49f11d61ef99e1fecec73a0b9a8bf45ed7e66923e71dadcadcf650b383901eb2 \
-    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
+    chrono                          0.4.41  c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                            4.5.23  3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84 \
-    clap_builder                    4.5.23  30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838 \
-    clap_derive                     4.5.18  4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab \
-    clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
-    colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
+    clap                            4.5.45  1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318 \
+    clap_builder                    4.5.44  b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8 \
+    clap_derive                     4.5.45  14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6 \
+    clap_lex                         0.7.5  b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675 \
+    colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
     concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
-    console                        0.15.10  ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b \
+    console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
     const_format                    0.2.34  126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd \
     const_format_proc_macros        0.2.34  1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744 \
     cookie                          0.18.1  4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747 \
     cookie_store                    0.21.1  2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9 \
+    cookie_store                    0.22.0  3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
+    core-foundation                 0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
-    cpufeatures                     0.2.15  0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6 \
-    crc32fast                        1.4.2  a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3 \
-    criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
-    criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
+    cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
+    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    criterion                        0.7.0  e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928 \
+    criterion-plot                   0.6.0  9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338 \
     crossbeam                        0.8.4  1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8 \
-    crossbeam-channel               0.5.13  33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2 \
-    crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
+    crossbeam-channel               0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
+    crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
-    crossbeam-queue                 0.3.11  df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35 \
-    crossbeam-utils                 0.8.20  22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80 \
-    crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
+    crossbeam-queue                 0.3.12  0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115 \
+    crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
+    crunchy                          0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
     crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     csv                              1.3.1  acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf \
-    csv-core                        0.1.11  5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70 \
+    csv-core                        0.1.12  7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d \
     darling                         0.10.2  0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858 \
-    darling                        0.20.10  6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989 \
+    darling                        0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
     darling_core                    0.10.2  f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b \
-    darling_core                   0.20.10  95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5 \
+    darling_core                   0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
     darling_macro                   0.10.2  d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72 \
-    darling_macro                  0.20.10  d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806 \
+    darling_macro                  0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
     dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     dashmap                          6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
-    data-encoding                    2.6.0  e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2 \
+    data-encoding                    2.9.0  2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476 \
     deadpool                        0.10.0  fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490 \
     deadpool-runtime                 0.1.4  092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b \
-    deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
+    deranged                         0.4.0  9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e \
     derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
     derive_builder                   0.9.0  a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0 \
     derive_builder_core              0.9.0  2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
-    dirs                             5.0.1  44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225 \
-    dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
+    dirs                             6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
+    dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
-    document-features               0.2.10  cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0 \
-    either                          1.13.0  60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0 \
+    document-features               0.2.11  95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d \
+    dyn-clone                       1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
+    either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     email_address                    0.2.9  e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449 \
     encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     enum-as-inner                    0.4.0  21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73 \
-    env_filter                       0.1.2  4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab \
-    env_logger                      0.11.6  dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0 \
-    equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
-    errno                            0.3.9  534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba \
+    env_filter                       0.1.3  186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0 \
+    env_logger                      0.11.8  13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f \
+    equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
+    errno                           0.3.13  778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad \
     event-listener                   2.5.3  0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0 \
-    event-listener                   5.3.1  6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba \
-    event-listener-strategy          0.5.2  0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1 \
+    event-listener                   5.4.1  e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab \
+    event-listener-strategy          0.5.4  8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93 \
     fast-socks5                      0.8.2  961ce1761191c157145a8c9f0c3ceabecd3a729d65c9a8d443674eaee3420f7e \
     fast-socks5                      0.9.6  f89f36d4ee12370d30d57b16c7e190950a1a916e7dbbb5fd5a412f5ef913fe84 \
     fast_chemail                     0.9.6  495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4 \
-    fastrand                         2.2.0  486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4 \
-    flate2                          1.0.34  a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0 \
+    fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
+    flate2                           1.1.2  4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d \
     float-cmp                       0.10.0  b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8 \
     flume                          0.10.14  1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
-    form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
+    form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
     futf                             0.1.5  df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843 \
     futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
     futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
     futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
     futures-executor                0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
     futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
-    futures-lite                     2.5.0  cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1 \
+    futures-lite                     2.6.1  f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad \
     futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
     futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
     futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
     futures-timer                    3.0.3  f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24 \
     futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
-    getopts                         0.2.21  14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5 \
-    getrandom                       0.2.15  c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7 \
+    getopts                         0.2.23  cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1 \
+    getrandom                       0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
+    getrandom                        0.3.3  26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4 \
     gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
-    glob                             0.3.2  a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2 \
-    globset                         0.4.15  15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19 \
+    glob                             0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
+    globset                         0.4.16  54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5 \
     gloo-timers                      0.3.0  bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994 \
-    h2                              0.3.26  81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8 \
-    h2                               0.4.6  524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205 \
-    half                             2.4.1  6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888 \
+    h2                              0.3.27  0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d \
+    h2                              0.4.12  f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386 \
+    half                             2.6.0  459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
-    hashbrown                       0.15.1  3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3 \
-    headers                          0.4.0  322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9 \
+    hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
+    headers                          0.4.1  b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb \
     headers-core                     0.3.0  54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
-    hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
-    hermit-abi                       0.4.0  fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc \
+    hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hostname                         0.3.1  3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867 \
-    html5ever                       0.29.0  2e15626aaf9c351bc696217cbe29cb9b5e86c43f8a46b5e2f5c6c5cf7cb904ce \
+    html5ever                       0.35.0  55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4 \
     html5gum                         0.7.0  b3918b5f36d61861b757261da986b51be562c7a87ac4e531d4158e67e08bff72 \
     http                            0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
-    http                             1.2.0  f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea \
+    http                             1.3.1  f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565 \
     http-body                        0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
-    http-body-util                   0.1.2  793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f \
-    httparse                         1.9.5  7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946 \
+    http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
+    http-serde                       2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
+    httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    humantime                        2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
+    humantime                        2.2.0  9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f \
     humantime-serde                  1.1.1  57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c \
-    hyper                          0.14.31  8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85 \
-    hyper                            1.5.2  256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0 \
-    hyper-rustls                    0.27.3  08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333 \
+    hyper                          0.14.32  41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7 \
+    hyper                            1.7.0  eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e \
+    hyper-rustls                    0.27.7  e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58 \
     hyper-timeout                    0.5.2  2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0 \
     hyper-tls                        0.5.0  d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905 \
     hyper-tls                        0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
-    hyper-util                      0.1.10  df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4 \
-    iana-time-zone                  0.1.61  235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220 \
+    hyper-util                      0.1.16  8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e \
+    iana-time-zone                  0.1.63  b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
-    icu_collections                  1.5.0  db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526 \
-    icu_locid                        1.5.0  13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637 \
-    icu_locid_transform              1.5.0  01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e \
-    icu_locid_transform_data         1.5.0  fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e \
-    icu_normalizer                   1.5.0  19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f \
-    icu_normalizer_data              1.5.0  f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516 \
-    icu_properties                   1.5.1  93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5 \
-    icu_properties_data              1.5.0  67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569 \
-    icu_provider                     1.5.0  6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9 \
-    icu_provider_macros              1.5.0  1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6 \
+    icu_collections                  2.0.0  200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47 \
+    icu_locale_core                  2.0.0  0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a \
+    icu_normalizer                   2.0.0  436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979 \
+    icu_normalizer_data              2.0.0  00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3 \
+    icu_properties                   2.0.1  016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b \
+    icu_properties_data              2.0.1  298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632 \
+    icu_provider                     2.0.0  03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af \
     ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             0.2.3  418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8 \
-    idna                             0.3.0  e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6 \
-    idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
-    idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
+    idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
+    idna_adapter                     1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                         2.6.0  707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da \
-    indicatif                       0.17.9  cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281 \
+    indexmap                        2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
+    indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
+    io-uring                         0.7.9  d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4 \
     ip_network                       0.4.1  aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1 \
     ipconfig                         0.3.2  b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f \
-    ipnet                           2.10.1  ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708 \
-    iri-string                       0.7.7  dc0f0a572e8ffe56e2ff4f769f32ffe919282c3916799f8b68688b6030063bea \
-    is-terminal                     0.4.13  261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b \
+    ipnet                           2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
+    iri-string                       0.7.8  dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2 \
     is_ci                            1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
-    itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
-    itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
+    itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
+    itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
     jetscii                          0.5.3  47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e \
-    js-sys                          0.3.72  6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9 \
-    jsonwebtoken                     9.3.0  b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f \
+    jiff                            0.2.15  be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49 \
+    jiff-static                     0.2.15  03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4 \
+    js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
+    jsonwebtoken                     9.3.1  5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde \
     kv-log-macro                     1.0.7  0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     levenshtein                      1.0.5  db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760 \
-    libc                           0.2.162  18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398 \
-    libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
+    libc                           0.2.175  6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543 \
+    libredox                         0.1.9  391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3 \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linkify                         0.10.0  f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780 \
-    linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
-    litemap                          0.7.3  643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704 \
-    litrs                            0.4.1  b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5 \
-    lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
-    log                             0.4.22  a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24 \
+    linux-raw-sys                    0.9.4  cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
+    litemap                          0.8.0  241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956 \
+    litrs                            0.4.2  f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed \
+    lock_api                        0.4.13  96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765 \
+    log                             0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
     lru-cache                        0.1.2  31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c \
+    lru-slab                         0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
     mac                              0.1.1  c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4 \
     mailchecker                      5.0.9  4c64fa7af9860896bdfe496f323ac278f256006fd248dd7730e37c5faa648b05 \
-    markup5ever                     0.14.0  82c88c6129bd24319e62a0359cb6b958fa7e8be6e19bb1663bc396b90883aca5 \
+    markup5ever                     0.35.0  311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3 \
     match_cfg                        0.1.0  ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4 \
+    match_token                     0.35.0  ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
     matches                         0.1.10  2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5 \
     md5                              0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
-    memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
+    memchr                           2.7.5  32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
-    miniz_oxide                      0.8.0  e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1 \
-    mio                              1.0.2  80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec \
+    miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
+    mio                              1.0.4  78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c \
     nanorand                         0.7.0  6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3 \
-    native-tls                      0.2.12  a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466 \
+    native-tls                      0.2.14  87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e \
     new_debug_unreachable            1.0.6  650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
@@ -287,72 +291,79 @@ cargo.crates \
     num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
     num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
-    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
+    num_cpus                        1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
-    object                          0.36.5  aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e \
-    octocrab                        0.42.1  7b97f949a7cb04608441c2ddb28e15a377e8b5142c2d1835ad2686d434de8558 \
-    once_cell                       1.20.2  1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775 \
-    oorandom                        11.1.4  b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9 \
-    openssl                        0.10.68  6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5 \
+    numeric-sort                     0.1.5  f2dcb6053ab98da45585315f79932c5c9821fab8efa4301c0d7b637c91630eb7 \
+    object                          0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
+    octocrab                        0.44.1  86996964f8b721067b6ed238aa0ccee56ecad6ee5e714468aa567992d05d2b91 \
+    once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
+    once_cell_polyfill              1.70.1  a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad \
+    oorandom                        11.1.5  d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e \
+    openssl                        0.10.73  8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8 \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
-    openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
-    openssl-src              300.4.0+3.4.0  a709e02f2b4aca747929cca5ed248880847c650233cf8b8cdc48f40aaf4898a6 \
-    openssl-sys                    0.9.104  45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741 \
+    openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
+    openssl-src              300.5.2+3.5.2  d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4 \
+    openssl-sys                    0.9.109  90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     pad                              0.1.6  d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3 \
-    papergrid                       0.13.0  d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd \
+    papergrid                       0.17.0  6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1 \
     par-stream                      0.10.2  8ef8c7bc0cbc89c3d02fb0cce36f609e8707150bd38c1cbce79c6b7906f4099a \
     parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
-    parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
-    parking_lot_core                0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
+    parking_lot                     0.12.4  70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13 \
+    parking_lot_core                0.9.11  bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5 \
     path-clean                       1.0.1  17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef \
-    pem                              3.0.4  8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae \
-    percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
-    phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
-    phf_generator                   0.10.0  5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6 \
-    phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
-    phf_shared                      0.10.0  b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096 \
-    phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
-    pin-project                      1.1.7  be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95 \
-    pin-project-internal             1.1.7  3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c \
-    pin-project-lite                0.2.15  915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff \
+    pem                              3.0.5  38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3 \
+    percent-encoding                 2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
+    phf                             0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
+    phf_codegen                     0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
+    phf_generator                   0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
+    phf_shared                      0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
+    pin-project                     1.1.10  677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a \
+    pin-project-internal            1.1.10  6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861 \
+    pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     piper                            0.2.4  96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066 \
-    pkg-config                      0.3.31  953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2 \
+    pkg-config                      0.3.32  7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c \
     plotters                         0.3.7  5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747 \
     plotters-backend                 0.3.7  df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a \
     plotters-svg                     0.3.7  51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670 \
-    polling                          3.7.4  a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f \
-    portable-atomic                  1.9.0  cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2 \
+    polling                         3.10.0  b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829 \
+    portable-atomic                 1.11.1  f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483 \
+    portable-atomic-util             0.2.4  d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507 \
+    potential_utf                    0.1.2  e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
-    ppv-lite86                      0.2.20  77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04 \
+    ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     precomputed-hash                 0.1.1  925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
     predicates                       3.1.3  a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573 \
-    predicates-core                  1.0.8  ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931 \
-    predicates-tree                 1.0.11  41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13 \
+    predicates-core                  1.0.9  727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa \
+    predicates-tree                 1.0.12  72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
-    proc-macro-crate                 3.2.0  8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b \
+    proc-macro-crate                 3.3.0  edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35 \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
-    proc-macro2                     1.0.89  f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e \
+    proc-macro2                    1.0.101  89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de \
     psl-types                       2.0.11  33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac \
-    publicsuffix                     2.2.3  96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457 \
-    pulldown-cmark                  0.12.2  f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14 \
+    publicsuffix                     2.3.0  6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf \
+    pulldown-cmark                  0.13.0  1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0 \
     pulldown-cmark-escape           0.11.0  007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae \
     pwned                            0.5.0  f75258f75c681eb691607acdb325d0150907bc68826365b07476834df2664974 \
-    quick-error                      1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
-    quinn                           0.11.5  8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684 \
-    quinn-proto                     0.11.8  fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6 \
-    quinn-udp                        0.5.7  7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da \
-    quote                           1.0.37  b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af \
+    quinn                           0.11.8  626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8 \
+    quinn-proto                    0.11.12  49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e \
+    quinn-udp                       0.5.13  fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970 \
+    quote                           1.0.40  1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
+    r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand                             0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
-    rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
-    rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
-    redox_syscall                    0.5.7  9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f \
-    redox_users                      0.4.6  ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43 \
+    rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
+    rayon                           1.11.0  368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f \
+    rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
+    redox_syscall                   0.5.17  5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77 \
+    redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
+    ref-cast                        1.0.24  4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf \
+    ref-cast-impl                   1.0.24  1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7 \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
@@ -360,184 +371,206 @@ cargo.crates \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     relative-path                    1.9.3  ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
     reqwest                        0.11.27  dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62 \
-    reqwest                         0.12.9  a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f \
-    reqwest_cookie_store             0.8.0  a0b36498c7452f11b1833900f31fbb01fc46be20992a50269c88cf59d79f54e9 \
-    resolv-conf                      0.7.0  52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00 \
-    ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
-    rstest                          0.24.0  03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89 \
-    rstest_macros                   0.24.0  ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b \
-    rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
-    rustc-hash                       2.0.0  583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152 \
+    reqwest                        0.12.23  d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb \
+    reqwest_cookie_store             0.9.0  5e75bc88d954b228850d19e3685cedb38c030a17da34aa01c307f95d6e33de34 \
+    resolv-conf                      0.7.4  95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3 \
+    ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
+    rstest                          0.26.1  f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49 \
+    rstest_macros                   0.26.1  9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0 \
+    rustc-demangle                  0.1.26  56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace \
+    rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
-    rustix                         0.38.40  99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0 \
-    rustls                         0.23.16  eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e \
-    rustls-native-certs              0.8.0  fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a \
+    rustix                           1.0.8  11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8 \
+    rustls                         0.23.31  c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc \
+    rustls-native-certs              0.8.1  7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3 \
     rustls-pemfile                   1.0.4  1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c \
-    rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
-    rustls-pki-types                1.10.0  16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b \
-    rustls-webpki                  0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
-    rustversion                     1.0.18  0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248 \
-    ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
+    rustls-pki-types                1.12.0  229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79 \
+    rustls-webpki                  0.103.4  0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc \
+    rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    schannel                        0.1.26  01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1 \
+    schannel                        0.1.27  1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d \
+    schemars                         0.9.0  4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f \
+    schemars                         1.0.4  82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     secrecy                         0.10.3  e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
-    security-framework-sys          2.12.1  fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2 \
-    semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
-    serde                          1.0.217  02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70 \
-    serde_derive                   1.0.217  5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0 \
-    serde_json                     1.0.134  d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d \
-    serde_path_to_error             0.1.16  af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6 \
-    serde_spanned                    0.6.8  87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1 \
+    security-framework               3.3.0  80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c \
+    security-framework-sys          2.14.0  49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32 \
+    semver                          1.0.26  56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0 \
+    serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
+    serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
+    serde_json                     1.0.143  d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a \
+    serde_path_to_error             0.1.17  59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a \
+    serde_spanned                    1.0.0  40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_with                      3.12.0  d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa \
-    serde_with_macros               3.12.0  8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e \
+    serde_with                      3.14.0  f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5 \
+    serde_with_macros               3.14.0  de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f \
     sha1                             0.6.1  c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770 \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha1_smol                        1.0.1  bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
-    shellexpand                      3.1.0  da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b \
+    shellexpand                      3.1.1  8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
-    signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
-    simple_asn1                      0.6.2  adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085 \
-    siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
-    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
-    smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
-    snafu                            0.8.5  223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019 \
-    snafu-derive                     0.8.5  03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917 \
+    signal-hook-registry             1.4.6  b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b \
+    simple_asn1                      0.6.3  297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb \
+    siphasher                        1.0.1  56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d \
+    slab                            0.4.11  7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589 \
+    smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
+    snafu                            0.8.7  0062a372b26c4a6e9155d099a3416d732514fd47ae2f235b3695b820afcee74a \
+    snafu-derive                     0.8.7  7e5fd9e3263fc19d73abd5107dbd4d43e37949212d2b15d4d334ee5db53022b8 \
     socket2                         0.4.10  9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d \
-    socket2                          0.5.7  ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c \
+    socket2                         0.5.10  e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678 \
+    socket2                          0.6.0  233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807 \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
-    string_cache                     0.8.7  f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b \
-    string_cache_codegen             0.5.2  6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988 \
+    string_cache                     0.8.9  bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f \
+    string_cache_codegen             0.5.4  c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0 \
     strsim                           0.9.3  6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
-    strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
-    strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
+    strum                           0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
+    strum_macros                    0.27.2  7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7 \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     supports-color                   3.0.2  c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6 \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.87  25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d \
+    syn                            2.0.106  ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6 \
     sync_wrapper                     0.1.2  2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160 \
-    sync_wrapper                     1.0.1  a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394 \
-    synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
+    sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
+    synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     system-configuration             0.5.1  ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7 \
     system-configuration             0.6.1  3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b \
     system-configuration-sys         0.5.0  a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9 \
     system-configuration-sys         0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
-    tabled                          0.17.0  c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a \
-    tabled_derive                    0.9.0  931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1 \
-    tempfile                        3.15.0  9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704 \
+    tabled                          0.20.0  e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d \
+    tabled_derive                   0.11.0  0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846 \
+    tempfile                        3.21.0  15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e \
     tendril                          0.4.3  d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0 \
-    termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
+    termtree                         0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
+    testing_table                    0.3.0  0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                        2.0.9  f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc \
+    thiserror                       2.0.16  3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                   2.0.9  7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4 \
-    thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
-    time                            0.3.36  5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885 \
-    time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
-    time-macros                     0.2.18  3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf \
-    tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
+    thiserror-impl                  2.0.16  6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960 \
+    thread_local                     1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
+    time                            0.3.41  8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40 \
+    time-core                        0.1.4  c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c \
+    time-macros                     0.2.22  3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49 \
+    tinystr                          0.8.1  5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
-    tinyvec                          1.8.0  445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938 \
+    tinyvec                         1.10.0  bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.42.0  5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551 \
-    tokio-macros                     2.4.0  693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752 \
+    tokio                           1.47.1  89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038 \
+    tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
-    tokio-rustls                    0.26.0  0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4 \
+    tokio-rustls                    0.26.2  8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b \
     tokio-socks                      0.5.2  0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f \
     tokio-stream                    0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
-    tokio-util                      0.7.12  61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a \
-    toml                            0.8.19  a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e \
-    toml_datetime                    0.6.8  0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41 \
-    toml_edit                      0.22.22  4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5 \
-    tower                            0.5.1  2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f \
-    tower-http                       0.6.1  8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97 \
+    tokio-util                      0.7.16  14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5 \
+    toml                             0.9.5  75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8 \
+    toml_datetime                   0.6.11  22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
+    toml_datetime                    0.7.0  bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3 \
+    toml_edit                      0.22.27  41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
+    toml_parser                      1.0.2  b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10 \
+    toml_writer                      1.0.2  fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64 \
+    tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
+    tower-http                       0.6.6  adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
-    tracing-attributes              0.1.28  395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d \
-    tracing-core                    0.1.33  e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c \
+    tracing-attributes              0.1.30  81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903 \
+    tracing-core                    0.1.34  b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678 \
     tracing-subscriber              0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
     trust-dns-proto                 0.21.2  9c31f240f59877c3d4bb3b3ea0ec5a6a0cff07323580ff8c7a605cd7d08b255d \
     trust-dns-resolver              0.21.2  e4ba72c2ea84515690c9fcef4c6c660bb9df3036ed1051686de84605b74fd558 \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
-    typed-builder                   0.20.0  7e14ed59dc8b7b26cacb2a92bad2e8b1f098806063898ab42a3bd121d7d45e75 \
-    typed-builder-macro             0.20.0  560b82d656506509d43abe30e0ba64c56b1953ab3d4fe7ba5902747a7a3cedd5 \
-    typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
-    unicase                          2.8.0  7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df \
-    unicode-bidi                    0.3.17  5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893 \
-    unicode-ident                   1.0.13  e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe \
+    typed-builder                   0.21.2  fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d \
+    typed-builder-macro             0.21.2  1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18 \
+    typenum                         1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
+    unicase                          2.8.1  75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539 \
+    unicode-bidi                    0.3.18  5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5 \
+    unicode-ident                   1.0.18  5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512 \
     unicode-normalization           0.1.24  5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956 \
-    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
-    unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
+    unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
+    unicode-width                    0.2.1  4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
+    url                              2.5.6  137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4 \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
-    utf16_iter                       1.0.5  c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.11.0  f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a \
-    value-bag                       1.10.0  3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2 \
+    uuid                            1.18.0  f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be \
+    value-bag                       1.11.1  943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5 \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
-    wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
+    wait-timeout                     0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
-    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.95  128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e \
-    wasm-bindgen-backend            0.2.95  cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358 \
-    wasm-bindgen-futures            0.4.45  cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b \
-    wasm-bindgen-macro              0.2.95  e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56 \
-    wasm-bindgen-macro-support      0.2.95  26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68 \
-    wasm-bindgen-shared             0.2.95  65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d \
-    web-sys                         0.3.72  f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112 \
+    wasi     0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
+    wasi                 0.14.2+wasi-0.2.4  9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3 \
+    wasm-bindgen                   0.2.100  1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
+    wasm-bindgen-backend           0.2.100  2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
+    wasm-bindgen-futures            0.4.50  555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61 \
+    wasm-bindgen-macro             0.2.100  7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407 \
+    wasm-bindgen-macro-support     0.2.100  8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de \
+    wasm-bindgen-shared            0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
+    web-sys                         0.3.77  33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    widestring                       1.1.0  7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311 \
+    web_atoms                        0.1.3  57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414 \
+    widestring                       1.2.0  dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
+    winapi-util                     0.1.10  0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
-    windows-registry                 0.2.0  e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0 \
-    windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
-    windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
+    windows-core                    0.61.2  c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3 \
+    windows-implement               0.60.0  a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836 \
+    windows-interface               0.59.1  bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8 \
+    windows-link                     0.1.3  5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a \
+    windows-registry                 0.5.3  5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e \
+    windows-result                   0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
+    windows-strings                  0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
+    windows-sys                     0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
     windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
+    windows-targets                 0.53.3  d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91 \
     windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
     windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
+    windows_aarch64_gnullvm         0.53.0  86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
     windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
     windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
+    windows_aarch64_msvc            0.53.0  c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c \
     windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
     windows_i686_gnu                0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
+    windows_i686_gnu                0.53.0  c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3 \
     windows_i686_gnullvm            0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
+    windows_i686_gnullvm            0.53.0  9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11 \
     windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
     windows_i686_msvc               0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
+    windows_i686_msvc               0.53.0  581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d \
     windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
     windows_x86_64_gnu              0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
+    windows_x86_64_gnu              0.53.0  2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba \
     windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
     windows_x86_64_gnullvm          0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
+    windows_x86_64_gnullvm          0.53.0  0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
-    winnow                          0.6.20  36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b \
+    windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
+    winnow                          0.7.12  f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95 \
     winreg                          0.50.0  524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1 \
-    wiremock                         0.6.2  7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646 \
-    write16                          1.0.0  d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936 \
-    writeable                        0.5.5  1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51 \
+    wiremock                         0.6.4  a2b8b99d4cdbf36b239a9532e31fe4fb8acc38d1897c1761e161550a7dc78e6a \
+    wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
+    writeable                        0.6.1  ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
-    yoke                             0.7.4  6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5 \
-    yoke-derive                      0.7.4  28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95 \
-    zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
-    zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
-    zerofrom                         0.1.4  91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55 \
-    zerofrom-derive                  0.1.4  0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5 \
+    yoke                             0.8.0  5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc \
+    yoke-derive                      0.8.0  38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6 \
+    zerocopy                        0.8.26  1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f \
+    zerocopy-derive                 0.8.26  9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181 \
+    zerofrom                         0.1.6  50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5 \
+    zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde \
-    zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
-    zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6
+    zerotrie                         0.2.2  36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595 \
+    zerovec                         0.11.4  e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b \
+    zerovec-derive                  0.11.1  5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f


### PR DESCRIPTION
#### Description

lychee: Update to 0.20.0

##### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
