### PR TITLE
xeus-zmq: fix build on macOS >=10.7 and =<10.12

### DIFF
--- a/devel/xeus-zmq/Portfile
+++ b/devel/xeus-zmq/Portfile
@@ -3,7 +3,14 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
+
+# std::optional
+legacysupport.use_mp_libcxx \
+                    yes
+legacysupport.newest_darwin_requires_legacy \
+                    16
 
 github.setup        jupyter-xeus xeus-zmq 3.1.1
 github.tarball_from archive
@@ -32,3 +39,15 @@ depends_lib-append  port:cppzmq \
 # https://trac.macports.org/ticket/66817
 # xclient_zmq.hpp:13:10: fatal error: 'optional' file not found
 compiler.cxx_standard 2017
+
+# xclient_zmq_impl.cpp:63:41: error: 'value' is
+# unavailable: introduced in macOS 10.13
+# std::optional<T>::value is missing from the libc++ system
+# library, and Clang reports this error even with
+# macports-libcxx (except for <Lion), so pass this flag.
+if {${os.platform} eq "darwin" && ${os.major} < 17 && ${os.major} > 10} {
+     if {[string match *clang* ${configure.compiler}]} {
+          configure.cxxflags-append \
+                    -D_LIBCPP_DISABLE_AVAILABILITY
+     }
+}


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
