### PR TITLE
oxker: update to 0.12.0

### DIFF
--- a/devel/oxker/Portfile
+++ b/devel/oxker/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        mrjackwills oxker 0.11.1 v
+github.setup        mrjackwills oxker 0.12.0 v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {@sikmir disroot.org:sikmir} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  124b8103017bcc800310c7a9802aa82868a02c50 \
-                    sha256  d86a67ea88855c9f712086233f11dbdaf6ca5bd8cf1443e68851a7bd5669e096 \
-                    size    200491
+                    rmd160  6f3d56deaff782724f5b9856e1372f398386d2b3 \
+                    sha256  ef6813b4f5e471c217d68acbeed67de3567f6c40723c8cb0ba029c42be5779dc \
+                    size    3604543
 
 destroot {
     xinstall -m 0755 \
@@ -29,22 +29,21 @@ destroot {
 }
 
 cargo.crates \
-    addr2line                       0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
+    addr2line                       0.25.1  1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b \
     adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
     allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
-    android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anstream                        0.6.20  3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192 \
     anstyle                         1.0.11  862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd \
     anstyle-parse                    0.2.7  4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2 \
     anstyle-query                    1.1.4  9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2 \
     anstyle-wincon                  3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
-    anyhow                          1.0.99  b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100 \
+    anyhow                         1.0.100  a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
-    backtrace                       0.3.75  6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002 \
+    backtrace                       0.3.76  bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
-    bitflags                         2.9.2  6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29 \
+    bitflags                         2.9.4  2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394 \
     bollard                         0.19.2  8796b390a5b4c86f9f2e8173a68c2791f4fa6b038b84e96dbc01c016d1e6722c \
     bollard-stubs                 1.49.0-rc.28.3.3  2e7814991259013d5a5bee4ae28657dae0747d843cf06c40f7fc0c2894d6fa38 \
     bumpalo                         3.19.0  46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43 \
@@ -52,12 +51,12 @@ cargo.crates \
     cansi                            2.2.1  4bdcae87153686017415ce77e48c53e6818a0a058f0e21b56640d1e944967ef8 \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
     castaway                         0.2.4  dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a \
-    cc                              1.2.33  3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f \
+    cc                              1.2.39  e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f \
     cfg-if                           1.0.3  2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9 \
-    chrono                          0.4.41  c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d \
-    clap                            4.5.45  1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318 \
-    clap_builder                    4.5.44  b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8 \
-    clap_derive                     4.5.45  14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6 \
+    chrono                          0.4.42  145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2 \
+    clap                            4.5.48  e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae \
+    clap_builder                    4.5.48  c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9 \
+    clap_derive                     4.5.47  bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c \
     clap_lex                         0.7.5  b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675 \
     colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
     compact_str                      0.8.1  3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32 \
@@ -70,7 +69,7 @@ cargo.crates \
     darling                        0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
     darling_core                   0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
     darling_macro                  0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
-    deranged                         0.4.0  9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e \
+    deranged                         0.5.4  a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071 \
     derive_more                      2.0.1  093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678 \
     derive_more-impl                 2.0.1  bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3 \
     directories                      6.0.0  16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
@@ -81,7 +80,8 @@ cargo.crates \
     either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
-    errno                           0.3.13  778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad \
+    errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
+    find-msvc-tools                  0.1.2  1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
     form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
@@ -93,9 +93,10 @@ cargo.crates \
     futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
     getrandom                       0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
     getrandom                        0.3.3  26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4 \
-    gimli                           0.31.1  07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f \
+    gimli                           0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
+    hashbrown                       0.16.0  5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     http                             1.3.1  f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565 \
@@ -105,9 +106,9 @@ cargo.crates \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     hyper                            1.7.0  eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e \
     hyper-named-pipe                 0.1.0  73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278 \
-    hyper-util                      0.1.16  8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e \
+    hyper-util                      0.1.17  3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8 \
     hyperlocal                       0.9.1  986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7 \
-    iana-time-zone                  0.1.63  b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8 \
+    iana-time-zone                  0.1.64  33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     icu_collections                  2.0.0  200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47 \
     icu_locale_core                  2.0.0  0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a \
@@ -120,11 +121,11 @@ cargo.crates \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                        2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
+    indexmap                        2.11.4  4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5 \
     indoc                            2.0.6  f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
-    insta                           1.43.1  154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371 \
+    insta                           1.43.2  46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0 \
     instability                      0.3.9  435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a \
-    io-uring                         0.7.9  d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4 \
+    io-uring                        0.7.10  046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b \
     is_terminal_polyfill            1.70.1  7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf \
     itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
@@ -132,28 +133,27 @@ cargo.crates \
     jiff-static                     0.2.15  03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4 \
     jiff-tzdb                        0.1.4  c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524 \
     jiff-tzdb-platform               0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
-    js-sys                          0.3.77  1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f \
+    js-sys                          0.3.81  ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.175  6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543 \
-    libredox                         0.1.9  391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3 \
+    libc                           0.2.176  58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174 \
+    libredox                        0.1.10  416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
-    linux-raw-sys                    0.9.4  cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12 \
+    linux-raw-sys                   0.11.0  df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039 \
     litemap                          0.8.0  241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956 \
     litrs                            0.4.2  f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed \
     lock_api                        0.4.13  96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765 \
-    log                             0.4.27  13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94 \
+    log                             0.4.28  34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432 \
     lru                             0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
-    memchr                           2.7.5  32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0 \
+    memchr                           2.7.6  f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273 \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                              1.0.4  78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c \
-    nu-ansi-term                    0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
+    nu-ansi-term                    0.50.1  d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399 \
     num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
-    object                          0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
+    object                          0.37.3  ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe \
     once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
     once_cell_polyfill              1.70.1  a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
-    overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     parking_lot                     0.12.4  70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13 \
     parking_lot_core                0.9.11  bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5 \
     paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
@@ -162,7 +162,7 @@ cargo.crates \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     portable-atomic                 1.11.1  f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483 \
     portable-atomic-util             0.2.4  d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507 \
-    potential_utf                    0.1.2  e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585 \
+    potential_utf                    0.1.3  84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     proc-macro2                    1.0.101  89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de \
@@ -178,20 +178,21 @@ cargo.crates \
     ref-cast-impl                   1.0.24  1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7 \
     rustc-demangle                  0.1.26  56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
-    rustix                           1.0.8  11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8 \
+    rustix                           1.1.2  cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e \
     rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     schemars                         0.9.0  4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f \
     schemars                         1.0.4  82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    serde                          1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
-    serde_derive                   1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
-    serde_json                     1.0.143  d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a \
+    serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
+    serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
+    serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
+    serde_json                     1.0.145  402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c \
     serde_jsonc                    1.0.108  7a58154381df481a41b7536101c0daccdaf2426f244334074c4c77b89b6253a7 \
     serde_repr                      0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
-    serde_spanned                    1.0.0  40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83 \
+    serde_spanned                    1.0.2  5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_with                      3.14.0  f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5 \
+    serde_with                      3.14.1  c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                     0.3.18  d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
@@ -211,55 +212,58 @@ cargo.crates \
     thiserror                       2.0.16  3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0 \
     thiserror-impl                  2.0.16  6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960 \
     thread_local                     1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
-    time                            0.3.41  8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40 \
-    time-core                        0.1.4  c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c \
-    time-macros                     0.2.22  3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49 \
+    time                            0.3.44  91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d \
+    time-core                        0.1.6  40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b \
+    time-macros                     0.2.24  30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3 \
     tinystr                          0.8.1  5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b \
     tokio                           1.47.1  89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038 \
     tokio-macros                     2.5.0  6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8 \
     tokio-util                      0.7.16  14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5 \
-    toml                             0.9.5  75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8 \
-    toml_datetime                    0.7.0  bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3 \
-    toml_parser                      1.0.2  b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10 \
+    toml                             0.9.7  00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0 \
+    toml_datetime                    0.7.2  32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1 \
+    toml_parser                      1.0.3  4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627 \
     tower-service                    0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                         0.1.41  784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0 \
     tracing-attributes              0.1.30  81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903 \
     tracing-core                    0.1.34  b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678 \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
-    tracing-subscriber              0.3.19  e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008 \
+    tracing-subscriber              0.3.20  2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5 \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     unicase                          2.8.1  75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539 \
-    unicode-ident                   1.0.18  5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512 \
+    unicode-ident                   1.0.19  f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
     unicode-truncate                 1.1.0  b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
-    url                              2.5.6  137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4 \
+    url                              2.5.7  08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.18.0  f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be \
+    uuid                            1.18.1  2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2 \
     valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi                          0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
-    wasi                          0.14.2+wasi-0.2.4  9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3 \
-    wasm-bindgen                   0.2.100  1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5 \
-    wasm-bindgen-backend           0.2.100  2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6 \
-    wasm-bindgen-macro             0.2.100  7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407 \
-    wasm-bindgen-macro-support     0.2.100  8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de \
-    wasm-bindgen-shared            0.2.100  1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d \
+    wasi                          0.14.7+wasi-0.2.4  883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c \
+    wasip2                        1.0.1+wasi-0.2.4  0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7 \
+    wasm-bindgen                   0.2.104  c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d \
+    wasm-bindgen-backend           0.2.104  671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19 \
+    wasm-bindgen-macro             0.2.104  7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119 \
+    wasm-bindgen-macro-support     0.2.104  9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7 \
+    wasm-bindgen-shared            0.2.104  bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows-core                    0.61.2  c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3 \
-    windows-implement               0.60.0  a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836 \
-    windows-interface               0.59.1  bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8 \
-    windows-link                     0.1.3  5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a \
-    windows-result                   0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
-    windows-strings                  0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
+    windows-core                    0.62.1  6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9 \
+    windows-implement               0.60.1  edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0 \
+    windows-interface               0.59.2  c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5 \
+    windows-link                     0.2.0  45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65 \
+    windows-result                   0.4.0  7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f \
+    windows-strings                  0.5.0  7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda \
+    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                     0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-sys                     0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
+    windows-sys                     0.61.1  6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
-    windows-targets                 0.53.3  d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91 \
+    windows-targets                 0.53.4  2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b \
     windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
     windows_aarch64_gnullvm         0.53.0  86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764 \
     windows_aarch64_msvc            0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
@@ -276,13 +280,13 @@ cargo.crates \
     windows_x86_64_gnullvm          0.53.0  0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.0  271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486 \
-    winnow                          0.7.12  f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95 \
-    wit-bindgen-rt                  0.39.0  6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1 \
+    winnow                          0.7.13  21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf \
+    wit-bindgen                     0.46.0  f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59 \
     writeable                        0.6.1  ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb \
     yoke                             0.8.0  5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc \
     yoke-derive                      0.8.0  38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6 \
-    zerocopy                        0.8.26  1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f \
-    zerocopy-derive                 0.8.26  9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181 \
+    zerocopy                        0.8.27  0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c \
+    zerocopy-derive                 0.8.27  88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831 \
     zerofrom                         0.1.6  50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5 \
     zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
     zerotrie                         0.2.2  36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595 \


### PR DESCRIPTION
#### Description
https://github.com/mrjackwills/oxker/releases/tag/v0.12.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
