### PR TITLE
ffmpeg*: drop '-Wl,-ld_classic'

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -20,6 +20,14 @@ version             8.0
 revision            1
 epoch               2
 
+# FIXME: drop this upon next update
+# drop "configure.ldflags-append -Wl,-ld_classic"; this was required at some point to build the port
+# this is no longer the case and causes dependents to fail with errors like:
+# "ld: chained fixups, seg_count exceeds number of segments in ....
+if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+    incr revision
+}
+
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {mascguy @mascguy} openmaintainer
@@ -321,15 +329,6 @@ platform darwin {
         if {[variant_isset rav1e]} {
             error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
         }
-    }
-
-    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
-    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
-    #
-    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
-    if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
-        configure.ldflags-append \
-                    -Wl,-ld_classic
     }
 }
 

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -21,6 +21,14 @@ version             4.4.6
 revision            2
 epoch               1
 
+# FIXME: drop this upon next update
+# drop "configure.ldflags-append -Wl,-ld_classic"; this was required at some point to build the port
+# this is no longer the case and causes dependents to fail with errors like:
+# "ld: chained fixups, seg_count exceeds number of segments in ....
+if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+    incr revision
+}
+
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {mascguy @mascguy} {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer
@@ -316,15 +324,6 @@ platform darwin {
         if {[variant_isset rav1e]} {
             error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
         }
-    }
-
-    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
-    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
-    #
-    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
-    if { ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
-        configure.ldflags-append \
-                    -Wl,-ld_classic
     }
 }
 

--- a/multimedia/ffmpeg4/Portfile
+++ b/multimedia/ffmpeg4/Portfile
@@ -19,6 +19,14 @@ set my_name         ffmpeg
 version             4.4.6
 revision            2
 
+# FIXME: drop this upon next update
+# drop "configure.ldflags-append -Wl,-ld_classic"; this was required at some point to build the port
+# this is no longer the case and causes dependents to fail with errors like:
+# "ld: chained fixups, seg_count exceeds number of segments in ....
+if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+    incr revision
+}
+
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {makr @mohd-akram} {mascguy @mascguy} openmaintainer
@@ -318,15 +326,6 @@ platform darwin {
         if {[variant_isset rav1e]} {
             error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
         }
-    }
-
-    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
-    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
-    #
-    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
-    if { ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
-        configure.ldflags-append \
-                    -Wl,-ld_classic
     }
 }
 

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -18,6 +18,14 @@ set my_name         ffmpeg
 version             6.1.2
 revision            8
 
+# FIXME: drop this upon next update
+# drop "configure.ldflags-append -Wl,-ld_classic"; this was required at some point to build the port
+# this is no longer the case and causes dependents to fail with errors like:
+# "ld: chained fixups, seg_count exceeds number of segments in ....
+if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+    incr revision
+}
+
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {mascguy @mascguy} openmaintainer
@@ -313,15 +321,6 @@ platform darwin {
         if {[variant_isset rav1e]} {
             error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
         }
-    }
-
-    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
-    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
-    #
-    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
-    if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
-        configure.ldflags-append \
-                    -Wl,-ld_classic
     }
 }
 

--- a/multimedia/ffmpeg7/Portfile
+++ b/multimedia/ffmpeg7/Portfile
@@ -13,6 +13,14 @@ set my_name         ffmpeg
 version             7.1.1
 revision            2
 
+# FIXME: drop this upon next update
+# drop "configure.ldflags-append -Wl,-ld_classic"; this was required at some point to build the port
+# this is no longer the case and causes dependents to fail with errors like:
+# "ld: chained fixups, seg_count exceeds number of segments in ....
+if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+    incr revision
+}
+
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {mascguy @mascguy} \
@@ -321,15 +329,6 @@ platform darwin {
         if {[variant_isset rav1e]} {
             error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
         }
-    }
-
-    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
-    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
-    #
-    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
-    if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
-        configure.ldflags-append \
-                    -Wl,-ld_classic
     }
 }
 

--- a/multimedia/ffmpeg8/Portfile
+++ b/multimedia/ffmpeg8/Portfile
@@ -13,6 +13,14 @@ set my_name         ffmpeg
 version             8.0
 revision            0
 
+# FIXME: drop this upon next update
+# drop "configure.ldflags-append -Wl,-ld_classic"; this was required at some point to build the port
+# this is no longer the case and causes dependents to fail with errors like:
+# "ld: chained fixups, seg_count exceeds number of segments in ....
+if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+    incr revision
+}
+
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {mascguy @mascguy} \
@@ -317,15 +325,6 @@ platform darwin {
         if {[variant_isset rav1e]} {
             error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
         }
-    }
-
-    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
-    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
-    #
-    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
-    if { ${os.major} == 23 && ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
-        configure.ldflags-append \
-                    -Wl,-ld_classic
     }
 }
 


### PR DESCRIPTION
This PR removes the addition of `configure.ldflags-append -Wl,-ld_classic` on macOS 14 and/or XCode 15 or above. It is certainly not needed on Tahoe and perhaps no longer on earlier versions either (we'll see what happens in the CI). For sure the conditional needs to be fine-tuned.

In any case, this resolves build issues of depends due to:
```
ld: chained fixups, seg_count exceeds number of segments in '/opt/local/libexec/ffmpeg7/lib/libswresample.5.3.100.dylib'
```

I have only verified this locally with `ffmpeg7` but at least for the newer versions this should be consistent (not sure about `ffmpeg` and `ffmpeg4`; we could leave them out).

Closes: https://trac.macports.org/ticket/72442
Closes: https://trac.macports.org/ticket/72926

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A354 x86_64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
