### PR TITLE
esmf: Another 10.6 build fix

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -85,6 +85,7 @@ pre-build {
                     ESMF_F90=${configure.f90} \
                     ESMF_F90COMPILEOPTS=${configure.f90flags} \
                     ESMF_C=${configure.cc} \
+                    ESMF_CLINKER=${configure.cc} \
                     ESMF_CXX=${configure.cxx} \
                     ESMF_CXXCOMPILEOPTS=${configure.cxxflags} \
                     ESMF_NETCDF=split \
@@ -137,6 +138,7 @@ pre-destroot {
                     ESMF_F90COMPILEOPTS=${configure.f90flags} \
                     "ESMF_F90LINKOPTS=-L${worksrcpath}/lib ${configure.ldflags}" \
                     ESMF_C=${configure.cc} \
+                    ESMF_CLINKER=${configure.cc} \
                     ESMF_CXX=${configure.cxx} \
                     ESMF_CXXCOMPILEOPTS=${configure.cxxflags} \
                     "ESMF_CXXLINKOPTS=-L${worksrcpath}/lib ${configure.ldflags}" \
@@ -206,5 +208,8 @@ post-destroot {
     file delete ${destroot}${prefix}/lib/preload.sh
 }
 
-# Exclude pre-release candidates
-github.livecheck.regex  {([0-9.]+)}
+# Livecheck of upstream "Releases" page (NOT Github).
+# Exclude pre-release candidates.
+livecheck.type      regex
+livecheck.url       ${homepage}/static/releases.html
+livecheck.regex     {^v([0-9.]+)}


### PR DESCRIPTION
#### Description

* Add ESMF_CLINKER definition needed for 10.6.
* Also improve livecheck.
* No rev bump.  Build fix and livecheck only.

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?