### PR TITLE
Switch to macports.org e-mail, and mark Java 24 distributions as EOL

### DIFF
--- a/audio/ddptools/Portfile
+++ b/audio/ddptools/Portfile
@@ -8,7 +8,7 @@ revision        0
 
 categories      audio
 platforms       {darwin any}
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 license         NoMirror
 supported_archs x86_64
 

--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -8,7 +8,7 @@ version             538.0.0
 revision            0
 categories          devel python
 license             Apache-2
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 description         Command-line interface for Google Cloud Platform products and services
 long_description    Google Cloud SDK is a set of tools for Google Cloud Platform. \
                     It contains gcloud, gsutil, and bq command-line tools, which you can \

--- a/devel/kustomize/Portfile
+++ b/devel/kustomize/Portfile
@@ -9,7 +9,7 @@ revision            0
 categories          devel
 installs_libs       no
 license             Apache-2
-maintainers         {breun.nl:nils @breun} \
+maintainers         {breun @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 

--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -7,7 +7,7 @@ github.setup        GoogleContainerTools skaffold 2.16.1 v
 revision            0
 
 categories          devel
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 platforms           darwin
 license             Apache-2
 

--- a/devel/xa/Portfile
+++ b/devel/xa/Portfile
@@ -6,7 +6,7 @@ name                xa
 version             2.4.1
 revision            0
 categories          devel
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 description         Open-source 6502 cross assembler
 long_description    xa is a high-speed, two-pass portable cross-assembler. It \
                     understands mnemonics and generates code for NMOS 6502s \

--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -13,7 +13,7 @@ platforms               {darwin any}
 supported_archs         noarch
 
 maintainers             openmaintainer \
-                        {breun.nl:nils @breun} \
+                        {breun @breun} \
                         {@RhetTbull gmail.com:rturnbull}
 
 license                 MIT

--- a/java/gng/Portfile
+++ b/java/gng/Portfile
@@ -9,7 +9,7 @@ github.tarball_from tarball
 revision        0
 
 categories      java devel
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 platforms       {darwin any}
 license         Apache-2
 supported_archs noarch

--- a/java/jarviz/Portfile
+++ b/java/jarviz/Portfile
@@ -9,7 +9,7 @@ revision        1
 
 categories      java
 platforms       {darwin any}
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 license         Apache-2
 supported_archs noarch
 

--- a/java/jdk21-graalvm/Portfile
+++ b/java/jdk21-graalvm/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 21
 name             jdk${feature}-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 21
 name             jdk${feature}
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        darwin
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          NFTC NoMirror

--- a/java/jdk22-graalvm/Portfile
+++ b/java/jdk22-graalvm/Portfile
@@ -7,7 +7,7 @@ deprecated.eol_version yes
 
 name             jdk22-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # GraalVM Free Terms and Conditions: https://www.oracle.com/downloads/licenses/graal-free-license.html
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries

--- a/java/jdk22/Portfile
+++ b/java/jdk22/Portfile
@@ -7,7 +7,7 @@ deprecated.eol_version yes
 
 name             jdk22
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        darwin
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          NFTC NoMirror

--- a/java/jdk23-graalvm/Portfile
+++ b/java/jdk23-graalvm/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 23
 name             jdk${feature}-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # GraalVM Free Terms and Conditions: https://www.oracle.com/downloads/licenses/graal-free-license.html
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries

--- a/java/jdk23/Portfile
+++ b/java/jdk23/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 23
 name             jdk${feature}
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        darwin
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          NFTC NoMirror

--- a/java/jdk24-graalvm/Portfile
+++ b/java/jdk24-graalvm/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 24
 name             jdk${feature}-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # GraalVM Free Terms and Conditions: https://www.oracle.com/downloads/licenses/graal-free-license.html
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries

--- a/java/jdk24/Portfile
+++ b/java/jdk24/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 24
 name             jdk${feature}
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        darwin
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          NFTC NoMirror

--- a/java/jenv/Portfile
+++ b/java/jenv/Portfile
@@ -8,7 +8,7 @@ revision        0
 
 categories      java
 platforms       any
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 license         MIT
 supported_archs noarch
 

--- a/java/ki-shell/Portfile
+++ b/java/ki-shell/Portfile
@@ -9,7 +9,7 @@ revision        1
 
 categories      java
 platforms       any
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 license         Apache-2
 supported_archs noarch
 

--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -10,7 +10,7 @@ revision        0
 
 categories      java devel
 license         Apache-2
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 platforms       any
 supported_archs noarch
 

--- a/java/maven32/Portfile
+++ b/java/maven32/Portfile
@@ -3,6 +3,9 @@
 PortSystem 1.0
 PortGroup select 1.0
 PortGroup java 1.0
+PortGroup deprecated 1.0
+
+deprecated.eol_version yes
 
 name            maven32
 version         3.2.5

--- a/java/maven4/Portfile
+++ b/java/maven4/Portfile
@@ -12,7 +12,7 @@ revision        1
 
 categories      java devel
 license         Apache-2
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 platforms       any
 supported_archs noarch
 

--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -8,7 +8,7 @@ revision        0
 name            micronaut
 categories      java
 platforms       {darwin any}
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 license         Apache-2
 supported_archs x86_64 arm64
 universal_variant no

--- a/java/mvnd1/Portfile
+++ b/java/mvnd1/Portfile
@@ -8,7 +8,7 @@ revision        0
 name            mvnd1
 categories      java
 platforms       darwin
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 license         Apache-2
 
 description     mvnd 1 -- The Maven Daemon based on Apache Maven 3

--- a/java/mvnd2/Portfile
+++ b/java/mvnd2/Portfile
@@ -10,7 +10,7 @@ revision        0
 name            mvnd2
 categories      java
 platforms       darwin
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 license         Apache-2
 
 description     mvnd 2 -- The Maven Daemon based on Apache Maven 4

--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 11
 name             openjdk${feature}-corretto
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 11
 name             openjdk${feature}-microsoft
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 11
 name             openjdk${feature}-openj9
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        darwin
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 11
 name             openjdk${feature}-sap
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 11
 name             openjdk${feature}-temurin
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 11
 name             openjdk${feature}-zulu
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 17
 name             openjdk${feature}-corretto
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 17
 name             openjdk${feature}-microsoft
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 17
 name             openjdk${feature}-openj9
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.14.0:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 17
 name             openjdk${feature}-sap
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 17
 name             openjdk${feature}-temurin
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 17
 name             openjdk${feature}-zulu
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 21
 name             openjdk${feature}-corretto
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk21-graalvm/Portfile
+++ b/java/openjdk21-graalvm/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 21
 name             openjdk${feature}-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 21
 name             openjdk${feature}-microsoft
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 21
 name             openjdk${feature}-openj9
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.15.0:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk21-oracle/Portfile
+++ b/java/openjdk21-oracle/Portfile
@@ -7,7 +7,7 @@ deprecated.eol_version yes
 
 name             openjdk21-oracle
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 21
 name             openjdk${feature}-sap
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 21
 name             openjdk${feature}-temurin
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 21
 name             openjdk${feature}-zulu
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -11,7 +11,7 @@ revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 
 # Builds on macOS 10.12.0+
 # Mapping to Darwin version: https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version

--- a/java/openjdk22-corretto/Portfile
+++ b/java/openjdk22-corretto/Portfile
@@ -7,7 +7,7 @@ deprecated.eol_version yes
 
 name             openjdk22-corretto
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto
 # and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version

--- a/java/openjdk22-graalvm/Portfile
+++ b/java/openjdk22-graalvm/Portfile
@@ -7,7 +7,7 @@ deprecated.eol_version yes
 
 name             openjdk22-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk22-openj9/Portfile
+++ b/java/openjdk22-openj9/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 22
 name             openjdk${feature}-openj9
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk22-oracle/Portfile
+++ b/java/openjdk22-oracle/Portfile
@@ -7,7 +7,7 @@ deprecated.eol_version yes
 
 name             openjdk22-oracle
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk22-sap/Portfile
+++ b/java/openjdk22-sap/Portfile
@@ -7,7 +7,7 @@ deprecated.eol_version yes
 
 name             openjdk22-sap
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk22-temurin/Portfile
+++ b/java/openjdk22-temurin/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature      22
 name             openjdk${feature}-temurin
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 license          GPL-2+
 # This port uses prebuilt binaries for a particular architecture

--- a/java/openjdk22-zulu/Portfile
+++ b/java/openjdk22-zulu/Portfile
@@ -7,7 +7,7 @@ deprecated.eol_version yes
 
 name             openjdk22-zulu
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk22/Portfile
+++ b/java/openjdk22/Portfile
@@ -13,7 +13,7 @@ revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 description         OpenJDK 22 (Short Term Support until September 2024)
 long_description    JDK 22 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.

--- a/java/openjdk23-corretto/Portfile
+++ b/java/openjdk23-corretto/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 23
 name             openjdk${feature}-corretto
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk23-openj9/Portfile
+++ b/java/openjdk23-openj9/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 23
 name             openjdk${feature}-openj9
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk23-sap/Portfile
+++ b/java/openjdk23-sap/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 23
 name             openjdk${feature}-sap
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk23-temurin/Portfile
+++ b/java/openjdk23-temurin/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature      23
 name             openjdk${feature}-temurin
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 license          GPL-2+
 # This port uses prebuilt binaries for a particular architecture

--- a/java/openjdk23-zulu/Portfile
+++ b/java/openjdk23-zulu/Portfile
@@ -7,7 +7,7 @@ deprecated.eol_version yes
 
 name             openjdk23-zulu
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk23/Portfile
+++ b/java/openjdk23/Portfile
@@ -18,7 +18,7 @@ revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 description         OpenJDK ${feature} (Short Term Support until March 2025)
 long_description    JDK ${feature} builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.

--- a/java/openjdk24-corretto/Portfile
+++ b/java/openjdk24-corretto/Portfile
@@ -1,11 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
+PortGroup        deprecated 1.0
+
+deprecated.eol_version yes
 
 set feature 24
 name             openjdk${feature}-corretto
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk24-graalvm/Portfile
+++ b/java/openjdk24-graalvm/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 24
 name             openjdk24-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} {mascguy @mascguy} openmaintainer
+maintainers      {breun @breun} {mascguy @mascguy} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk24-openj9/Portfile
+++ b/java/openjdk24-openj9/Portfile
@@ -1,11 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
+PortGroup        deprecated 1.0
+
+deprecated.eol_version yes
 
 set feature 24
 name             openjdk${feature}-openj9
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.15.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk24-sap/Portfile
+++ b/java/openjdk24-sap/Portfile
@@ -1,11 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
+PortGroup        deprecated 1.0
+
+deprecated.eol_version yes
 
 set feature 24
 name             openjdk${feature}-sap
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.12 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk24-temurin/Portfile
+++ b/java/openjdk24-temurin/Portfile
@@ -1,11 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem       1.0
+PortGroup        deprecated 1.0
+
+deprecated.eol_version yes
 
 set feature      24
 name             openjdk${feature}-temurin
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 license          GPL-2+
 # This port uses prebuilt binaries for a particular architecture

--- a/java/openjdk24-zulu/Portfile
+++ b/java/openjdk24-zulu/Portfile
@@ -8,7 +8,7 @@ deprecated.eol_version yes
 set feature 24
 name             openjdk${feature}-zulu
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror

--- a/java/openjdk24/Portfile
+++ b/java/openjdk24/Portfile
@@ -1,6 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           deprecated 1.0
+
+deprecated.eol_version yes
 
 set feature 24
 
@@ -15,7 +18,7 @@ revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 description         OpenJDK ${feature} (Short Term Support until September 2025)
 long_description    {*}${description} \
     \n\nJDK ${feature} builds of OpenJDK, the Open-Source implementation \

--- a/java/openjdk25-graalvm/Portfile
+++ b/java/openjdk25-graalvm/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 25
 name             openjdk${feature}-graalvm
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 25
 name             openjdk${feature}-zulu
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 11 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 8
 name             openjdk${feature}-corretto
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 8
 name             openjdk${feature}-openj9
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.10.0:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 8
 name             openjdk${feature}-temurin
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 set feature 8
 name             openjdk${feature}-zulu
 categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
+maintainers      {breun @breun} openmaintainer
 
 # JVMMinimumSystemVersion in Contents/Info.plist is set to macOS 10.6.0 for x86_64:
 # /usr/libexec/PlistBuddy -c "Print :JavaVM:JVMMinimumSystemVersion" Contents/Info.plist

--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -9,7 +9,7 @@ revision        0
 
 categories      java
 platforms       {darwin any}
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 license         Apache-2
 supported_archs noarch
 

--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -8,7 +8,7 @@ version         5.0.1
 revision        0
 
 categories      lang java
-maintainers     {breun.nl:nils @breun} openmaintainer
+maintainers     {breun @breun} openmaintainer
 platforms       {darwin any}
 license         Apache-2
 supported_archs noarch

--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -10,7 +10,7 @@ github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
 platforms           {darwin any}
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 license             Apache-2
 
 description         Statically typed programming language for the JVM, \

--- a/python/py-makelive/Portfile
+++ b/python/py-makelive/Portfile
@@ -11,7 +11,7 @@ supported_archs     noarch
 platforms           {darwin any}
 license             MIT
 
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 
 description         Convert an photo + video pair into a Live Photo.
 long_description    {*}${description} \

--- a/python/py-whenever/Portfile
+++ b/python/py-whenever/Portfile
@@ -11,7 +11,7 @@ supported_archs     noarch
 platforms           {darwin any}
 license             MIT
 
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 
 description         Typed and DST-safe datetimes for Python.
 long_description    {*}${description} \

--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -18,7 +18,7 @@ categories          sysutils devel
 license             MIT
 installs_libs       no
 
-maintainers         {breun.nl:nils @breun} \
+maintainers         {breun @breun} \
                     openmaintainer
 
 checksums           rmd160  38150b170472a02463f5ba45dbd86728d2aa8261 \

--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -24,7 +24,7 @@ long_description    K9s provides a curses based terminal UI to interact with \
 categories          sysutils devel
 installs_libs       no
 license             Apache-2
-maintainers         {breun.nl:nils @breun} \
+maintainers         {breun @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 

--- a/sysutils/kube-ps1/Portfile
+++ b/sysutils/kube-ps1/Portfile
@@ -10,7 +10,7 @@ revision            0
 categories          sysutils
 platforms           {darwin any}
 supported_archs     noarch
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 license             Apache-2
 
 description         Kubernetes prompt info for bash and zsh

--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -10,7 +10,7 @@ revision            1
 categories          sysutils
 platforms           any
 supported_archs     noarch
-maintainers         {breun.nl:nils @breun} @gearnode openmaintainer
+maintainers         {breun @breun} @gearnode openmaintainer
 license             Apache-2
 
 description         Power tools for kubectl

--- a/sysutils/mac-brightnessctl/Portfile
+++ b/sysutils/mac-brightnessctl/Portfile
@@ -7,7 +7,7 @@ PortGroup           makefile 1.0
 github.setup        rakalex mac-brightnessctl 0.2.1
 revision            0
 categories          sysutils
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 license             MIT
 
 description mac-brightnessctl is a command line tool for controlling the keyboard backlight brightness on macOS.

--- a/sysutils/stern/Portfile
+++ b/sysutils/stern/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/stern/stern 1.33.0 v
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 # macOS 11 is the oldest version that provides a Go version that is recent enough to build Stern
 platforms           {darwin >= 20}
 revision            1

--- a/textproc/chordii/Portfile
+++ b/textproc/chordii/Portfile
@@ -6,7 +6,7 @@ name                chordii
 version             4.5.3
 
 categories          textproc
-maintainers         {breun.nl:nils @breun} openmaintainer
+maintainers         {breun @breun} openmaintainer
 platforms           darwin
 license             GPL-2
 description         Produce a professional looking PostScript sheet-music from an ASCII file containing lyrics and chords information.

--- a/textproc/pdfjam-extras/Portfile
+++ b/textproc/pdfjam-extras/Portfile
@@ -12,7 +12,7 @@ github.tarball_from     tarball
 version                 20191118
 
 categories              textproc pdf
-maintainers             {breun.nl:nils @breun} openmaintainer
+maintainers             {breun @breun} openmaintainer
 license                 GPL-2
 platforms               any
 supported_archs         noarch


### PR DESCRIPTION
Switch to macports.org e-mail, and mark Java 24 distributions as EOL.