### PR TITLE
zig: fix duplicate LC_RPATH

### DIFF
--- a/lang/zig/Portfile
+++ b/lang/zig/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 
 github.setup        ziglang zig 0.15.1
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          lang
 license             MIT
@@ -29,7 +29,8 @@ checksums           rmd160  70778e45663b7cdd41b2e564d7dd1576f6c9ef94 \
                     size    32716320
 
 # https://github.com/ziglang/zig/pull/23264
-patchfiles-append   patch-macos-libc++-dynamic-link.diff
+patchfiles-append   patch-macos-libc++-dynamic-link.diff \
+                    patch-duplicate-LC_RPATH.diff
 patch.args          -p1
 
 set llvm_version    20

--- a/lang/zig/Portfile
+++ b/lang/zig/Portfile
@@ -28,7 +28,8 @@ checksums           rmd160  70778e45663b7cdd41b2e564d7dd1576f6c9ef94 \
                     sha256  f7d587087e551a206ad2e1c1a10e8124f5ecaec1f1efc69b0de6df89af80245c \
                     size    32716320
 
-# https://github.com/ziglang/zig/pull/23264
+# macos stage3: add link support for system libc++: https://github.com/ziglang/zig/pull/23264
+# Fix duplicate LC_RPATH entries on macOS Tahoe: https://github.com/ziglang/zig/pull/25152
 patchfiles-append   patch-macos-libc++-dynamic-link.diff \
                     patch-duplicate-LC_RPATH.diff
 patch.args          -p1

--- a/lang/zig/files/patch-duplicate-LC_RPATH.diff
+++ b/lang/zig/files/patch-duplicate-LC_RPATH.diff
@@ -1,0 +1,19 @@
+diff --git a/src/main.zig b/src/main.zig
+index eef7b75fd0e7..26d44c4463be 100644
+--- a/src/main.zig
++++ b/src/main.zig
+@@ -3389,6 +3389,14 @@ fn buildOutputType(
+     var file_system_inputs: std.ArrayListUnmanaged(u8) = .empty;
+     defer file_system_inputs.deinit(gpa);
+
++    // Deduplicate rpath entries
++    var rpath_dedup = std.StringArrayHashMapUnmanaged(void){};
++    for (create_module.rpath_list.items) |rpath| {
++        try rpath_dedup.put(arena, rpath, {});
++    }
++    create_module.rpath_list.clearRetainingCapacity();
++    try create_module.rpath_list.appendSlice(arena, rpath_dedup.keys());
++
+     var create_diag: Compilation.CreateDiagnostic = undefined;
+     const comp = Compilation.create(gpa, arena, &create_diag, .{
+         .dirs = dirs,


### PR DESCRIPTION
#### Description

Fix 'duplicate LC_RPATH' error using patch from https://github.com/ziglang/zig/pull/25152.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?