### PR TITLE
aerc: update to 0.21.0

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile    1.0
 PortGroup           sourcehut   1.0
 
-sourcehut.setup     rjarry aerc 0.20.1
+sourcehut.setup     rjarry aerc 0.21.0
 revision            0
 
 homepage            https://aerc-mail.org
@@ -22,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  f41a3bbe8372bb037b31cca521fa82c532876c44 \
-                    sha256  fbfbf2cc4f6e251731698d6d1b7be4e88835b4e089d55e3254d37d450700db07 \
-                    size    474975
+checksums           rmd160  270e1cdb69c82e7ae3ed73e4f7df9c3386f33444 \
+                    sha256  3f1469bbaea982fc58352f2682932ecc2fb50c705994d96b2343e771747745a7 \
+                    size    614327
 
 depends_build-append \
                     port:go \


### PR DESCRIPTION
#### Description
[Changelog](https://git.sr.ht/~rjarry/aerc/refs/0.21.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
