### PR TITLE
antlr: Fix mistake, remove noarch

### DIFF
--- a/lang/antlr/Portfile
+++ b/lang/antlr/Portfile
@@ -8,7 +8,6 @@ version               2.7.7
 revision              4
 categories            lang java
 license               public-domain
-supported_archs       noarch
 maintainers           {@Dave-Allured noaa.gov:dave.allured} \
                       openmaintainer
 

--- a/lang/antlr/Portfile
+++ b/lang/antlr/Portfile
@@ -26,6 +26,9 @@ checksums             rmd160  0b7951a28b748e912721fe0f6de4095d9f8da57d \
                       sha256  853aeb021aef7586bda29e74a6b03006bcb565a755c86b66032d8ec31b67dbb9 \
                       size    1816180
 
+# This because *.a files are arch specific, but test can not currently detect.
+test.ignore_archs     yes
+
 patchfiles            patch-configure.diff antlr-DESTDIR.patch \
                       patch-lib-cpp-antlr-CharScanner.hpp.diff
 


### PR DESCRIPTION
#### Description

* antlr:  Remove noarch.  Was inserted by mistake in previous PR.
* This is critical, to prevent wrong arch files being provided on OS versions supporting dual arch types.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?