### PR TITLE
libfido2: update source

### DIFF
--- a/security/libfido2/Portfile
+++ b/security/libfido2/Portfile
@@ -9,9 +9,9 @@ PortGroup           legacysupport 1.1
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
+# next release download from https://developers.yubico.com/libfido2/Releases/
 github.setup        Yubico libfido2 1.16.0
-github.tarball_from releases
-extract.rename      yes
+github.tarball_from tarball
 revision            2
 
 categories          security crypto


### PR DESCRIPTION
## Port Update

### Changes
* Fix Source Inconsistency

addresses: 
https://github.com/macports/macports-ports/commit/ba611a0273ccdce958bfab9140e4d12a5f8e63f0#commitcomment-166102908

### Testing Performed
- [x] Port builds successfully locally
- [x] Port lint passes with 0 errors and 0 warnings
- [x] Dependencies verified
- [x] Installation tested

### Port Details
- **Category**: security
- **Version**: 1.16.0
- **Homepage**: https://developers.yubico.com/libfido2/
- **License**: bsd
- **Dependencies**: libcbor, mandoc, pkgconfig

### Maintainer
@trodemaster (openmaintainer)

**Tested on**

macOS 15.6.1 Xcode 16.4 / Command Line Tools 16.4.0.0.1.1747106510 (arm64)