### PR TITLE
bstring: update to 1.0.2

### DIFF
--- a/textproc/bstring/Portfile
+++ b/textproc/bstring/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        msteinert bstring 1.0.1 v
+github.setup        msteinert bstring 1.0.2 v
 github.tarball_from releases
 revision            0
 
@@ -20,9 +20,9 @@ long_description    ${name} is a fork of Paul Hsieh's Better String Library. \
 
 homepage            https://github.com/msteinert/bstring
 
-checksums           rmd160  f967ae6d2ec3162419f8d8792fa094bd1eaa4acf \
-                    sha256  ba3d3726bf70a0920196199097bd7d341cf362eb7dbd64018a8936815817a0cc \
-                    size    488074
+checksums           rmd160  21007dd4abd42029c5e5539639560081af0f570b \
+                    sha256  7fac6e52b449817b285858764053b7deb40336860c17b0213385470b3c498048 \
+                    size    510826
 
 depends_build       path:bin/pkg-config:pkgconfig
 
@@ -37,9 +37,7 @@ variant tests description "Build and run tests" {
 
 post-destroot {
     # Install documentation
-    if {[variant_isset docs]} {
-        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
-        xinstall -m 644 -W ${worksrcpath} README.md COPYING \
-            ${destroot}${prefix}/share/doc/${name}
-    }
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} README.md COPYING \
+        ${destroot}${prefix}/share/doc/${name}
 }


### PR DESCRIPTION
## bstring Port Update

This PR updates the bstring port to version 1.0.2 and fixes a documentation installation issue.

### Description
bstring is a fork of Paul Hsieh's Better String Library. It provides a comprehensive string library for C with features like autotools build system, updated test suite based on Check, Valgrind integration, and continuous integration via GitHub Actions.

### Key Changes
* update to version 1.0.2
* fix documentation installation in post-destroot
* update checksums for new version

### Testing Performed
- [x] Port builds successfully locally
- [x] Port lint passes with 0 errors and 0 warnings
- [x] Dependencies verified
- [x] Installation tested
- [x] Tests variant tested

**Tested on**

macOS 15.6.1 Xcode 16.4 / Command Line Tools 16.4.0.0.1.1747106510 (arm64)

### Port Details
- **Category**: textproc, devel
- **Version**: 1.0.2
- **Homepage**: https://github.com/msteinert/bstring
- **License**: BSD
- **Dependencies**: pkgconfig

### Maintainer
@trodemaster (openmaintainer)