### PR TITLE
osxphotos: update to 0.72.2

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.72.1
+version                 0.72.2
 revision                0
 
 categories              graphics python
@@ -25,21 +25,23 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  d45bcb1437c12516982c60e0d80c9afb0a4ba1c1 \
-                        sha256  1c1d6325f65a5b7613f8cba3a88695247b33c2bd0e08bd2259d2e7a48e5d6e8b \
-                        size    2278434
+checksums               rmd160  cbcaff78ddf79e431e6deceafa2cdc83eab18038 \
+                        sha256  02f802e55b852612271d7167ada0dbcadabe71476160659a4e2fcfafa942cf70 \
+                        size    2312097
 
 python.default_version  313
 
 depends_build-append    port:py${python.version}-setuptools
 
-depends_lib-append      port:py${python.version}-bitmath \
+depends_lib-append      port:py${python.version}-beautifulsoup4 \
+                        port:py${python.version}-bitmath \
                         port:py${python.version}-bpylist2 \
                         port:py${python.version}-cgmetadata \
                         port:py${python.version}-click \
                         port:py${python.version}-mac-alias \
                         port:py${python.version}-makelive \
                         port:py${python.version}-mako \
+                        port:py${python.version}-markdown2 \
                         port:py${python.version}-more-itertools \
                         port:py${python.version}-objexplore \
                         port:py${python.version}-osxmetadata \


### PR DESCRIPTION
#### Description

Update to osxphotos 0.72.2.

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?