### PR TITLE
portmidi: update to 2.0.6

### DIFF
--- a/audio/portmidi/Portfile
+++ b/audio/portmidi/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 epoch               1
-github.setup        PortMidi portmidi 2.0.4 v
+github.setup        PortMidi portmidi 2.0.6 v
 github.tarball_from archive
 revision            0
 
@@ -16,9 +16,9 @@ license             MIT
 description         Free, cross platform, open-source, real-time MIDI I/O library.
 long_description    ${description}
 
-checksums           rmd160  381735e44525259ccb485431468357e92abfd4ac \
-                    sha256  64893e823ae146cabd3ad7f9a9a9c5332746abe7847c557b99b2577afa8a607c \
-                    size    263225
+checksums           rmd160  9b0d16020a16dc91c794832d99b06b61a08076d1 \
+                    sha256  81d22b34051621cd56c8d5ef12908ef2a59764c9cdfba6dae47aabddb71ac914 \
+                    size    193068
 
 # Building the Java interface and pmdefaults is disabled. They could be
 # added as separate ports, with a dependency on an appropriate openjdk
@@ -28,7 +28,7 @@ patchfiles          patch-CMakeLists.txt.diff
 
 # The author forgot to bump the version
 post-patch {
-    reinplace "s|2.0.3|${version}|g" ${worksrcpath}/CMakeLists.txt
+    reinplace "s|2.0.4|${version}|g" ${worksrcpath}/CMakeLists.txt
 }
 
 configure.args      -DCMAKE_BUILD_WITH_INSTALL_RPATH=OFF \


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
