### PR TITLE
mdf2iso: Update to 0.3.1

### DIFF
--- a/sysutils/mdf2iso/Portfile
+++ b/sysutils/mdf2iso/Portfile
@@ -1,14 +1,17 @@
-PortSystem 	   1.0
-name 		   mdf2iso
-version		   0.3.0
-homepage	   http://mdf2iso.berlios.de/
-description	   Tool to convert mdf (Alcohol 120% images) images to iso images.
-long_description    ${description}
-categories	   sysutils
-platforms      darwin
-use_bzip2      yes
-maintainers    nomaintainer
-master_sites   http://download.berlios.de/mdf2iso http://download2.berlios.de/mdf2iso
-checksums      md5 a190625318476a196930ac66acd8fd07
-distname       ${name}-${version}-src
-worksrcdir     ${name}
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+
+name                    mdf2iso
+version                 0.3.0
+homepage                http://mdf2iso.berlios.de/
+description             Tool to convert mdf (Alcohol 120% images) to iso images.
+long_description        ${description}
+categories              sysutils
+platforms               darwin
+use_bzip2               yes
+maintainers             nomaintainer
+master_sites            http://download.berlios.de/mdf2iso http://download2.berlios.de/mdf2iso
+checksums               md5 a190625318476a196930ac66acd8fd07
+distname                ${name}-${version}-src
+worksrcdir              ${name}

--- a/sysutils/mdf2iso/Portfile
+++ b/sysutils/mdf2iso/Portfile
@@ -3,15 +3,23 @@
 PortSystem              1.0
 
 name                    mdf2iso
-version                 0.3.0
-homepage                http://mdf2iso.berlios.de/
-description             Tool to convert mdf (Alcohol 120% images) to iso images.
-long_description        ${description}
+version                 0.3.1
+revision                0
 categories              sysutils
-platforms               darwin
-use_bzip2               yes
+license                 GPL-2+
 maintainers             nomaintainer
-master_sites            http://download.berlios.de/mdf2iso http://download2.berlios.de/mdf2iso
-checksums               md5 a190625318476a196930ac66acd8fd07
-distname                ${name}-${version}-src
-worksrcdir              ${name}
+
+description             Convert MDF (Alcohol 120% images) to ISO images
+long_description        ${description}.
+
+homepage                https://packages.debian.org/sid/mdf2iso
+master_sites            debian:m/${name}
+distname                ${name}_${version}.orig
+worksrcdir              ${name}-${version}
+
+checksums               rmd160  d07bf6d072486382c71dc06ab04d529f769db180 \
+                        sha256  906f0583cb3d36c4d862da23837eebaaaa74033c6b0b6961f2475b946a71feb7 \
+                        size    193860
+
+patch.pre_args-replace  -p0 -p1
+patchfiles              implicit.patch

--- a/sysutils/mdf2iso/files/implicit.patch
+++ b/sysutils/mdf2iso/files/implicit.patch
@@ -1,0 +1,18 @@
+Fix implicit declarations
+
+error: call to undeclared library function 'exit' with type
+'void (int) __attribute__((noreturn))' [-Wimplicit-function-declaration]
+
+See: https://trac.macports.org/wiki/WimplicitFunctionDeclaration
+
+diff -urN a/configure b/configure
+--- a/configure	2015-02-23 05:47:52.000000000 -0500
++++ b/configure	2025-08-26 21:31:22.000000000 -0400
+@@ -3218,6 +3218,7 @@
+ cat confdefs.h >>conftest.$ac_ext
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ #include <ctype.h>
+ #if ((' ' & 0x0FF) == 0x020)
+ # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')


### PR DESCRIPTION
#### Description

Update mdf2iso to 0.3.1 and fix implicit declarations when configuring

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.7 23H124 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
