### PR TITLE
groovy: update to 5.0.0

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         4.0.28
+version         5.0.0
 revision        0
 
 categories      lang java
@@ -30,15 +30,15 @@ master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zi
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  1281a6a21b18795b6fdcbb0a5eea99d832cb3c4d \
-                sha256  6a052bfd2ca77d57e0db304a313dd9a729945c5a31420e6d48505be4840bfc54 \
-                size    30311613
+checksums       rmd160  d6b232ad2ea7d3060a89f759e5875bf9871d13ea \
+                sha256  7cacb815c96252494ca4b9a6889936fe59680a3c2ee1569b252546a991a9855c \
+                size    34483473
 
 worksrcdir      ${name}-${version}
 
 use_configure   no
 
-java.version    1.8+
+java.version    11+
 java.fallback   openjdk21
 
 build {}
@@ -60,7 +60,7 @@ destroot {
     }
 
     # Add symlinks to the scripts
-    foreach f { grape grape_completion groovy groovy_completion groovyConsole groovyConsole_completion groovyc groovyc_completion groovydoc groovydoc_completion groovysh groovysh_completion java2groovy startGroovy } {
+    foreach f { grape grape_completion groovy groovy_completion groovyc groovyc_completion groovyConsole groovyConsole_completion groovydoc groovydoc_completion groovysh groovysh_completion java2groovy startGroovy } {
         ln -s ../share/java/${name}/bin/${f} ${destroot}${prefix}/bin
     }
 }


### PR DESCRIPTION
#### Description

Update to Apache Groovy 5.0.0.

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?