### PR TITLE
zizmor: Update to 1.14.2

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.13.0 v
+github.setup        zizmorcore zizmor 1.14.2 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  b5f5b193a8f5867613f7db8ecf48cbf256822b94 \
-                    sha256  1a59d2678ab901173de42bead03bfcadd22ec3b0c9208ebaffc89ec63d088434 \
-                    size    514915
+                    rmd160  579a9158f8eafd31d602468dea3c37c343133f93 \
+                    sha256  c2b0d5edcb3a008b62412522740885bd75164cb4239bb2acd4007acaad60815a \
+                    size    507217
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -30,19 +30,20 @@ destroot {
 }
 
 
+
 cargo.crates \
     Inflector                          0.11.4  fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3 \
     addr2line                          0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
     adler2                              2.0.0  512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627 \
     ahash                              0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
     aho-corasick                        1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
-    annotate-snippets                  0.12.3  4b0f1e2f8ec4bff67c7e1867001ec452595daf315cce10c393b7d4274024f878 \
+    annotate-snippets                  0.12.4  a8ee2f071d418442e50c643c4e7a4051ce3abd9dba11713cc6cdf4f4a3f3cca5 \
     anstream                           0.6.20  3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192 \
     anstyle                            1.0.10  55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9 \
     anstyle-parse                       0.2.6  3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9 \
     anstyle-query                       1.1.2  79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c \
     anstyle-wincon                      3.0.7  ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e \
-    anyhow                             1.0.99  b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100 \
+    anyhow                            1.0.100  a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61 \
     arrayvec                            0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert_cmd                         2.0.17  2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66 \
     async-trait                        0.1.88  e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5 \
@@ -63,14 +64,14 @@ cargo.crates \
     bytecount                           0.6.8  5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce \
     bytes                              1.10.1  d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a \
     cacache                            13.1.0  5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b \
-    camino                             1.1.12  dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5 \
+    camino                              1.2.0  e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603 \
     cc                                 1.2.20  04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a \
     cfg-if                              1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     cfg_aliases                         0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    clap                               4.5.47  7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931 \
+    clap                               4.5.48  e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae \
     clap-verbosity-flag                 3.0.4  9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394 \
-    clap_builder                       4.5.47  2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6 \
-    clap_complete                      4.5.57  4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad \
+    clap_builder                       4.5.48  c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9 \
+    clap_complete                      4.5.58  75bf0b32ad2e152de789bb635ea4d3078f6b838ad7974143e99b99f45a04af4a \
     clap_complete_nushell               4.5.8  0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce \
     clap_derive                        4.5.47  bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c \
     clap_lex                            0.7.4  f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6 \
@@ -152,7 +153,7 @@ cargo.crates \
     idna                                1.0.3  686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e \
     idna_adapter                        1.2.0  daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71 \
     ignore                             0.4.23  6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b \
-    indexmap                           2.11.0  f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9 \
+    indexmap                           2.11.4  4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5 \
     indicatif                          0.18.0  70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd \
     insta                              1.43.2  46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0 \
     inventory                          0.3.20  ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83 \
@@ -201,10 +202,10 @@ cargo.crates \
     parking_lot                        0.12.3  f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27 \
     parking_lot_core                   0.9.10  1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8 \
     percent-encoding                    2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
-    pest                                2.8.1  1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323 \
-    pest_derive                         2.8.1  bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc \
-    pest_generator                      2.8.1  87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966 \
-    pest_meta                           2.8.1  edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5 \
+    pest                                2.8.2  21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8 \
+    pest_derive                         2.8.2  bc58706f770acb1dbd0973e6530a3cff4746fb721207feb3a8a6064cd0b6c663 \
+    pest_generator                      2.8.2  6d4f36811dfe07f7b8573462465d5cb8965fffc2e71ae377a33aecf14c2c9a2f \
+    pest_meta                           2.8.2  42919b05089acbd0a5dcd5405fb304d17d1053847b81163d09c4ad18ce8e8420 \
     pin-project                        1.1.10  677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a \
     pin-project-internal               1.1.10  6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861 \
     pin-project-lite                   0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
@@ -249,10 +250,11 @@ cargo.crates \
     schemafy_core                       0.6.0  2bec29dddcfe60f92f3c0d422707b8b56473983ef0481df8d5236ed3ab8fdf24 \
     schemafy_lib                        0.6.0  af3d87f1df246a9b7e2bfd1f4ee5f88e48b11ef9cfc62e63f0dead255b1a6f5f \
     scopeguard                          1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    serde                             1.0.219  5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6 \
+    serde                             1.0.226  0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd \
     serde-sarif                         0.8.0  a053c46f18a8043570d4e32fefc4c6377f82bf29ec310a33e93f273048e3b0be \
-    serde_derive                      1.0.219  5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00 \
-    serde_json                        1.0.143  d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a \
+    serde_core                        1.0.226  ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4 \
+    serde_derive                      1.0.226  8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33 \
+    serde_json                        1.0.145  402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c \
     serde_json_path                     0.7.2  b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33 \
     serde_json_path_core                0.2.2  dde67d8dfe7d4967b5a95e247d4148368ddd1e753e500adb34b3ffe40c6bc1bc \
     serde_json_path_macros              0.1.6  517acfa7f77ddaf5c43d5f119c44a683774e130b4247b7d3210f8924506cfac8 \
@@ -322,7 +324,7 @@ cargo.crates \
     tree-sitter                        0.25.9  ccd2a058a86cfece0bf96f7cce1021efef9c8ed0e892ab74639173e5ed7a34fa \
     tree-sitter-bash                   0.23.3  329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e \
     tree-sitter-language                0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
-    tree-sitter-powershell             0.25.8  d76347b6c5300ae20622847aa53c88005d13b6999708ffbe4618b509ddb45178 \
+    tree-sitter-powershell             0.25.9  ae0e37101b110badaf99aa40460915a8797ceba15fc0ed22773280377a8dffb6 \
     tree-sitter-yaml                    0.7.1  3d5893f2a05e57c86a2338aa3aed167a1e5c68b8fdff3bf4a460941f2d8fc944 \
     try-lock                            0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     typed-builder                      0.21.0  ce63bcaf7e9806c206f7d7b9c1f38e0dce8bb165a80af0898161058b19248534 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.14.2


##### Tested on

macOS 15.6.1 24G90 arm64
Xcode 26.0.1 17A400


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
