### PR TITLE
osxphotos: update to 0.72.3

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.72.2
+version                 0.72.3
 revision                0
 
 categories              graphics python
@@ -25,9 +25,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  cbcaff78ddf79e431e6deceafa2cdc83eab18038 \
-                        sha256  02f802e55b852612271d7167ada0dbcadabe71476160659a4e2fcfafa942cf70 \
-                        size    2312097
+checksums               rmd160  2879cc64c6032aef7111036288ed1c8d5f43cdba \
+                        sha256  7750595667e46cf5d4036a565738aa7c5ab3b6cc132a392d67614d41de8b1ca8 \
+                        size    2317550
 
 python.default_version  313
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.72.3.

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?