### PR TITLE
wxWidgets-3.0: support macOS 26

### DIFF
--- a/graphics/wxWidgets-3.0/Portfile
+++ b/graphics/wxWidgets-3.0/Portfile
@@ -106,8 +106,15 @@ patchfiles-append   patch-configure.diff
 # 10.6-on-PPC hack; tested also on Rosetta:
 patchfiles-append   patch-ppc.diff
 
+patchfiles-append   patch-libpng.diff
+
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" ${patch.dir}/configure
+
+    if {${os.platform} eq "darwin" && [vercmp ${macosx_sdk_version} >= 26]} {
+        # https://developer.apple.com/documentation/macos-release-notes/macos-26-release-notes#AGL
+        reinplace "s| -framework AGL||g" ${patch.dir}/configure
+    }
 
     file mkdir ${selectdir}
     system "echo \"${wxWidgets.wxdir}/wx-config\n${wxWidgets.wxdir}/wxrc-${branch}\" > ${select.file}"

--- a/graphics/wxWidgets-3.0/files/patch-libpng.diff
+++ b/graphics/wxWidgets-3.0/files/patch-libpng.diff
@@ -1,0 +1,28 @@
+This is libpng 893b8113f04d408cc6177c6de19c9889a48faa24, backported to the
+version in wxWidgets-3.0
+
+https://github.com/pnggroup/libpng/commit/893b8113f04d408cc6177c6de19c9889a48faa24
+
+--- src/png/pngpriv.h
++++ src/png/pngpriv.h
+@@ -342,18 +342,8 @@
+     */
+ #  include <float.h>
+ 
+-#  if ( ( (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
+-    defined(THINK_C) || defined(TARGET_OS_MAC) ) && !wxOSX_USE_IPHONE ) || defined(__SC__)
+-     /* We need to check that <math.h> hasn't already been included earlier
+-      * as it seems it doesn't agree with <fp.h>, yet we should really use
+-      * <fp.h> if possible.
+-      */
+-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
+-#      include <fp.h>
+-#    endif
+-#  else
+-#    include <math.h>
+-#  endif
++#  include <math.h>
++
+ #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
+      /* Amiga SAS/C: We must include builtin FPU functions when compiling using
+       * MATH=68881


### PR DESCRIPTION
 - Backport a libpng patch. https://github.com/pnggroup/libpng/commit/893b8113f04d408cc6177c6de19c9889a48faa24
 - Don’t link against the AGL framework, removed from the macOS 26 SDK. https://developer.apple.com/documentation/macos-release-notes/macos-26-release-notes#AGL

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
