### PR TITLE
mvnd1: update to 1.0.3

### DIFF
--- a/java/mvnd1/Portfile
+++ b/java/mvnd1/Portfile
@@ -3,8 +3,8 @@
 PortSystem      1.0
 PortGroup select 1.0
 
-version         1.0.2
-revision        1
+version         1.0.3
+revision        0
 name            mvnd1
 categories      java
 platforms       {darwin any}
@@ -44,14 +44,14 @@ select.file     ${filespath}/${name}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier amd64
-    checksums       rmd160  6d55549468ba215dcc239c0666f22e988c405a4d \
-                    sha256  926b0512ac3df2dd05770f61eeafbf97cfeafd14bb903fdea90b34bc8165ad21 \
-                    size    23228475
+    checksums       rmd160  63f2bb86a1abe7c39a1f47ac88ae3c7f5d7e49e5 \
+                    sha256  93e700500b41495c6da8c3ba7fd7b2b0ac738b2b83bffdef66128bba74a5d51d \
+                    size    23334472
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums       rmd160  9b3e1fe42a2b7e39d5e0080161ba1372fe74a7ea \
-                    sha256  a0f9fe345ca76726806fc17ef78caf73e3e1887921c8c156d53341564803e24b \
-                    size    23289264
+    checksums       rmd160  20d353512303e38e7fdd9bf721cdc2b3f9f016dc \
+                    sha256  b5528c92d5b0e14a8a47ddff138c19d93ac01f6cb8a28514f8fa40f2ceb65194 \
+                    size    23430536
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Maven Daemon 1.0.3.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?