### PR TITLE
pngcheck: Update to 4.0.0

### DIFF
--- a/graphics/pngcheck/Portfile
+++ b/graphics/pngcheck/Portfile
@@ -1,16 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
 
-name                pngcheck
-version             3.0.3
+github.setup        pnggroup pngcheck 4.0.0 v
+github.tarball_from archive
 revision            0
 categories          graphics
 license             MIT GPL-2
-platforms           darwin
 maintainers         nomaintainer
-description         validate and inspect PNG, JNG and MNG files
-long_description    pngcheck verifies the integrity of PNG, JNG and MNG files \
+description         Validate and inspect PNG, JNG and MNG files
+long_description    ${name} verifies the integrity of PNG, JNG and MNG files \
                     (by checking the internal 32-bit CRCs [checksums] and \
                     decompressing the image data)\; it can optionally dump \
                     almost all of the chunk-level information in the image in \
@@ -20,34 +21,22 @@ long_description    pngcheck verifies the integrity of PNG, JNG and MNG files \
                     its palette (assuming it has one)\; or to extract the \
                     embedded text annotations. This is a command-line program \
                     with batch capabilities.
-homepage            http://www.libpng.org/pub/png/apps/pngcheck.html
-master_sites        http://www.libpng.org/pub/png/src/
+homepage            https://www.libpng.org/pub/png/apps/pngcheck.html
 
-checksums           rmd160  c772a7e562c471c25a6150f857cddd89d8053f20 \
-                    sha256  c36a4491634af751f7798ea421321642f9590faa032eccb0dd5fb4533609dee6 \
-                    size    63766
+checksums           rmd160  260e47c8ead46211ab56a1238f00675b3e9dc466 \
+                    sha256  ed13f49bc1205bdf7cd0fc208b6e0eef550da021d1631f7180f718a4db379398 \
+                    size    69977
 
-depends_lib         port:zlib
+depends_lib-append  port:zlib
 
-variant universal   {}
+configure.args-append \
+                    -DPNGCHECK_ENABLE_AUX_TOOLS=ON
 
-use_configure       no
-
-build.pre_args-append   -f Makefile.unx
-build.args-append       CC="${configure.cc} [get_canonical_archflags cc]" \
-                        LD="${configure.cc} [get_canonical_archflags ld]" \
-                        ZLIB="${configure.ldflags} -lz" \
-                        ZINC="${configure.cppflags}"
-
-destroot {
-    xinstall -m 755 -W ${worksrcpath} pngcheck pngsplit png-fix-IDAT-windowsize ${destroot}${prefix}/bin
-
-    set docdir ${prefix}/share/doc/${subport}
-    xinstall -d ${destroot}${docdir}
-    xinstall -m 644 ${worksrcpath}/README ${destroot}${docdir}
-    set man1dir ${prefix}/share/man/man1
-    xinstall -d ${destroot}${man1dir}
-    xinstall -m 644 ${worksrcpath}/pngcheck.1 ${destroot}${man1dir}
+post-destroot {
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} \
+        README.md \
+        CHANGELOG \
+        gpl/COPYING \
+        ${destroot}${prefix}/share/doc/${name}
 }
-
-livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
#### Description

Update pngcheck to 4.0.0 and switch to new upstream. [pngcheck's homepage contains a "Change of Address" note](https://www.libpng.org/pub/png/apps/pngcheck.html) that points to the new upstream.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.7 23H124 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
