### PR TITLE
sikarugir: add port based on obsolete kegworks

### DIFF
--- a/emulators/sikarugir/Portfile
+++ b/emulators/sikarugir/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        Sikarugir-App Creator 1.0 v
+github.tarball_from releases
+revision            0
+name                sikarugir
+platforms           {darwin >= 20}
+# Winery is LGPL-2.1 but will be changed later once the new codebase it finished
+license             LGPL-2.1
+categories          emulators
+
+supported_archs     x86_64
+maintainers         {@Gcenx}
+homepage            https://github.com/Sikarugir-App
+
+description         ${name} is a user-friendly tool used to make ports of Microsoft Windows software to Apple's macOS.
+long_description    {*}${description}
+
+distname            Creator-v${version}
+use_xz              yes
+
+checksums           sha256  f98d737bf4d1b5274e4a74102b8995ab57fcbb408343cb5d631a09cc4d96cb0f \
+                    size    1462908
+
+use_configure       no
+build {}
+
+destroot {
+    move "${workpath}/Creator.app" "${destroot}${applications_dir}/Sikarugir Creator.app"
+    system -W ${destroot}${applications_dir} "/usr/bin/codesign --deep --force --sign - 'Sikarugir Creator.app'"
+}
+


### PR DESCRIPTION
Sikarugir is the successor of Kegworks which seems to no longer download templates required for it to work.

https://github.com/Sikarugir-App/Sikarugir

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
