### PR TITLE
geographiclib: update to 2.5.2

### DIFF
--- a/gis/geographiclib/Portfile
+++ b/gis/geographiclib/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        geographiclib geographiclib 2.4 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        geographiclib geographiclib 2.5.2 v
+github.tarball_from archive
 revision            0
 categories          gis
 maintainers         {gmail.com:tlockhart1976 @lockhart} gmail.com:crmoore \
@@ -22,9 +21,9 @@ long_description \
 
 homepage            https://geographiclib.sourceforge.io/
 
-checksums           rmd160  12d95fa08349517fec9e1eeb483a331b2be93cff \
-                    sha256  d306693b14dc7fe3a3d6e85cb05ec6a67b13232c60261d22a4aab0c6a1e7a48a \
-                    size    1458638
+checksums           rmd160  b271e7ba3d90331293f524315183a62564473097 \
+                    sha256  15485087b91722d1115229e983e0bce96869f5cea6049278381132d24865e919 \
+                    size    1466583
 
 depends_build-append    path:bin/doxygen:doxygen
 


### PR DESCRIPTION
#### Description
https://github.com/geographiclib/geographiclib/blob/main/NEWS

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
