### PR TITLE
openjdk25: build without -reproducible flag on macOS 12 and older

### DIFF
--- a/java/openjdk25/Portfile
+++ b/java/openjdk25/Portfile
@@ -1,4 +1,5 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 
 set feature 25
@@ -10,7 +11,7 @@ name                openjdk${feature}
 # See https://github.com/openjdk/jdk25u/tags for the version and build number that matches the latest tag that ends with '-ga'
 version             ${feature}
 set build 36
-revision            0
+revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -38,6 +39,11 @@ depends_build       port:${bootjdk_port} \
 
 # Boot JDK license/redistributability should not affect license/redistributability of this port
 license_noconflict  ${bootjdk_port}
+
+if {${os.major} < 22} {
+    # linker of macOS 12 and older cannot deal with '-reproducible' flag
+    patchfiles-append   non-reproducible.diff
+}
 
 set tpath ${prefix}/Library/Java
 use_xcode           yes

--- a/java/openjdk25/files/non-reproducible.diff
+++ b/java/openjdk25/files/non-reproducible.diff
@@ -1,0 +1,13 @@
+diff --git a/make/autoconf/flags-ldflags.m4 b/make/autoconf/flags-ldflags.m4
+index 509e0dd825f..ef9df055cb8 100644
+--- a/make/autoconf/flags-ldflags.m4
++++ b/make/autoconf/flags-ldflags.m4
+@@ -100,7 +100,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
+   if test "x$OPENJDK_TARGET_OS" = xmacosx && test "x$TOOLCHAIN_TYPE" = xclang; then
+     # FIXME: We should really generalize SET_SHARED_LIBRARY_ORIGIN instead.
+     OS_LDFLAGS_JVM_ONLY="-Wl,-rpath,@loader_path/. -Wl,-rpath,@loader_path/.."
+-    OS_LDFLAGS="-mmacosx-version-min=$MACOSX_VERSION_MIN -Wl,-reproducible"
++    OS_LDFLAGS="-mmacosx-version-min=$MACOSX_VERSION_MIN"
+   fi
+ 
+   # Setup debug level-dependent LDFLAGS


### PR DESCRIPTION
#### Description

Build without `-reproducible` linker flag on macOS 12 and older, because it doesn't seem to be supported on those OS versions.