### PR TITLE
openjdk25-zulu: update to 25.28.85

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -6,7 +6,12 @@ set feature 25
 name             openjdk${feature}-zulu
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 20}
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,14 +19,14 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-# https://www.azul.com/downloads/?version=java-25-ea&os=macos&package=jdk#zulu
-version      ${feature}.0.47
-set build    34
+# https://www.azul.com/downloads/?version=java-25&package=jdk#zulu
+version      ${feature}.28.85
+set build    36
 revision     0
 
 set openjdk_version ${feature}.0.0
 
-description  Azul Zulu Community OpenJDK ${feature} (Early Access)
+description  Azul Zulu Community OpenJDK ${feature} (Long Term Support until September 2033)
 long_description {*}${description} \
     \n\nAzul® Zulu® is a Java Development Kit (JDK), and a compliant \
     implementation of the Java Standard Edition (SE) specification that \
@@ -33,16 +38,18 @@ long_description {*}${description} \
 master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_x64
-    checksums    rmd160  27e98d939528ee34a800d92853917a5a48b47319 \
-                 sha256  ea0675044ccc7bdeaa2251af44181055126caebd6dc57722c0b93de763d1604b \
-                 size    226486201
+    set jdk_arch x64
+    checksums    rmd160  322c915d762600187b092961c03dbd53ecf70ea4 \
+                 sha256  c2cde1d313d904b793c3760214eefa207ecca7df04e7c4084abdf1f6bbebc27a \
+                 size    226469608
 } elseif {${configure.build_arch} eq "arm64"} {
-    distname     zulu${version}-beta-jdk${openjdk_version}-beta.${build}-macosx_aarch64
-    checksums    rmd160  52f97d2b3eb23865def7710d074445a356a9c692 \
-                 sha256  ed78d97ceb1ae7474f1c5117bb80dfaf6afa33561a094ddf7cd47736c7291279 \
-                 size    223966926
+    set jdk_arch aarch64
+    checksums    rmd160  16c2d650d712a9e52811e409f36c3a96516c9a5d \
+                 sha256  73f64f6bad7c3df31fba740fbcbbbef7c1a5cedeffbb5df386dd79bc72aba9b6 \
+                 size    223949294
 }
+
+distname     zulu${version}-ca-jdk${openjdk_version}-macosx_${jdk_arch}
 
 worksrcdir   ${distname}/zulu-${feature}.jdk
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.28.85.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?