### PR TITLE
chordii: discontinued upstream

### DIFF
--- a/textproc/chordii/Portfile
+++ b/textproc/chordii/Portfile
@@ -1,6 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           deprecated 1.0
+
+deprecated.upstream_support no
 
 name                chordii
 version             4.5.3


### PR DESCRIPTION
#### Description

Indicate that chordii is no longer receiving support upstream.