### PR TITLE
k9s: update to 0.50.12

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.50.10 v
+go.setup            github.com/derailed/k9s 0.50.12 v
 go.offline_build    no
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {breun @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  1360523d54ece0e126f096abd789044b5bcda9cd \
-                    sha256  ee6d0905bb1821a630829929586ad184ee3a9816827f8a2647278e4d66b9434b \
-                    size    6808221
+checksums           rmd160  36f5bb59cd04a7b2d13bd1e710158ac2813188f2 \
+                    sha256  b3e0fa057bfb1af9e1823128dbfe624526f5660957a14a03484bd98911266d26 \
+                    size    6808697
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

Update to k9s 0.50.12.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?