### PR TITLE
openjdk25-temurin: new port

### DIFF
--- a/java/openjdk25-temurin/Portfile
+++ b/java/openjdk25-temurin/Portfile
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+set feature      25
+name             openjdk${feature}-temurin
+categories       java devel
+maintainers      {breun @breun} openmaintainer
+platforms        {darwin any}
+license          GPL-2+
+# This port uses prebuilt binaries for a particular architecture
+# They are not universal binaries
+universal_variant no
+
+# https://adoptium.net/temurin/releases/?version=25&os=mac&arch=any&mode=filter
+supported_archs  x86_64 arm64
+
+version      ${feature}
+set build    36
+revision     0
+
+# End of availability: https://adoptium.net/support
+description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least September 2031)
+long_description {*}${description} \
+    \n\nOpenJDK ${feature} (Java Development Kit) distribution from Adoptium.
+
+master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/download/jdk-${version}%2B${build}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    set arch_classifier x64
+    checksums    rmd160  d3e9aaecccab7fbb357b1c5db7333cc3c7b7a23d \
+                 sha256  9eca779ae00a5e2e06744ed096be91ec52c2f545d8d9495e5b57fa2892bcca20 \
+                 size    120208295
+} elseif {${configure.build_arch} eq "arm64"} {
+    set arch_classifier aarch64
+    checksums    rmd160  e48db023f8cc171bb7b5c7bbee51e83a3f9812a5 \
+                 sha256  6630ea0f19db61843a8fa84a84b2c71cd120c4155bb5a0e42a74593b0d70fee4 \
+                 size    136283843
+} else {
+    set arch_classifier unsupported_arch
+}
+
+distname     OpenJDK${feature}U-jdk_${arch_classifier}_mac_hotspot_${version}_${build}
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://adoptium.net
+
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin${feature}-binaries
+livecheck.regex     jdk-(${feature}\[\.0-9\]+)\+
+
+use_configure    no
+build {}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under
+# /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-${feature}-eclipse-temurin.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under
+    # /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Eclipse Temurin based on OpenJDK 25.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?