### PR TITLE
pandoc: Update to version 3.8, dependency fix

### DIFF
--- a/textproc/pandoc/Portfile
+++ b/textproc/pandoc/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jgm pandoc 3.7.0.2
+github.setup        jgm pandoc 3.8
 revision            0
 categories          textproc haskell
 license             GPL-3
@@ -30,11 +30,12 @@ installs_libs       no
 github.tarball_from archive
 
 # Note: When updating, please also update the checksums on legacy versions below
-checksums           rmd160  5ace54b0f973c94ca87576fe8f4d7337177c6673 \
-                    sha256  a098c1dc8051844e3992f8396c6c947dccbc57b6ca3df2f2c47b9f7fa9f11246 \
-                    size    7878848
+checksums           rmd160  12bace6f7b69fb57e160ca2b761e9f8fd7a3add6 \
+                    sha256  2d375526e7d26d46ebcdaf107564c8bbfd68e40a7af425906e9612889699bcf6 \
+                    size    7985699
 
-depends_lib-append  port:zlib
+depends_lib-append  port:libffi \
+                    port:zlib
 
 depends_run-append  port:groff
 
@@ -142,15 +143,15 @@ if {(${os.platform} eq {darwin}
     switch ${build_arch} {
         arm64 {
             checksums \
-                    rmd160  106752a53aca04e6afb09a8f1a9f9425e89d17c2 \
-                    sha256  66a579bd8aae83de0bbeba43900953b075a6a3caaa7d1bfc19173e8f95d2ea17 \
-                    size    41939149
+                    rmd160  581076c3571db637afa2dd38aef00613b6a307db \
+                    sha256  7cfaa04a57816397dd6498fd50ada01bdeb04feefab737da37d493fb30131533 \
+                    size    42413815
         }
         x86_64 {
-             checksums \
-                    rmd160  46d9496e0229bc192347ecb0a58da9c8dd6a1be0 \
-                    sha256  5495af2c548bd49fe00c28a7f6dadaa1348e6338b92368d3d6e29fd3e16061d1 \
-                    size    23273183
+            checksums \
+                    rmd160  287be41d01af683749b68f169d483eca91517678 \
+                    sha256  07a7fb7db6346710f3c9b06e6eb0ce49a66afa0d1969aa0158ecb14d9eaecb20 \
+                    size    23581194
         }
         default {
             known_fail  yes


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/72898

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
