### PR TITLE
libsidplayfp: fix build with C11 compilers

### DIFF
--- a/audio/libsidplayfp/Portfile
+++ b/audio/libsidplayfp/Portfile
@@ -26,3 +26,6 @@ depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         port:libgcrypt
 
 compiler.cxx_standard   2011
+
+# remove this patch on next release
+patchfiles-append   patch-fix-pre-cxx20.diff

--- a/audio/libsidplayfp/files/patch-fix-pre-cxx20.diff
+++ b/audio/libsidplayfp/files/patch-fix-pre-cxx20.diff
@@ -1,0 +1,42 @@
+--- src/builders/residfp-builder/residfp/resample/SincResampler.cpp
++++ src/builders/residfp-builder/residfp/resample/SincResampler.cpp
+@@ -25,7 +25,11 @@
+ #include <algorithm>
+ #include <iterator>
+ #include <numeric>
+-#include <version>
++#ifdef __has_include
++#  if __has_include(<version>)
++#    include <version>
++#  endif
++#endif
+ #include <cassert>
+ #include <cstring>
+ #include <cmath>
+@@ -94,8 +98,10 @@ double I0(double x)
+  */
+ int convolve(const int* a, const short* b, int bLength)
+ {
+-#if defined(__has_cpp_attribute) && __has_cpp_attribute( assume )
++#if defined(__has_cpp_attribute)
++#  if __has_cpp_attribute( assume )
+     [[assume( bLength > 0 )]];
++#  endif
+ #endif
+     int out = 0;
+ #ifndef __clang__
+--- src/simpleMixer.h
++++ src/simpleMixer.h
+@@ -25,7 +25,11 @@
+ #define SIMPLEMIXER_H
+ 
+ #include <vector>
+-#include <version>
++#ifdef __has_include
++#  if __has_include(<version>)
++#    include <version>
++#  endif
++#endif
+ #include <cstdint>
+ 
+ #ifdef __cpp_lib_math_constants


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
