### PR TITLE
jsoncons: update to 1.4.0

### DIFF
--- a/devel/jsoncons/Portfile
+++ b/devel/jsoncons/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            danielaparker jsoncons 1.3.2 v
+github.setup            danielaparker jsoncons 1.4.0 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -15,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             A C++, header-only library for constructing JSON and JSON-like data formats
 long_description        {*}${description}
 
-checksums               rmd160  3ea3cda1fecf0d123d46d50b6313b7c3cb2c103b \
-                        sha256  f22fb163df1a12c2f9ee5f95cad9fc37c6cfbefe0ae6f30aba7440832ef70fbe \
-                        size    1504068
+checksums               rmd160  61bc4280cfdbc2d3aedfe917842e048f11528502 \
+                        sha256  e21c50e0be2130f92d8ac0b91d87a2a5e95487e12c19c7cad30667b585e545e2 \
+                        size    1537117
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description
https://github.com/danielaparker/jsoncons/releases/tag/v1.4.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
