### PR TITLE
Remove ctreleaven as maintainer

### DIFF
--- a/devel/geany-plugins/Portfile
+++ b/devel/geany-plugins/Portfile
@@ -11,7 +11,7 @@ checksums           rmd160  314438f4c18ad7b9cf58b045e1245c616bf98af8 \
 
 license             GPL-2+
 categories          devel
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         plugins to extend the geany IDE
 

--- a/devel/libupnp/Portfile
+++ b/devel/libupnp/Portfile
@@ -16,7 +16,7 @@ checksums           sha1    ca4b9826c4f122898c2d39f4ec95d608c4d29a0a \
 
 categories          devel
 platforms           darwin
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         portable open source UPnP development kit
 long_description \

--- a/devel/mediainfolib/Portfile
+++ b/devel/mediainfolib/Portfile
@@ -15,7 +15,7 @@ description         Supplies technical and tag information about a video or audi
 long_description    {*}${description}
 homepage            https://mediaarea.net
 categories          devel multimedia
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 license             BSD
 
 # make pkg-config act like on Linux, no '-I/opt/local/include' in cflags

--- a/devel/zenlib/Portfile
+++ b/devel/zenlib/Portfile
@@ -16,7 +16,7 @@ description         Shared library for mediainfolib and mediainfo
 long_description    {*}${description}
 homepage            https://mediaarea.net
 categories          devel
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 license             BSD
 
 depends_build-append port:pkgconfig

--- a/gnome/grisbi/Portfile
+++ b/gnome/grisbi/Portfile
@@ -13,7 +13,7 @@ checksums           rmd160  4eca5dff3eecbe048bc679a4bc647962568ce6c7 \
                     size    12877828
 categories          gnome finance
 license             GPL-2+
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 installs_libs       no
 
 description         easy Personnal Finance Manager

--- a/graphics/guetzli/Portfile
+++ b/graphics/guetzli/Portfile
@@ -18,7 +18,7 @@ long_description    Guetzli is a {*}${description}.  Guetzli-generated images ar
 categories          graphics
 #supported_archs     x86_64 ??
 license             Apache-2
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 depends_build       port:pkgconfig
 

--- a/lang/4th/Portfile
+++ b/lang/4th/Portfile
@@ -4,7 +4,7 @@ name                4th
 version             3.64.1
 categories          lang
 platforms           darwin
-maintainers         {ctreleaven @ctreleaven}
+maintainers         nomaintainer
 license             LGPL-3
 description         very small Forth compiler
 long_description    4tH is a very small Forth compiler that can create \

--- a/lang/gforth/Portfile
+++ b/lang/gforth/Portfile
@@ -5,7 +5,7 @@ version             0.7.3
 revision            3
 categories          lang
 license             GPL-3+
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         fast and portable implementation of the ANS Forth language
 long_description \

--- a/multimedia/dav1d/Portfile
+++ b/multimedia/dav1d/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  994a0255e3349d67fbb9ad26969764736218c559 \
 
 categories          multimedia
 license             BSD
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         small and fast AV1 decoder
 long_description    dav1d is an AV1 decoder that is open-source, cross-platform and \

--- a/multimedia/hdhomerun_gui/Portfile
+++ b/multimedia/hdhomerun_gui/Portfile
@@ -10,7 +10,7 @@ revision            1
 categories          multimedia
 platforms           darwin
 license             GPL-3
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 description         HDHomeRun configuration utility, GTK GUI
 long_description    Provides a utility program to access, configure and test \
                     HDHomeRun network tuner devices from SiliconDust including viewing \

--- a/multimedia/libcec/Portfile
+++ b/multimedia/libcec/Portfile
@@ -13,7 +13,7 @@ checksums           rmd160  cc0ddc71fb0fda221096e99752b96414018dd6dd \
 
 categories          multimedia
 license             {GPL-2+ OpenSSLException}
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 description         USB CEC Adapter communication Library
 long_description    libCEC, in combination with the right hardware, permits control of \
                     other devices with the TV remote control via existing HDMI cabling

--- a/multimedia/libopenshot-audio/Portfile
+++ b/multimedia/libopenshot-audio/Portfile
@@ -16,7 +16,7 @@ license             GPL-3+
 # no links or usage of openssl
 license_noconflict  openssl
 platforms           darwin
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         Library for creating and editing videos
 long_description    ${description}

--- a/multimedia/libopenshot/Portfile
+++ b/multimedia/libopenshot/Portfile
@@ -17,7 +17,7 @@ license             GPL-3+
 # qt-qtmultimedia, qt-svg, qt-qtwebkit all have OpenSSLException
 # does not link with or use anything else that depends on openssl
 license_noconflict  openssl openssl10 libpaper
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         Library for creating and editing videos
 long_description    {*}${description}. Includes python bindings but not ruby.

--- a/multimedia/mediainfo/Portfile
+++ b/multimedia/mediainfo/Portfile
@@ -12,7 +12,7 @@ checksums           rmd160  ad4f855ad81f2ee2bf9b3f383c80730d0acf9de3 \
 
 name                mediainfo
 categories          multimedia
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 license             BSD
 
 description         Identifies audio and video codecs in a media file. CLI

--- a/multimedia/mythtv-pkg.27/Portfile
+++ b/multimedia/mythtv-pkg.27/Portfile
@@ -9,7 +9,7 @@ categories          multimedia
 platforms           darwin
 supported_archs     x86_64
 license             GPL-2
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         personal video recorder (PVR) and media centre system package
 

--- a/multimedia/mythtv.27/Portfile
+++ b/multimedia/mythtv.27/Portfile
@@ -25,7 +25,7 @@ categories          multimedia
 # i386 unsupported -- https://trac.macports.org/ticket/40337
 supported_archs     x86_64
 license             GPL-2
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 homepage            https://www.mythtv.org/
 universal_variant   no

--- a/multimedia/mythtv.28/Portfile
+++ b/multimedia/mythtv.28/Portfile
@@ -26,7 +26,7 @@ categories          multimedia
 # i386 unsupported -- https://trac.macports.org/ticket/40337
 supported_archs     x86_64
 license             GPL-2
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 homepage            https://www.mythtv.org/
 universal_variant   no
 

--- a/multimedia/mythweb.27/Portfile
+++ b/multimedia/mythweb.27/Portfile
@@ -17,7 +17,7 @@ revision            1
 categories          multimedia www
 platforms           any
 license             GPL-2 LGPL-2.1
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 supported_archs     noarch
 conflicts           mythweb.25 mythweb.26
 

--- a/multimedia/mythweb.28/Portfile
+++ b/multimedia/mythweb.28/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  87d3dca327aa5ece6cb546bc94a0433e8ecb3de4 \
 categories          multimedia www
 platforms           any
 license             GPL-2 LGPL-2.1
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 supported_archs     noarch
 conflicts           mythweb.25 mythweb.26 mythweb.27
 

--- a/multimedia/openshot-qt/Portfile
+++ b/multimedia/openshot-qt/Portfile
@@ -14,7 +14,7 @@ checksums           rmd160  01ae2064be7e56f5c11dc155c4f8aa3035250172 \
 homepage            https://www.openshot.org/
 categories          multimedia
 license             GPL-3+
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         simple and powerful video editor
 long_description    Award-winning free and open-source video editor dedicated to \

--- a/multimedia/p8-platform/Portfile
+++ b/multimedia/p8-platform/Portfile
@@ -10,7 +10,7 @@ github.tarball_from tarball
 name                p8-platform
 categories          multimedia
 license             GPL-2+
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 description         Pulse-Eight platform library
 long_description    Platform support library used by libCEC and binary add-ons for Kodi
 homepage            https://www.pulse-eight.com/

--- a/multimedia/xmltv/Portfile
+++ b/multimedia/xmltv/Portfile
@@ -28,7 +28,7 @@ long_description        {*}${description}
 
 master_sites            {*}${github.master_sites}
 license                 GPL-2
-maintainers             {ctreleaven @ctreleaven} openmaintainer
+maintainers             nomaintainer
 
 homepage                http://www.xmltv.org/
 platforms               {darwin any}

--- a/net/hdhomerun/Portfile
+++ b/net/hdhomerun/Portfile
@@ -9,7 +9,7 @@ categories          net multimedia
 platforms           darwin
 supported_archs     x86_64 arm64
 license             LGPL-3+
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 description         HDHomeRun device configuration utility
 homepage            https://www.silicondust.com/
 

--- a/python/py-mysqlclient/Portfile
+++ b/python/py-mysqlclient/Portfile
@@ -16,7 +16,7 @@ name                py-mysqlclient
 categories-append   devel databases
 platforms           {darwin any}
 license             GPL-2
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         Python3 interface to MySQL/MariaDB, fork of MySQL-python
 long_description    {*}${description}

--- a/security/libpreludedb/Portfile
+++ b/security/libpreludedb/Portfile
@@ -7,7 +7,7 @@ version             5.2.0
 revision            1
 categories          security
 license             GPL-2+
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 platforms           darwin
 
 description         library for easy access to the Prelude database

--- a/security/prelude-lml/Portfile
+++ b/security/prelude-lml/Portfile
@@ -7,7 +7,7 @@ version             5.2.0
 revision            6
 categories          security
 license             GPL-2+
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         Prelude Sensor for analyzing logs and collecting Syslog events
 

--- a/security/prelude-manager/Portfile
+++ b/security/prelude-manager/Portfile
@@ -7,7 +7,7 @@ version             5.2.0
 revision            1
 categories          security
 license             GPL-2+
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         collects and normalize security events from Prelude sensors
 

--- a/sysutils/MacPorts_daemondo/Portfile
+++ b/sysutils/MacPorts_daemondo/Portfile
@@ -9,7 +9,7 @@ categories          sysutils
 platforms           darwin
 supported_archs     x86_64
 license             BSD
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         HACK to get daemondo into mpkg
 long_description    Nasty ${description}. \

--- a/sysutils/libirman/Portfile
+++ b/sysutils/libirman/Portfile
@@ -5,7 +5,7 @@ version             0.5.2
 
 categories          sysutils
 license             GPL-2+
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 platforms           darwin
 description         interface with Irman-compatible IR receivers
 long_description    Libirman enables interfacing with Irman-compatible infra-red receivers \

--- a/sysutils/lirc/Portfile
+++ b/sysutils/lirc/Portfile
@@ -7,7 +7,7 @@ version             0.10.2
 revision            0
 categories          sysutils net
 license             {GPL-2+ OpenSSLException}
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 description         Linux Infrared Remote Control
 long_description \
     LIRC enables receiving and/or sending infra-red remote controls signals.\

--- a/sysutils/logrotate/Portfile
+++ b/sysutils/logrotate/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  9e1edb08441ae239a8471f81b8d589772e3d5243 \
 
 categories          sysutils
 license             GPL-2
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 
 description         Rotates, compresses, and mails system logs
 

--- a/x11/liberation-fonts/Portfile
+++ b/x11/liberation-fonts/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  1b63abd6acc8dc50e9d5264809196d9ba5180b18 \
 categories          x11 fonts
 platforms           any
 supported_archs     noarch
-maintainers         {ctreleaven @ctreleaven} openmaintainer
+maintainers         nomaintainer
 # See homepage re license -
 license             SIL
 installs_libs       no


### PR DESCRIPTION
#### Description

Remove `ctreleaven` as maintainer per [this request](https://lists.macports.org/pipermail/macports-dev/2025-August/046413.html).