### PR TITLE
py-whenever: update to 0.8.9

### DIFF
--- a/python/py-whenever/Portfile
+++ b/python/py-whenever/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-whenever
-version             0.8.8
+version             0.8.9
 revision            0
 
 supported_archs     noarch
@@ -24,9 +24,9 @@ long_description    {*}${description} \
 
 homepage            https://pypi.org/project/whenever/
 
-checksums           rmd160  057b373ee7053df38ad9dbe783c9d4fef80b3602 \
-                    sha256  d0674d410fbbcf495f6cca0f1f575279e402887d20e4c1ca7d11309cd41b8125 \
-                    size    235496
+checksums           rmd160  7ff19360f44ae910100ed1ddf1e9656f7ba5abde \
+                    sha256  2df8bdbd2b7898f404a2fd61f6eeb8641ccd191d4878b5d1853f3507bd22b2c6 \
+                    size    240155
 
 python.versions     313
 


### PR DESCRIPTION
#### Description

Update to Whenever 0.8.9.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?