### PR TITLE
google-cloud-sdk: update to 539.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             538.0.0
+version             539.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  e87e1ce9a04089c860938c24fb74935e40469c73 \
-                    sha256  16f6b677939a6239868a0f7690fd116ebcef5e799b5e6333b40bf4f03368c542 \
-                    size    55363520
+    checksums       rmd160  895ccc24f0f06901f17953484f599be0b091948a \
+                    sha256  3c5e531a222653423c6e89d6413b14fbc244ef36890078902e8ab8dc382f6f8f \
+                    size    55414150
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  d7d0b3970c8fd1477db5aa0dba45213c56a12a21 \
-                    sha256  2ce1e9878e54ed0d76c715542cefaa9bf11c6e18f71ceceb182c63b7954c74c2 \
-                    size    56897016
+    checksums       rmd160  fdd3188d3de4809d3d80fcd1292443abf95159fe \
+                    sha256  45089aa49102fdfa42ee886795063f59a462219a14a7709345e7ea0e3c89f145 \
+                    size    56944180
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  0fe4bb4442f351839461875b08b1c1546fe976b1 \
-                    sha256  ef756bb422fb53cf134ecefc72d0e5486e6249b2322b4dc9d70db46236f41590 \
-                    size    56832631
+    checksums       rmd160  67d9859aab170ec8574f7a6c42e23fde30eefed0 \
+                    sha256  07731bea80c3414846ff77779e8f4bd058b1e1835e6c64da22089c8a5817d44a \
+                    size    56879321
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 539.0.0.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?