### PR TITLE
vtk: Fix configure option for external eigen3

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -27,7 +27,7 @@ compiler.blacklist-append {clang < 1100}
 
 gitlab.instance     https://gitlab.kitware.com
 gitlab.setup        vtk vtk 9.5.1 v
-revision            1
+revision            2
 categories          graphics devel
 license             BSD
 
@@ -55,7 +55,7 @@ depends_lib-append  path:share/pkgconfig/eigen3.pc:eigen3 \
                     port:${proj_version}
 
 configure.args-append \
-                    -DVTK_MODULE_USE_EXTERNAL_VTK_eigen3:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_eigen:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_hdf5:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_libproj:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_libxml2:BOOL=ON


### PR DESCRIPTION
#### Description

* Use MacPorts eigen3 port, rather than VTK bundled copy.
* Fixes incorrect configure option in previous PR #29262.
* See discussion on that commit for more details.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?