### PR TITLE
giza: Fix path for fortran mod file

### DIFF
--- a/science/giza/Portfile
+++ b/science/giza/Portfile
@@ -5,7 +5,7 @@ PortGroup compilers 1.0
 PortGroup github    1.0
 
 github.setup        danieljprice giza 1.5.0 v
-revision            0
+revision            1
 categories          science graphics fortran
 maintainers         {monash.edu:daniel.price @danieljprice}
 description         C/Fortran graphics library, PGPLOT replacement
@@ -26,7 +26,15 @@ extract.rename      yes
 
 conflicts           pgplot
 
-depends_build       port:pkgconfig
+# Sane location for giza.mod (fortran module file).
+# https://trac.macports.org/ticket/57103
+patchfiles          patch.src_Makefile_am.diff
+use_autoreconf      yes
+
+depends_build       port:autoconf \
+                    port:automake \
+                    port:libtool \
+                    port:pkgconfig
 
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:xorg-libX11
@@ -44,4 +52,9 @@ post-destroot {
     system "install_name_tool -id ${prefix}/lib/libcpgplot.dylib ${destroot}${prefix}/lib/libcpgplot.dylib"
     system "install_name_tool -id ${prefix}/lib/libpgplot.dylib ${destroot}${prefix}/lib/libpgplot.dylib"
     system "install_name_tool -id ${prefix}/lib/libgiza.dylib ${destroot}${prefix}/lib/libgiza.dylib"
+}
+
+notes-append {
+The fortran mod file for giza was moved to a standard install location,\
+${prefix}/include/giza.mod.
 }

--- a/science/giza/files/patch.src_Makefile_am.diff
+++ b/science/giza/files/patch.src_Makefile_am.diff
@@ -1,0 +1,12 @@
+# Use normal path for fortran mod file, giza.mod.
+# https://trac.macports.org/ticket/57103
+--- src/Makefile.am.orig	2025-04-03 23:49:59
++++ src/Makefile.am	2025-08-26 22:02:26
+@@ -7,7 +7,7 @@
+ # only compile libpglot.a and giza.mod if we have a working Fortran compiler
+ if HAVE_FC
+ lib_LTLIBRARIES += libpgplot.la
+-fmoddir = $(libdir)/$(FC)/modules
++fmoddir = $(includedir)
+ fmod_DATA = giza.mod
+ endif


### PR DESCRIPTION
#### Description

* Use normal include path for fortran mod file, giza.mod.
* Original path was accidentally littered with extra MacPorts install components.
* Closes: https://trac.macports.org/ticket/57103

###### Type(s)

- [x] enhancement

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?