### PR TITLE
py-matplotlib: removed references to missing variants

### DIFF
--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -21,7 +21,7 @@ long_description    Matplotlib strives to produce publication quality 2D \
                     graphics. The library uses numpy for handling large data \
                     sets and supports a variety of output backends. This port \
                     provides variants for the different GUIs (gtk2, gtk3, \
-                    tkinter, qt4, qt5, cairo, latex).
+                    tkinter, qt5, cairo, latex).
 
 homepage            https://matplotlib.org/
 
@@ -155,8 +155,7 @@ if {${name} ne ${subport}} {
         depends_run-append  bin:pdftops:poppler
     }
 
-    if {![variant_isset tkinter] && ![variant_isset qt5] &&
-        ![variant_isset qt4] && ![variant_isset pyside] && ![variant_isset pyside2]} {
+    if {![variant_isset tkinter] && ![variant_isset qt5] && ![variant_isset pyside2]} {
             default_variants-append +cairo
     }
 


### PR DESCRIPTION
#### Description

https://github.com/macports/macports-ports/commit/91dc01dadd6b14d05a84ac7d0aad1b3 removed the 'qt4' and 'pyside' variants, but there are still some references to them that should be removed as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.0 25A354 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
