### PR TITLE
cdo: remove blacklisting and fix bug

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -6,7 +6,7 @@ PortGroup                   legacysupport 1.0
 
 name                        cdo
 version                     2.5.3
-revision                    1
+revision                    2
 maintainers                 {takeshi @tenomoto} \
                             {me.com:remko.scharroo @remkos} \
                             openmaintainer
@@ -14,11 +14,14 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/30034
+master_sites                https://code.mpimet.mpg.de/attachments/download/30045
 
-checksums           rmd160  ee1d5a3d3b38cd538330f2957baa8fec36ef5458 \
-                    sha256  0145cdba866a02b3e9b269e2ff7728ce61e21761332888041f05dc033676fa08 \
-                    size    14007141
+# Temporarily added because of stealth update of v2.5.3
+dist_subdir                 ${name}/${version}_1
+
+checksums           rmd160  149cf2014684bc75f834265d6d05a79e3c66024c \
+                    sha256  470fee8f4d2b4eddf9ec82d0adccf1f6b4821ddf34b33bfe6b7069b6b6457b40 \
+                    size    13973520
 
 long_description \
     CDO is a collection of command line Operators               \
@@ -28,12 +31,9 @@ long_description \
 
 fetch.ignore_sslcert        yes
 
-# Since cdo 2.4.0, we need to select C++20 capable compilers.
-# On MacOS-13 compilation with /usr/bin/clang++ fails, so we blacklist it.
-# https://github.com/macports/macports-ports/pull/24069
-
+# Since version 2.4.0, cdo requires C++20 capable compilers.
+# https://code.mpimet.mpg.de/news/536
 compiler.cxx_standard       2020
-compiler.blacklist-append   clang
 
 compiler.thread_local_storage yes
 compilers.choose            cc cxx
@@ -47,7 +47,8 @@ depends_lib                 port:netcdf \
                             port:proj9 \
                             port:fftw-3
 
-patchfiles                  patch-cdo-mach-task-10.8.diff
+patchfiles                  patch-cdo-mach-task-10.8.diff \
+                            patch-cdo-missing-strings-h.diff
 
 configure.args              --with-netcdf=${prefix} \
                             --disable-dependency-tracking \

--- a/science/cdo/files/patch-cdo-missing-strings-h.diff
+++ b/science/cdo/files/patch-cdo-missing-strings-h.diff
@@ -1,0 +1,33 @@
+--- libcdi/src/cdilib.c.orig	2025-08-10 15:04:59
++++ libcdi/src/cdilib.c	2025-08-28 11:11:59
+@@ -39726,7 +39726,7 @@
+ #ifdef _WIN32
+ #define strcasecmp _stricmp
+ #else
+-#include <unistd.h>
++#include <strings.h>
+ #endif
+ 
+ enum VarStatus
+--- libcdi/src/stream_cdf_i.c.orig	2025-08-10 14:41:01
++++ libcdi/src/stream_cdf_i.c	2025-08-28 11:13:25
+@@ -23,7 +23,7 @@
+ #ifdef _WIN32
+ #define strcasecmp _stricmp
+ #else
+-#include <unistd.h>
++#include <strings.h>
+ #endif
+ 
+ enum VarStatus
+--- src/lib/healpix//bl.h.orig	2022-10-14 08:27:42
++++ src/lib/healpix//bl.h	2025-08-28 11:12:38
+@@ -18,6 +18,8 @@
+ 
+ #ifdef _MSC_VER
+ #define strcasecmp _stricmp
++#else
++#include <strings.h>
+ #endif
+ 
+ #ifdef _MSC_VER


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/72890
Fixes https://trac.macports.org/ticket/72909

#### Description

This attempts to fix:
* https://trac.macports.org/ticket/72890 by reducing the scope of the clang blacklisting, eventually removing it in its entirety.
* https://trac.macports.org/ticket/72909 by fixing a bug in the latest cdo source code

In addition an upstream stealth update to v2.5.3 is now used.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.6.1 24G90 x86_64
Command Line Tools 16.4.0.0.1.1747106510


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
