### PR TITLE
osm2pgsql: update to 2.2.0

### DIFF
--- a/gis/osm2pgsql/Portfile
+++ b/gis/osm2pgsql/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           boost 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        osm2pgsql-dev osm2pgsql 2.1.1
+github.setup        osm2pgsql-dev osm2pgsql 2.2.0
 revision            0
 github.tarball_from archive
 
@@ -22,9 +22,9 @@ license             GPL-2+
 
 homepage            https://osm2pgsql.org
 
-checksums           rmd160  0cde62068f4d9ffcdd2da0c1f11a5073aceabd91 \
-                    sha256  b084e4a79317043410ff13ece4350a801384bd34e6c2c5959fa1e1424ce195b0 \
-                    size    2712681
+checksums           rmd160  c8d65c8435548456091dc3e2a1d2f0a535965859 \
+                    sha256  567dad078f8a66d6d706ac1876b5251b688109d16974909d89ce2056d6e9f258 \
+                    size    2729137
 
 # It uses include variant
 compiler.cxx_standard 2017


### PR DESCRIPTION
#### Description
https://github.com/osm2pgsql-dev/osm2pgsql/releases/tag/2.2.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
