### PR TITLE
lagrange: update to 1.18.8

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           gitea 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.18.7 v
+gitea.setup         gemini lagrange 1.18.8 v
 revision            0
 categories          net gemini
 license             BSD
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  deeb3551942e7c09e2f2b2f3baac0008bdd15fb5 \
-                    sha256  6dfc6a1d25c5c62a5ab64d7560dd590339654a7ada882d19a9eced6e870a5b04 \
-                    size    8894632
+checksums           rmd160  80b949de8726779fac89d87ba3ed5380f787447e \
+                    sha256  88d946b5a0f2ebba915d77ca732798bc0796377dd9a7d4aa954ec4b7aa17979d \
+                    size    8897514
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://github.com/skyjake/lagrange/releases/tag/v1.18.8

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
