### PR TITLE
openssl3: Update to 3.5.4

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            26
+revision            27
 
 categories          devel security
 license             MIT

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -11,14 +11,14 @@ legacysupport.newest_darwin_requires_legacy 8
 set major_v         3
 # For former rollback to 3.1.x release where needed. Must now stay.
 epoch               1
-github.setup        openssl openssl ${major_v}.5.3 openssl-
+github.setup        openssl openssl ${major_v}.5.4 openssl-
 name                openssl3
 revision            0
 
 github.tarball_from releases
-checksums           rmd160  afe75ecf9a8ec490a08db5545aec2013f2d909a4 \
-                    sha256  c9489d2abcf943cdc8329a57092331c598a402938054dc3a22218aea8a8ec3bf \
-                    size    53183370
+checksums           rmd160  ca7069bb89c9ec7d67209dd836715ebbfc8bb296 \
+                    sha256  967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99 \
+                    size    53190367
 
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                openssh
 version             10.0p2
 distname            openssh-10.0p1
-revision            4
+revision            5
 categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                29
+revision                30
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588


### PR DESCRIPTION
#### Description

Upstream advisory at:
  https://openssl-library.org/news/secadv/20250930.txt

CVE: CVE-2025-9230
CVE: CVE-2025-9231
CVE: CVE-2025-9232

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.0.1 25A362 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
