### PR TITLE
giza: Fix build for 10.7, add openmaintainer

### DIFF
--- a/science/giza/Portfile
+++ b/science/giza/Portfile
@@ -7,7 +7,9 @@ PortGroup github    1.0
 github.setup        danieljprice giza 1.5.0 v
 revision            0
 categories          science graphics fortran
-maintainers         {monash.edu:daniel.price @danieljprice}
+maintainers         {monash.edu:daniel.price @danieljprice} \
+                    openmaintainer
+
 description         C/Fortran graphics library, PGPLOT replacement
 long_description    giza is a 2D scientific plotting library \
                     for C/Fortran built on the cairo graphics library. \
@@ -30,6 +32,13 @@ depends_build       port:pkgconfig
 
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:xorg-libX11
+
+# Xcode clang of 10.7 fails with error:
+# <stdin>:2579:2: error: invalid instruction mnemonic 'cvtsi2ssl' and others
+# https://github.com/william-dawson/NTPoly/issues/192
+# Note: This fixes same errors from gfortran, as well as clang.
+compiler.blacklist-append \
+                    {clang < 500}
 
 compilers.setup     require_fortran -g95
 


### PR DESCRIPTION
#### Description

* Blacklist 10.7 Xcode clang, fix "invalid instruction mnemonic cvtsi2ssl".
* Add openmaintainer.
* No rev bump.  Build fix only.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only. OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
