### PR TITLE
openjdk21-jetbrains: update to 21.0.8b1115.48

### DIFF
--- a/java/openjdk21-jetbrains/Portfile
+++ b/java/openjdk21-jetbrains/Portfile
@@ -5,7 +5,7 @@ PortGroup        github 1.0
 
 set feature 21
 set openjdk_version ${feature}.0.8
-set jbr_version b1097.42
+set jbr_version b1115.48
 github.setup     JetBrains JetBrainsRuntime ${openjdk_version}${jbr_version} jbr-release-
 github.tarball_from archive
 name             openjdk${feature}-jetbrains
@@ -41,14 +41,14 @@ use_bzip2        no
 
 if {${configure.build_arch} eq "x86_64"} {
     set jbr_arch x64
-    checksums    rmd160  18705afb56fcc473212c5bb0dd359bb17d4635a3 \
-                 sha256  573509ea10fc651758864cf221c67a2b00592ca2c1ac9be66d9ff8f39528fa66 \
-                 size    95819186
+    checksums    rmd160  39d5ea48c35cda64bb2ad3e3fa0aa68ffe95ef1d \
+                 sha256  e8ee0e60d2ca9c131c91795c626f21b8d7d0f799699f6647f22a096e63c28a7b \
+                 size    95831404
 } else {
     set jbr_arch aarch64
-    checksums    rmd160  2a5dce94a7c4f60ad8a7b0dfe1df5e8ec6a394ee \
-                 sha256  efb48777210d76103438634303b6b7bcbe898b53873576237fbcd17bac66b234 \
-                 size    94718177
+    checksums    rmd160  858abd27d7cb5fe7262f6e894218bb8edef731aa \
+                 sha256  78242527f7a51b4cd725b9afc9c1f309dedd57a67b8d9412d3ca84fe0351c4b7 \
+                 size    94721417
 }
 
 distname         jbr-${openjdk_version}-osx-${jbr_arch}-${jbr_version}


### PR DESCRIPTION
#### Description

Update to 21.0.8b1115.48.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?