### PR TITLE
osxphotos: update to 0.73.0

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.72.3
+version                 0.73.0
 revision                0
 
 categories              graphics python
@@ -25,9 +25,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  2879cc64c6032aef7111036288ed1c8d5f43cdba \
-                        sha256  7750595667e46cf5d4036a565738aa7c5ab3b6cc132a392d67614d41de8b1ca8 \
-                        size    2317550
+checksums               rmd160  4be1b85a461d849b302450ae5fc1aba765255094 \
+                        sha256  b968e6cc8186284a8528657105654ce6869b4e168cbc55c307f183530eae2c3a \
+                        size    2327235
 
 python.default_version  313
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.73.0.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?