### PR TITLE
py-zipfile-deflate64: Xcode ≥ 16.3 compatibility

### DIFF
--- a/python/py-zipfile-deflate64/Portfile
+++ b/python/py-zipfile-deflate64/Portfile
@@ -24,5 +24,8 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools_scm
 
+    patchfiles-append \
+                    patch-zlib.diff
+
     livecheck.type  none
 }

--- a/python/py-zipfile-deflate64/files/patch-zlib.diff
+++ b/python/py-zipfile-deflate64/files/patch-zlib.diff
@@ -1,0 +1,61 @@
+This adapts
+https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9
+(2024-01-14), which appeared in zlib 1.3.1 (2024-01-22), to the snapshot of zlib
+in zipfile-deflate64 0.2.0 (2022-01-05). This zlib snapshot is based on zlib
+1.2.11 (2017-01-15).
+
+This patch is necessary for compatibility with the Clang compiler in Xcode ≥
+16.3: TARGET_OS_MAC as it was used in zutil.h intends to refer to the Classic
+Mac OS. This macro has long been defined by the macOS SDK to mean modern macOS,
+but was only defined by <TargetConditionals.h>, which was not ordinarily
+#included by any part of the zipfile-deflate64 build.
+https://github.com/llvm/llvm-project/commit/6e1f19168bca7e3bd4eefda50ba03eac8441dbbf
+(2023-12-07, in upstream Clang 18.1, 2024-01-29, and in Xcode 16.3, 2025-03-31)
+now has the compiler itself defining this macro unconditionally for Apple
+targets
+(https://releases.llvm.org/18.1.0/tools/clang/docs/ReleaseNotes.html#clang-frontend-potentially-breaking-changes),
+with the effect of breaking code like this that used the macro in a different
+way. There was some discussion of this at
+https://github.com/madler/zlib/pull/895.
+
+--- zlib/zutil.h	2022-01-05 09:23:23
++++ zlib/zutil.h	2025-09-20 03:33:30
+@@ -130,17 +130,8 @@
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
+ #endif
+ 
+ #ifdef __acorn
+@@ -163,19 +154,12 @@
+ #  define OS_CODE 19
+ #endif
+ 
+-#if defined(_BEOS_) || defined(RISCOS)
+-#  define fdopen(fd,mode) NULL /* No fdopen() */
+-#endif
+-
+ #if (defined(_MSC_VER) && (_MSC_VER > 600)) && !defined __INTERIX
+ #  if defined(_WIN32_WCE)
+-#    define fdopen(fd,mode) NULL /* No fdopen() */
+ #    ifndef _PTRDIFF_T_DEFINED
+        typedef int ptrdiff_t;
+ #      define _PTRDIFF_T_DEFINED
+ #    endif
+-#  else
+-#    define fdopen(fd,type)  _fdopen(fd,type)
+ #  endif
+ #endif
+ 


### PR DESCRIPTION
This adapts https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9 (2024-01-14), which appeared in zlib 1.3.1 (2024-01-22), to the snapshot of zlib in zipfile-deflate64 0.2.0 (2022-01-05). This zlib snapshot is based on zlib 1.2.11 (2017-01-15).

This patch is necessary for compatibility with the Clang compiler in Xcode ≥ 16.3: TARGET_OS_MAC as it was used in zutil.h intends to refer to the Classic Mac OS. This macro has long been defined by the macOS SDK to mean modern macOS, but was only defined by <TargetConditionals.h>, which was not ordinarily https://github.com/llvm/llvm-project/commit/6e1f19168bca7e3bd4eefda50ba03eac8441dbbf (2023-12-07, in upstream Clang 18.1, 2024-01-29, and in Xcode 16.3, 2025-03-31) now has the compiler itself defining this macro unconditionally for Apple targets (https://releases.llvm.org/18.1.0/tools/clang/docs/ReleaseNotes.html#clang-frontend-potentially-breaking-changes), with the effect of breaking code like this that used the macro in a different way. There was some discussion of this at https://github.com/madler/zlib/pull/895.

The upstream project, https://github.com/brianhelba/zipfile-deflate64/, appears dead, with no updates since 2022-01-05, and no action on pull requests since then either. https://github.com/brianhelba/zipfile-deflate64/issues/45 was reported against the upstream on 2025-04-24 for this exact problem. But @brianhelba anyway in case it helps.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
