### PR TITLE
xfig: remove obsolete legacysupport

### DIFF
--- a/graphics/xfig/Portfile
+++ b/graphics/xfig/Portfile
@@ -1,10 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.1
-
-# strndup
-legacysupport.newest_darwin_requires_legacy 10
 
 name                xfig
 version             3.2.9a


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/72007

#### Description

As pointed out in https://trac.macports.org/ticket/72007, `legacysupport` is no longer needed.
No need to bump the revision, as nothing will change in the binaries.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.6.1 24G90 x86_64
Command Line Tools 16.4.0.0.1.1747106510


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
