### PR TITLE
knot, libknot, knot-resolver: fix build on macOS >=10.7 and =<10.13

### DIFF
--- a/net/knot-resolver/Portfile
+++ b/net/knot-resolver/Portfile
@@ -46,7 +46,20 @@ configure.args      -Dkeyfile_default=${prefix}/var/lib/knot-resolver/root.ds \
                     -Dunit_tests=disabled
 
 # Should match knot port
-platforms {darwin >= 15}
+platforms {darwin >= 11}
+
+# error: address argument to atomic operation must be a
+# pointer to non-const _Atomic type on macOS <10.14
+# Uses C17 atomics.
+compiler.c_standard 2017
+
+# EHOSTDOWN and ENOTRECOVERABLE was enabled by default in the kernel
+# with macOS 10.10. For 10.7-10.9 it's possible to use this only
+# with the -D__DARWIN_C_LEVEL=__DARWIN_C_FULL flag.
+if {${os.platform} eq "darwin" && ${os.major} < 14 && ${os.major} > 10} {
+    configure.cflags-append \
+                     -D__DARWIN_C_LEVEL=__DARWIN_C_FULL
+}
 
 startupitem.create      yes
 startupitem.netchange   yes

--- a/net/knot/Portfile
+++ b/net/knot/Portfile
@@ -37,9 +37,23 @@ depends_lib         port:fstrm \
                     port:userspace-rcu
 
 # Should match knot-resolver port
-platforms {darwin >= 15}
+platforms {darwin >= 11}
 
-patchfiles          patch-src-knot-server-quic-handler.c.diff
+# error: address argument to atomic operation must be a
+# pointer to non-const _Atomic type on macOS <10.14
+# Uses C17 atomics.
+compiler.c_standard 2017
+
+patchfiles-append   patch-src-knot-server-quic-handler.c.diff
+
+# https://github.com/CZ-NIC/knot/pull/35
+# TCP Fast Open API support was implemented in macOS 10.11.
+# Despite the correctness of the compatibility patch, it
+# wasn't be added to upstream.
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    patchfiles-append \
+                    patch-for-macos-10.11-and-older.diff
+}
 
 post-patch {
     reinplace "s|task_t|k_task_t|g" \

--- a/net/knot/files/patch-for-macos-10.11-and-older.diff
+++ b/net/knot/files/patch-for-macos-10.11-and-older.diff
@@ -1,0 +1,74 @@
+--- src/contrib/net.c
++++ src/contrib/net.c
+@@ -6,12 +6,12 @@
+ #include <assert.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#include <sys/socket.h>
+ #include <sys/types.h>   // OpenBSD
+ #include <netinet/tcp.h> // TCP_FASTOPEN
+ #include <netinet/in.h>
+ #include <poll.h>
+ #include <stdbool.h>
+-#include <sys/socket.h>
+ #include <sys/uio.h>
+ #include <unistd.h>
+ 
+--- src/contrib/net.c
++++ src/contrib/net.c
+@@ -21,6 +21,10 @@
+ #include "contrib/sockaddr.h"
+ #include "contrib/time.h"
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ /*!
+  * \brief Enable socket option.
+  */
+@@ -238,7 +242,7 @@ static int tfo_connect(int sock, const struct sockaddr_storage *addr)
+ 	return KNOT_EOK;
+ #elif defined(__FreeBSD__)
+ 	return sockopt_enable(sock, IPPROTO_TCP, TCP_FASTOPEN);
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
+ 	/* Connection is performed lazily when first data is sent. */
+ 	sa_endpoints_t ep = {
+ 		.sae_dstaddr = (const struct sockaddr *)addr,
+--- src/utils/common/netio.c
++++ src/utils/common/netio.c
+@@ -17,6 +17,10 @@
+ #include <sys/uio.h>
+ #endif
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ #include "utils/common/netio.h"
+ #include "utils/common/msg.h"
+ #include "utils/common/tls.h"
+@@ -347,7 +351,7 @@ static int fastopen_connect(int sockfd, const struct addrinfo *srv)
+ #if defined( __FreeBSD__)
+ 	const int enable = 1;
+ 	return setsockopt(sockfd, IPPROTO_TCP, TCP_FASTOPEN, &enable, sizeof(enable));
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
+ 	// connection is performed lazily when first data are sent
+ 	struct sa_endpoints ep = {0};
+ 	ep.sae_dstaddr = srv->ai_addr;
+--- src/knot/server/server.c
++++ src/knot/server/server.c
+@@ -192,7 +192,11 @@ static bool enable_pktinfo(int sock, int family)
+ 		break;
+ 	case AF_INET6:
+ 		level = IPPROTO_IPV6;
++#if defined(IPV6_RECVPKTINFO)
+ 		option = IPV6_RECVPKTINFO; /* Multiplatform */
++#else
++		option = IPV6_PKTINFO;
++#endif
+ 		break;
+ 	default:
+ 		assert(0);


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
