### PR TITLE
vtk: Update to 9.5.2

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -26,14 +26,14 @@ compiler.blacklist-append {clang < 1100}
 # not from the official VTK download page in gz format.
 
 gitlab.instance     https://gitlab.kitware.com
-gitlab.setup        vtk vtk 9.5.1 v
-revision            2
+gitlab.setup        vtk vtk 9.5.2 v
+revision            0
 categories          graphics devel
 license             BSD
 
-checksums           rmd160  d4a3f7a499ffe88a423b06b928202138c7c00439 \
-                    sha256  8cb1f8c98c3a3e98bfa0bf358c2c8a5db4ab72b4e2bd5e845ed99d8d206d0c87 \
-                    size    40308191
+checksums           rmd160  06caa56eedf6a01d1e10bcc07ab2242e2dee1252 \
+                    sha256  a85763e3c040b6ae3139f1097339369456e1cc9d2aa6920f46da3709ddbe48e4 \
+                    size    40310394
 
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \
                     openmaintainer
@@ -52,13 +52,15 @@ set proj_version    proj9
 depends_lib-append  path:share/pkgconfig/eigen3.pc:eigen3 \
                     port:hdf5 \
                     port:libxml2 \
-                    port:${proj_version}
+                    port:${proj_version} \
+                    port:tiff
 
 configure.args-append \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_eigen:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_hdf5:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_libproj:BOOL=ON \
-                    -DVTK_MODULE_USE_EXTERNAL_VTK_libxml2:BOOL=ON
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_libxml2:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_tiff:BOOL=ON
 
 mpi.enforce_variant hdf5
 


### PR DESCRIPTION
#### Description

* Update VTK 9.5.1 --> 9.5.2.
* Switch from bundled to MacPorts libtiff.

###### Type(s)

###### Tested on

CI only.  OS 13, 14, 15 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?