### PR TITLE
bstring: new port, version 1.0.1

### DIFF
--- a/textproc/bstring/Portfile
+++ b/textproc/bstring/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        msteinert bstring 1.0.1 v
+github.tarball_from releases
+revision            0
+
+categories          textproc devel
+license             BSD
+maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
+
+description         The Better String Library for C
+long_description    ${name} is a fork of Paul Hsieh's Better String Library. \
+                    It provides a comprehensive string library for C with \
+                    features like autotools build system, updated test suite \
+                    based on Check, Valgrind integration, and continuous \
+                    integration via GitHub Actions.
+
+homepage            https://github.com/msteinert/bstring
+
+checksums           rmd160  f967ae6d2ec3162419f8d8792fa094bd1eaa4acf \
+                    sha256  ba3d3726bf70a0920196199097bd7d341cf362eb7dbd64018a8936815817a0cc \
+                    size    488074
+
+depends_build       path:bin/pkg-config:pkgconfig
+
+use_autoreconf      yes
+
+variant tests description "Build and run tests" {
+    depends_lib-append  port:check
+    configure.args-append --enable-tests
+    test.run            yes
+    test.target         check
+}
+
+post-destroot {
+    # Install documentation
+    if {[variant_isset docs]} {
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+        xinstall -m 644 -W ${worksrcpath} README.md COPYING \
+            ${destroot}${prefix}/share/doc/${name}
+    }
+}


### PR DESCRIPTION
## New Port Submission

This PR adds a new port for bstring version 1.0.1 to the textproc category.

### Description
The Better String Library for C - a fork of Paul Hsieh's Better String Library providing comprehensive string functions for C programming with improved memory safety and performance.

### Key Features
* Comprehensive string manipulation functions
* Safer memory handling than standard C strings
* Improved performance over traditional string operations
* Enhanced API for modern C development

### Testing Performed
- [x] Port builds successfully locally
- [x] Port lint passes with 0 errors and 0 warnings
- [x] Dependencies verified
- [x] Installation tested

**Tested on**

macOS 15.6.1 Xcode 16.4 / Command Line Tools 16.4.0.0.1.1747106510 (arm64)
macOS 15.6.1 Command Line Tools 16.4.0.0.1.1747106510 (x86_64)

### Port Details
- **Category**: textproc
- **Version**: 1.0.1
- **Homepage**: https://github.com/msteinert/bstring
- **License**: BSD
- **Dependencies**: pkgconfig, autoconf, automake, libtool, check

### Maintainer
@trodemaster (openmaintainer)