### PR TITLE
janet: fix legacy OS X builds for 1.39.0

### DIFF
--- a/lang/janet/Portfile
+++ b/lang/janet/Portfile
@@ -2,11 +2,12 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 github.setup        janet-lang janet 1.39.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          lang
 license             MIT


### PR DESCRIPTION
#### Description

#29182 removed the `legacysupport` port group, as it was thought to no longer be necessary. This was, in fact, incorrect. Builds for legacy OS X systems are [currently broken](https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/245900). This PR fixes legacy OS X builds by re-adding the `legacysupport` port group (which seems to still be needed).

I apologize for breaking the builds 😞. What the recommended way to test port changes to legacy OS X versions, as I do not have access to these older systems?

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 / Command Line Tools 16.4.0.0.1.1747106510

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? **Not possible due to https://trac.macports.org/ticket/66358**, but `sudo port -vs install` works.
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?