### PR TITLE
doxygen-devel: add clangparser variant

### DIFF
--- a/textproc/doxygen-devel/Portfile
+++ b/textproc/doxygen-devel/Portfile
@@ -194,6 +194,20 @@ variant qt5 conflicts qt4 description {Include the GUI wizard based on Qt5} {
                         -Dforce_qt=Qt5
 }
 
+# LLVM/Clang version to use for the clangparser variant.
+set llvm_version 20
+
+variant clangparser description {Use libclang for CLANG_ASSISTED_PARSING} {
+    depends_lib-append port:clang-${llvm_version}
+    # Tell doxygen to use libclang.
+    # Tell its cmake where to find clang and llvm.
+    # Tell cmake to embed the rpath for libclang.
+    configure.args-append \
+        -Duse_libclang=ON \
+        -DCMAKE_PREFIX_PATH=${prefix}/libexec/llvm-${llvm_version} \
+        -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
+}
+
 livecheck.type          regex
 livecheck.name          ${my_name}
 livecheck.url           ${homepage}/download.html


### PR DESCRIPTION
#### Description

Add a `+clangparser` variant to doxygen-devel. This allows the use of `CLANG_ASSISTED_PARSING` in doxygen.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
I was unable to install with trace mode enabled (`-t`). Build processes were killed when I tried.