### PR TITLE
arpwatch: Attempt to fix build with macOS 26 SDK

### DIFF
--- a/net/arpwatch/Portfile
+++ b/net/arpwatch/Portfile
@@ -43,6 +43,8 @@ post-extract {
     system -W ${worksrcpath} "wget https://standards-oui.ieee.org/oui/oui.csv"
 }
 
+patchfiles          _getshort.patch
+
 set sharedir ${prefix}/share/${name}-${version}
 set ethercodes ${sharedir}/ethercodes.dat
 post-patch {

--- a/net/arpwatch/files/_getshort.patch
+++ b/net/arpwatch/files/_getshort.patch
@@ -1,0 +1,16 @@
+Work around lack of _getshort in resolv.h in Xcode 26.
+
+./dns.c:118:10: error: call to undeclared function '_getshort'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+--- dns.c.orig	2023-09-05 12:50:56.000000000 -0500
++++ dns.c	2025-09-25 21:24:34.000000000 -0500
+@@ -51,6 +51,10 @@
+ #include <string.h>
+ #include <stdio.h>
+ 
++#if defined(__APPLE__) && !defined(_getshort)
++#define _getshort res_9_getshort
++#endif
++
+ #include "gnuc.h"
+ #ifdef HAVE_OS_PROTO_H
+ #include "os-proto.h"


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/73043

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

but notably not tested on a version affected by the problem (e.g. macOS 26).

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
