### PR TITLE
mise: Update to 2025.8.21

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.8.20 v
+github.setup        jdx mise 2025.8.21 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  82d847bf93fb3393f4bf1ee751ae121a80e5ffc8 \
-                    sha256  f92d22face0128612fe27039f80beae0cd30335240cb7be1aff22b429048f485 \
-                    size    5146355
+                    rmd160  95323a99d870b86bda71611605e0c86dcdc6be42 \
+                    sha256  07275ce0441c834c1bc50a2ac00ccd7b26b02579a4787f4009282834cef21599 \
+                    size    5151581
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -84,7 +84,6 @@ notes {
   internal data structures change. Restarting the terminal session
   will resolve those issues.
 }
-
 
 cargo.crates \
     addr2line                       0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
@@ -708,7 +707,7 @@ cargo.crates \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     versions                         6.3.2  f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139 \
     versions                         7.0.0  80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f \
-    vfox                         2025.8.20  fc2f5ab8907eb4f5b2fb51df197b91b59d6975ad07553bbac127c2dfd5be55a1 \
+    vfox                         2025.8.21  ac7b8bab10dd95b0e6294b3f0015f6d6b3b5a973ef0f9c825661b64f47ab8fee \
     vte                             0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \


### PR DESCRIPTION
#### Description

mise: Update to 2025.8.21


##### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
