### PR TITLE
splash: Update to 3.11.5

### DIFF
--- a/science/splash/Portfile
+++ b/science/splash/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup compilers 1.0
 PortGroup github    1.0
 
-github.setup        danieljprice splash 3.11.4 v
+github.setup        danieljprice splash 3.11.5 v
 github.tarball_from releases
 distname            ${name}-v${version}
 revision            0
 
-checksums           rmd160  a4046c22b669aedfd7b17047cf5702a34cd4e0be \
-                    sha256  1399562bba20434310f0916d2de496b020697958fa4e1de2d2616815054d1e66 \
-                    size    2612764
+checksums           rmd160  d51c2101c908fbc846d5366a770c378e1c8ccc35 \
+                    sha256  357d217c0bd61b7346f32f713d4315339fbf559eec289bcc57645bdc4215ff63 \
+                    size    2609758
 
 categories          science graphics
 maintainers         {monash.edu:daniel.price @danieljprice} openmaintainer
@@ -19,7 +19,7 @@ description         Smoothed Particle Hydrodynamics visualisation tool
 long_description    SPLASH is a tool for visualisation of (mainly astrophysical) \
                     Smoothed Particle Hydrodynamics simulations
 
-homepage            http://users.monash.edu.au/~dprice/splash
+homepage            https://users.monash.edu.au/~dprice/splash
 license             GPL-2+
 
 worksrcdir          ${name}


### PR DESCRIPTION
#### Description

* Update 3.11.4 --> 3.11.5.
* Fix homepage URL.

###### Type(s)

###### Tested on

CI only. OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

@herbygillot
@reneeotten