### PR TITLE
lychee: Update to 0.20.1

### DIFF
--- a/devel/lychee/Portfile
+++ b/devel/lychee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo  1.0
 PortGroup           github 1.0
 
-github.setup        lycheeverse lychee 0.20.0 lychee-v
+github.setup        lycheeverse lychee 0.20.1 lychee-v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ long_description    {*}${description} \
     reStructuredText, or any other text file or website!
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6aaa72424c7353dab55a49ba513df2a66afc015c \
-                    sha256  defb37caebeddc0fdfa7205c0d69d58ed55fabb0cbfa5b48954b2442ec90c170 \
-                    size    900490
+                    rmd160  839279ab96732ae8b64c6dda7cc856aa2a661dbc \
+                    sha256  d030de91cf5cd96924987461911aa04e78404f6372e0734e20a5c31e2df4608a \
+                    size    901748
 
 depends_lib         path:lib/libssl.dylib:openssl
 
@@ -29,6 +29,7 @@ destroot {
         ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
         ${destroot}${prefix}/bin/
 }
+
 
 cargo.crates \
     addr2line                       0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
@@ -101,7 +102,7 @@ cargo.crates \
     clap_lex                         0.7.5  b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675 \
     colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
     concurrent-queue                 2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
-    console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
+    console                         0.16.0  2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d \
     const_format                    0.2.34  126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd \
     const_format_proc_macros        0.2.34  1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744 \
     cookie                          0.18.1  4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747 \
@@ -206,7 +207,7 @@ cargo.crates \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hostname                         0.3.1  3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867 \
     html5ever                       0.35.0  55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4 \
-    html5gum                         0.7.0  b3918b5f36d61861b757261da986b51be562c7a87ac4e531d4158e67e08bff72 \
+    html5gum                         0.8.0  ba6fbe46e93059ce8ee19fbefdb0c7699cc7197fcaac048f2c3593f3e5da845f \
     http                            0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
     http                             1.3.1  f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565 \
     http-body                        0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
@@ -240,7 +241,7 @@ cargo.crates \
     ignore                          0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
     indexmap                        2.10.0  fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661 \
-    indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
+    indicatif                       0.18.0  70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd \
     io-uring                         0.7.9  d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4 \
     ip_network                       0.4.1  aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1 \
     ipconfig                         0.3.2  b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f \
@@ -292,7 +293,6 @@ cargo.crates \
     num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                        1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
-    number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
     numeric-sort                     0.1.5  f2dcb6053ab98da45585315f79932c5c9821fab8efa4301c0d7b637c91630eb7 \
     object                          0.36.7  62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87 \
     octocrab                        0.44.1  86996964f8b721067b6ed238aa0ccee56ecad6ee5e714468aa567992d05d2b91 \
@@ -493,6 +493,7 @@ cargo.crates \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                    0.2.1  4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
+    unit-prefix                      0.5.1  323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                              2.5.6  137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4 \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \


### PR DESCRIPTION
#### Description

lychee: Update to 0.20.1


##### Tested on

macOS 15.6.1 24G90 arm64
Xcode 26.0.1 17A400


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
