### PR TITLE
portmidi: fix build on case-sensitive filesystems

### DIFF
--- a/audio/portmidi/Portfile
+++ b/audio/portmidi/Portfile
@@ -24,7 +24,10 @@ checksums           rmd160  9b0d16020a16dc91c794832d99b06b61a08076d1 \
 # added as separate ports, with a dependency on an appropriate openjdk
 # port, if there is interest.
 
-patchfiles          patch-CMakeLists.txt.diff
+patchfiles-append   patch-CMakeLists.txt.diff
+
+# can be removed as soon as it appears in upstream
+patchfiles-append   patch-rename-coremidi-framework.diff
 
 # The author forgot to bump the version
 post-patch {

--- a/audio/portmidi/files/patch-CMakeLists.txt.diff
+++ b/audio/portmidi/files/patch-CMakeLists.txt.diff
@@ -1,7 +1,7 @@
 Don't overwrite the deployment target that MacPorts sets.
---- CMakeLists.txt.orig
+--- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -37,9 +37,6 @@ endif()
+@@ -39,9 +39,6 @@ endif()
  # Always build with position-independent code (-fPIC)
  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
  

--- a/audio/portmidi/files/patch-rename-coremidi-framework.diff
+++ b/audio/portmidi/files/patch-rename-coremidi-framework.diff
@@ -1,0 +1,19 @@
+--- pm_common/CMakeLists.txt
++++ pm_common/CMakeLists.txt
+@@ -105,14 +105,14 @@ elseif(UNIX AND APPLE)
+       ${CMAKE_THREAD_LIBS_INIT}
+       -Wl,-framework,CoreAudio
+       -Wl,-framework,CoreFoundation
+-      -Wl,-framework,CoreMidi
++      -Wl,-framework,CoreMIDI
+       -Wl,-framework,CoreServices
+       PARENT_SCOPE)
+   target_link_libraries(portmidi PRIVATE
+       Threads::Threads
+       -Wl,-framework,CoreAudio
+       -Wl,-framework,CoreFoundation
+-      -Wl,-framework,CoreMidi
++      -Wl,-framework,CoreMIDI
+       -Wl,-framework,CoreServices
+   )
+   # set to CMake default; is this right?:


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
