### PR TITLE
legacy-support-devel: Update to latest master - v20250924.

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -30,7 +30,7 @@ subport ${name} {
     conflicts           ${name}-devel
     github.setup        macports macports-legacy-support ${release_ver} v
     # Change github.tarball_from to 'releases' or 'archive' next update
-    # N.B.: That's a nice theory, but neither choice works correctly
+    # N.B.: Needs testing - earlier attempts at that didn't work.
     github.tarball_from tarball
     revision            0
     checksums           rmd160  80bea072afe759d0aa13bed02205e7165e116b51 \
@@ -41,16 +41,14 @@ subport ${name} {
 subport ${name}-devel {
     conflicts           ${name}
     github.setup        macports macports-legacy-support \
-                        17cb4f9a1e313356db8acd1b3f8ae317ddacaf11
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    # N.B.: That's a nice theory, but neither choice works correctly
-    github.tarball_from tarball
-    version             20250728
+                        f89c155cbc2ca8714e4ada66c11b222353e8d87a
+    github.tarball_from archive
+    version             20250924
     revision            0
     livecheck.type      none
-    checksums           rmd160  80bea072afe759d0aa13bed02205e7165e116b51 \
-                        sha256  aa9f267e7d25a10ea359e571a1fb180440f8d81aca1f250b95df42a4b1a65ddc \
-                        size    227836
+    checksums           rmd160  3d6ca0af242f859e201c387bde0b0e9aa6ce7883 \
+                        sha256  37c8483ac0594a009e1509f4ddd2eff42c4707cedba58a8ec34bcf779834e144 \
+                        size    228476
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
 }


### PR DESCRIPTION
Notable changes since last -devel:

- Updates SDK version handling for SDK 26.

Due to the strictness of the version detection, this update is required for successful builds with SDK 26.  But since `legacy-support` doesn't offer any enhancements for OS versions later than 10.15, this is only a problem for clients that unncesessarily use it for later OS versions.

Also switches `github.tarball_from` to `archive` for the -devel version, after verifying that this works correctly (earlier attempts didn't).  The release version is left unchanged for now.

TESTED:
Tested both normal and -devel versions -/+universal on 10.4-10.5 ppc, 10.4-10.5 ppc64, 10.4-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-26.x arm64.
Builds and passes all tests on all tested platforms, except for the aforementioned problem building the release version for OS 26.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S165, ppc64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, ppc (i386 Rosetta), Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, ppc (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.8 22H730, arm64, Xcode 15.2 15C500b
macOS 14.8 23J21, arm64, Xcode 16.2 16C5032a
macOS 15.7 24G222, arm64, Xcode 26.0 17A324
macOS 26.0 25A354, arm64, Xcode 26.0.1 17A400
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
