### PR TITLE
google-cloud-sdk: fix livecheck

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -178,5 +178,5 @@ notes "
     You must source them manually in your ~/.zshrc:
         source '${prefix}/libexec/google-cloud-sdk/completion.zsh.inc'"
 
-livecheck.url       https://cloud.google.com/sdk/docs/install-sdk
-livecheck.regex     {google-cloud-cli-([\d\.]+)-darwin}
+livecheck.url       https://cloud.google.com/sdk/docs/release-notes
+livecheck.regex     {([\d\.]+) \(\d{4}-\d{2}-\d{2}\)}


### PR DESCRIPTION
#### Description

google-cloud-sdk: fix livecheck

###### Type(s)
* [x]  bugfix

###### Tested on
macOS 15.7 24G222 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
