### PR TITLE
google-cloud-sdk: update to 538.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             537.0.0
+version             538.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -20,21 +20,23 @@ platforms           {darwin any}
 supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
-    distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  62c9003f234de793f28907d4b7aaa3b6f66198ee \
-                    sha256  a211593b97c8488af74610895260e0cf8adc307e43e634e86d0c95262d838378 \
-                    size    55201416
+    set arch_classifier x86
+    checksums       rmd160  e87e1ce9a04089c860938c24fb74935e40469c73 \
+                    sha256  16f6b677939a6239868a0f7690fd116ebcef5e799b5e6333b40bf4f03368c542 \
+                    size    55363520
 } elseif { ${configure.build_arch} eq "x86_64" } {
-    distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  98c2edd92ac6e30d0ef77313cfd9f0e6ad1009bb \
-                    sha256  16aa4e94d2333309ff1e3c8784e0f978d15f3958f06fe4333e3e12e7dbdac857 \
-                    size    56733054
+    set arch_classifier x86_64
+    checksums       rmd160  d7d0b3970c8fd1477db5aa0dba45213c56a12a21 \
+                    sha256  2ce1e9878e54ed0d76c715542cefaa9bf11c6e18f71ceceb182c63b7954c74c2 \
+                    size    56897016
 } elseif { ${configure.build_arch} eq "arm64" } {
-    distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  5e7b65c46b9edc8fb2263e1a651a6cf511c0b025 \
-                    sha256  c0e4b4dc598b06569efa8303efb5ceb3ebf3f7a6814a2a533db31efecc6db440 \
-                    size    56665978
+    set arch_classifier arm
+    checksums       rmd160  0fe4bb4442f351839461875b08b1c1546fe976b1 \
+                    sha256  ef756bb422fb53cf134ecefc72d0e5486e6249b2322b4dc9d70db46236f41590 \
+                    size    56832631
 }
+
+distname            ${name}-${version}-darwin-${arch_classifier}
 
 homepage            https://cloud.google.com/sdk/
 master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 538.0.0.

###### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?