### PR TITLE
aacgain: fix compile on Tahoe (MacOS 26)

### DIFF
--- a/audio/aacgain/Portfile
+++ b/audio/aacgain/Portfile
@@ -35,4 +35,7 @@ platform darwin {
     configure.cflags-append -DHAS_LRINTF
 }
 
+compiler.cxx_standard   2003
+configure.cxxflags-append -std=c++03
+
 livecheck.type      none


### PR DESCRIPTION
clang tries to compile this with C++11, resulting in compilation errors, e.g.
```
:info:build atom_standard.cpp:25:28: error: constant expression evaluates to 169 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
:info:build    25 | static const char name[5]={0251,'n', 'a', 'm', '\0'};
:info:build       |                            ^~~~
```
Switching to older C++ standard resolves the issue

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
