### PR TITLE
tabiew: update to 0.11.1

### DIFF
--- a/textproc/tabiew/Portfile
+++ b/textproc/tabiew/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        shshemi tabiew 0.11.0 v
+github.setup        shshemi tabiew 0.11.1 v
 github.tarball_from archive
 revision            0
 categories          textproc
@@ -15,9 +15,9 @@ long_description    {*}${description}
 license             MIT
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  cc51e7d71a0ecf0018682805e2c469f9ee1f0cff \
-                    sha256  67a123d541a95a10ba18f2e0bc2e4f14c01dae818a3d6dff9ca9faa294fccafb \
-                    size    6395314
+                    rmd160  43f1cf614c1b3f6c790b4084fb24f3430e6ca40c \
+                    sha256  da3b74987f318471aa9701a80deb69837be82df9c9308f4380abfb26df2abf79 \
+                    size    9267568
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/tw ${destroot}${prefix}/bin/
@@ -151,6 +151,7 @@ cargo.crates \
     futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
     futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
     futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
+    futures-timer                    3.0.3  f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24 \
     futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
     fuzzy-matcher                    0.3.7  54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94 \
     fwf-rs                           0.2.0  f33a10d3d9a188a3af12eaf00aca1391dc7d16adba94450f4049cd45fcf58e7b \
@@ -244,6 +245,8 @@ cargo.crates \
     object_store                    0.12.1  d94ac16b433c0ccf75326388c893d2835ab7457ea35ab8ba5d745c053ef5fa16 \
     once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
+    openssl-src                   300.4.2+3.4.1  168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2 \
+    openssl-sys                    0.9.109  90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571 \
     ordered-float                    4.6.0  7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951 \
     parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                     0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
@@ -291,6 +294,7 @@ cargo.crates \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
+    proc-macro-crate                 3.3.0  edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35 \
     proc-macro2                     1.0.95  02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778 \
     psm                             0.1.26  6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f \
     quick-xml                       0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
@@ -325,14 +329,18 @@ cargo.crates \
     regex                           1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
     regex-automata                   0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
+    relative-path                    1.9.3  ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
     reqwest                        0.12.15  d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rmp                             0.8.14  228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4 \
     rmp-serde                        1.3.0  52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db \
     roff                             0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
+    rstest                          0.23.0  0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035 \
+    rstest_macros                   0.23.0  825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a \
     rusqlite                        0.36.0  3de23c3319433716cf134eed225fe9986bc24f63bed9be9f20c329029e672dc7 \
     rustc-demangle                  0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
+    rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                           1.0.7  c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266 \
     rustls                         0.23.27  730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321 \
@@ -347,6 +355,7 @@ cargo.crates \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     security-framework               3.2.0  271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316 \
     security-framework-sys          2.14.0  49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32 \
+    semver                          1.0.26  56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0 \
     serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
     serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
     serde_json                     1.0.140  20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373 \
@@ -416,6 +425,7 @@ cargo.crates \
     tracing-core                    0.1.33  e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     tui-input                       0.12.1  dce25d24adf2c5350c57426f25cf12bc767455a6d9202be155458fc768ea1268 \
+    tui-scrollview                   0.5.1  ef6e1d736488ba64c2e74637089a6b9ca666ccd2eaade3ab83854f415f1d260b \
     typenum                         1.18.0  1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     unicode-ident                   1.0.18  5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512 \


### PR DESCRIPTION
#### Description
https://github.com/shshemi/tabiew/releases/tag/v0.11.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
