### PR TITLE
openjdk25: new port

### DIFF
--- a/java/openjdk25/Portfile
+++ b/java/openjdk25/Portfile
@@ -30,8 +30,7 @@ checksums           rmd160  9919ec33c84a719d0cf89bc2dceef8bebe00ff74 \
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 
-depends_lib         port:freetype \
-                    port:libiconv
+depends_lib         port:libiconv
 depends_build       port:${bootjdk_port} \
                     port:autoconf \
                     port:gmake \
@@ -55,9 +54,6 @@ configure.args      --with-debug-level=release \
                     --with-extra-cxxflags="${configure.cxxflags}" \
                     --with-extra-ldflags="${configure.ldflags}" \
                     --with-boot-jdk=/Library/Java/JavaVirtualMachines/jdk-${boot_feature}-azul-zulu.jdk/Contents/Home \
-                    --with-freetype=system \
-                    --with-freetype-include=${prefix}/include/freetype2 \
-                    --with-freetype-lib=${prefix}/lib \
                     --disable-warnings-as-errors \
                     --disable-precompiled-headers \
                     --with-vendor-name="MacPorts" \

--- a/java/openjdk25/Portfile
+++ b/java/openjdk25/Portfile
@@ -1,0 +1,173 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
+
+set feature 25
+
+# See https://github.com/openjdk/jdk/blob/master/doc/building.md#boot-jdk-requirements
+set boot_feature 24
+
+name                openjdk${feature}
+# See https://github.com/openjdk/jdk25u/tags for the version and build number that matches the latest tag that ends with '-ga'
+version             ${feature}
+set build 36
+revision            0
+categories          java devel
+supported_archs     x86_64 arm64
+license             GPL-2+
+maintainers         {breun @breun} openmaintainer
+description         OpenJDK ${feature} (Long Term Support)
+long_description    {*}${description} \
+    \n\nJDK ${feature} builds of OpenJDK, the Open-Source implementation \
+    of the Java Platform, Standard Edition, and related projects.
+homepage            https://openjdk.org/projects/jdk/${feature}/
+master_sites        https://github.com/openjdk/jdk${feature}u/archive/refs/tags
+distname            jdk-${version}-ga
+worksrcdir          jdk${feature}u-${distname}
+
+checksums           rmd160  9919ec33c84a719d0cf89bc2dceef8bebe00ff74 \
+                    sha256  7b84e7c96086b4e75ee128921d301427012447bdfbe1741398725ab6218afe11 \
+                    size    119351769
+
+set bootjdk_port    openjdk${boot_feature}-zulu
+
+depends_lib         port:freetype \
+                    port:libiconv
+depends_build       port:${bootjdk_port} \
+                    port:autoconf \
+                    port:gmake \
+                    port:bash
+
+# Boot JDK license/redistributability should not affect license/redistributability of this port
+license_noconflict  ${bootjdk_port}
+
+set tpath ${prefix}/Library/Java
+use_xcode           yes
+use_configure    yes
+configure.cmd       ${prefix}/bin/bash configure
+configure.pre_args  --prefix=${tpath}
+set bug_url "https://trac.macports.org/newticket?port=${name}"
+# default configure args
+configure.args      --with-debug-level=release \
+                    --with-native-debug-symbols=none \
+                    --with-version-string=${version}+${build} \
+                    --with-sysroot=`xcrun --sdk macosx --show-sdk-path` \
+                    --with-extra-cflags="${configure.cflags}" \
+                    --with-extra-cxxflags="${configure.cxxflags}" \
+                    --with-extra-ldflags="${configure.ldflags}" \
+                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/jdk-${boot_feature}-azul-zulu.jdk/Contents/Home \
+                    --with-freetype=system \
+                    --with-freetype-include=${prefix}/include/freetype2 \
+                    --with-freetype-lib=${prefix}/lib \
+                    --disable-warnings-as-errors \
+                    --disable-precompiled-headers \
+                    --with-vendor-name="MacPorts" \
+                    --with-vendor-url="https://www.macports.org" \
+                    --with-vendor-bug-url="${bug_url}" \
+                    --with-vendor-vm-bug-url="${bug_url}" \
+                    --with-conf-name=release
+
+if {[option configure.ccache]} {
+    # replace MacPorts ccache integration into JDK
+    configure.ccache        no
+    depends_build-append    path:bin/ccache:ccache
+    configure.args-append   --enable-ccache \
+                            --with-ccache-dir=${ccache_dir}
+}
+
+variant release \
+    conflicts debug optimized \
+    description {OpenJDK with no debug information, all optimizations and no asserts} {
+    configure.args-append   --with-debug-level=release
+}
+
+variant optimized \
+    conflicts debug release \
+    description {OpenJDK with no debug information, all optimizations, no asserts and HotSpot is 'optimized'} {
+    configure.args-append   --with-debug-level=optimized
+}
+
+variant debug \
+    conflicts optimized release \
+    description {OpenJDK with debug information, all optimizations and all asserts} {
+    configure.args-append   --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
+}
+
+variant client \
+    conflicts core minimal server zero \
+    description {JVM with normal interpreter, C1 and no C2 compiler} {
+    configure.args-append   --with-jvm-variants=client
+}
+
+variant server \
+    conflicts client core minimal zero \
+    description {JVM with normal interpreter, and a tiered C1/C2 compiler} {
+    configure.args-append   --with-jvm-variants=server
+}
+
+variant minimal \
+    conflicts client core server zero \
+    description {JVM with reduced form of normal interpreter having C1, no C2 compiler and optional features stripped out} {
+    configure.args-append   --with-jvm-variants=minimal
+}
+
+variant core \
+    conflicts client minimal server zero \
+    description {JVM with normal interpreter only and no compiler} {
+    configure.args-append   --with-jvm-variants=core
+}
+
+variant zero \
+    conflicts client core minimal server \
+    description {JVM with C++ based interpreter only, no compiler} {
+    configure.args-append   --with-jvm-variants=zero \
+                            --with-libffi=${prefix} \
+                            --enable-libffi-bundling
+    depends_lib-append         port:libffi
+}
+
+if {![variant_isset debug] && ![variant_isset optimized] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset client] && ![variant_isset core] && ![variant_isset minimal] && ![variant_isset server]} {
+    default_variants-append +server
+}
+
+build.type          gnu
+build.target        images
+use_parallel_build  no
+set jdkn jdk-${version}.jdk
+set bundle_dir build/release/images/jdk-bundle/${jdkn}/Contents
+
+test.run            yes
+test.cmd            ${bundle_dir}/Home/bin/java
+test.target         --version
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-${feature}-macports.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/${bundle_dir} ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree      yes
+
+post-destroot {
+    delete ${worksrcpath}
+}
+
+notes "
+If you want to make ${name} the default JDK, add this to shell profile:
+export JAVA_HOME=${jdk}/Contents/Home
+"
+    
+livecheck.type      regex
+livecheck.url       https://github.com/openjdk/jdk${feature}u/tags
+livecheck.regex     jdk-(${feature}\.\[0-9.\]+)-ga


### PR DESCRIPTION
#### Description

New port for OpenJDK 25.

###### Tested on

macOS 26.0 25A354 arm64
Xcode 26.1 17B5025f

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?