### PR TITLE
tenv: update to 4.7.21

### DIFF
--- a/sysutils/tenv/Portfile
+++ b/sysutils/tenv/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/tofuutils/tenv 4.7.7 v
+go.setup            github.com/tofuutils/tenv 4.7.21 v
 go.offline_build    no
 revision            0
 
@@ -22,9 +22,9 @@ license             Apache-2
 maintainers         {icloud.com:github.ssk @suhailskhan} \
                     openmaintainer
 
-checksums           rmd160  c08b97af89f64389515a4a238b91d0fa8569edb9 \
-                    sha256  7415f7f163b9782ee460dbc37f08993aa9935e7ee4fc34143dc51ef4dac3f2a4 \
-                    size    814370
+checksums           rmd160  84e67829d1fab8c618802163e65fb94194bfef99 \
+                    sha256  e320d79495cc15f22386f7b305bb4915fbb5d349e8b6d5713ca1750266cb1275 \
+                    size    813965
 
 build.env-append    CGO_ENABLED=0
 build.args-append   -o ${worksrcpath}/build/ \


### PR DESCRIPTION
#### Description

Created with [seaport](https://seaport.rtfd.io/), the modern MacPorts portfile updater.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.6.1 24G90
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?