### PR TITLE
fatsort: Fix out-of-bounds index to fix segfault on arm64

### DIFF
--- a/sysutils/fatsort/Portfile
+++ b/sysutils/fatsort/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fatsort
 version             1.6.5.640
-revision            0
+revision            1
 categories          sysutils
 platforms           darwin freebsd linux
 license             GPL-2+
@@ -30,6 +30,8 @@ checksums           rmd160  4c41df05db01d73958598dfb0b0e6b88647152fe \
 
 use_configure       no
 variant universal   {}
+
+patchfiles-append   sort.c.patch
 
 # endianness.c:30: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘value’
 # Old Xcode gcc does not understand these endianness macros.

--- a/sysutils/fatsort/files/sort.c.patch
+++ b/sysutils/fatsort/files/sort.c.patch
@@ -1,0 +1,15 @@
+Fix out-of-bounds index which caused crash on arm64 systems.
+Reported to the developer by email.
+--- src/sort.c	(revision 650)
++++ src/sort.c	(working copy)
+@@ -514,8 +514,8 @@
+ 	lname[0]='\0';
+ 	*reordered=0;
+ 	
+-	utf16le_lname[MAX_PATH_LEN*4]='\0';
+-	utf16le_lname[MAX_PATH_LEN*4+1]='\0';
++	utf16le_lname[MAX_PATH_LEN*2]='\0';
++	utf16le_lname[MAX_PATH_LEN*2+1]='\0';
+ 	
+ 	while (chain != NULL) {
+ 		device_seekset(fs->device, getClusterOffset(fs, chain->cluster));


### PR DESCRIPTION
#### Description

fatsort: Fix out-of-bounds index to fix segfault on arm64

Closes: https://trac.macports.org/ticket/72753

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.6 24G84 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
