### PR TITLE
pdal: patch for "no matching member function for call to 'basic_sort'"

### DIFF
--- a/gis/pdal/Portfile
+++ b/gis/pdal/Portfile
@@ -55,6 +55,11 @@ if {${name} eq ${subport}} {
 
     if {${name} eq ${subport}} {
         patchfiles-append   patch-powerpc.diff
+
+        # Build fails on macOS 11 and older, see https://trac.macports.org/ticket/72983.
+        if { ${os.platform} eq "darwin" && ${os.major} < 21 } {
+            patchfiles-append patch-pointview.diff
+        }
     }
 
     # Starting with Xcode 15, the port libunwind is causing crashes,

--- a/gis/pdal/files/patch-pointview.diff
+++ b/gis/pdal/files/patch-pointview.diff
@@ -1,0 +1,70 @@
+Addresses https://trac.macports.org/ticket/72983
+Patch taken from https://github.com/PDAL/PDAL/tree/issue-4817
+
+--- pdal/PointView.cpp.orig
++++ pdal/PointView.cpp
+@@ -81,8 +81,7 @@ PointId PointView::addPoint()
+     return tableId;
+ }
+ 
+-template<typename Sorter>
+-void PointView::basic_sort(Sorter sort, Compare comp)
++void PointView::basic_sort(SortFunc sort, Compare comp)
+ {
+     std::vector<PointId> order(size());
+ 
+@@ -102,12 +101,12 @@ void PointView::sort(Dimension::Id dim)
+     {
+         return compare(dim, id1, id2);
+     };
+-    basic_sort(std::sort<std::vector<PointId>::iterator, PointView::Compare>, comp);
++    basic_sort(static_cast<SortFunc>(&std::sort), comp);
+ }
+ 
+ void PointView::sort(Compare comp)
+ {
+-    basic_sort(std::sort<std::vector<PointId>::iterator, PointView::Compare>, comp);
++    basic_sort(static_cast<SortFunc>(&std::sort), comp);
+ }
+ 
+ void PointView::stableSort(Dimension::Id dim)
+@@ -116,12 +115,12 @@ void PointView::stableSort(Dimension::Id dim)
+     {
+         return compare(dim, id1, id2);
+     };
+-    basic_sort(std::stable_sort<std::vector<PointId>::iterator, PointView::Compare>, comp);
++    basic_sort(static_cast<SortFunc>(&std::stable_sort), comp);
+ }
+ 
+ void PointView::stableSort(Compare comp)
+ {
+-    basic_sort(std::stable_sort<std::vector<PointId>::iterator, PointView::Compare>, comp);
++    basic_sort(static_cast<SortFunc>(&std::stable_sort), comp);
+ }
+ 
+ void PointView::calculateBounds(BOX2D& output) const
+
+--- pdal/PointView.hpp.orig
++++ pdal/PointView.hpp
+@@ -262,6 +262,11 @@ public:
+     void calculateBounds(BOX3D& box) const;
+ 
+     using Compare = std::function<bool(PointId id1, PointId id2)>;
++    // This is necessary due to a bug in older OSX compilers.
++    using SortFunc = void (*)(std::vector<PointId>::iterator,
++                              std::vector<PointId>::iterator,
++                              Compare);
++
+     void sort(Dimension::Id id);
+     void sort(Compare comp);
+     void stableSort(Dimension::Id id);
+@@ -416,8 +421,7 @@ private:
+     PointId index(PointId id) const
+         { return m_index[id]; }
+ 
+-    template<typename Sorter>
+-    void basic_sort(Sorter sort, Compare comp);
++    void basic_sort(SortFunc sort, Compare comp);
+ };
+ 
+ struct PointViewLess


### PR DESCRIPTION
Patch provided by upstream developer, applied to macOS 11 and older platforms.

Closes: https://trac.macports.org/ticket/72983

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
