### PR TITLE
symfony-cli: update to 5.14.2

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.12.0
+version             5.14.2
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,17 +44,17 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  f907ad2b837416d515a7554ea257bca39dff665e \
-                        sha256  327f8cc77e3ddec57a560520521a2da5aeee1dc8b9a45d53ac2e60487b0fba48 \
-                        size    290034
+    checksums           rmd160  a2776e498c912330fc75b8ac31aa04262cd381cb \
+                        sha256  7347c365f04572807a358f0171859d90f66194bdeb28c09e955d27415dca6f5a \
+                        size    289631
 } else {
     build {}
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  d10d8473e3e3f74ae5e42281af47b3fb8dc5e001 \
-                        sha256  596f0aeed501aa6d37e4c8d173154ff7854d7ed2260f04a8148215d90bd1ed02 \
-                        size    12600046
+    checksums           rmd160  2563935ec41f8e2d166a7438325b3f22c73b438c \
+                        sha256  ba3346c9755fd02af62e13dd6e19de5d88e3c33c07ce767ed67e7dd7e902b5b1 \
+                        size    12270538
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.14.2

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
