### PR TITLE
freehdl: fix build on Sequoia

### DIFF
--- a/science/freehdl/Portfile
+++ b/science/freehdl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                freehdl
 version             0.0.8
-revision            0
+revision            1
 categories          science math
 # most files are GPL or LGPL but there are some restrictively-licensed IEEE headers
 license             Restrictive

--- a/science/freehdl/files/patch-freehdl_kernel-db_hh.diff
+++ b/science/freehdl/files/patch-freehdl_kernel-db_hh.diff
@@ -17,3 +17,12 @@ Index: freehdl/kernel-db.hh
    }
  };
  
+@@ -595,7 +595,7 @@
+     return *d;
+   }
+ 
+-  typename kind::data_type &get (db_basic_key key) { return get (this->get_key (key)); }
++  typename kind::data_type &get (db_basic_key key) { return get (internal_explorer.get_key (key)); }
+ };
+ 
+


### PR DESCRIPTION
#### Description

freehdl: fix build on Sequoia

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
