### PR TITLE
hugo: update to 0.150.0

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.148.1 v
+go.setup            github.com/gohugoio/hugo 0.150.0 v
 go.offline_build    no
 revision            0
 
-checksums           rmd160  be8a83e0b6e5c2c6833ceb74f3aa4b1007f8e897 \
-                    sha256  1fc153999cf7ba7bca88a85a75a30951587c8741fa742060ecc5c21c2f84a24e \
-                    size    14612804
+checksums           rmd160  371bd3b93e30025961b034899320afd2677e1cfe \
+                    sha256  ebb96dfbefad2941ec49aaa714e593720b2fcf60d85365b479938a5aa1594cd9 \
+                    size    14632845
 
 categories          www
 installs_libs       no


### PR DESCRIPTION
#### Description
hugo: update to 0.150.0

###### Tested on
macOS 15.3.1 24D70 arm64
Xcode 16.2 16C5032a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?