### PR TITLE
hamlib: update to 4.6.5

### DIFF
--- a/science/hamlib/Portfile
+++ b/science/hamlib/Portfile
@@ -20,11 +20,11 @@ long_description    Flexible and portable shared libraries that offer a \
 
 homepage            https://hamlib.github.io
 
-github.setup    Hamlib Hamlib 4.6.3
+github.setup    Hamlib Hamlib 4.6.5
 github.tarball_from releases
-checksums       rmd160  0e90d6fdb838267f4011c348d3fc847b021ae54f \
-                sha256  aefd1b1e53a8548870a266ae362044ad3ff43008d10f1050c965cf99ac5a9630 \
-                size    2922305
+checksums       rmd160  fe5405d19f5b0cac6a5d9e861df73ad98809c942 \
+                sha256  90d6f1dba59417c00f8f4545131c7efd31930cd0e178598980a8210425e3852e \
+                size    2947731
 revision        0
 
 distname        hamlib-${version}
@@ -35,11 +35,12 @@ depends_build-append \
 depends_lib-append \
     port:libtool \
     port:libusb-compat \
-    port:libxml2
+    port:libxml2 \
+    port:readline
 
 compiler.cxx_standard 2011
 
-set python_versions { 2.7 3.6 3.7 3.8 3.9 3.10 }
+set python_versions { 3.10 3.11 3.12 3.13 }
 # python binding is not enabled by default
 set default_python_variant ""
 


### PR DESCRIPTION
#### Description

Update to 4.6.5
Added support for Python 3.13
Closes: https://trac.macports.org/ticket/72282

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
macOS 26.0 25A354 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
