### PR TITLE
openjdk17-jetbrains: update to 17.0.14-b1367.22 and mark as EOL

### DIFF
--- a/java/openjdk17-jetbrains/Portfile
+++ b/java/openjdk17-jetbrains/Portfile
@@ -2,8 +2,11 @@
 
 PortSystem       1.0
 PortGroup        github 1.0
+PortGroup        deprecated 1.0
 
-github.setup     JetBrains JetBrainsRuntime 17.0.12-b1087.25 jbr-release-
+deprecated.eol_version yes
+
+github.setup     JetBrains JetBrainsRuntime 17.0.14-b1367.22 jbr-release-
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
 name             openjdk17-jetbrains
@@ -33,14 +36,14 @@ use_bzip2        no
 
 if {${configure.build_arch} eq "x86_64"} {
     set jbr_arch x64
-    checksums    rmd160  8ab6acf03111e9cf47b38af5ac67e327d34b032f \
-                  sha256  f493cde28a0eebb651de27d5a045ca371feebf9d84b08793c54b7b822db974e9 \
-                 size    72414723
+    checksums    rmd160  51e676349de2451728fb6035bb9064aae1befc35 \
+                 sha256  a6c7f0fa976baa35d3b325b5c3bfafa7498b97e4d5bf24e353487fe343b0078a \
+                 size    72132168
 } else {
     set jbr_arch aarch64
-    checksums    rmd160  0a2894366ec87fb0d5d0baf517f9bd053f9d34df \
-                 sha256  29ace32648a20c6cfa44ae5a611c44d2cdfc6eeb2724bbe21496e38fafaccd95 \
-                 size    71299414
+    checksums    rmd160  864f4b22f5292561ccf39031ec9e17dbd12863f4 \
+                 sha256  3a43a0701971a52cb41e68678aa0f31a53b7901e48db05ab2b3d9c3b6ff84372 \
+                 size    71129246
 }
 
 distname         jbr-[lindex [split ${version} -] 0]-osx-${jbr_arch}-[lindex [split ${version} -] 1]


### PR DESCRIPTION
#### Description

Update to JetBrains Runtime 17.0.14-b1367.22 and mark as EOL.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?