### PR TITLE
vdt: update to 0.4.6

### DIFF
--- a/math/vdt/Portfile
+++ b/math/vdt/Portfile
@@ -5,9 +5,8 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        dpiparo vdt 0.4.4 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        dpiparo vdt 0.4.6 v
+github.tarball_from archive
 #github.setup        cjones051073 vdt b376d0f9e8cc97689d89f7f8c40c3a4644f48679
 #version             0.4.1
 revision            0
@@ -15,9 +14,9 @@ revision            0
 # turn off livecheck for git commits
 #livecheck.type      none
 
-checksums           rmd160  819b256c0875775d1a8d7ddff70675ff4f8af853 \
-                    sha256  fb9a8b67e857722f2573c67d2413e7dcce01bf6be6c5ac9632ade12d0ef272eb \
-                    size    59969
+checksums           rmd160  6c9d0463f5ea7c23a6f9d7caece23ebe97e8d172 \
+                    sha256  1820feae446780763ec8bbb60a0dbcf3ae1ee548bdd01415b1fb905fd4f90c54 \
+                    size    60081
 
 categories          math
 maintainers         {jonesc @cjones051073} openmaintainer
@@ -27,15 +26,13 @@ description         A collection of fast and inline implementations of mathemati
 long_description    ${name} provides {*}${description}.
 
 compiler.cxx_standard 2011
+# error: no member named 'copysign' in namespace
+# 'std'; did you mean simply 'copysign'?
+# Xcode Clang on macOS <10.9 does not support std::copysign
+compiler.blacklist-append \
+                    {clang < 600}
 
 # Disable extensions on Apple silicon for now
 if { ${configure.build_arch} in [list arm64 ppc ppc64] } {
     configure.args-append   -DSSE=OFF -DNEON=OFF
-}
-
-if {${os.major} >= 25} {
-    pre-configure {
-        # -Ofast is depreciated and warning causes build error with -Werror
-        reinplace "s|\-Ofast|\-O3|g" ${worksrcpath}/CMakeLists.txt
-    }
 }


### PR DESCRIPTION
* fix build on macOS 10.8

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
