### PR TITLE
hamclock: Update to 4.21

### DIFF
--- a/x11/hamclock/Portfile
+++ b/x11/hamclock/Portfile
@@ -8,8 +8,12 @@ PortGroup           makefile 1.0
 legacysupport.newest_darwin_requires_legacy 15
 
 name                hamclock
-version             4.20
+version             4.21
 revision            0
+checksums           rmd160  25fb5309cac75f9fa8a9692176c6aa25c351a69f \
+                    sha256  6ad57d5b91a122cb1dfebc0ba30bec901105bc87c3ac89ff2537fcb7e923d9d2 \
+                    size    1969275
+
 categories          x11
 license             MIT
 maintainers         nomaintainer
@@ -23,9 +27,6 @@ homepage            https://www.clearskyinstitute.com/ham/HamClock
 master_sites        ${homepage}/
 distname            ESPHamClock-V${version}
 extract.suffix      .tgz
-checksums           rmd160  b580cb6e5f10b1aa000291c8243ab7a90a8602d2 \
-                    sha256  a4670e452b6472e916a0fb1343a8c61998d8420287fbd404725cd8357f4ce9ee \
-                    size    1966954
 
 worksrcdir          ESPHamClock
 
@@ -47,8 +48,11 @@ compiler.cxx_standard   2017
 configure.cxxflags-append \
                         -DNO_UPGRADE
 
-# If desired, there are targets for other sizes.
-build.target            hamclock-1600x960
+default_variants    +1600x960
+variant 800x480     description {Window 800x480}   {build.target hamclock-800x480  }
+variant 1600x960    description {Window 1600x960}  {build.target hamclock-1600x960 }
+variant 2400x1440   description {Window 2400x1440} {build.target hamclock-2400x1440}
+variant 3200x1920   description {Window 3200x1920} {build.target hamclock-3200x1920}
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
     build.env-append    LIBS=-lMacportsLegacySupport


### PR DESCRIPTION
#### Description

* Update hamclock 4.20 --> 4.21.
* Add variants for four different window sizes from upstream.
* Keep same original window size by use of default variant.
* Move checksums adjacent to version numbering.

###### Type(s)

- [x] enhancement

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?