### PR TITLE
ggc: update to 5.0.0

### DIFF
--- a/devel/ggc/Portfile
+++ b/devel/ggc/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/bmf-san/ggc 4.0.0 v
+go.setup            github.com/bmf-san/ggc 5.0.0 v
 revision            0
 
 description         \
@@ -23,6 +23,8 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
+go.offline_build    no
+
 build.args-append   \
     -ldflags \" -X main.version=${version} \"
 
@@ -38,28 +40,6 @@ destroot {
     }
 }
 
-checksums           ${distname}${extract.suffix} \
-                        rmd160  ca067b1d735275bba79b1241304e1401a305a829 \
-                        sha256  6256153b5f79c8320860978456645442fd696ed8a8bb706418cc4e1627661023 \
-                        size    1168348
-
-go.vendors          gopkg.in/yaml.v3 \
-                        lock    v3.0.1 \
-                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
-                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
-                        size    91208 \
-                    gopkg.in/check.v1 \
-                        lock    20d25e280405 \
-                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
-                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
-                        size    30360 \
-                    golang.org/x/term \
-                        lock    v0.34.0 \
-                        rmd160  c17f07f42813271264c518e71ffb0e025c096903 \
-                        sha256  ed10832a496fc6e6af32e8a0933942b042f362bb117ccb232a0553bc057da308 \
-                        size    15937 \
-                    golang.org/x/sys \
-                        lock    v0.35.0 \
-                        rmd160  94ac3a8dd72c3a5b79bc8f068285b77634935368 \
-                        sha256  b1c65be93d2d2ced17bd5ad9386a2385fd7258c708d3879f69e2485a1cea1011 \
-                        size    1531744
+checksums           rmd160  0be63e2145a5f70d837bb5e4703792f590db656a \
+                    sha256  8602c62d8005c708a4e54cff6da2f21fe31753d2fd24b588bba7d67993441bda \
+                    size    1192683


### PR DESCRIPTION
Upstream introduced a dependency incompatible with offline build

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
