### PR TITLE
regclient: update to 0.9.2

### DIFF
--- a/net/regclient/Portfile
+++ b/net/regclient/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/regclient/regclient 0.9.0 v
+go.setup            github.com/regclient/regclient 0.9.2 v
 go.offline_build    no
 revision            0
 
@@ -17,9 +17,9 @@ license             Apache-2
 maintainers         {icloud.com:github.ssk @suhailskhan} \
                     openmaintainer
 
-checksums           rmd160  3a19966ddc1ef12e79941e895e1784f8dbe05b39 \
-                    sha256  3bd9e7ad3e3b99d9d11303597a1ce36f7c96d3c84562af47fa6ff552ed869b71 \
-                    size    374654
+checksums           rmd160  67817fe10fdb0582e829cc0496ff46eb48d23643 \
+                    sha256  ce53e082dd289c5f5b4cf0972bc8ff41d02b48114a010784f0f3261cc1c721ad \
+                    size    375178
 
 pre-build {
     xinstall -d ${worksrcpath}/build/f


### PR DESCRIPTION
#### Description

Created with [seaport](https://seaport.rtfd.io/), the modern MacPorts portfile updater.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.6.1 24G90
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?