### PR TITLE
BRiAl: update to 1.2.14

### DIFF
--- a/math/BRiAl/Portfile
+++ b/math/BRiAl/Portfile
@@ -4,9 +4,9 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               boost 1.0
 
-github.setup            BRiAl BRiAl 1.2.12
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from     tarball
+github.setup            BRiAl BRiAl 1.2.14
+github.tarball_from     releases
+use_bzip2               yes
 revision                0
 
 categories              math
@@ -17,9 +17,9 @@ maintainers             nomaintainer
 description             Successor to PolyBoRi
 long_description        {*}${description}
 
-checksums               rmd160  073b57ce9e8da2633dd15af82f994f684b84bf20 \
-                        sha256  8dd066dc4d7dac5a677db74c1717bc379f389256f9924ed1c65559c91bb90148 \
-                        size    1722554
+checksums               rmd160  d89030934f0e8e229c9c38b550a1baf0e182d490 \
+                        sha256  48cd95f167381699e2c538bfbf6eac35ca046dee79f797059f3879abdf5b7e66 \
+                        size    1222756
 
 patchfiles              patch-disable-boost-unit-tests.diff
 
@@ -29,8 +29,9 @@ autoreconf.args         -fvi
 compiler.c_standard     1999
 compiler.cxx_standard   2011
 
-depends_build-append    port:pkgconfig \
-                        port:libtool
+depends_build-append    path:bin/pkg-config:pkgconfig
 
 depends_lib-append      port:libpng \
                         port:m4ri
+
+github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.10 20G1427 x86_64
Command Line Tools 12.5.1.0.1.1623191612

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Thanks @barracuda156 here is the non-draft PR.
