### PR TITLE
bun: Update to v1.2.22

### DIFF
--- a/devel/bun/Portfile
+++ b/devel/bun/Portfile
@@ -1,25 +1,51 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           npm 1.0
+PortGroup           github 1.0
 
-npm.nodejs_version  22
+github.setup        oven-sh bun 1.2.22 v
+git.branch          ${github.project}-${github.tag_prefix}${github.version}
 
-name                bun
-version             1.2.18
 maintainers         {johnlindop.com:git @JLindop} openmaintainer
-revision            0
 
-description         JavaScript runtime built from scratch to serve the modern JavaScript ecosystem
+description         Bun is an all-in-one toolkit for JavaScript and TypeScript apps.
 
-long_description    Bun is an all-in-one JavaScript runtime & toolkit designed for \
-                    speed, complete with a bundler, test runner, and Node.js-compatible \
-                    package manager
+long_description    Bun is a fast JavaScript runtime designed as a drop-in replacement for Node.js. \
+                    It's written in Zig and powered by JavaScriptCore under the hood, \
+                    dramatically reducing startup times and memory usage.
 
 categories          devel
 homepage            https://bun.sh
 license             MIT
 
-checksums           rmd160  7aceebfde49033091343741e914545892d95dcae \
-                    sha256  48bccb43b95fcaa18ae7662a33bafc369e88192d6643c837955084cd72d28900 \
-                    size    5674
+# Checksums of source zip
+checksums           rmd160  89953c041f3941084e0168479396c778da5e8e10 \
+                    sha256  35101dfffd4c63e178c09b746512b28a7080be2a98e54293f5ef5a8f9032d400 \
+                    size    34697263
+
+supported_archs     arm64 x86_64
+
+if {${configure.build_arch} eq "arm64"} {
+    set dist_arch "aarch64"
+    checksums       rmd160  541a474d99af1b37c2e0905f2f41082b7d3ed9fe \
+                    sha256  eb8c7e09cbea572414a0a367848e1acbf05294a946a594405a014b1fb3b3fc76 \
+                    size    22178114
+} elseif {${configure.build_arch} eq "x86_64"} {
+    set dist_arch "x64"
+    checksums       rmd160  ce5d6f45b497c23f1642fdcf6c6b58df4b599e8f \
+                    sha256  a7484721a7ead45887c812e760b124047e663173cf2a3ba7c5aa1992cb22cd3e \
+                    size    24742163
+} else {
+    set dist_arch ${configure.build_arch}
+}
+
+distname            ${name}-${os.platform}-${dist_arch}
+use_zip             yes
+use_configure       no
+
+build {}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/bun ${destroot}${prefix}/bin/bun
+    file link -symbolic ${destroot}${prefix}/bin/bunx bun
+}


### PR DESCRIPTION
bun: Update to v1.2.22

#### Description
* Version bump to v1.2.22
* Switch PortGroup from `npm` to `github` - IMO it should not be necessary to use `npm` to install the thing that replaces `npm` (and `node`).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] security fix
- [x] enhancement
- [ ] bugfix

###### Tested on
macOS 15.6.1 24G90 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
