### PR TITLE
openjdk25-zulu: update to 25.0.47

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.45
-set build    33
+version      ${feature}.0.47
+set build    34
 revision     0
 
 set openjdk_version ${feature}.0.0
@@ -32,19 +32,16 @@ long_description {*}${description} \
 
 master_sites https://cdn.azul.com/zulu/bin/
 
-# No .tar.gz (yet?) for arm64
-use_zip yes
-
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_x64
-    checksums    rmd160  185eb5144336949ced5be9cc2aad8acff8d53372 \
-                 sha256  abbabc6271f6d867f7f7bdfc5d7d7e79e511b8e3a226ea14ea897c929e3712b5 \
-                 size    229986097
+    checksums    rmd160  27e98d939528ee34a800d92853917a5a48b47319 \
+                 sha256  ea0675044ccc7bdeaa2251af44181055126caebd6dc57722c0b93de763d1604b \
+                 size    226486201
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_aarch64
-    checksums    rmd160  fd1eaaaba21961500f679a53c07a545601a3e2e3 \
-                 sha256  d4fe968859b2e5b733327648681dfa2cfe6182533f6c7b117dcc85d8a2642d79 \
-                 size    227463392
+    checksums    rmd160  52f97d2b3eb23865def7710d074445a356a9c692 \
+                 sha256  ed78d97ceb1ae7474f1c5117bb80dfaf6afa33561a094ddf7cd47736c7291279 \
+                 size    223966926
 }
 
 worksrcdir   ${distname}/zulu-${feature}.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.0.47.

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?