### PR TITLE
aom: fix typo in configure args (ENABLE_TESTS)

### DIFF
--- a/multimedia/aom/Portfile
+++ b/multimedia/aom/Portfile
@@ -43,7 +43,7 @@ depends_build-append    port:git \
 
 configure.args-append   -DBUILD_SHARED_LIBS=ON \
                         -DENABLE_EXAMPLES=ON \
-                        -DDENABLE_TESTS=OFF \
+                        -DENABLE_TESTS=OFF \
                         -DENABLE_DOCS=OFF \
                         -DGIT_EXECUTABLE=${prefix}/bin/git \
                         -DPERL_EXECUTABLE=${prefix}/bin/perl \


### PR DESCRIPTION
aom: fix typo in configure args (ENABLE_TESTS)

Correct -DDENABLE_TESTS=OFF to -DENABLE_TESTS=OFF so tests are not built. No functional change to installed files; no rev-bump.

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26 Public Beta
Xcode 26 Beta

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
