### PR TITLE
py-rencode: update to 1.0.8

### DIFF
--- a/python/py-rencode/Portfile
+++ b/python/py-rencode/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        aresch rencode 1.0.6 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        aresch rencode 1.0.8 v
+github.tarball_from archive
 name                py-rencode
 revision            0
 license             GPL-3+
@@ -15,15 +14,24 @@ maintainers         nomaintainer
 description         Python module for fast (basic) object serialization similar to bencode
 long_description    {*}${description}
 
-checksums           rmd160  b8571be3ea709a76e22dea6749cd1a56fed290f7 \
-                    sha256  63c586de1497d951b9f211f2fbf7dddc1d0d8378f5564000005a352efcf0744b \
-                    size    25466
+checksums           rmd160  5c2ef868d5ff1c284b541a549e162281009d829b \
+                    sha256  480aab74948a7f339b749b5c39bdb4caf15429f4b49a998c770d5f371098d351 \
+                    size    26072
 
 python.versions     39 310 311 312 313
 
+patchfiles          fix-build-tahoe-aarch64.diff
+
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-cython
+         port:py${python.version}-setuptools \
+         port:py${python.version}-cython
+
+    python.pep517         yes
+    python.pep517_backend poetry
+
+    # https://trac.macports.org/ticket/64425
+    build.cmd       pyproject-build-${python.branch} --wheel --no-isolation --outdir ${workpath}
 
     test.run        yes
     python.test_framework

--- a/python/py-rencode/files/fix-build-tahoe-aarch64.diff
+++ b/python/py-rencode/files/fix-build-tahoe-aarch64.diff
@@ -1,0 +1,13 @@
+diff --git build.py build.py
+index 658ada2..01645a2 100644
+--- build.py
++++ build.py
+@@ -11,7 +11,7 @@ from setuptools import Extension
+ from setuptools.command.build_ext import build_ext
+ 
+ 
+-COMPILE_ARGS = ["-march=native", "-O3", "-msse", "-msse2", "-mfma", "-mfpmath=sse"]
++COMPILE_ARGS = ["-O3"]
+ LINK_ARGS: list[str] = []
+ INCLUDE_DIRS: list[str] = []
+ LIBRARIES: list[str] = []


### PR DESCRIPTION
#### Description

Update py-rencode to 1.0.8.

The additional patch I added fixes a failure to build on Tahoe aarch64:

    Compiling rencode/_rencode.pyx because it changed.
    [1/1] Cythonizing rencode/_rencode.pyx
    clang: error: unsupported option '-msse' for target 'arm64-apple-darwin25.0.0'
    clang: error: unsupported option '-msse2' for target 'arm64-apple-darwin25.0.0'
    clang: error: unsupported option '-mfma' for target 'arm64-apple-darwin25.0.0'

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? 
- [ ] tried a full install with `sudo port -vst install`? - Not possible due to https://trac.macports.org/ticket/66358
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?