### PR TITLE
pymol: add upstream PyQT6 fixes for apbs_gui

### DIFF
--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -100,7 +100,8 @@ depends_run-append  port:py${python.version}-pyqt5
 
 patchfiles          pymol_shell.diff \
                     setup.py.diff \
-                    patch-boost-include.diff
+                    patch-boost-include.diff \
+                    apbs_gui_qt6.diff
 
 if {${subport} eq "pymol-devel"} {
     patchfiles-replace setup.py.diff patch-devel-setup.py.diff

--- a/science/pymol/files/apbs_gui_qt6.diff
+++ b/science/pymol/files/apbs_gui_qt6.diff
@@ -1,0 +1,55 @@
+From e6d9eb9c4b99e55e99b50c78266ac34b0f942eca Mon Sep 17 00:00:00 2001
+From: Jarrett Johnson <jarrett.johnson@schrodinger.com>
+Date: Fri, 26 Sep 2025 10:57:23 -0400
+Subject: [PATCH] Port over Qt6 changes for APBS dialog
+
+Fixes #469
+---
+ data/startup/apbs_gui/__init__.py | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+diff --git data/startup/apbs_gui/__init__.py.orig  data/startup/apbs_gui/__init__.py
+index d7a242949..5b99259e6 100644
+--- data/startup/apbs_gui/__init__.py.orig
++++ data/startup/apbs_gui/__init__.py
+@@ -144,11 +144,11 @@ def get_cb_pseudocharge(resn, name):
+             def result():
+                 msgbox = QMessageBox(QMessageBox.Question, 'Continue?',
+                     method + ' emmitted warnings, do you want to continue?',
+-                    QMessageBox.Yes | QMessageBox.No , form._dialog)
++                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No , form._dialog)
+                 msgbox.setDetailedText(warnings)
+                 return msgbox.exec_()
+ 
+-            if result == QMessageBox.No:
++            if result == QMessageBox.StandardButton.No:
+                 raise SilentAbort
+ 
+     if form.do_apbs.isChecked():
+@@ -266,9 +266,9 @@ def run_finally(args):
+             return
+ 
+         quit_msg = "Finished with Success. Close the APBS dialog?"
+-        if QMessageBox.Yes == QMessageBox.question(
+-                form._dialog, 'Finished', quit_msg, QMessageBox.Yes,
+-                QMessageBox.No):
++        if QMessageBox.StandardButton.Yes == QMessageBox.question(
++                form._dialog, 'Finished', quit_msg, QMessageBox.StandardButton.Yes,
++                QMessageBox.StandardButton.No):
+             form._dialog.close()
+ 
+     def handle_exception(e, stdout):
+@@ -276,11 +276,10 @@ def handle_exception(e, stdout):
+             return
+ 
+         msg = str(e) or 'unknown error'
+-        msgbox = QMessageBox(QMessageBox.Critical, 'Error',
+-                             msg, QMessageBox.Close, form._dialog)
++        msgbox = QMessageBox(QMessageBox.Icon.Critical, 'Error', msg, QMessageBox.StandardButton.Close, form._dialog)
+         if stdout.strip():
+             msgbox.setDetailedText(stdout)
+-        msgbox.exec_()
++        msgbox.exec()
+ 
+     # "Abort" button callback
+     def abort():


### PR DESCRIPTION
Pymol: Add the last remaining fixes for using PyQT6 to the apbs_gui python code.

#### Description
These changes eliminate the last known QT6 compatibility error when running pymol 3.1.0 against py313-pyqt6 with py313-pyqt5 uninstalled. With apbs and pdb2pqr installed, this patch eliminates at run time error when the Electrostatic plugin is used under PyQT6.

Traceback (most recent call last):
File "/opt/local/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pymol/pymol_path/data/startup/apbs_gui/init.py", line 269, in run_finally
if QMessageBox.Yes == QMessageBox.question(
^^^^^^^^^^^^^^^
AttributeError: type object 'ResizableMessageBox' has no attribute 'Yes'
QThreadStorage: entry 1 destroyed before end of thread 0x6000008a02f0
QThreadStorage: entry 0 destroyed before end of thread 0x6000008a02f0

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7 24G222 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
