### PR TITLE
gimp-lqr-plugin: allow for automake 1.18

### DIFF
--- a/graphics/gimp-lqr-plugin/Portfile
+++ b/graphics/gimp-lqr-plugin/Portfile
@@ -5,7 +5,7 @@ PortGroup       active_variants 1.1
 
 name            gimp-lqr-plugin
 version         0.7.2
-revision        3 
+revision        3
 license         GPL-2
 maintainers     {devans @dbevans} openmaintainer
 categories      graphics
@@ -24,7 +24,8 @@ master_sites    http://liquidrescale.wikidot.com/local--files/en:download-page-s
 use_bzip2       yes
 
 checksums       rmd160  1e03d5f6eb8b2914bdfa2e05eb33db0850f47f24 \
-                sha256  169e11164e4fe4e93a0f06e545748bd77b206b7a471bdebf7dd3bc8a008e647a
+                sha256  169e11164e4fe4e93a0f06e545748bd77b206b7a471bdebf7dd3bc8a008e647a \
+                size    784455
 
 depends_build   port:autoconf \
                 port:automake \

--- a/graphics/gimp-lqr-plugin/files/patch-autogen.sh.diff
+++ b/graphics/gimp-lqr-plugin/files/patch-autogen.sh.diff
@@ -8,8 +8,8 @@ https://github.com/carlobaldassi/gimp-lqr-plugin/issues/12
 https://github.com/carlobaldassi/gimp-lqr-plugin/pull/13
 
 Disable maintainer mode.
---- autogen.sh.orig	2010-03-30 12:19:38.000000000 -0500
-+++ autogen.sh	2024-08-04 02:49:08.000000000 -0500
+--- autogen.sh.orig	2010-03-30 19:19:38
++++ autogen.sh	2025-09-02 16:19:59
 @@ -13,7 +13,7 @@
  FILE=src/render.c
  
@@ -28,14 +28,17 @@ Disable maintainer mode.
  if (autoconf --version) < /dev/null > /dev/null 2>&1; then
      VER=`autoconf --version \
           | grep -iw autoconf | sed "s/.* \([0-9.]*\)[-a-z0-9]*$/\1/"`
-@@ -52,8 +52,17 @@
+@@ -52,8 +52,20 @@
      DIE=1;
  fi
  
 -echo -n "checking for automake >= $AUTOMAKE_REQUIRED_VERSION ... "
 -if (automake-1.7 --version) < /dev/null > /dev/null 2>&1; then
 +printf "checking for automake >= %s ... " "$AUTOMAKE_REQUIRED_VERSION"
-+if (automake-1.17 --version) < /dev/null > /dev/null 2>&1; then
++if (automake-1.18 --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake-1.18
++   ACLOCAL=aclocal-1.18
++elif (automake-1.17 --version) < /dev/null > /dev/null 2>&1; then
 +   AUTOMAKE=automake-1.17
 +   ACLOCAL=aclocal-1.17
 +elif (automake-1.16 --version) < /dev/null > /dev/null 2>&1; then
@@ -48,7 +51,7 @@ Disable maintainer mode.
     AUTOMAKE=automake-1.7
     ACLOCAL=aclocal-1.7
  elif (automake-1.8 --version) < /dev/null > /dev/null 2>&1; then
-@@ -85,7 +94,7 @@
+@@ -85,7 +97,7 @@
      check_version $VER $AUTOMAKE_REQUIRED_VERSION
  fi
  
@@ -57,7 +60,7 @@ Disable maintainer mode.
  if (glib-gettextize --version) < /dev/null > /dev/null 2>&1; then
      VER=`glib-gettextize --version \
           | grep glib-gettextize | sed "s/.* \([0-9.]*\)/\1/"`
-@@ -98,7 +107,7 @@
+@@ -98,7 +110,7 @@
      DIE=1
  fi
  
@@ -66,7 +69,7 @@ Disable maintainer mode.
  if (intltoolize --version) < /dev/null > /dev/null 2>&1; then
      VER=`intltoolize --version \
           | grep intltoolize | sed "s/.* \([0-9.]*\)/\1/"`
-@@ -130,7 +139,7 @@
+@@ -130,7 +142,7 @@
  echo
  echo "I am going to run ./configure with the following arguments:"
  echo


### PR DESCRIPTION
#### Description

Add `automake 1.18` (the latest version of automake) to the list of possible versions of automake in `gimp-lqr-plugin`'s `autogen.sh`. This is a workaround until https://github.com/carlobaldassi/gimp-lqr-plugin/pull/15 is merged (this was triggered by https://github.com/carlobaldassi/gimp-lqr-plugin/issues/11 itself triggered by https://trac.macports.org/ticket/70485 ).

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.6 24G84 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
