### PR TITLE
lft: Fix build failure on macOS 26

### DIFF
--- a/net/lft/Portfile
+++ b/net/lft/Portfile
@@ -19,7 +19,6 @@ long_description LFT, short for Layer Four Traceroute, is a \
     et al.  Also includes whob, a prefix whois client.
 license       Copyleft
 homepage      http://pwhois.org/lft/
-platforms     darwin
 master_sites  http://pwhois.org/get/
 
 checksums     rmd160 a62b93e141f7236de66165e0eb0a4f84f10bcbca \
@@ -27,6 +26,8 @@ checksums     rmd160 a62b93e141f7236de66165e0eb0a4f84f10bcbca \
               size   377135
 
 depends_lib   port:libpcap
+
+patchfiles-append   lft_types.h.patch
 
 configure.args    --mandir=\\\${prefix}/share/man
 

--- a/net/lft/files/lft_types.h.patch
+++ b/net/lft/files/lft_types.h.patch
@@ -1,0 +1,19 @@
+Fix:
+
+./lft_types.h:227:5: error: type name requires a specifier or qualifier
+  227 |     SLIST_ENTRY(trace_packet_info_s) next_by_hop;
+      |     ^
+--- lft_types.h.orig	2020-04-09 15:46:51.000000000 -0500
++++ lft_types.h	2025-09-16 23:00:25.000000000 -0500
+@@ -120,9 +120,9 @@
+ #include "lft_lsrr.h"
+ #include "whois.h"
+ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(DARWIN)
+ #include <sys/queue.h>
+-#elif !defined(DARWIN) && !defined(NETBSD)
++#elif !defined(NETBSD)
+ #include "lft_queue.h"
+ #endif
+ 


### PR DESCRIPTION
#### Description

lft: Fix build failure on macOS 26

Closes: https://trac.macports.org/ticket/72989

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
