### PR TITLE
colima: update to 0.9.1

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.8.4 v
+go.setup            github.com/abiosoft/colima 0.9.1 v
 revision            0
 
 description         Run Kubernetes and Docker containers with minimal setup
@@ -21,9 +21,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  40f16e81a540baabe806ed0ec518d21160d87f03 \
-                    sha256  e02f3abf3ad7911fe4665b1c3291f03677edc0efa93e8d37b337d76149a7202b \
-                    size    619108
+checksums           rmd160  59d66469190099b7951c7ff7ea6bfca5de957697 \
+                    sha256  1fe95da6dbe584783e2ae521759aaacd3ba52bd6c44632f95b5adc0d97345460 \
+                    size    626959
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

Update to colima 0.9.1.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?