### PR TITLE
openjdk21-jetbrains: update to 21.0.8-b1140.54

### DIFF
--- a/java/openjdk21-jetbrains/Portfile
+++ b/java/openjdk21-jetbrains/Portfile
@@ -5,7 +5,7 @@ PortGroup        github 1.0
 
 set feature 21
 set openjdk_version ${feature}.0.8
-set jbr_version b1138.52
+set jbr_version b1140.54
 github.setup     JetBrains JetBrainsRuntime ${openjdk_version}${jbr_version} jbr-release-
 github.tarball_from archive
 name             openjdk${feature}-jetbrains
@@ -41,14 +41,16 @@ use_bzip2        no
 
 if {${configure.build_arch} eq "x86_64"} {
     set jbr_arch x64
-    checksums    rmd160  737126593706948ae5c04f64aaee8d4407d25488 \
-                 sha256  b251c6f9968a2e59fd2c6e0dcad86240a1583c51944e90be941d0f8a419b492a \
-                 size    95834247
-} else {
+    checksums    rmd160  33a72c35a0e29286fb999423e6171cb9e7554a8e \
+                 sha256  4eaff7206b45d9bf9b2721c7c495f4c555cfeda4c71ae62950fddf155bf4a309 \
+                 size    95835139
+} elseif {${configure.build_arch} eq "arm64"} {
     set jbr_arch aarch64
-    checksums    rmd160  f0ba4f3e0fa10f571cae77c5875d2c2b21c2102f \
-                 sha256  70b0041ebfc3fa5fbb400c61fcf53d1f9f6322179dd0a8b59c5ae61fd3e675db \
-                 size    94730189
+    checksums    rmd160  f3424941ce7d6ac08a34a77febffbb67fbca435f \
+                 sha256  1fa3a1557152c06d2176c3f217d5676b11cc954b31121c0a063844b48c4a98f3 \
+                 size    94730953
+} else {
+    set jbr_arch unsupported_arch
 }
 
 distname         jbr-${openjdk_version}-osx-${jbr_arch}-${jbr_version}


### PR DESCRIPTION
#### Description

Update to JetBrains Runtime 21.0.8-b1140.54.

###### Tested on

macOS 26.0.1 25A362 arm64
Xcode 26.1 17B5025f

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?