### PR TITLE
py-numba: update to 0.62.0

### DIFF
--- a/python/py-numba/Portfile
+++ b/python/py-numba/Portfile
@@ -2,15 +2,14 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           compiler_wrapper 1.0
 
 name                py-numba
-version             0.61.2
+version             0.62.0
 revision            0
 categories-append   devel
 license             BSD
 
-python.versions     39 310 311 312 313
+python.versions     310 311 312 313
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -22,32 +21,45 @@ long_description    Numba is an Open Source NumPy-aware optimizing compiler \
 
 homepage            https://numba.pydata.org/
 
-checksums           rmd160  58888f40f88483dbc8510dddf7fe5d7b6faddb91 \
-                    sha256  8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d \
-                    size    2820615
+checksums           rmd160  3939f992129a5dbba15d5f20940d7c1d5cf3a405 \
+                    sha256  2afcc7899dc93fefecbb274a19c592170bc2dbfae02b00f83e305332a9857a5a \
+                    size    2749680
 
-variant tbb description "Add support for TBB" {
-    if {$subport ne $name} {
-        depends_lib-append  port:onetbb
-        build.env-append    TBBROOT=${prefix}/libexec/onetbb
+
+variant openmp description "Add OpenMP support" {
+    compiler.openmp_version 2.5
+
+    build.env-delete    NUMBA_DISABLE_OPENMP=1
+
+    if {[string match *clang* ${configure.compiler}]} {
+        depends_lib-append  port:libomp
+
+        patchfiles-append   patch-setup.py.diff
+
+        post-patch {
+            reinplace "s|__OPENMP_INC__|${prefix}/include/libomp|" setup.py
+            reinplace "s|__OPENMP_LIB__|${prefix}/lib/libomp|" setup.py
+        }
     }
 }
 
-if {${name} ne ${subport}} {
-    compiler.openmp_version 2.5
+variant tbb description "Add TBB support" {
+    build.env-delete    NUMBA_DISABLE_TBB=1
 
+    depends_lib-append  port:onetbb
+
+    build.env-append    TBBROOT=${prefix}/libexec/onetbb
+}
+
+if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-llvmlite \
                         port:py${python.version}-numpy
 
-    if {${python.version} eq 39} {
-        version         0.59.1
-        checksums       rmd160  808ec94a7bde37a3d68da2b47f925e2710001f79 \
-                        sha256  76f69132b96028d2774ed20415e8c528a34e3299a40581bae178f0994a2f370b \
-                        size    2652730
-    } else {
-        # Requires numpy 2.0
-        build.args-append   --skip-dependency-check
-    }
+    build.env-append    NUMBA_DISABLE_TBB=1 \
+                        NUMBA_DISABLE_OPENMP=1
+
+    # Requires numpy 2.0
+    build.args-append   --skip-dependency-check
 
     livecheck.type      none
 }

--- a/python/py-numba/files/patch-setup.py.diff
+++ b/python/py-numba/files/patch-setup.py.diff
@@ -1,0 +1,15 @@
+--- setup.py.orig	2025-09-22 17:47:37
++++ setup.py	2025-09-22 18:02:37
+@@ -255,10 +255,9 @@
+         # They are binary compatible and may not safely coexist in a process, as
+         # libiomp5 is more prevalent and often linked in for NumPy it is used
+         # here!
+-        ompcompileflags = ['-fopenmp']
++        ompcompileflags = ['-L__OPENMP_LIB__', '-fopenmp']
+         omplinkflags = ['-fopenmp=libiomp5']
+-        omppath = ['lib', 'clang', '*', 'include', 'omp.h']
+-        have_openmp = check_file_at_path(omppath)
++        have_openmp = '__OPENMP_INC__'
+     else:
+         cpp11flags = ['-std=c++11']
+         ompcompileflags = ['-fopenmp']


### PR DESCRIPTION
#### Description

Update py-numba to 0.62.0 (following the py-llvmlite upgrade at https://github.com/macports/macports-ports/pull/29438)
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.6.1 24G90 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
