### PR TITLE
nrsc5: update to 3.0.1

### DIFF
--- a/audio/nrsc5/Portfile
+++ b/audio/nrsc5/Portfile
@@ -8,25 +8,22 @@ PortGroup           legacysupport 1.1
 # _strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        theori-io nrsc5 073726340ede83c596187f89d4442ab8d5180b77
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        theori-io nrsc5 3.0.1 v
+github.tarball_from archive
 
-revision            0
-version             1.0-20240327
 categories          audio
-maintainers         {netjibbing.com:blake @trodemaster} \
-                    openmaintainer
+maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
+
 license             GPL-3+
 
 description         This program receives NRSC-5 digital radio stations using an RTL-SDR dongle
 long_description    {*}${description}. It offers a command-line interface \
                     as well as an API upon which other applications can be built.
 
-checksums           rmd160  75f0e0458de45d23ab8e010505ae967c3c0f455d \
-                    sha256  a325d36638aed27e211235d98bf7675bb3d63c6df67ce14cab524bb86fe947fa \
-                    size    23170595
-
+checksums           rmd160  c34f475365429c50ce33e9f8c90f231c077fe27e \
+                    sha256  6c7608a5da2e26b8940ca55423e9fa45c61ca9f6fe816b6dd298029ff419a91e \
+                    size    23182772
+                                        
 patchfiles          CMakeLists.txt.diff
 
 # cc1: error: unrecognized command line option "-std=gnu11"
@@ -48,5 +45,4 @@ depends_build-append \
 
 depends_lib-append  port:rtl-sdr \
                     port:libao \
-                    port:fftw-3-single \
-                    port:faad2
+                    port:fftw-3-single


### PR DESCRIPTION
## Port Update

This PR updates nrsc5 from commit-based version 1.0-20240327 to proper release 3.0.1.

### Description
nrsc5 is a program that receives NRSC-5 digital radio stations using an RTL-SDR dongle. It offers a command-line interface as well as an API upon which other applications can be built.

### Changes Made
* Update to version 3.0.1 from commit-based version
* Switch to proper release tarball
* Update maintainer email address
* Remove faad2 dependency as build patches its own version; once patch is upstreamed faad2 will be added back

### Testing Performed
- [x] Port builds successfully locally
- [x] Port lint passes with 0 errors and 0 warnings
- [x] Dependencies verified
- [x] Installation tested

**Tested on**

macOS 15.6.1 Xcode 16.4 / Command Line Tools 16.4.0.0.1.1747106510 (arm64)
macOS 15.6.1 Command Line Tools 16.4.0.0.1.1747106510 (x86_64)

### Port Details
- **Category**: audio
- **Version**: 3.0.1 (updated from commit-based 1.0-20240327)
- **Homepage**: https://github.com/theori-io/nrsc5
- **License**: GPL-3+
- **Dependencies**: rtl-sdr, libao, fftw-3-single

### Maintainer
@trodemaster (openmaintainer)