### PR TITLE
neovim, -devel: update to 0.11.4 and 20250901

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -63,7 +63,7 @@ subport neovim-devel {}
 if {${subport} eq ${name}} {
     # stable
 
-    github.setup        neovim neovim 0.11.3 v
+    github.setup        neovim neovim 0.11.4 v
     github.tarball_from archive
     revision            0
     conflicts           neovim-devel
@@ -80,10 +80,10 @@ if {${subport} eq ${name}} {
         tree-sitter-grammars  tree-sitter-markdown  0.5.0   v  ""  treesitter_markdown
     }
 
-    checksums           neovim-0.11.3.tar.gz \
-                        rmd160  d03e19c0f082b92f4c4bcd4814b04bb201efe4d4 \
-                        sha256  7f1ce3cc9fe6c93337e22a4bc16bee71e041218cc9177078bd288c4a435dbef0 \
-                        size    12933589 \
+    checksums           neovim-0.11.4.tar.gz \
+                        rmd160  1d183e760f8be125f8ddf78187112a10b06a9f08 \
+                        sha256  83cf9543bedab8bec8c11cd50ccd9a4bf1570420a914b9a28f83ad100ca6d524 \
+                        size    12961606 \
                         tree-sitter-c-0.24.1.tar.gz \
                         rmd160  12c732f8ccc097fd1ef4f171c19a89d06cfb85cd \
                         sha256  25dd4bb3dec770769a407e0fc803f424ce02c494a56ce95fedc525316dcf9b48 \
@@ -111,9 +111,9 @@ if {${subport} eq ${name}} {
 } else {
     # devel
 
-    github.setup        neovim neovim 7bf04bc01fdba15c2ec55de2fe22a74683a318cf
+    github.setup        neovim neovim 3c601d02dc030fde5fc11a1b1cba01728add2197
     github.tarball_from archive
-    version             20250714-[string range ${github.version} 0 6]
+    version             20250901-[string range ${github.version} 0 6]
     revision            0
     conflicts           neovim
     github.livecheck.branch \
@@ -129,10 +129,10 @@ if {${subport} eq ${name}} {
         tree-sitter-grammars  tree-sitter-markdown  0.5.0   v  ""  treesitter_markdown
     }
 
-    checksums           neovim-7bf04bc01fdba15c2ec55de2fe22a74683a318cf.tar.gz \
-                        rmd160  b12218232cc26b72399de0eeaee5f56b57eafc9b \
-                        sha256  b528d80d294993045fe1b74946a7bfa954d07dd97645be5e8ffd76df7009720e \
-                        size    13197909 \
+    checksums           neovim-3c601d02dc030fde5fc11a1b1cba01728add2197.tar.gz \
+                        rmd160  a0c90cc79df7572dbfde8e69fe20028b7023a223 \
+                        sha256  64455f79b52d7d89cd29ed60d9fd80d3340d155f5555b642d0399b6cd8a02657 \
+                        size    13328140 \
                         tree-sitter-c-0.24.1.tar.gz \
                         rmd160  12c732f8ccc097fd1ef4f171c19a89d06cfb85cd \
                         sha256  25dd4bb3dec770769a407e0fc803f424ce02c494a56ce95fedc525316dcf9b48 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- update neovim to 0.11.4
- update neovim-devel to 20250901

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.6 23H626 arm64
Xcode 15.4 15F31d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
