### PR TITLE
blink: re-fix build on macOS <10.12 and >13

### DIFF
--- a/emulators/blink/Portfile
+++ b/emulators/blink/Portfile
@@ -8,9 +8,7 @@ PortGroup           legacysupport   1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 github.setup        jart blink 1.1.0
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-revision            0
+revision            1
 epoch               1
 
 description         tiniest x86-64-linux emulator
@@ -23,15 +21,14 @@ long_description    \
     and is also faster at running ephemeral programs such as compilers.
 
 categories          emulators
-platforms           {darwin >= 16}
 installs_libs       no
 license             ISC
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  91b18326691d8265edd332f2e892bf6403511836 \
-                    sha256  6eb54dd5f58edf79305451641f4911135a210c27b8e98eb4b2840e94778c91f3 \
-                    size    2984666
+checksums           rmd160  39a9d2d2c08388e705bd8a7f11af52b357952e44 \
+                    sha256  2649793e1ebf12027f5e240a773f452434cefd9494744a858cd8bff8792dba68 \
+                    size    2984430
 
 depends_build-append \
                     port:gmake
@@ -43,6 +40,20 @@ compiler.c_standard 2017
 # https://github.com/jart/blink/pull/142
 build.cmd           ${prefix}/bin/gmake
 build.target
+
+# blinkenlights.c:3609:29: error: use of undeclared identifier
+# 'F_DUPFD_CLOEXEC' on macOS <10.7
+# https://github.com/jart/blink/pull/197
+# remove this if it will be merged upstream
+patchfiles-append   patch-f-dupfd-cloexec.diff
+
+platform darwin {
+    # incompatibility with the new Xcode 15 linker
+    if {([vercmp ${xcodeversion} 15] >= 0) || ([vercmp ${xcodecltversion} 15] >= 0)} {
+        configure.ldflags-append \
+                    -Wl,-ld_classic
+    }
+}
 
 destroot {
     xinstall -m 0755 \

--- a/emulators/blink/files/patch-f-dupfd-cloexec.diff
+++ b/emulators/blink/files/patch-f-dupfd-cloexec.diff
@@ -1,0 +1,171 @@
+--- blink/blinkenlights.c
++++ blink/blinkenlights.c
+@@ -3559,9 +3559,11 @@ static void GetOpts(int argc, char *argv[]) {
+   FLAG_nolinear = !wantunsafe;
+ }
+ 
++#ifdef HAVE_JIT
+ static void AddPath_StartOp_Tui(P) {
+   Jitter(m, rde, 0, 0, "qc", StartOp_Tui);
+ }
++#endif
+ 
+ static bool FileExists(const char *path) {
+   return !VfsAccess(AT_FDCWD, path, F_OK, 0);
+@@ -3606,7 +3608,7 @@ int VirtualMachine(int argc, char *argv[]) {
+         tty = VfsOpen(AT_FDCWD, "/dev/tty", O_RDWR | O_NOCTTY, 0);
+       }
+       if (tty != -1) {
+-        tty = VfsFcntl(tty, F_DUPFD_CLOEXEC, kMinBlinkFd);
++        tty = VfsFcntl(tty, F_DUPFD, kMinBlinkFd);
+       }
+       if (tty == -1) {
+         WriteErrorString("failed to open /dev/tty\n");
+--- blink/demangle.c
++++ blink/demangle.c
+@@ -139,10 +139,20 @@ static void SpawnCxxFilt(void) {
+   }
+   unassert(!close(pipefds[0][1]));
+   unassert(!close(pipefds[1][0]));
++#ifndef F_DUPFD_CLOEXEC
++  g_cxxfilt.reader = fcntl(pipefds[0][0], F_DUPFD, kMinBlinkFd);
++  fcntl(g_cxxfilt.reader, F_SETFD, FD_CLOEXEC);
++#else
+   g_cxxfilt.reader = fcntl(pipefds[0][0], F_DUPFD_CLOEXEC, kMinBlinkFd);
++#endif
+   unassert(g_cxxfilt.reader != -1);
+   unassert(!close(pipefds[0][0]));
++#ifndef F_DUPFD_CLOEXEC
++  g_cxxfilt.writer = fcntl(pipefds[1][1], F_DUPFD, kMinBlinkFd);
++  fcntl(g_cxxfilt.writer, F_SETFD, FD_CLOEXEC);
++#else
+   g_cxxfilt.writer = fcntl(pipefds[1][1], F_DUPFD_CLOEXEC, kMinBlinkFd);
++#endif
+   unassert(g_cxxfilt.writer != -1);
+   unassert(!close(pipefds[1][1]));
+   unassert(!atexit(CloseCxxFilt));
+--- blink/errfd.c
++++ blink/errfd.c
+@@ -48,6 +48,11 @@ int WriteError(int fd, const char *buf, int len) {
+ 
+ void WriteErrorInit(void) {
+   if (g_errfd) return;
++#ifndef F_DUPFD_CLOEXEC
++  g_errfd = fcntl(2, F_DUPFD, kMinBlinkFd);
++  fcntl(g_errfd, F_SETFD, FD_CLOEXEC);
++#else
+   g_errfd = fcntl(2, F_DUPFD_CLOEXEC, kMinBlinkFd);
++#endif
+   if (g_errfd == -1) exit(200);
+ }
+--- blink/log.c
++++ blink/log.c
+@@ -120,7 +120,12 @@ static void OpenLog(void) {
+       return;
+     }
+   }
++#ifndef F_DUPFD_CLOEXEC
++  unassert((g_log.fd = fcntl(fd, F_DUPFD, kMinBlinkFd)) != -1);
++  unassert(fcntl(g_log.fd, F_SETFL, FD_CLOEXEC) != -1);
++#else
+   unassert((g_log.fd = fcntl(fd, F_DUPFD_CLOEXEC, kMinBlinkFd)) != -1);
++#endif
+   unassert(!close(fd));
+ }
+ 
+--- blink/path.c
++++ blink/path.c
+@@ -156,7 +156,7 @@ void(SetupCod)(struct Machine *m) {
+   DisLoadElf(&g_dis, &m->system->elf);
+   g_cod = VfsOpen(AT_FDCWD_LINUX, "/tmp/blink.s",
+                   O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
+-  g_cod = VfsFcntl(g_cod, F_DUPFD_CLOEXEC, kMinBlinkFd);
++  g_cod = VfsFcntl(g_cod, F_DUPFD, kMinBlinkFd);
+ #endif
+ }
+ 
+--- blink/syscall.c
++++ blink/syscall.c
+@@ -1409,8 +1409,18 @@ static int SysDup3(struct Machine *m, i32 fildes, i32 newfildes, i32 flags) {
+ static int SysDupf(struct Machine *m, i32 fildes, i32 minfildes, int cmd) {
+   struct Fd *fd;
+   int lim, oflags, newfildes;
++  int cmdnative = cmd;
+   if (minfildes >= (lim = GetFileDescriptorLimit(m->system))) return emfile();
+-  if ((newfildes = VfsFcntl(fildes, cmd, minfildes)) != -1) {
++  if (cmd == F_DUPFD_LINUX) {
++    cmdnative = F_DUPFD;
++  } else if (cmd == F_DUPFD_CLOEXEC_LINUX) {
++#ifndef F_DUPFD_CLOEXEC
++    cmdnative = F_DUPFD;
++#else
++    cmdnative = F_DUPFD_CLOEXEC;
++#endif
++  }
++  if ((newfildes = VfsFcntl(fildes, cmdnative, minfildes)) != -1) {
+     if (newfildes >= lim) {
+       VfsClose(newfildes);
+       return emfile();
+@@ -1418,7 +1428,7 @@ static int SysDupf(struct Machine *m, i32 fildes, i32 minfildes, int cmd) {
+     LOCK(&m->system->fds.lock);
+     unassert(fd = GetFd(&m->system->fds, fildes));
+     oflags = fd->oflags & ~O_CLOEXEC;
+-    if (cmd == F_DUPFD_CLOEXEC) {
++    if (cmd == F_DUPFD_CLOEXEC_LINUX) {
+       oflags |= O_CLOEXEC;
+     }
+     unassert(ForkFd(&m->system->fds, fd, newfildes, oflags));
+@@ -3241,10 +3251,8 @@ static int SysFcntlGetownEx(struct Machine *m, i32 fildes, i64 addr) {
+ static int SysFcntl(struct Machine *m, i32 fildes, i32 cmd, i64 arg) {
+   int rc, fl;
+   struct Fd *fd;
+-  if (cmd == F_DUPFD_LINUX) {
+-    return SysDupf(m, fildes, arg, F_DUPFD);
+-  } else if (cmd == F_DUPFD_CLOEXEC_LINUX) {
+-    return SysDupf(m, fildes, arg, F_DUPFD_CLOEXEC);
++  if (cmd == F_DUPFD_LINUX || cmd == F_DUPFD_CLOEXEC_LINUX) {
++    return SysDupf(m, fildes, arg, cmd);
+   }
+   if (!(fd = GetAndLockFd(m, fildes))) return -1;
+   if (cmd == F_GETFD_LINUX) {
+--- blink/vfs.c
++++ blink/vfs.c
+@@ -1733,7 +1733,11 @@ int VfsFcntl(int fd, int cmd, ...) {
+   }
+   va_start(ap, cmd);
+   // CLOEXEC is already handled by the syscall layer.
++#ifndef F_DUPFD_CLOEXEC
++  if (cmd == F_DUPFD) {
++#else
+   if (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC) {
++#endif
+     if (info->device->ops->Dup) {
+       ret = info->device->ops->Dup(info, &newinfo);
+       if (ret != -1) {
+--- blink/xlat.h
++++ blink/xlat.h
+@@ -8,6 +8,7 @@
+ #include <sys/stat.h>
+ #include <sys/statvfs.h>
+ #include <sys/time.h>
++#include <sys/types.h>
+ #include <termios.h>
+ 
+ #include "blink/linux.h"
+--- configure
++++ configure
+@@ -295,12 +295,12 @@ replace() {
+ 
+ comment() {
+   hassstr "$1"
+-  replace "$1" "// $1"
++  replace "$1\$" "// $1"
+ }
+ 
+ uncomment() {
+   hassstr "$1"
+-  replace "// $1" "$1"
++  replace "// $1\$" "$1"
+ }
+ 
+ for x; do


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
