### PR TITLE
zig: update minimum OS version

### DIFF
--- a/lang/zig/Portfile
+++ b/lang/zig/Portfile
@@ -12,7 +12,10 @@ revision            0
 categories          lang
 license             MIT
 maintainers         nomaintainer
-platforms           {darwin >= 20}
+
+# Minimum OS version is macOS 13.0
+# https://ziglang.org/download/0.15.1/release-notes.html#OS-Version-Requirements
+platforms           {darwin >= 22}
 
 description         Zig programming language
 


### PR DESCRIPTION
#### Description

Update minimum OS version to macOS 13 Ventura. https://ziglang.org/download/0.15.1/release-notes.html#OS-Version-Requirements mentions this as the minimum version, which is confirmed by builds indeed failing on macOS 12 and older in the [Port Health](https://ports.macports.org/port/zig/details/) overview.