### PR TITLE
dagger: update to 0.18.17

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.16 v
+github.setup        dagger dagger 0.18.17 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  00a346202cf295266d8bb9529ee152e3e6b17707 \
-                            sha256  1feaca91268dbca810b5685992c522ea13cc45f66521a7bcc81f925a9c7e2c23 \
-                            size    19512795
+        checksums           rmd160  dfcb674abc751df906139293748564ab3e627159 \
+                            sha256  9c7a29fdb610130e5d991a6f818a83212b14b91a759024905167141a40e3dfe5 \
+                            size    19639322
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  4f82333917188b3ca186ae34e661cae9cebb58aa \
-                            sha256  cf34a1cb3815181ab9220526d91270a765991d1602e75045e619ffcc66e3125f \
-                            size    18624580
+        checksums           rmd160  d83413273618e5a2d30b7819c9cdbe0006af3176 \
+                            sha256  93ad14c8d2137bb5cdda950ee0484c7fe97f6186657272610b32139c3a65773d \
+                            size    18535819
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

###### Tested on

macOS 15.6.1 24G90 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
