### PR TITLE
libcbor: update to 0.13.0

### DIFF
--- a/devel/libcbor/Portfile
+++ b/devel/libcbor/Portfile
@@ -4,22 +4,21 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        PJK libcbor 0.11.0 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        PJK libcbor 0.13.0 v
+github.tarball_from archive
 revision            0
 
 categories          devel
-maintainers         {@trodemaster netjibbing.com:blake} \
-                    openmaintainer
+maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
+
 license             MIT
 description         library for parsing and generating CBOR
 long_description    {*}${description}, the general-purpose schema-less binary data format.
 
-checksums           rmd160  ac5fb12ca64d9b3f9c6684a3d0d9c4a1eb94c2e3 \
-                    sha256  9862c5fa2e21103dd1bdae0cc3c030c4dd997893eb85c30b318b5c0efb617ab7 \
-                    size    293549
-
+checksums           rmd160  ad9bb702516b6d055650a1e3f90335f33005e97b \
+                    sha256  95a7f0dd333fd1dce3e4f92691ca8be38227b27887599b21cd3c4f6d6a7abb10 \
+                    size    299917
+                    
 configure.args-append    -DBUILD_SHARED_LIBS=ON
 
 variant tests description {enable tests} {


### PR DESCRIPTION
## Port Update

This PR updates libcbor from version 0.11.0 to 0.13.0.

### Description
libcbor is a library for parsing and generating CBOR (Concise Binary Object Representation), the general-purpose schema-less binary data format.

### Changes Made
* Update to version 0.13.0
* Update checksums for new release
* Update maintainer email address
* Version brings improved CBOR compliance and bug fixes

### Testing Performed
- [x] Port builds successfully locally
- [x] Port lint passes with 0 errors and 0 warnings
- [x] Dependencies verified
- [x] Installation tested

**Tested on**

macOS 15.6.1 Xcode 16.4 / Command Line Tools 16.4.0.0.1.1747106510 (arm64)
macOS 15.6.1 Command Line Tools 16.4.0.0.1.1747106510 (x86_64)

### Port Details
- **Category**: devel
- **Version**: 0.13.0 (updated from 0.11.0)
- **Homepage**: https://github.com/PJK/libcbor
- **License**: MIT
- **Dependencies**: cmake

### Maintainer
@trodemaster (openmaintainer)