### PR TITLE
poetry: update to 2.1.4

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    poetry
-version                 2.0.1
+version                 2.1.4
 revision                0
 categories-append       devel
 platforms               {darwin any}
@@ -23,21 +23,20 @@ long_description        Poetry: Dependency Management for Python. \
 
 homepage                https://python-poetry.org/
 
-checksums               rmd160  937fc3b1d45ce641856c71cd518150691e4d5875 \
-                        sha256  a2987c3162f6ded6db890701a6fc657d2cfcc702e9421ef4c345211c8bffc5d5 \
-                        size    2846041
+checksums               rmd160  91364465c2cdb9965a3661f745df77116568a297 \
+                        sha256  bed4af5fc87fb145258ac5b1dae77de2cd7082ec494e3b2f66bca0f477cbfc5c \
+                        size    3435981
 
-variant python39 conflicts python310 python311 python312 description {Use Python 3.9} {}
-variant python310 conflicts python39 python311 python312 description {Use Python 3.10} {}
-variant python311 conflicts python39 python310 python312 description {Use Python 3.11} {}
-variant python312 conflicts python39 python310 python311 description {Use Python 3.12} {}
-variant python313 conflicts python39 python310 python311 description {Use Python 3.13} {}
+variant python310 conflicts python311 python312 python313 description {Use Python 3.10} {}
+variant python311 conflicts python310 python312 python313 description {Use Python 3.11} {}
+variant python312 conflicts python310 python311 python313 description {Use Python 3.12} {}
+variant python313 conflicts python310 python311 python312 description {Use Python 3.13} {}
 
-if {![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312] } {
+if {![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312] } {
     default_variants +python313
 }
 
-foreach pv {313 312 311 310 39} {
+foreach pv {313 312 311 310} {
     if {[variant_isset python${pv}]} {
         python.default_version  ${pv}
         break
@@ -56,7 +55,6 @@ depends_lib-append \
     port:py${python.version}-cachecontrol \
     port:py${python.version}-filelock \
     port:py${python.version}-cleo \
-    port:py${python.version}-crashtest \
     port:py${python.version}-dulwich \
     port:py${python.version}-fastjsonschema \
     port:py${python.version}-installer \
@@ -71,16 +69,14 @@ depends_lib-append \
     port:py${python.version}-tomlkit \
     port:py${python.version}-trove-classifiers \
     port:py${python.version}-virtualenv \
-    port:py${python.version}-xattr
+    port:py${python.version}-xattr \
+    port:py${python.version}-findpython \
+    port:py${python.version}-pbs_installer
+
 
 if {${python.version} < 311} {
     depends_lib-append \
         port:py${python.version}-tomli
-}
-
-if {${python.version} < 310} {
-    depends_lib-append \
-        port:py${python.version}-importlib-metadata
 }
 
 # Shell completion

--- a/python/py-poetry-core/Portfile
+++ b/python/py-poetry-core/Portfile
@@ -8,14 +8,14 @@ PortGroup           select 1.0
 # compatible with this port. py-poetry-core is closely coupled to poetry,
 # both in terms of APIs but also the version pinning.
 name                py-poetry-core
-version             2.0.1
+version             2.1.3
 revision            0
 
 distname            poetry_core-${version}
 
-checksums           rmd160  676cd58ac137a39c0fe6c26994c0465cce94650f \
-                    sha256  10177c2772469d9032a49f0d8707af761b1c597cea3b4fb31546e5cd436eb157 \
-                    size    355487
+checksums           rmd160  94c4d63be4226ffe2fe8452a31a2651ad201b1e8 \
+                    sha256  0522a015477ed622c89aad56a477a57813cace0c8e7ff2a2906b7ef4a2e296a4 \
+                    size    365027
 
 categories-append   devel
 supported_archs     noarch


### PR DESCRIPTION
#### Description

I had removed python 3.9 earlier in the year when certain bugs in the Python portgroup were preventing the new dependencies from building on 3.9. However, now that we are months away from 3.9 being EOL forever I lean towards just removing 3.9 support.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.4 24E248 x86_64
Xcode 16.3 16E140

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
