### PR TITLE
elixir: update to 1.18.4

### DIFF
--- a/lang/elixir/Portfile
+++ b/lang/elixir/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        elixir-lang elixir 1.18.2 v
+github.setup        elixir-lang elixir 1.18.4 v
 github.tarball_from archive
 revision            0
 epoch               1
@@ -26,9 +26,9 @@ homepage            https://elixir-lang.org/
 
 depends_lib         port:erlang
 
-checksums           rmd160  52deb7ccb2fe693b05e3476fb4115de42d3ee54f \
-                    sha256  efc8d0660b56dd3f0c7536725a95f4d8b6be9f11ca9779d824ad79377753e916 \
-                    size    3391256
+checksums           rmd160  b83e9ba2ecbe98ea3e9ef6988e3c864d1098682f \
+                    sha256  8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0 \
+                    size    3397219
 # bin/mix
 conflicts           arb
 


### PR DESCRIPTION
#### Description

Updates Elixir to 1.18.4

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.6.1 24G90 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
