### PR TITLE
openjdk25-corretto: update to 25.0.0.36.2

### DIFF
--- a/java/openjdk25-corretto/Portfile
+++ b/java/openjdk25-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-24/releases
-version      ${feature}.0.0.36.1
+version      ${feature}.0.0.36.2
 revision     0
 
 description  Amazon Corretto OpenJDK ${feature} (Long Term Support)
@@ -32,14 +32,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set corretto_arch x64
-    checksums    rmd160  bca3a4c86fccb0e996862387a79da9ecf72c3e80 \
-                 sha256  c7367135297ca2517b7d77b92d39dcde7fb1cbc00e6fdbfb3465a72ebbdc5353 \
-                 size    221086513
+    checksums    rmd160  7adc324e23b14fa34582b6a7e5e969abf495c5d5 \
+                 sha256  a64f90dde4695612902c58b1df286089f3af26b0b96d9c4fb7774812118f624f \
+                 size    221082645
 } elseif {${configure.build_arch} eq "arm64"} {
     set corretto_arch aarch64
-    checksums    rmd160  058e820192f6d74fed8266e2ea4f2dcea4a2cd49 \
-                 sha256  b0543d6a82128453f274cd089546b66dca7f6c83db278f5412095feba1b943e5 \
-                 size    218653102
+    checksums    rmd160  00ae642d79b86bd7bbb18839acc681408e051750 \
+                 sha256  62dc483ae2d51d995e7ec756cda0a3b2491293946f3e9281cc2e9a1b8f11d1bd \
+                 size    218657604
 }
 
 distname     amazon-corretto-${version}-macosx-${corretto_arch}


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 25.0.0.36.2.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?