### PR TITLE
x86_64-binutils: Update to 2.45 and add targets haiku and solaris

### DIFF
--- a/cross/x86_64-binutils/Portfile
+++ b/cross/x86_64-binutils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 name                x86_64-binutils
-version             2.42
+version             2.45
 revision            0
 maintainers         {@kamischi web.de:karl-michael.schindler} \
                     openmaintainer
@@ -21,7 +21,7 @@ if {$subport eq $name} {
     destroot            {}
 }
 
-foreach ostarget {linux dragonfly freebsd netbsd openbsd} {
+foreach ostarget {linux dragonfly freebsd haiku netbsd openbsd solaris} {
     subport x86_64-${ostarget}-binutils {
         crossbinutils.setup     x86_64-${ostarget} ${version}
         # Depend on base package for installing the docs


### PR DESCRIPTION
#### Description

x86_64-binutils: Update to 2.45 and add targets haiku and solaris

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.7 24G222 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
