### PR TITLE
osxphotos: update to 0.73.1

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.73.0
+version                 0.73.1
 revision                0
 
 categories              graphics python
@@ -25,9 +25,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  4be1b85a461d849b302450ae5fc1aba765255094 \
-                        sha256  b968e6cc8186284a8528657105654ce6869b4e168cbc55c307f183530eae2c3a \
-                        size    2327235
+checksums               rmd160  5cf3ad9a5bab13ca7c3125a592ef9e01b1e61585 \
+                        sha256  ceafaa5747dfb018ac3635c95272ed76dc7dffff5fa1786487f39188c5ced900 \
+                        size    2327760
 
 python.default_version  313
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.73.1.

###### Tested on

macOS 26.0.1 25A362 arm64
Xcode 26.1 17B5025f

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?