### PR TITLE
legacy-support: Update to v1.5.2.

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -21,7 +21,7 @@ long_description    {*}${description}
 epoch               1
 
 # Primary release version
-set release_ver     1.5.1
+set release_ver     1.5.2
 
 # Binary compatibility version
 set compat_ver      1.0.0
@@ -29,13 +29,11 @@ set compat_ver      1.0.0
 subport ${name} {
     conflicts           ${name}-devel
     github.setup        macports macports-legacy-support ${release_ver} v
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    # N.B.: Needs testing - earlier attempts at that didn't work.
-    github.tarball_from tarball
+    github.tarball_from archive
     revision            0
-    checksums           rmd160  80bea072afe759d0aa13bed02205e7165e116b51 \
-                        sha256  aa9f267e7d25a10ea359e571a1fb180440f8d81aca1f250b95df42a4b1a65ddc \
-                        size    227836
+    checksums           rmd160  58a9837f78a72cb2204d674cc41e028b10bff71b \
+                        sha256  16da882281d26d8ddfb434acfde0828fc3e4119aab332445f65688ae879e9962 \
+                        size    228427
 }
 
 subport ${name}-devel {


### PR DESCRIPTION
Notable functional changes since v1.5.1:

- Updates headers for macOS 26 SDK.

Also switches `github.tarball_from` to `archive` for the release version.

Closes: https://trac.macports.org/ticket/72738

TESTED:
Tested both normal and -devel versions -/+universal on 10.4-10.5 ppc, 10.4-10.5 ppc64, 10.4-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-26.x arm64.
Builds and passes all tests on all tested platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, ppc, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S165, ppc64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, ppc (i386 Rosetta), Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, ppc (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, ppc (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.8 22H730, arm64, Xcode 15.2 15C500b
macOS 14.8 23J21, arm64, Xcode 16.2 16C5032a
macOS 15.7 24G222, arm64, Xcode 26.0 17A324
macOS 26.0 25A354, arm64, Xcode 26.0.1 17A400
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
