### PR TITLE
openjdk24-graalvm: mark as EOL

### DIFF
--- a/java/openjdk24-graalvm/Portfile
+++ b/java/openjdk24-graalvm/Portfile
@@ -1,6 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
+PortGroup        deprecated 1.0
+
+deprecated.eol_version yes
 
 set feature 24
 name             openjdk24-graalvm


### PR DESCRIPTION
#### Description

GraalVM Community Edition 24 has reached end of life.