### PR TITLE
vtk: Fix build for 10.14

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -17,7 +17,10 @@ compiler.cxx_standard 2017
 
 # some older Clang say they support C++11 when they don't
 # this is the same blacklisting as for jsoncpp, on which vtk depends.
-compiler.blacklist-append {clang < 900}
+# compiler.blacklist-append {clang < 900}
+
+# VTK 9.5.1+ Cmake says: Apple Clang 11.0 or later is required
+compiler.blacklist-append {clang < 1100}
 
 # Note, gitlab instance downloads distfile from gitlab tag in bz2 format,
 # not from the official VTK download page in gz format.


### PR DESCRIPTION
#### Description

Blacklist clang < 11.0.  Should fix 10.14 Mojave configure error.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?