### PR TITLE
ImageMagick: Update to version 6.9.13-28

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -13,11 +13,12 @@ legacysupport.newest_darwin_requires_legacy 10
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.13-21
+version                     6.9.13-28
 revision                    0
-checksums                   rmd160  e933a953d06f5bbaec3fc5eb77279ba73292583d \
-                            sha256  985b9bf373c8b67c9df66d53247bdbb44aa79d133e75fb84d73179b238af8471 \
-                            size    9620376
+
+checksums                   rmd160  9f8678bd29d9499fff3799c27fe6b78b9aee44f5 \
+                            sha256  b4fd389d6dae8384431f238aecd9f50b785065dade7e6bf3f7b226410edbaf26 \
+                            size    9634420
 
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}


### PR DESCRIPTION
Note: fixes HIGH severity vulnerability
* https://nvd.nist.gov/vuln/detail/CVE-2025-55298

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
