### PR TITLE
ctris: update to v0.43

### DIFF
--- a/games/ctris/Portfile
+++ b/games/ctris/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dominikhackl ctris 0.42.1 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        dominikhackl ctris 0.43 v
+github.tarball_from archive
 categories          games
 license             GPL-2
 maintainers         nomaintainer
@@ -16,14 +15,20 @@ long_description \
     library. It works very fast and efficiently, so it should be possible to \
     play it even over a slow remote terminal.
 
-checksums           rmd160  9c80ee73be45d49cb4e37240af4924370d10a5dc \
-                    sha256  8b030224f62a210aabe39af486b2197ac7b96ef369776af51282e1b4d4f5cfb6 \
-                    size    16114
+checksums           rmd160  f30c7cda4849a49d6fc5587b30002fb5808432d5 \
+                    sha256  21f19ea3402a19ba993affe2e7c322b8806b94e459cb710a4b33d6aa7add31a8 \
+                    size    16663
 
-patchfiles          patch-Makefile.diff
+#remove patch-version at the next update
+patchfiles          patch-Makefile.diff \
+                    patch-version.diff
 
 configure {
     reinplace "s|__PREFIX__|${prefix}|" ${worksrcpath}/Makefile
     reinplace "s|__CC__|${configure.cc}|" ${worksrcpath}/Makefile
     reinplace "s|__CFLAGS__|${configure.cflags} [get_canonical_archflags cc]|" ${worksrcpath}/Makefile
 }
+
+github.livecheck.regex \
+                    {([0-9.]+)}
+

--- a/games/ctris/files/patch-version.diff
+++ b/games/ctris/files/patch-version.diff
@@ -1,0 +1,11 @@
+--- ctris_orig.h	2025-10-01 21:14:02.000000000 +0200
++++ ctris.h	2025-10-01 21:14:13.000000000 +0200
+@@ -15,7 +15,7 @@
+ #include <limits.h>
+ #include <time.h>
+ 
+-#define VERSION "v0.42" // version info
++#define VERSION "v0.43" // version info
+ #define HEIGHT 24 // height of the screen
+ #define WIDTH 80 // width of the screen
+ #define BOARD_HEIGHT (HEIGHT - 5) // height of the board


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.10 20G1427 x86_64
Command Line Tools 12.5.1.0.1.1623191612

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

When ran the version is shown 0.42 but is 0.43 (https://github.com/0xminik/ctris/pull/4)