### PR TITLE
kubie: Update to 0.26.0

### DIFF
--- a/sysutils/kubie/Portfile
+++ b/sysutils/kubie/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        sbstp kubie 0.25.2 v
+github.setup        sbstp kubie 0.26.0 v
 github.tarball_from archive
 revision            0
 
@@ -30,9 +30,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  fd1e2500b28eb517b882b0e11a7ff74577b02548 \
-                    sha256  4d41e441eb006999f91f962b264730ec092a1352b16e45094f703144e855857e \
-                    size    41730
+                    rmd160  c02fc0dec22b06b26047c5501a5bad001e5a5e84 \
+                    sha256  b4f9d92f69714a700deb79eb20c657a0d6fe1fb7bc6f205e9affe739c73e4961 \
+                    size    42000
 
 destroot {
     set bashcomp_dir ${prefix}/share/bash-completion/completions
@@ -54,6 +54,7 @@ destroot {
         ${destroot}${fishcomp_dir}/${name}.fish
 }
 
+
 cargo.crates \
     adler2                           2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
     aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
@@ -64,13 +65,13 @@ cargo.crates \
     anstyle-parse                    0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                    1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                   3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
-    anyhow                          1.0.97  dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f \
+    anyhow                          1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     attohttpc                       0.29.2  48404d931ab11b3a7a5267291b3b8f3590f09b86181381f8e82a7e562ed832c0 \
     autocfg                          1.4.0  ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26 \
     aws-lc-fips-sys                 0.13.3  29003a681b2b9465c1139bfb726da452a841a8b025f35953f3bce71139f10b21 \
-    aws-lc-rs                       1.13.0  19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878 \
-    aws-lc-sys                      0.28.0  b9f7720b74ed28ca77f90769a71fd8c637a0137f6fae4ae947e1050229cff57f \
+    aws-lc-rs                       1.13.1  93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7 \
+    aws-lc-sys                      0.29.0  61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     beef                             0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
     bindgen                         0.69.5  271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088 \
@@ -82,13 +83,14 @@ cargo.crates \
     bytes                           1.10.0  f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9 \
     cc                              1.2.15  c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af \
     cexpr                            0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
-    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    cfg-if                           1.0.1  9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chrono                          0.4.40  1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c \
     clang-sys                        1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    clap                            4.5.35  d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944 \
-    clap_builder                    4.5.35  2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9 \
-    clap_derive                     4.5.32  09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7 \
+    clap                            4.5.40  40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f \
+    clap_builder                    4.5.40  e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e \
+    clap_complete                   4.5.54  aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677 \
+    clap_derive                     4.5.40  d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce \
     clap_lex                         0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     cmake                           0.1.54  e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0 \
     colorchoice                      1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
@@ -105,7 +107,7 @@ cargo.crates \
     darling_core                   0.20.10  95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5 \
     darling_macro                  0.20.10  d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806 \
     defer-drop                       1.3.0  f613ec9fa66a6b28cdb1842b27f9adf24f39f9afc4dcdd9fdecee4aca7945c57 \
-    deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
+    deranged                         0.4.0  9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e \
     derive_builder                  0.20.2  507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947 \
     derive_builder_core             0.20.2  2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8 \
     derive_builder_macro            0.20.2  ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c \
@@ -151,7 +153,7 @@ cargo.crates \
     ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                     1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
-    indexmap                         2.7.1  8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652 \
+    indexmap                         2.9.0  cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
     itoa                            1.0.14  d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674 \
@@ -159,17 +161,16 @@ cargo.crates \
     js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                           0.2.171  c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6 \
+    libc                           0.2.174  1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776 \
     libloading                       0.8.6  fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                    0.9.2  6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9 \
     litemap                          0.7.4  4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104 \
-    log                             0.4.26  30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e \
+    log                             0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
     memchr                           2.7.4  78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3 \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.8.5  8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5 \
-    nix                             0.24.3  fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069 \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
@@ -214,31 +215,31 @@ cargo.crates \
     serde_yaml           0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     shell-quote                      0.7.2  fb502615975ae2365825521fa1529ca7648fd03ce0b0746604e0683856ecd7e4 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
-    signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
+    signal-hook                     0.3.18  d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
     signal-hook-registry             1.4.2  a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1 \
-    skim                            0.16.1  0735e2a3c31d1b0742df1f624da11492d5ffe34aec5d027030e54eb1b70704bb \
+    skim                            0.20.2  19a285c48e203135e5d58eb0fc632e3303c127f2056c8e50c8a11c504b7132b4 \
+    skim-common                      0.2.0  d8312ae7ca1a5883e68042b9c6bce05bfc12f06b814ecfda06c34abfb6c88175 \
+    skim-tuikit                      0.6.5  18fa16dc8ef0aa72471eb80bf1d43b62e841abf1cd2429216c44cdfd886545f0 \
     smallvec                        1.14.0  7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd \
     stable_deref_trait               1.2.0  a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
     syn                             2.0.98  36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1 \
     synstructure                    0.13.1  c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971 \
-    tempfile                        3.19.1  7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf \
+    tempfile                        3.20.0  e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1 \
     term                             0.7.0  c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
     thiserror                       2.0.11  d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                  2.0.11  26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2 \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
-    time                            0.3.37  35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21 \
-    time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
+    time                            0.3.41  8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40 \
+    time-core                        0.1.4  c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c \
     timer                            0.2.0  31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b \
     tinystr                          0.7.6  9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f \
-    tuikit                           0.5.0  5e19c6ab038babee3d50c8c12ff8b910bdb2196f62278776422f50390d8e53d8 \
     unicase                          2.8.1  75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539 \
     unicode-ident                   1.0.17  00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe \
-    unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
-    unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
+    unicode-width                    0.2.1  4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c \
     unsafe-libyaml                  0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.4  32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60 \


### PR DESCRIPTION
#### Description

kubie: Update to 0.26.0


##### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
