### PR TITLE
netdata: update to 2.6.3

### DIFF
--- a/sysutils/netdata/Portfile
+++ b/sysutils/netdata/Portfile
@@ -8,7 +8,7 @@ PortGroup               legacysupport   1.1
 # clock_gettime, utimensat
 legacysupport.newest_darwin_requires_legacy 16
 
-github.setup            netdata netdata 2.6.2 v
+github.setup            netdata netdata 2.6.3 v
 github.tarball_from     releases
 revision                0
 
@@ -53,9 +53,9 @@ depends_lib-append      bin:curl:curl \
 
 distname                ${name}-v${version}
 
-checksums               rmd160  c26ef2230ddb2c1f3c5c38a13acfc025a5dc9579 \
-                        sha256  b56912a6bf0666c3f6304c60be547af69857431ad7596ff7de999178bf0ea0e2 \
-                        size    32783823
+checksums               rmd160  aff06f37179e2701b9a2d785dc26f58596352b59 \
+                        sha256  ae99834889c04b5d49b1b03cf1db8812a9b3c6498dd097414bee01a3844c9001 \
+                        size    32799972
 
 set netdata_user        netdata
 set netdata_group       netdata


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
