### PR TITLE
oxker: update to 0.11.1

### DIFF
--- a/devel/oxker/Portfile
+++ b/devel/oxker/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        mrjackwills oxker 0.10.5 v
+github.setup        mrjackwills oxker 0.11.1 v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {@sikmir disroot.org:sikmir} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  e5d6ed64ebcd0ca2e0bf2fc829cd172638b6822c \
-                    sha256  d8c79a1732320d84d149b0db892f3875a6513c7c36b05b4c37d22dfebdf5dee0 \
-                    size    185501
+                    rmd160  124b8103017bcc800310c7a9802aa82868a02c50 \
+                    sha256  d86a67ea88855c9f712086233f11dbdaf6ca5bd8cf1443e68851a7bd5669e096 \
+                    size    200491
 
 destroot {
     xinstall -m 0755 \
@@ -34,29 +34,30 @@ cargo.crates \
     allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anstream                        0.6.19  301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933 \
+    anstream                        0.6.20  3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192 \
     anstyle                         1.0.11  862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd \
     anstyle-parse                    0.2.7  4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2 \
-    anstyle-query                    1.1.3  6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9 \
-    anstyle-wincon                   3.0.9  403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882 \
-    anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
-    autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
+    anstyle-query                    1.1.4  9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2 \
+    anstyle-wincon                  3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
+    anyhow                          1.0.99  b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100 \
+    atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
+    autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
     backtrace                       0.3.75  6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
-    bitflags                         2.9.1  1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967 \
-    bollard                         0.18.1  97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30 \
-    bollard-stubs                 1.47.1-rc.27.3.1  3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da \
-    bumpalo                         3.18.1  793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee \
+    bitflags                         2.9.2  6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29 \
+    bollard                         0.19.2  8796b390a5b4c86f9f2e8173a68c2791f4fa6b038b84e96dbc01c016d1e6722c \
+    bollard-stubs                 1.49.0-rc.28.3.3  2e7814991259013d5a5bee4ae28657dae0747d843cf06c40f7fc0c2894d6fa38 \
+    bumpalo                         3.19.0  46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43 \
     bytes                           1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
     cansi                            2.2.1  4bdcae87153686017415ce77e48c53e6818a0a058f0e21b56640d1e944967ef8 \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
-    castaway                         0.2.3  0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5 \
-    cc                              1.2.27  d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc \
-    cfg-if                           1.0.1  9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268 \
+    castaway                         0.2.4  dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a \
+    cc                              1.2.33  3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f \
+    cfg-if                           1.0.3  2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9 \
     chrono                          0.4.41  c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d \
-    clap                            4.5.40  40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f \
-    clap_builder                    4.5.40  e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e \
-    clap_derive                     4.5.40  d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce \
+    clap                            4.5.45  1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318 \
+    clap_builder                    4.5.44  b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8 \
+    clap_derive                     4.5.45  14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6 \
     clap_lex                         0.7.5  b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675 \
     colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
     compact_str                      0.8.1  3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32 \
@@ -76,14 +77,14 @@ cargo.crates \
     dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     document-features               0.2.11  95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d \
-    dyn-clone                       1.0.19  1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005 \
+    dyn-clone                       1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
     either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
-    errno                           0.3.12  cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18 \
+    errno                           0.3.13  778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
-    form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
+    form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
     futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
     futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
     futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
@@ -94,7 +95,7 @@ cargo.crates \
     getrandom                        0.3.3  26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4 \
     gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
-    hashbrown                       0.15.4  5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5 \
+    hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     http                             1.3.1  f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565 \
@@ -102,9 +103,9 @@ cargo.crates \
     http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    hyper                            1.6.0  cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80 \
+    hyper                            1.7.0  eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e \
     hyper-named-pipe                 0.1.0  73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278 \
-    hyper-util                      0.1.14  dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb \
+    hyper-util                      0.1.16  8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e \
     hyperlocal                       0.9.1  986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7 \
     iana-time-zone                  0.1.63  b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
@@ -116,13 +117,14 @@ cargo.crates \
     icu_properties_data              2.0.1  298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632 \
     icu_provider                     2.0.0  03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af \
     ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
-    idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
+    idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                         2.9.0  cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e \
+    indexmap                        2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
     indoc                            2.0.6  f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
     insta                           1.43.1  154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371 \
-    instability                      0.3.7  0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d \
+    instability                      0.3.9  435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a \
+    io-uring                         0.7.9  d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4 \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
@@ -132,12 +134,12 @@ cargo.crates \
     jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.174  1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776 \
-    libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
+    libc                           0.2.175  6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543 \
+    libredox                         0.1.9  391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3 \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                    0.9.4  cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
     litemap                          0.8.0  241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956 \
-    litrs                            0.4.1  b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5 \
+    litrs                            0.4.2  f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed \
     lock_api                        0.4.13  96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765 \
     log                             0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
     lru                             0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
@@ -155,7 +157,7 @@ cargo.crates \
     parking_lot                     0.12.4  70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13 \
     parking_lot_core                0.9.11  bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5 \
     paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
-    percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    percent-encoding                 2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
     pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     portable-atomic                 1.11.1  f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483 \
@@ -163,61 +165,62 @@ cargo.crates \
     potential_utf                    0.1.2  e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
-    proc-macro2                     1.0.95  02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778 \
+    proc-macro2                    1.0.101  89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de \
     quote                           1.0.40  1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
     r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
-    rand                             0.9.1  9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97 \
+    rand                             0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
     ratatui                         0.29.0  eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b \
-    redox_syscall                   0.5.13  0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6 \
-    redox_users                      0.5.0  dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b \
+    redox_syscall                   0.5.17  5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77 \
+    redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
     ref-cast                        1.0.24  4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf \
     ref-cast-impl                   1.0.24  1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7 \
-    rustc-demangle                  0.1.25  989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f \
+    rustc-demangle                  0.1.26  56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
-    rustix                           1.0.7  c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266 \
-    rustversion                     1.0.21  8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d \
+    rustix                           1.0.8  11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8 \
+    rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     schemars                         0.9.0  4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f \
+    schemars                         1.0.4  82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
     serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
-    serde_json                     1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
+    serde_json                     1.0.143  d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a \
     serde_jsonc                    1.0.108  7a58154381df481a41b7536101c0daccdaf2426f244334074c4c77b89b6253a7 \
     serde_repr                      0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
-    serde_spanned                    0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
+    serde_spanned                    1.0.0  40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_with                      3.13.0  bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42 \
+    serde_with                      3.14.0  f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                     0.3.18  d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
     signal-hook-mio                  0.2.4  34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd \
-    signal-hook-registry             1.4.5  9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410 \
+    signal-hook-registry             1.4.6  b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b \
     similar                          2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
-    slab                            0.4.10  04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d \
+    slab                            0.4.11  7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589 \
     smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
-    socket2                         0.5.10  e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678 \
+    socket2                          0.6.0  233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807 \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
     strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
-    syn                            2.0.103  e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8 \
+    syn                            2.0.106  ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
-    thiserror                       2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
-    thiserror-impl                  2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
+    thiserror                       2.0.16  3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0 \
+    thiserror-impl                  2.0.16  6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960 \
     thread_local                     1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
     time                            0.3.41  8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40 \
     time-core                        0.1.4  c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c \
     time-macros                     0.2.22  3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49 \
     tinystr                          0.8.1  5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b \
-    tokio                           1.45.1  75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779 \
+    tokio                           1.47.1  89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038 \
     tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
-    tokio-util                      0.7.15  66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df \
-    toml                            0.8.23  dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362 \
-    toml_datetime                   0.6.11  22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c \
-    toml_edit                      0.22.27  41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a \
+    tokio-util                      0.7.16  14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5 \
+    toml                             0.9.5  75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8 \
+    toml_datetime                    0.7.0  bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3 \
+    toml_parser                      1.0.2  b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10 \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-attributes              0.1.30  81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903 \
@@ -231,10 +234,10 @@ cargo.crates \
     unicode-truncate                 1.1.0  b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
-    url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \
+    url                              2.5.6  137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.17.0  3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d \
+    uuid                            1.18.0  f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be \
     valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi                          0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
@@ -253,11 +256,10 @@ cargo.crates \
     windows-link                     0.1.3  5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a \
     windows-result                   0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
     windows-strings                  0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
-    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-sys                     0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
-    windows-targets                 0.53.2  c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef \
+    windows-targets                 0.53.3  d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91 \
     windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
     windows_aarch64_gnullvm         0.53.0  86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
     windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
@@ -274,15 +276,15 @@ cargo.crates \
     windows_x86_64_gnullvm          0.53.0  0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
-    winnow                          0.7.11  74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd \
+    winnow                          0.7.12  f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95 \
     wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
     writeable                        0.6.1  ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb \
     yoke                             0.8.0  5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc \
     yoke-derive                      0.8.0  38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6 \
-    zerocopy                        0.8.25  a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb \
-    zerocopy-derive                 0.8.25  28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef \
+    zerocopy                        0.8.26  1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f \
+    zerocopy-derive                 0.8.26  9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181 \
     zerofrom                         0.1.6  50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5 \
     zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
     zerotrie                         0.2.2  36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595 \
-    zerovec                         0.11.2  4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428 \
+    zerovec                         0.11.4  e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b \
     zerovec-derive                  0.11.1  5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f


### PR DESCRIPTION
#### Description
https://github.com/mrjackwills/oxker/releases/tag/v0.11.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
