### PR TITLE
py-markdown2: update to 2.5.4, add Python 3.13 subport

### DIFF
--- a/python/py-markdown2/Portfile
+++ b/python/py-markdown2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        trentm python-markdown2 2.4.0
+github.setup        trentm python-markdown2 2.5.4
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
 revision            0
@@ -20,11 +20,11 @@ description         A fast and complete implementation of Markdown in Python
 long_description    {*}${description}. Markdown2 comes with a number of extensions \
                     for things like syntax coloring, tables, header-ids.
 
-checksums           rmd160  20f4b789ec3d2942f0a7ec598ed727595c6e5ca8 \
-                    sha256  7390432aa051a674a3cb77cd1748c9bc4d0ffab3ce358331fe92a6727d245448 \
-                    size    1065930
+checksums           rmd160  c202d2cba2519905843c4d3afd7cfeaeabe5a3db \
+                    sha256  04cfc434e3de866416e1da45f970956014fdfb73dc6318a820ea04ce238e3b55 \
+                    size    1113002
 
-python.versions     39 310 311 312
+python.versions     39 310 311 312 313
 
 if {${name} ne ${subport}} {
     # Required for code highlighting and tests to pass


### PR DESCRIPTION
#### Description

Update to 2.5.4, add subport for Python 3.13.

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?