### PR TITLE
opencv4: fix ffmpeg8 builds

### DIFF
--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -112,6 +112,10 @@ patchfiles-append   patch-dylib_suffix.diff
 # this only adds a macro, no effect on other platforms.
 patchfiles-append   patch-parallel_impl.cpp-cv_pause.diff
 
+# Fixes builds against ffmpeg 8.0. This is currently upstreamed in
+# opencv git, but not as part of the current upstream 4.12.0 release.
+patchfiles-append   patch-ffmpeg8.diff
+
 platform darwin {
     if {${opencv_latest}} {
         # Drop scrollwheel code, for 10.11 and earlier

--- a/graphics/opencv4/files/patch-ffmpeg8.diff
+++ b/graphics/opencv4/files/patch-ffmpeg8.diff
@@ -1,0 +1,33 @@
+--- modules/videoio/src/cap_ffmpeg_impl.hpp
++++ modules/videoio/src/cap_ffmpeg_impl.hpp
+@@ -685,7 +685,10 @@ void CvCapture_FFMPEG::close()
+     if( video_st )
+     {
+ #ifdef CV_FFMPEG_CODECPAR
++// avcodec_close removed in FFmpeg release 8.0
++# if (LIBAVCODEC_BUILD < CALC_FFMPEG_VERSION(62, 11, 100))
+         avcodec_close( context );
++# endif
+ #endif
+         video_st = NULL;
+     }
+@@ -2005,7 +2008,18 @@ void CvCapture_FFMPEG::get_rotation_angle()
+ 
+     rotation_angle = 0;
+ #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(57, 68, 100)
+     const uint8_t *data = 0;
++    // av_stream_get_side_data removed in FFmpeg release 8.0
++# if (LIBAVCODEC_BUILD < CALC_FFMPEG_VERSION(62, 11, 100))
+     data = av_stream_get_side_data(video_st, AV_PKT_DATA_DISPLAYMATRIX, NULL);
++# else
++    AVPacketSideData* sd = video_st->codecpar->coded_side_data;
++    int nb_sd = video_st->codecpar->nb_coded_side_data;
++    if (sd && nb_sd > 0)
++    {
++        const AVPacketSideData* mtx = av_packet_side_data_get(sd,  nb_sd, AV_PKT_DATA_DISPLAYMATRIX);
++        data = mtx->data;
++    }
++# endif
+     if (data)
+     {
+         rotation_angle = -cvRound(av_display_rotation_get((const int32_t*)data));


### PR DESCRIPTION
#### Description

ffmpeg-devel has moved to ffmpeg 8.0, which breaks the current opencv4 build. This patch is copied from an upcoming opencv change (post 4.12) to fix macports opencv (currently still on 4.9)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.6 24G84 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
