### PR TITLE
splash: Fix build for 10.7

### DIFF
--- a/science/splash/Portfile
+++ b/science/splash/Portfile
@@ -30,6 +30,13 @@ if {![variant_isset pgplot]} {
 
 use_configure       no
 
+# Xcode clang of 10.7 fails with error:
+# work/.tmp/cciqeg1w.s:1174:2: error: invalid instruction mnemonic 'cvtsi2sdl' etc.
+# https://github.com/william-dawson/NTPoly/issues/192
+# Note: This fixes same errors from gfortran, as well as clang.
+compiler.blacklist-append \
+                    {clang < 500}
+
 compilers.setup     require_fortran -g95 -gcc44 -clang
 
 build.cmd           make


### PR DESCRIPTION
#### Description

* Blacklist 10.7 Xcode clang, fix "invalid instruction mnemonic cvtsi2sdl".
* No rev bump. Build fix only.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?