### PR TITLE
Add version 2.45 to crossbinutils

### DIFF
--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -111,6 +111,11 @@ array set crossbinutils.versions_info {
         sha256  ce2017e059d63e67ddb9240e9d4ec49c2893605035cd60e92ad53177f4377237 \
         size    27285788
     }}
+    2.45 {xz {
+        rmd160  04407793ec050b946eb982f1572e2806c63a3fb2 \
+        sha256  c50c0e7f9cb188980e2cc97e4537626b1672441815587f1eab69d2a1bfbef5d2 \
+        size    27868232
+    }}
 }
 
 proc crossbinutils.setup {target version} {


### PR DESCRIPTION
#### Description

Add latest version 2.45 to crossbinutils

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.7 24G222 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

