### PR TITLE
qt5-qtbase: Fix build on macOS 26

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1061,6 +1061,10 @@ foreach {module module_info} [array get modules] {
             # this patch is specific to version 5.15
             patchfiles-append patch-qt515-highsierra1.diff
 
+            # macOS Tahoe removed AGL.framework
+            # https://trac.macports.org/ticket/72729
+            patchfiles-append patch-qtbase-tahoe-no-agl-framework.diff
+
             # find the Rez program
             patchfiles-append patch-find_rez.diff
             post-patch {
@@ -1272,6 +1276,7 @@ foreach {module module_info} [array get modules] {
             # ICU requires C++17
             compiler.cxx_standard   2017
             configure.args-append   QMAKE_CXXFLAGS_GNUCXX11=-std=c++17
+            patchfiles-append       patch-qtbase-icu-cxx11.diff
 
             # Additional options:
             configure.args-append       \

--- a/aqua/qt5/files/patch-qtbase-icu-cxx11.diff
+++ b/aqua/qt5/files/patch-qtbase-icu-cxx11.diff
@@ -1,0 +1,19 @@
+icu config test: require C++11 (actually C++17)
+
+ICU headers now require C++17, and while the Portfile already sets
+`QMAKE_CXXFLAGS_GNUCXX11=-std=c++17`, the config test does not actually add
+`-std=${QMAKE_CXXFLAGS_GNUCXX11}` unless the project file declares that C++11
+is required.
+
+--- ./src/corelib/configure.json.orig   2025-09-18 11:39:50
++++ ./src/corelib/configure.json        2025-09-18 11:40:27
+@@ -102,7 +102,8 @@
+                     "UCollator *collator = ucol_open(\"ru_RU\", &status);",
+                     "if (!U_FAILURE(status))",
+                     "    ucol_close(collator);"
+-                ]
++                ],
++                "qmake": "CONFIG += c++11"
+             },
+             "headers": [ "unicode/utypes.h", "unicode/ucol.h", "unicode/ustring.h" ],
+             "sources": [

--- a/aqua/qt5/files/patch-qtbase-tahoe-no-agl-framework.diff
+++ b/aqua/qt5/files/patch-qtbase-tahoe-no-agl-framework.diff
@@ -1,0 +1,23 @@
+macOS Tahoe no longer has AGL.framework, remove it
+
+--- ./mkspecs/common/mac.conf.orig      2025-09-17 21:42:08
++++ ./mkspecs/common/mac.conf   2025-09-17 23:13:58
+@@ -18,8 +18,7 @@
+
+ # sdk.prf will prefix the proper SDK sysroot
+ QMAKE_INCDIR_OPENGL     = \
+-    /System/Library/Frameworks/OpenGL.framework/Headers \
+-    /System/Library/Frameworks/AGL.framework/Headers/
++    /System/Library/Frameworks/OpenGL.framework/Headers
+
+ QMAKE_FIX_RPATH         = install_name_tool -id
+
+@@ -30,7 +29,7 @@
+ QMAKE_REL_RPATH_BASE    = @loader_path
+
+ QMAKE_LIBS_DYNLOAD      =
+-QMAKE_LIBS_OPENGL       = -framework OpenGL -framework AGL
++QMAKE_LIBS_OPENGL       = -framework OpenGL
+ QMAKE_LIBS_THREAD       =
+
+ QMAKE_INCDIR_WAYLAND    =


### PR DESCRIPTION
#### Description

AGL.framework no longer exists, but is apparently also not needed — just remove it on Tahoe and above.

Additionally, the configure test for ICU fails because ICU now required C++17, but the config test did not pass the required flag. Some attempts seem to have been made to fix this, but they weren't sufficient in my testing unless the qmake project file also declared 'CONFIG += c++11'. Add a patch that does that.

Closes: https://trac.macports.org/ticket/72729

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
