### PR TITLE
update to oath-toolkit: 2.6.13

### DIFF
--- a/security/oath-toolkit/Portfile
+++ b/security/oath-toolkit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                oath-toolkit
-version             2.6.12
+version             2.6.13
 revision            0
 categories          security devel
 maintainers         {alum.wpi.edu:arno+macports @fracai} openmaintainer
@@ -22,9 +22,9 @@ long_description    The OATH Toolkit contains a shared library, command line \
 homepage            https://www.nongnu.org/oath-toolkit/
 master_sites        savannah
 
-checksums           rmd160  b1fb77b34fdf2459d0899a9fcb8e33f9b9485097 \
-                    sha256  cafdf739b1ec4b276441c6aedae6411434bbd870071f66154b909cc6e2d9e8ba \
-                    size    4706950
+checksums           rmd160  ebb0e532933abb252ead4b3e14e101dd581acc62 \
+                    sha256  5b5d82e9a4455206d24fcbd7ee58bf4c79398a2e67997d80bd45ae927586b18b \
+                    size    3847530
 
 depends_build-append \
                     port:gtk-doc \


### PR DESCRIPTION
#### Description

update oath-toolkit to 2.6.13

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.6 24G84 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- n/a: tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
