### PR TITLE
openjdk25-microsoft: new port

### DIFF
--- a/java/openjdk25-microsoft/Portfile
+++ b/java/openjdk25-microsoft/Portfile
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+set feature 25
+name             openjdk${feature}-microsoft
+categories       java devel
+maintainers      {breun @breun} openmaintainer
+
+platforms        {darwin any}
+
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://learn.microsoft.com/java/openjdk/download#openjdk-25
+supported_archs  x86_64 arm64
+
+version      ${feature}
+set build    36
+revision     0
+
+# End of life date: https://learn.microsoft.com/en-us/java/openjdk/support#release-and-servicing-roadmap
+description  Microsoft Build of OpenJDK ${feature} (Long Term Support)
+long_description {*}${description} \
+\n\nOpenJDK ${feature} distribution from Microsoft.
+
+master_sites https://aka.ms/download-jdk/
+
+if {${configure.build_arch} eq "x86_64"} {
+    set arch_classifier x64
+    checksums    rmd160  5c98c119c9bb9b41460e2edec792abc8da9028f8 \
+                 sha256  256209a8c394a1901f9f5d1fb8c8d7fd07cf12e63edaaae498eb88172d356fa1 \
+                 size    220156992
+} elseif {${configure.build_arch} eq "arm64"} {
+    set arch_classifier aarch64
+    checksums    rmd160  ccce056641e55fc2696fc818d1edbbf7bfbc9e17 \
+                 sha256  564bbc735a1337579652c87336bab8281345415c70cfdbb1a583601cfb40d3e3 \
+                 size    217514437
+} else {
+    set arch_classifier unsupported_arch
+}
+
+distname     microsoft-jdk-${feature}.0.0-macOS-${arch_classifier}
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://www.microsoft.com/openjdk
+
+livecheck.type      regex
+livecheck.url       https://learn.microsoft.com/java/openjdk/download
+livecheck.regex     microsoft-jdk-(${feature}\.\[0-9\.\]+)-macOS-.*\.tar\.gz
+
+use_configure    no
+build {}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-${feature}-microsoft.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Microsoft Build of OpenJDK 25.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?