### PR TITLE
lagrange: update to 1.19.2

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 gitea.domain        git.skyjake.fi
-gitea.setup         skyjake the_Foundation 1.10.0 v
+gitea.setup         skyjake the_Foundation 1.10.1 v
 revision            0
 categories          devel
 license             BSD
@@ -18,9 +18,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Opinionated C11 library for low-level functionality
 long_description    {*}${description}
 
-checksums           rmd160  c215658469925992643ff277a1ad0a3c40ba55cb \
-                    sha256  ee9369e493636db07c604a97e5e43c1282205bfccf58f06d346d9fab3e9e3d05 \
-                    size    222952
+checksums           rmd160  846c85cc8abbb89a7c21776cbb4586c77c7630bf \
+                    sha256  ea726c390df1e1f17bc057976075225b218af3c89defed85bc628a1ff4615657 \
+                    size    223167
 
 depends_build-append \
                     port:pkgconfig

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           gitea 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.19.1 v
+gitea.setup         gemini lagrange 1.19.2 v
 revision            0
 categories          net gemini
 license             BSD
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  4e97526f949f583669d1c641f7ebe119574576d2 \
-                    sha256  2f868f18f10b3f7a0b1bb7b106e10a2e6196be7a962d4f398e0a56eae245e7e8 \
-                    size    8928014
+checksums           rmd160  9f28180be659cf53d6c73c788b30def4699d4283 \
+                    sha256  d2c84d4c7f07085a33a8565c53d259afd125827e4bdeef8e944638b7277c2cd0 \
+                    size    8928401
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://github.com/skyjake/lagrange/releases/tag/v1.19.2
https://git.skyjake.fi/skyjake/the_Foundation/releases/tag/v1.10.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
