### PR TITLE
lowdown: update to 2.0.2

### DIFF
--- a/textproc/lowdown/Portfile
+++ b/textproc/lowdown/Portfile
@@ -11,24 +11,33 @@ legacysupport.newest_darwin_requires_legacy 13
 
 name                lowdown
 categories          textproc
-version             1.2.0
+version             2.0.2
 revision            0
 license             BSD
 
 description         simple markdown translator
-long_description    lowdown translates markdown to either HTML \
-                    or a roff document using either -man or -ms
-homepage            https://kristaps.bsd.lv/lowdown/
-master_sites        ${homepage}/snapshots/
+long_description    lowdown is a Markdown translator producing HTML5, \
+                    roff documents in the ms and man formats, LaTeX, \
+                    gemini ("gemtext"), OpenDocument, and ANSI/UTF8 \
+                    terminal output. The open source C source code \
+                    has no dependencies.
+
+homepage            https://kristaps.bsd.lv/lowdown
+master_sites        ${homepage}/snapshots
 maintainers         {judaew @judaew} openmaintainer
 
-checksums           rmd160 10cdf6dc095109b61acc015f047afea3cbd900a8 \
-                    sha256 4a853e1e49bca6ef532d075228b84585a29d88bbf4a7d26a70c5d4df260b9a3f \
-                    size   280790
+checksums           rmd160 ad4ae437b573bf815b7e90a9ccb52dfd3fdd1cbe \
+                    sha256 d59f2ad82f981a63051bb61d8d04c02c8c49428ac29c435dff03a92e210b0004 \
+                    size   299643
+
+depends_build-append \
+                    port:bmake
 
 configure.universal_args
-configure.pre_args      PREFIX=${prefix}
-configure.args          MANDIR=${prefix}/share/man
+configure.pre_args  PREFIX=${prefix}
+configure.args      MANDIR=${prefix}/share/man
+
+build.cmd           bmake
 
 # The install target installs only binaries but does not install the library
 # and pkg-config pc file.


### PR DESCRIPTION
#### Description
lowdown: update to 2.0.2
* Use `bmake` to build instead of `make` (starting upstream v1.4.0)
* Clean up Portfile

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?