### PR TITLE
vtk: Use MacPorts eigen3 library

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -49,7 +49,7 @@ mpi.setup
 
 set proj_version    proj9
 
-depends_lib-append  port:path:share/pkgconfig/eigen3.pc:eigen3 \
+depends_lib-append  path:share/pkgconfig/eigen3.pc:eigen3 \
                     port:hdf5 \
                     port:libxml2 \
                     port:${proj_version}


### PR DESCRIPTION
#### Description

vtk: Avoid broken bundled eigen3 version.
Closes https://trac.macports.org/ticket/72956

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?