### PR TITLE
google-cloud-sdk: update to 536.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             535.0.0
+version             536.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  cf4c94e59276e18a8ea4e7e0a52118f58bfc8a8b \
-                    sha256  3bd08ac3746337267378d8f514e12aeb850192b54eabdbb592f78c0cf65cf5f8 \
-                    size    55103517
+    checksums       rmd160  1bead1140ac4f9b9d3472432c8b663cab4eafd41 \
+                    sha256  b86eccfc87180a77904545b7dcbfb1e2cfbbb1d0b01687d6368d405df35a6870 \
+                    size    55152981
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  d876c6c4b64cdf7e8ff4be168acd3ab3f703a091 \
-                    sha256  9c911d51f60f39796a4eeb0eff56a5cbb5f16d36df60beb1e3f2bfdfb48f5cdc \
-                    size    56636239
+    checksums       rmd160  03eacc4ecb84b2722665c87297628859251df76e \
+                    sha256  77d3dc1a104580345a8493418e9ee2335cfe465d30524ef4912f0787d8a0836f \
+                    size    56688336
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  7a5ab278c32b9442506890c465a40e93f10aaa98 \
-                    sha256  f7162d25a1189c67aeed6ad11cdd5f342ce3815ddda22f2ca3121572b5f4d974 \
-                    size    56569124
+    checksums       rmd160  59820d0d2880a8dfdf947a68dcda91819499fc5d \
+                    sha256  c4667be2b763dd614dedced3cf883743198ce9053a1764d6209c124fe9d8b261 \
+                    size    56622619
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 536.0.0.

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?