### PR TITLE
ImageMagick7: Update to 7.1.2-3

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -21,13 +21,13 @@ legacysupport.newest_darwin_requires_legacy 10
 # Imagick will run but may behave surprisingly in Unknown on line 0.
 
 name                ImageMagick7
-github.setup        ImageMagick ImageMagick 7.1.2-1
+github.setup        ImageMagick ImageMagick 7.1.2-3
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  cc3af690ecc67010629f4e5f5bb06309571c7d90 \
-                    sha256  9306407381a7bf0ac5d97074eca3ce9dfaac65ced4d44f6a47bc24fbfc693e9a \
-                    size    15704122
+checksums           rmd160  c9a08dee3f6201e63f94113e97de8e0b65b4e4f3 \
+                    sha256  b16415e8694a2e15e5282d64fc7b358f309ff3a514a90eb5da268676c772de3d \
+                    size    15718858
 
 categories          graphics devel
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \


### PR DESCRIPTION
#### Description

Update 7.1.2-1 --> 7.1.2-3

###### Type(s)

- [x] security fix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?