### PR TITLE
wxWidgets-3.2: Fix build on macOS 26

### DIFF
--- a/graphics/wxWidgets-3.2/Portfile
+++ b/graphics/wxWidgets-3.2/Portfile
@@ -43,7 +43,8 @@ dist_subdir         wxWidgets/${version}
 worksrcdir          ${distname}/build
 patch.dir           ${worksrcpath}/..
 
-patchfiles          configure.patch
+patchfiles          configure.patch \
+                    dd3f2509499e0e6aac4ebf8dab72b5d496c5bfbc.patch
 
 set selectdir       ${workpath}/select
 select.group        wxWidgets

--- a/graphics/wxWidgets-3.2/files/dd3f2509499e0e6aac4ebf8dab72b5d496c5bfbc.patch
+++ b/graphics/wxWidgets-3.2/files/dd3f2509499e0e6aac4ebf8dab72b5d496c5bfbc.patch
@@ -1,0 +1,31 @@
+From dd3f2509499e0e6aac4ebf8dab72b5d496c5bfbc Mon Sep 17 00:00:00 2001
+From: Vadim Zeitlin <vadim@wxwidgets.org>
+Date: Mon, 15 Sep 2025 22:38:04 +0200
+Subject: [PATCH] Don't link with unnecessary and now removed AGL framework
+
+This framework has apparently been deprecated since quite some time and
+was removed from macOS 26, so linking with it resulted in an error.
+
+Don't do this any longer.
+
+Closes #25798.
+
+Upstream-Status: Backport [https://github.com/wxWidgets/wxWidgets/commit/dd3f2509499e0e6aac4ebf8dab72b5d496c5bfbc]
+---
+ configure    | 2 +-
+ configure.ac | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 02147ce0254c..7ad2bbeea576 100755
+--- ./configure
++++ ./configure
+@@ -30865,7 +30865,7 @@ if test "$wxUSE_OPENGL" = "yes" -o "$wxUSE_OPENGL" = "auto"; then
+ 
+ 
+     if test "$wxUSE_OSX_COCOA" = 1; then
+-        OPENGL_LIBS="-framework OpenGL -framework AGL"
++        OPENGL_LIBS="-framework OpenGL"
+     elif test "$wxUSE_MSW" = 1; then
+         OPENGL_LIBS="-lopengl32"
+     elif test "$wxUSE_X11" = 1 -o "$wxUSE_GTK" = 1 -o "$wxUSE_QT" = 1; then


### PR DESCRIPTION
#### Description

AGL framework was removed from macOS, but it was apparently not needed anyway. Backport an upstream patch that removes it.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? (see also #29379)
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
