### PR TITLE
Qgis3 upd

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -24,25 +24,25 @@ subport ${name-ltr} {}
 
 if {${subport} eq ${name}} {
     # Latest version
-    github.setup    qgis QGIS 3_44_2 final-
+    github.setup    qgis QGIS 3_44_3 final-
     github.tarball_from archive
     revision        0
     set app_name    QGIS3
 
-    checksums       rmd160  9f9ee727bc66b0f9c8e55e42a63e5520be047612 \
-                    sha256  24963f3ff0c1171171dba67561afd6eb22a79af8ec06820db10f77f4cc31d543 \
-                    size    216243706
+    checksums       rmd160  bb203bf57ae265ad5ebf7534b3b528707ab08e3b \
+                    sha256  3bebfc0cf1bbd5b784724874f28b91d7af1d8a9b387267b3ba22334ab64f73db \
+                    size    216253453
 } else {
     # LTR version
-    github.setup    qgis QGIS 3_40_10 final-
+    github.setup    qgis QGIS 3_40_11 final-
     github.tarball_from archive
     revision        0
     set app_name    QGIS3-LTR
     description     {*}${description} (LTR)
 
-    checksums       rmd160  f3ee15e91095f20a6598600d3be84215bd4a6309 \
-                    sha256  494b7a9532d6f91fa437f0761ecacec3b9562ae867c64ba445ea57b94b42b631 \
-                    size    213321447
+    checksums       rmd160  67f3c32526c7dc3be97676c2ea129fffc4338030 \
+                    sha256  89eaab04f4166a9449d2270eecd12ae6ca1298d5618498880bcee72aed065483 \
+                    size    213360235
 }
 
 version             [string map {_ .} ${github.version}]

--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -163,6 +163,7 @@ configure.args-append \
                     -DQWT_INCLUDE_DIR=${prefix}/libexec/qt5/lib/qwt.framework/Versions/Current/Headers \
                     -DQWT_LIBRARY=${prefix}/libexec/qt5/lib/qwt.framework/Versions/Current/qwt \
                     -DSPATIALINDEX_LIBRARY=${prefix}/lib/libspatialindex.dylib \
+                    -DUSE_CCACHE=OFF \
                     -DUSE_OPENCL=ON \
                     -DWITH_3D=ON \
                     -DWITH_BINDINGS=FALSE \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- `qgis3`: update to 3.44.3 
- `qgis3-ltr`: update to 3.40.11
- Configure to not use Ccache if present. Closes: https://trac.macports.org/ticket/67543

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.7.2 23H311 arm64
Xcode 16.2 16C5032a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
