### PR TITLE
vtk: Update to 9.5.1

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -23,10 +23,14 @@ compiler.blacklist-append {clang < 900}
 # not from the official VTK download page in gz format.
 
 gitlab.instance     https://gitlab.kitware.com
-gitlab.setup        vtk vtk 9.5.0 v
-revision            1
+gitlab.setup        vtk vtk 9.5.1 v
+revision            0
 categories          graphics devel
 license             BSD
+
+checksums           rmd160  d4a3f7a499ffe88a423b06b928202138c7c00439 \
+                    sha256  8cb1f8c98c3a3e98bfa0bf358c2c8a5db4ab72b4e2bd5e845ed99d8d206d0c87 \
+                    size    40308191
 
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \
                     openmaintainer
@@ -37,10 +41,6 @@ long_description    ${description} is an open-source, freely \
                     image processing and visualization.
 
 homepage            https://www.vtk.org
-
-checksums           rmd160  71620582086344c5117bb9aea908ba151412950c \
-                    sha256  cf5f0a42c62bc784eb91670434bf1d3d1f15befed16c8d1a9446d96b3f7c7193 \
-                    size    40292755
 
 mpi.setup
 


### PR DESCRIPTION
#### Description

Update vtk 9.5.0 --> 9.5.1

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?