### PR TITLE
openjdk21-jetbrains: update to 21.0.8b1097.42

### DIFF
--- a/java/openjdk21-jetbrains/Portfile
+++ b/java/openjdk21-jetbrains/Portfile
@@ -5,7 +5,7 @@ PortGroup        github 1.0
 
 set feature 21
 set openjdk_version ${feature}.0.8
-set jbr_version b1038.68
+set jbr_version b1097.42
 github.setup     JetBrains JetBrainsRuntime ${openjdk_version}${jbr_version} jbr-release-
 github.tarball_from archive
 name             openjdk${feature}-jetbrains
@@ -41,14 +41,14 @@ use_bzip2        no
 
 if {${configure.build_arch} eq "x86_64"} {
     set jbr_arch x64
-    checksums    rmd160  4fdfc129c65379963530e7616a4b91c8ba86e914 \
-                 sha256  0d15754f4b845ce781d233cee58d56a854a5fa30cb82b07c879e72f52c2f4d7e \
-                 size    95813019
+    checksums    rmd160  18705afb56fcc473212c5bb0dd359bb17d4635a3 \
+                 sha256  573509ea10fc651758864cf221c67a2b00592ca2c1ac9be66d9ff8f39528fa66 \
+                 size    95819186
 } else {
     set jbr_arch aarch64
-    checksums    rmd160  7f68a3228c95d7f0d053603b0fdfaa7f952f7d5c \
-                 sha256  f892f49ad8742694d884cd67eee6baa13dc29f53005243bf1ab1d437e531e286 \
-                 size    94710807
+    checksums    rmd160  2a5dce94a7c4f60ad8a7b0dfe1df5e8ec6a394ee \
+                 sha256  efb48777210d76103438634303b6b7bcbe898b53873576237fbcd17bac66b234 \
+                 size    94718177
 }
 
 distname         jbr-${openjdk_version}-osx-${jbr_arch}-${jbr_version}


### PR DESCRIPTION
#### Description

Update to [JetBrains Runtime 21.0.8b1097.42](https://github.com/JetBrains/JetBrainsRuntime/releases/tag/jbr-release-21.0.8b1097.42).

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?