### PR TITLE
ramalama: Add missing py-yaml dependency

### DIFF
--- a/llm/ramalama/Portfile
+++ b/llm/ramalama/Portfile
@@ -7,6 +7,7 @@ PortGroup           python 1.0
 
 github.setup        containers ramalama 0.12.2 v
 github.tarball_from archive
+revision            1
 checksums           rmd160  cd45573d0a9425c83e814b40d615edf814edc927 \
                     sha256  2feb67a5b3c62a1ad58de7803eed42701fe9e5e8cfaca90d853a590d5a1ecc9e \
                     size    822829
@@ -27,7 +28,8 @@ python.default_version  313
 
 depends_run-append  \
                     port:krunkit \
-                    port:podman
+                    port:podman \
+                    port:py${python.version}-yaml
 
 notes \
     "${name} defaults to running AI models in podman containers in a podman\


### PR DESCRIPTION
#### Description

ramalama didn't declare a dependency on it, and fails to run without it.

Fixes: fee5ad975bfe1238e37ecae4abc08d3885798e68
Fixes: #29461

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.0 25A354 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
