### PR TITLE
emacs{,-app}{,-devel}: add missing deps, update -devel to 20250924

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -116,7 +116,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         30.2
-    revision        1
+    revision        2
     checksums       rmd160  fefdd3fcd453d733114f609a3e122b2529cc7410 \
                     sha256  1d79a4ba4d6596f302a7146843fe59cf5caec798190bcc07c907e7ba244b076d \
                     size    83059014
@@ -129,17 +129,17 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs 25380c8e14567894f1e847b5f2ce75f0265293d8
+    github.setup    emacs-mirror emacs db3d6f06c389e06922964fb4869d19ba9040c16e
     github.tarball_from archive
     epoch           5
-    version         20250816
-    revision        1
+    version         20250924
+    revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  f1d603f1d185c5e1f8fc9fc10a36f219baa16c60 \
-                    sha256  b509a8389090cc59c44797ad19796e4e68d94bded2e3b45fcaa249e5ec8f6a19 \
-                    size    52268149
+    checksums       rmd160  591d36fc54fc696d35e026f6d8a80d0230ed1394 \
+                    sha256  664d4fa8443c884ecbbddebfc799f9142dada9911eaff7b0fb116a4b0c63c2fe \
+                    size    52379510
 
     livecheck.type none
 
@@ -329,12 +329,16 @@ variant treesitter description {Builds emacs with tree-sitter support} {
         port:tree-sitter-heex \
         port:tree-sitter-elixir \
         port:tree-sitter-lua \
-        port:tree-sitter-php
+        port:tree-sitter-php \
+        port:tree-sitter-phpdoc
 
     if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
         depends_run-append \
             port:tree-sitter-markdown \
-            port:tree-sitter-go-work
+            port:tree-sitter-go-work \
+            port:tree-sitter-jsdoc \
+            port:tree-sitter-gitattributes \
+            port:tree-sitter-liquid
     }
 
     notes-append "


### PR DESCRIPTION
#### Description

- php-ts-mode needs tree-sitter-phpdoc (since Emacs 30 (emacs{,-app}))
- mhtml-ts-mode needs tree-sitter-jsdoc (new in Emacs 31 (emacs{,-app}-devel))
- treesit-x.el needs tree-sitter-{gitattributes,liquid} (new in Emacs 31 (emacs{,-app}-devel))

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7 24G222 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
