### PR TITLE
openjdk25-graalvm: new submission

### DIFF
--- a/java/openjdk25-graalvm/Portfile
+++ b/java/openjdk25-graalvm/Portfile
@@ -1,0 +1,80 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+set feature 25
+name             openjdk${feature}-graalvm
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+
+# JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11 for x86_64:
+# /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist
+# Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any >= 20}
+
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://github.com/graalvm/graalvm-ce-builds/releases
+supported_archs  x86_64 arm64
+
+version          ${feature}.0.0
+set build        37
+revision         0
+
+description      GraalVM Community Edition based on OpenJDK ${feature} (support until March 2026)
+long_description GraalVM is an advanced JDK with ahead-of-time Native Image compilation
+
+master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    set graalvm_arch x64
+    checksums    rmd160  3a5473a82a4ff49803107427eab5440e7846e1db \
+                 sha256  04278cf867d040e29dc71dd7727793f0ea67eb72adce8a35d04b87b57906778d \
+                 size    309601958
+} elseif {${configure.build_arch} eq "arm64"} {
+    set graalvm_arch aarch64
+    checksums    rmd160  6c2198ec66deccbff9821a0af70e8faa50a1d6f8 \
+                 sha256  c446d5aaeda98660a4c14049d299e9fba72105a007df89f19d27cf3979d37158 \
+                 size    325159880
+}
+
+distname     graalvm-community-jdk-${version}_macos-${graalvm_arch}_bin
+
+worksrcdir   graalvm-community-openjdk-${feature}+${build}.1
+
+homepage     https://www.graalvm.org
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-${feature}-graalvm-community.jdk
+
+destroot {
+    xinstall -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for GraalVM Community Edition 25.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?