### PR TITLE
async-profiler: update to 4.1

### DIFF
--- a/java/async-profiler/Portfile
+++ b/java/async-profiler/Portfile
@@ -5,13 +5,13 @@ PortGroup               github 1.0
 PortGroup               java 1.0
 PortGroup               makefile 1.0
 
-github.setup            async-profiler async-profiler 4.0 v
+github.setup            async-profiler async-profiler 4.1 v
 github.tarball_from     archive
 revision                0
 
-checksums               rmd160  45825ca6e9599dce922ac0086fd6c4efaba4a260 \
-                        sha256  7beb736868af485d6b0b624e42141f78df0ca8403188adc17965b7153261aa55 \
-                        size    2139146
+checksums               rmd160  51f200aa77e2d31f17c51bcbbe5d3a2bbf3ecf0a \
+                        sha256  6f11022645000deb9dde4cf74c5bbdb5486554bb5fb968f03e77fa6d3610203a \
+                        size    2406985
 
 categories              java
 platforms               macosx


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.7.8 23H730 arm64
Command Line Tools 16.2.0.0.1.1733547573

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
