### PR TITLE
algol68g: Update to 3.9.5

### DIFF
--- a/lang/algol68g/Portfile
+++ b/lang/algol68g/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                algol68g
-version             3.7.7
+version             3.9.5
 revision            0
 categories          lang algol devel
 license             GPL-3
@@ -16,9 +16,9 @@ homepage            https://jmvdveer.home.xs4all.nl/algol.html
 master_sites        https://jmvdveer.home.xs4all.nl/ \
                     https://github.com/NevilleDNZ/algol68g-mirror/archive/refs/tags/
 
-checksums           rmd160  ad311d64fdd65800792b75394b84aaf51f11b306 \
-                    sha256  91079b549aafb82eefb0aad2708ab266364fcc6fd34eb8f339fc79180d704a12 \
-                    size    665935
+checksums           rmd160  21a75ab32e3f3cc82f1c04bc613feea00caf4848 \
+                    sha256  10a07ec0f47e42367a1411f9ce309e13e4b7bee66bb5c218b212ff023bdaa39b \
+                    size    669324
 
 extract.rename      yes
 
@@ -127,5 +127,5 @@ variant R description {Enable R support} {
 }
 
 livecheck.type      regex
-livecheck.url       ${homepage}
+livecheck.url       [lindex ${master_sites} 0]/en.download.algol-68-genie-current.html
 livecheck.regex     algol68g-(\[0-9.\]+)${extract.suffix}

--- a/lang/algol68g/files/0006-Fix-endianness-includes-and-macros.patch
+++ b/lang/algol68g/files/0006-Fix-endianness-includes-and-macros.patch
@@ -3,6 +3,8 @@ From: barracuda156 <vital.had@gmail.com>
 Date: Sat, 20 Jan 2024 16:48:45 +0800
 Subject: [PATCH 6/6] Fix endianness includes and macros
 
+2025 Sept 17: Updated 2 of 4 patches for algol68g version 3.9.5.
+
 ---
  a68g-config.h               | 8 +++++++-
  configure.ac                | 2 +-
@@ -29,19 +31,19 @@ index d3a0e0e..3c87975 100644
  
  /* Define to 1 if you have the <errno.h> header file. */
  #define HAVE_ERRNO_H 1
-diff --git configure.ac configure.ac
-index e27241e..2e8c6f5 100644
---- configure.ac
-+++ configure.ac
-@@ -514,7 +514,7 @@ AC_HEADER_DIRENT
+
+--- configure.ac.orig	2025-09-15 08:48:43
++++ configure.ac	2025-09-17 18:10:37
+@@ -567,7 +567,7 @@
  AC_HEADER_SYS_WAIT
  AC_HEADER_TIOCGWINSZ
  
--AC_CHECK_HEADERS([assert.h complex.h ctype.h endian.h errno.h execinfo.h fcntl.h fenv.h float.h libgen.h limits.h regex.h setjmp.h signal.h stdarg.h stddef.h stdio.h stdlib.h sys/ioctl.h sys/resource.h sys/time.h termios.h time.h unistd.h])
-+AC_CHECK_HEADERS([assert.h complex.h ctype.h endian.h machine/endian.h sys/endian.h errno.h execinfo.h fcntl.h fenv.h float.h libgen.h limits.h regex.h setjmp.h signal.h stdarg.h stddef.h stdio.h stdlib.h sys/ioctl.h sys/resource.h sys/time.h termios.h time.h unistd.h])
+-AC_CHECK_HEADERS([assert.h complex.h ctype.h endian.h errno.h execinfo.h fcntl.h fenv.h float.h libgen.h limits.h malloc.h regex.h setjmp.h signal.h stdarg.h stddef.h stdio.h stdlib.h sys/ioctl.h sys/resource.h sys/time.h termios.h time.h unistd.h])
++AC_CHECK_HEADERS([assert.h complex.h ctype.h endian.h machine/endian.h sys/endian.h errno.h execinfo.h fcntl.h fenv.h float.h libgen.h limits.h malloc.h regex.h setjmp.h signal.h stdarg.h stddef.h stdio.h stdlib.h sys/ioctl.h sys/resource.h sys/time.h termios.h time.h unistd.h])
  
  #
  # Functions we expect.
+
 diff -u src/a68g/rts-sounds.c.orig src/a68g/rts-sounds.c
 --- src/a68g/rts-sounds.c.orig	2025-08-08 14:52:48
 +++ src/a68g/rts-sounds.c	2025-08-09 23:33:53
@@ -64,18 +66,17 @@ diff -u src/a68g/rts-sounds.c.orig src/a68g/rts-sounds.c
  #endif
  
  // From public Microsoft RIFF documentation.
-diff --git src/include/a68g-includes.h src/include/a68g-includes.h
-index 6134842..a680378 100644
---- src/include/a68g-includes.h
-+++ src/include/a68g-includes.h
+
+--- src/include/a68g-includes.h.orig	2025-09-15 08:46:38
++++ src/include/a68g-includes.h	2025-09-17 18:24:09
 @@ -75,6 +75,10 @@
  
  #if defined (HAVE_ENDIAN_H)
- #  include <endian.h>
+   #include <endian.h>
 +#elif defined (HAVE_MACHINE_ENDIAN_H)
-+#  include <machine/endian.h>
++  #include <machine/endian.h>
 +#elif defined (HAVE_SYS_ENDIAN_H)
-+#  include <sys/endian.h>
++  #include <sys/endian.h>
  #endif
  
  #if defined (HAVE_ERRNO_H)


### PR DESCRIPTION
#### Description

* Update algol68g 3.7.7 --> 3.9.5.
* Update 1 patch file with 2 changed patch hunks.
* Fix livecheck.

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?