### PR TITLE
mythtv*: mark as unsupported

### DIFF
--- a/multimedia/mythtv-pkg.27/Portfile
+++ b/multimedia/mythtv-pkg.27/Portfile
@@ -1,6 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           deprecated 1.0
+
+deprecated.macports_support no
 
 name                mythtv-pkg.27
 version             Fixes-0.27.4

--- a/multimedia/mythtv.27/Portfile
+++ b/multimedia/mythtv.27/Portfile
@@ -3,6 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qt4 1.0
+PortGroup           deprecated 1.0
+
+deprecated.macports_support no
 
 set shorthash       3c7582e9
 # set fullhash      3c7582e973dbf8174283898ebfcf190acbfb61f9

--- a/multimedia/mythtv.28/Portfile
+++ b/multimedia/mythtv.28/Portfile
@@ -6,6 +6,9 @@ PortGroup           perl5 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
 PortGroup           conflicts_build 1.0
+PortGroup           deprecated 1.0
+
+deprecated.macports_support no
 
 set shorthash       8238e839
 # set fullhash      8238e839c90de35f7c64380d2c4e360192862a34


### PR DESCRIPTION
#### Description

Mark `mythtv*` ports as unsupported per [this thread](https://lists.macports.org/pipermail/macports-dev/2025-August/046413.html).