### PR TITLE
macos-trash: Update to 2.0.0

### DIFF
--- a/sysutils/macos-trash/Portfile
+++ b/sysutils/macos-trash/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
-github.setup        sindresorhus macos-trash 1.2.0 v
+github.setup        sindresorhus macos-trash 2.0.0 v
 revision            0
 github.tarball_from archive
 
@@ -19,19 +19,13 @@ description         command-line program that moves items to the trash
 long_description    ${name} is a small command-line program that moves \
                     files or folders to the trash, written in Swift
 
-checksums           rmd160  0fc3fbf74364226cf9e8b90bc8fbc1edb509260e \
-                    sha256  c4472b5c8024806720779bc867da1958fe871fbd93d200af8a2cc4ad1941be28 \
-                    size    2986
+checksums           rmd160  5a73588b188ed8834ae98d5cf5702df76df7231e \
+                    sha256  95eeea2a96e5d989145da4697206062798b9f708101dc426ae5a489969619114 \
+                    size    3123
 
-minimum_xcodeversions {20 13}
+minimum_xcodeversions {23 16.1}
 
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} requires macOS 11 or later."
-        return -code error "incompatible macOS version"
-    }
-}
+platforms           {darwin >= 23}
 
 use_configure       no
 use_xcode           yes


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A354 arm64
Xcode 26.0 17A324


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
