### PR TITLE
google-cloud-sdk: update to 541.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             540.0.0
+version             541.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  40a879a8865636f100b08753579d153653c2a482 \
-                    sha256  bd0e0e11f3f8f99b5b8059142e46731007b52690d3d5767b025f29dab507549b \
-                    size    55470260
+    checksums       rmd160  a4bc3d7ee99a9d32e4099b30f65def0757e9f923 \
+                    sha256  94d68049a084cc24fe5a1a48385a4d4bf4395e594ec7507f43b01cb7a15351b4 \
+                    size    55568086
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  f166995ed2a8269ca1bc154271ea0073d74f40dd \
-                    sha256  5b52fca721979d371c083f99463cf4b8f36d42f5d10fcb2381ffaf13536a2c98 \
-                    size    57000100
+    checksums       rmd160  7e7fb3d81045e26bd8e6fd6f08ab448095682c37 \
+                    sha256  af8a11d40b66f3bc8ab7e4d1b0a6cc939b55afcc988c5b8c66926f6778c5defc \
+                    size    57101414
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  1ea092ca08fd1c9cffc89d23ed4b90e437a6bedf \
-                    sha256  d7af233c272ef0a422db75e42be0cbd11f8a9af3a6da11b4b46278c6a399fda4 \
-                    size    56932346
+    checksums       rmd160  a3b74c5cd916ab24094d372e1182b04f94f2865e \
+                    sha256  4e7d06da030ae24ea0f1f647da654ed4b20759e063240cd4ba9431c96f0ea506 \
+                    size    57037470
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 541.0.0.

###### Tested on

macOS 26.0.1 25A362 arm64
Xcode 26.1 17B5025f

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?