### PR TITLE
ruby-build: Update to 20250916.1

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20250908 v
+github.setup        rbenv ruby-build 20250916.1 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  d2bc1ceab440e742c10196f2188934ad4759c63b \
-                    sha256  057167bb7507be05f75449bc9b7531f68420de2b1347f5a50b99a0fc07bb197c \
-                    size    98011
+checksums           rmd160  7e7d517d9e30bc34f1ed00bb8d3e729a05b53974 \
+                    sha256  3e2c33a21a21cda5b4f8725850f9f142a4af0a4062b8b40d1e3c9fae7b50f3b2 \
+                    size    97347
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20250916.1


##### Tested on

macOS 15.6.1 24G90 arm64
Xcode 26.0 17A324


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
