### PR TITLE
google-cloud-sdk: update to 540.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             539.0.0
+version             540.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  895ccc24f0f06901f17953484f599be0b091948a \
-                    sha256  3c5e531a222653423c6e89d6413b14fbc244ef36890078902e8ab8dc382f6f8f \
-                    size    55414150
+    checksums       rmd160  40a879a8865636f100b08753579d153653c2a482 \
+                    sha256  bd0e0e11f3f8f99b5b8059142e46731007b52690d3d5767b025f29dab507549b \
+                    size    55470260
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  fdd3188d3de4809d3d80fcd1292443abf95159fe \
-                    sha256  45089aa49102fdfa42ee886795063f59a462219a14a7709345e7ea0e3c89f145 \
-                    size    56944180
+    checksums       rmd160  f166995ed2a8269ca1bc154271ea0073d74f40dd \
+                    sha256  5b52fca721979d371c083f99463cf4b8f36d42f5d10fcb2381ffaf13536a2c98 \
+                    size    57000100
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  67d9859aab170ec8574f7a6c42e23fde30eefed0 \
-                    sha256  07731bea80c3414846ff77779e8f4bd058b1e1835e6c64da22089c8a5817d44a \
-                    size    56879321
+    checksums       rmd160  1ea092ca08fd1c9cffc89d23ed4b90e437a6bedf \
+                    sha256  d7af233c272ef0a422db75e42be0cbd11f8a9af3a6da11b4b46278c6a399fda4 \
+                    size    56932346
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 540.0.0.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?