### PR TITLE
google-cloud-sdk: update to 536.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             536.0.0
+version             536.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1bead1140ac4f9b9d3472432c8b663cab4eafd41 \
-                    sha256  b86eccfc87180a77904545b7dcbfb1e2cfbbb1d0b01687d6368d405df35a6870 \
-                    size    55152981
+    checksums       rmd160  3be8ee8c287e235f255acbc3e5d42629af624335 \
+                    sha256  115412089190ee2e092973055294a2d35829aec460a1f99cfe9035085f5a9773 \
+                    size    55153154
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  03eacc4ecb84b2722665c87297628859251df76e \
-                    sha256  77d3dc1a104580345a8493418e9ee2335cfe465d30524ef4912f0787d8a0836f \
-                    size    56688336
+    checksums       rmd160  9f3ced9b23e45ade7dfee856cb5995506827d37b \
+                    sha256  03330e3f66ccc61b3031ff066d861fca5e46df27d1f3a52edcd9eb07a0141b53 \
+                    size    56688498
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  59820d0d2880a8dfdf947a68dcda91819499fc5d \
-                    sha256  c4667be2b763dd614dedced3cf883743198ce9053a1764d6209c124fe9d8b261 \
-                    size    56622619
+    checksums       rmd160  9ebacb26dfd2c9c9f41c8caa5d47fddd8c3c4e6b \
+                    sha256  a0690f950ab0036613760bc1bf86a90213236e63e7b22d073998d606418de58e \
+                    size    56622833
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -171,7 +171,7 @@ destroot {
 
 notes "
     google-cloud-sdk zsh completions aren't loaded automatically.
-    You must source them manually in your .zshrc:
+    You must source them manually in your ~/.zshrc:
         source '${prefix}/libexec/google-cloud-sdk/completion.zsh.inc'"
 
 livecheck.url       https://cloud.google.com/sdk/docs/install-sdk


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 536.0.1.

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?