### PR TITLE
ruby-build: Disable Homebrew

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        rbenv ruby-build 20250925 v
+revision            1
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -25,3 +26,6 @@ use_configure       no
 build {}
 destroot.cmd        ./install.sh
 destroot.env        PREFIX=${destroot}${prefix}
+patchfiles          patch-ruby-build-no-homebrew.diff
+
+notes               "This port patches ruby-build to ignore Homebrew formulae when looking for library dependencies."

--- a/ruby/ruby-build/files/patch-ruby-build-no-homebrew.diff
+++ b/ruby/ruby-build/files/patch-ruby-build-no-homebrew.diff
@@ -1,0 +1,12 @@
+--- bin/ruby-build.orig	2025-09-23 11:49:15
++++ bin/ruby-build	2025-09-23 12:05:37
+@@ -20,6 +20,9 @@
+ 
+ OLDIFS="$IFS"
+ 
++# Disable Homebrew.
++brew() { false; }
++
+ # Have shell functions inherit the ERR trap.
+ set -E
+ 


### PR DESCRIPTION
#### Description

This PR is related to #28748.

This PR adds a patch to completely disable Homebrew while executing ruby-build.

I admit this may be a bit extreme.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 15.7 24G222 arm64
Xcode 26.0 17A324

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
