### PR TITLE
zizmor: Update to 1.13.0

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.12.1 v
+github.setup        zizmorcore zizmor 1.13.0 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  96621a47df00e9f468c95521091325962802220c \
-                    sha256  1caa4b9884d7755cd5679f629ecbfe7d028cbb508fae9ed423129b48f7f3dbaf \
-                    size    491933
+                    rmd160  b5f5b193a8f5867613f7db8ecf48cbf256822b94 \
+                    sha256  1a59d2678ab901173de42bead03bfcadd22ec3b0c9208ebaffc89ec63d088434 \
+                    size    514915
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -29,19 +29,20 @@ destroot {
     xinstall -m 0755 ${release_dir}/${name} ${destroot}${prefix}/bin/
 }
 
+
 cargo.crates \
     Inflector                          0.11.4  fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3 \
     addr2line                          0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
     adler2                              2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
     ahash                              0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                        1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
-    annotate-snippets                  0.11.5  710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4 \
+    annotate-snippets                  0.12.3  4b0f1e2f8ec4bff67c7e1867001ec452595daf315cce10c393b7d4274024f878 \
     anstream                           0.6.20  3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192 \
     anstyle                            1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
     anstyle-parse                       0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                       1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                      3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
-    anyhow                             1.0.98  e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487 \
+    anyhow                             1.0.99  b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100 \
     arrayvec                            0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert_cmd                         2.0.17  2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66 \
     async-trait                        0.1.88  e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
@@ -62,16 +63,16 @@ cargo.crates \
     bytecount                           0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
     bytes                              1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
     cacache                            13.1.0  5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b \
-    camino                             1.1.11  5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0 \
+    camino                             1.1.12  dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5 \
     cc                                 1.2.20  04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a \
     cfg-if                              1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                         0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    clap                               4.5.43  50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f \
-    clap-verbosity-flag                 3.0.3  eeab6a5cdfc795a05538422012f20a5496f050223c91be4e5420bfd13c641fb1 \
-    clap_builder                       4.5.43  c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65 \
-    clap_complete                      4.5.56  67e4efcbb5da11a92e8a609233aa1e8a7d91e38de0be865f016d14700d45a7fd \
+    clap                               4.5.47  7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931 \
+    clap-verbosity-flag                 3.0.4  9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394 \
+    clap_builder                       4.5.47  2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6 \
+    clap_complete                      4.5.57  4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad \
     clap_complete_nushell               4.5.8  0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce \
-    clap_derive                        4.5.41  ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491 \
+    clap_derive                        4.5.47  bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
     colorchoice                         1.0.3  5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990 \
     console                           0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
@@ -151,9 +152,9 @@ cargo.crates \
     idna                                1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                        1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                             0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
-    indexmap                           2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
+    indexmap                           2.11.0  f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9 \
     indicatif                          0.18.0  70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd \
-    insta                              1.43.1  154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371 \
+    insta                              1.43.2  46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0 \
     inventory                          0.3.20  ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83 \
     io-uring                            0.7.8  b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013 \
     ipnet                              2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
@@ -172,7 +173,7 @@ cargo.crates \
     lock_api                           0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
     log                                0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
     lsp-types                          0.94.1  c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1 \
-    matchers                            0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
+    matchers                            0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     memchr                              2.7.5  32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0 \
     memmap2                            0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
     miette                             5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
@@ -182,7 +183,7 @@ cargo.crates \
     mio                                 1.0.3  2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd \
     nohash-hasher                       0.2.0  2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451 \
     nom                                 7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
-    nu-ansi-term                       0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
+    nu-ansi-term                       0.50.1  d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399 \
     num                                 0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
     num-bigint                          0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
     num-cmp                             0.1.0  63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa \
@@ -196,7 +197,6 @@ cargo.crates \
     once_cell                          1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
     os_info                            3.10.0  2a604e53c24761286860eba4e2c8b23a0161526476b1de520139d69cdb85a6b5 \
     outref                              0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
-    overload                            0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     owo-colors                          4.2.2  48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e \
     parking_lot                        0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                   0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
@@ -231,12 +231,10 @@ cargo.crates \
     ref-cast-impl                      1.0.24  1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7 \
     referencing                        0.30.0  c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e \
     reflink-copy                       0.1.26  78c81d000a2c524133cc00d2f92f019d399e57906c3b7119271a2495354fe895 \
-    regex                              1.11.1  b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191 \
-    regex-automata                     0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
+    regex                              1.11.2  23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912 \
     regex-automata                      0.4.9  809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908 \
-    regex-syntax                       0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
-    reqwest                           0.12.22  cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531 \
+    reqwest                           0.12.23  d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb \
     reqwest-middleware                  0.4.2  57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e \
     ring                              0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rustc-demangle                     0.1.24  719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f \
@@ -254,7 +252,7 @@ cargo.crates \
     serde                             1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
     serde-sarif                         0.8.0  a053c46f18a8043570d4e32fefc4c6377f82bf29ec310a33e93f273048e3b0be \
     serde_derive                      1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
-    serde_json                        1.0.142  030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7 \
+    serde_json                        1.0.143  d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a \
     serde_json_path                     0.7.2  b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33 \
     serde_json_path_core                0.2.2  dde67d8dfe7d4967b5a95e247d4148368ddd1e753e500adb34b3ffe40c6bc1bc \
     serde_json_path_macros              0.1.6  517acfa7f77ddaf5c43d5f119c44a683774e130b4247b7d3210f8924506cfac8 \
@@ -290,9 +288,9 @@ cargo.crates \
     termtree                            0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     text-size                           1.1.1  f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233 \
     thiserror                          1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                          2.0.12  567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708 \
+    thiserror                          2.0.16  3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0 \
     thiserror-impl                     1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                     2.0.12  7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d \
+    thiserror-impl                     2.0.16  6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960 \
     thread_local                        1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     time                               0.3.41  8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40 \
     time-core                           0.1.4  c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c \
@@ -318,10 +316,10 @@ cargo.crates \
     tracing                            0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-attributes                 0.1.28  395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d \
     tracing-core                       0.1.34  b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678 \
-    tracing-indicatif                  0.3.12  e1983afead46ff13a3c93581e0cec31d20b29efdd22cbdaa8b9f850eccf2c352 \
+    tracing-indicatif                  0.3.13  04d4e11e0e27acef25a47f27e9435355fecdc488867fa2bc90e75b0700d2823d \
     tracing-log                         0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
-    tracing-subscriber                 0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
-    tree-sitter                        0.25.8  6d7b8994f367f16e6fa14b5aebbcb350de5d7cbea82dc5b00ae997dd71680dd2 \
+    tracing-subscriber                 0.3.20  2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5 \
+    tree-sitter                        0.25.9  ccd2a058a86cfece0bf96f7cce1021efef9c8ed0e892ab74639173e5ed7a34fa \
     tree-sitter-bash                   0.23.3  329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e \
     tree-sitter-language                0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
     tree-sitter-powershell             0.25.8  d76347b6c5300ae20622847aa53c88005d13b6999708ffbe4618b509ddb45178 \
@@ -365,10 +363,7 @@ cargo.crates \
     web-time                            1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-roots                       0.26.9  29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b \
     webpki-roots                        1.0.0  2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb \
-    winapi                              0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
-    winapi-i686-pc-windows-gnu          0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                         0.1.9  cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb \
-    winapi-x86_64-pc-windows-gnu        0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     windows                            0.61.1  c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419 \
     windows-collections                 0.2.0  3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8 \
     windows-core                       0.61.0  4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.13.0


##### Tested on

macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
