### PR TITLE
dagger: update to 0.18.19

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.17 v
+github.setup        dagger dagger 0.18.19 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  dfcb674abc751df906139293748564ab3e627159 \
-                            sha256  9c7a29fdb610130e5d991a6f818a83212b14b91a759024905167141a40e3dfe5 \
-                            size    19639322
+        checksums           rmd160  a46b4fc5c39cb8341f194666fd0f20b788c0a2e2 \
+                            sha256  8f5c2572061a5382d1053bd1838d2f5ec87f9ec8f3314dd820d4ea3e3ad221aa \
+                            size    19815802
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  d83413273618e5a2d30b7819c9cdbe0006af3176 \
-                            sha256  93ad14c8d2137bb5cdda950ee0484c7fe97f6186657272610b32139c3a65773d \
-                            size    18535819
+        checksums           rmd160  7fec17abee76298bcce788a23e1d576a14e95b4e \
+                            sha256  1213e12d4133b00f48be7866c1552bbf3dd3e2c8bd000b6175f1877ed6220c91 \
+                            size    18689864
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

###### Tested on

macOS 15.6.1 24G90 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?