### PR TITLE
splash: Update to 3.11.4

### DIFF
--- a/science/splash/Portfile
+++ b/science/splash/Portfile
@@ -2,26 +2,27 @@
 
 PortSystem          1.0
 PortGroup compilers 1.0
+PortGroup github    1.0
 
-name                splash
-version             2.9.1
-revision            2
+github.setup        danieljprice splash 3.11.4 v
+github.tarball_from releases
+distname            ${name}-v${version}
+revision            0
+
+checksums           rmd160  a4046c22b669aedfd7b17047cf5702a34cd4e0be \
+                    sha256  1399562bba20434310f0916d2de496b020697958fa4e1de2d2616815054d1e66 \
+                    size    2612764
+
 categories          science graphics
-platforms           darwin
-maintainers         {monash.edu:daniel.price @danieljprice}
+maintainers         {monash.edu:daniel.price @danieljprice} openmaintainer
 description         Smoothed Particle Hydrodynamics visualisation tool
 long_description    SPLASH is a tool for visualisation of (mainly astrophysical) \
                     Smoothed Particle Hydrodynamics simulations
 
 homepage            http://users.monash.edu.au/~dprice/splash
-master_sites        ${homepage}/releases/
 license             GPL-2+
 
 worksrcdir          ${name}
-
-checksums           rmd160  86e3585d601d5a65e2b0b81a14a3f212414eb12f \
-                    sha256  212bbe16c56d1a009acbd263689ef6a30052d5bb4878aad345d97927fbdd1996 \
-                    size    2186770
 
 if {![variant_isset pgplot]} {
     default_variants    +giza


### PR DESCRIPTION
#### Description

* Update splash 2.9.1 --> 3.11.4.
* Fix broken builds.
* Add openmaintainer.

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?