### PR TITLE
commons-lang3: Update to 3.18.0, re-allow JDK > 11

### DIFF
--- a/java/commons-lang3/Portfile
+++ b/java/commons-lang3/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                commons-lang3
-version             3.12.0
+version             3.18.0
 
-checksums           rmd160  3980bb44f7492f9411f23916a122eca627dd8e1b \
-                    sha256  fb73e7475cb76fc400a58da92b8d8d930717424917f96b80bb70f4366fd8ac25 \
-                    size    1072858
+checksums           rmd160  94cd94f05acb947927a0cbff450d6c027c016b1f \
+                    sha256  4a94ddeb6a5819c5d0aa5678d16cf97a672b06398b93a0e4f90594032ca991f7 \
+                    size    1236581
 
 categories          java
 license             Apache-2
@@ -30,7 +30,7 @@ homepage            https://commons.apache.org/lang/
 distname            ${name}-${version}-src
 master_sites        apache:commons/lang/source/
 
-java.version        11
+java.version        11+
 # Use latest LTS Java as fallback
 java.fallback       openjdk11
 


### PR DESCRIPTION
#### Description

This was originally limited to 11 only because of
https://trac.macports.org/ticket/63375, but the root cause for that seems to have been https://trac.macports.org/ticket/61445, which has been fixed in the java PortGroup now.

In any case, I can successfully install commons-lang3 3.18.0 against openjdk25-zulu now, so I guess this restriction is no longer needed. This allows users to clean up their old JDK installs, and fixes build on Tahoe where openjdk11 doesn't install (I haven't investigated why).

See: https://trac.macports.org/ticket/63375
See: https://trac.macports.org/ticket/61445

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
