### PR TITLE
weechat: update to 4.7.1

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.6.3
+version             4.7.1
 revision            0
-checksums           rmd160  2993420724648d78525b3b1addc1b5d6cfd7acf2 \
-                    sha256  5c0b5efa969b873c4be582019b18523ee403e7430b8223825bcdb44a89f5815d \
-                    size    2763576
+checksums           rmd160  c8683962267f791620f688e7f14b98fa55b25504 \
+                    sha256  e83fb71ca251c5dd74bd9c5a6bd3f85dc2eb8ecec0955f43c07f3e0911edb7d3 \
+                    size    2768340
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes

--- a/irc/weechat/files/no-extra-gcc-warnings.patch
+++ b/irc/weechat/files/no-extra-gcc-warnings.patch
@@ -1,11 +1,11 @@
 Remove extra warning flags that are not understood by old GCC versions.
 https://github.com/weechat/weechat/issues/891#issuecomment-1693308171
---- CMakeLists.txt.orig	2024-04-07 11:37:29.000000000 -0500
-+++ CMakeLists.txt	2024-05-17 23:06:30.000000000 -0500
-@@ -33,8 +33,6 @@
+--- CMakeLists.txt.orig	2025-08-16 12:49:19
++++ CMakeLists.txt	2025-09-16 16:16:35
+@@ -35,8 +35,6 @@
  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char -fms-extensions -Wall -Wextra")
- if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-   # extra options specific to gcc/g++
+ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+   # extra options specific to GCC
 -  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat-overflow=2 -Wformat-truncation=2")
 -  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat-overflow=2 -Wformat-truncation=2")
  endif()


### PR DESCRIPTION
#### Description
weechat: update to 4.7.1
* no-extra-gcc-warnings.patch: update patch to work with a newer file from upstream

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
