### PR TITLE
google-cloud-sdk: update to 537.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             536.0.1
+version             537.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3be8ee8c287e235f255acbc3e5d42629af624335 \
-                    sha256  115412089190ee2e092973055294a2d35829aec460a1f99cfe9035085f5a9773 \
-                    size    55153154
+    checksums       rmd160  62c9003f234de793f28907d4b7aaa3b6f66198ee \
+                    sha256  a211593b97c8488af74610895260e0cf8adc307e43e634e86d0c95262d838378 \
+                    size    55201416
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  9f3ced9b23e45ade7dfee856cb5995506827d37b \
-                    sha256  03330e3f66ccc61b3031ff066d861fca5e46df27d1f3a52edcd9eb07a0141b53 \
-                    size    56688498
+    checksums       rmd160  98c2edd92ac6e30d0ef77313cfd9f0e6ad1009bb \
+                    sha256  16aa4e94d2333309ff1e3c8784e0f978d15f3958f06fe4333e3e12e7dbdac857 \
+                    size    56733054
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  9ebacb26dfd2c9c9f41c8caa5d47fddd8c3c4e6b \
-                    sha256  a0690f950ab0036613760bc1bf86a90213236e63e7b22d073998d606418de58e \
-                    size    56622833
+    checksums       rmd160  5e7b65c46b9edc8fb2263e1a651a6cf511c0b025 \
+                    sha256  c0e4b4dc598b06569efa8303efb5ceb3ebf3f7a6814a2a533db31efecc6db440 \
+                    size    56665978
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 537.0.0.

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?