### PR TITLE
ruby-build: Update to 20250908

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250829 v
+github.setup        rbenv ruby-build 20250908 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  22186b829d9d847e63e518e471129077fbd22d56 \
-                    sha256  8dafe0a69151592385c7114023e6cf5423022479f9054435df2d19ed6b42bff7 \
-                    size    98022
+checksums           rmd160  d2bc1ceab440e742c10196f2188934ad4759c63b \
+                    sha256  057167bb7507be05f75449bc9b7531f68420de2b1347f5a50b99a0fc07bb197c \
+                    size    98011
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250908


##### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
