### PR TITLE
libfido2: update to 1.16.0

### DIFF
--- a/security/libfido2/Portfile
+++ b/security/libfido2/Portfile
@@ -9,21 +9,20 @@ PortGroup           legacysupport 1.1
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        Yubico libfido2 1.15.0
-# Change github.tarball_from to 'releases' or 'archive' next update
+github.setup        Yubico libfido2 1.16.0
 github.tarball_from tarball
 revision            0
 
 categories          security crypto
-maintainers         {@trodemaster netjibbing.com:blake} \
-                    openmaintainer
+maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
+
 license             bsd
 description         library to communicate with a FIDO device over USB
 long_description    provides library functionality and command-line tools to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.
 
-checksums           rmd160  ef6a3a7c6627c0f2c37c2b7471b247d6c31de1bb \
-                    sha256  7f0a8d48bb9f296b8579de007a80935e8b20cd0d0b8436452f87a24bdd8a3f0a \
-                    size    672574
+checksums           rmd160  4adb73f4f695393b92ab32d541f0a9980b2c2586 \
+                    sha256  c9795fff9183eaf111114e8619ff79a4aea9aeac2ddc5935616b1e32dd60e3b2 \
+                    size    682408
 
 depends_build-append \
                     port:mandoc \


### PR DESCRIPTION
## Port Update

This PR updates libfido2 from version 1.15.0 to 1.16.0.

### Description
libfido2 provides library functionality and command-line tools to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.

### Changes Made
* Update to version 1.16.0
* Update maintainer email address

### Testing Performed
- [x] Port builds successfully locally
- [x] Port lint passes with 0 errors and 0 warnings
- [x] Dependencies verified
- [x] Installation tested

**Tested on**

macOS 15.6.1 Xcode 16.4 / Command Line Tools 16.4.0.0.1.1747106510 (arm64)
macOS 15.6.1 Command Line Tools 16.4.0.0.1.1747106510 (x86_64)

### Port Details
- **Category**: security
- **Version**: 1.16.0 (updated from 1.15.0)
- **Homepage**: https://github.com/Yubico/libfido2
- **License**: BSD
- **Dependencies**: mandoc, pkgconfig, libcbor, openssl

### Maintainer
@trodemaster (openmaintainer)