### PR TITLE
libfido2: update tarball extraction from releases

### DIFF
--- a/security/libfido2/Portfile
+++ b/security/libfido2/Portfile
@@ -10,8 +10,9 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 github.setup        Yubico libfido2 1.16.0
-github.tarball_from tarball
-revision            1
+github.tarball_from releases
+extract.rename      yes
+revision            2
 
 categories          security crypto
 maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer


### PR DESCRIPTION
## Port Fix

This PR fixes tarball extraction issues for libfido2 when using GitHub releases as the source.

### Description
The port was experiencing extraction failures when downloading tarballs from GitHub releases due to unexpected naming conventions. This fix switches to using the releases source and adds proper tarball renaming to handle the naming inconsistencies.

### Changes
* switch from tarball to releases source
* add extract.rename to handle unexpected tarball names  
* bump revision for the fix

### Testing Performed
- [x] Port builds successfully locally
- [x] Port lint passes with 0 errors and 0 warnings
- [x] Dependencies verified
- [x] Installation tested

**Tested on**

macOS 15.6.1 Xcode 16.4 / Command Line Tools 16.4.0.0.1.1747106510 (arm64)

### Port Details
- **Category**: security
- **Version**: 1.16.0
- **Homepage**: https://github.com/Yubico/libfido2
- **License**: BSD
- **Dependencies**: libcbor, mandoc, pkgconfig

### Maintainer
@trodemaster (openmaintainer)