### PR TITLE
symfony-cli: update to 5.15.0

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.14.2
+version             5.15.0
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,17 +44,17 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  a2776e498c912330fc75b8ac31aa04262cd381cb \
-                        sha256  7347c365f04572807a358f0171859d90f66194bdeb28c09e955d27415dca6f5a \
-                        size    289631
+    checksums           rmd160  92fb5871f6f89798c01e100a95efda99d4abd570 \
+                        sha256  504ee83ffc085adc5ecc5bf7e01ed029891c2854495a8ab2bc5874ff6e36997a \
+                        size    289965
 } else {
     build {}
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  2563935ec41f8e2d166a7438325b3f22c73b438c \
-                        sha256  ba3346c9755fd02af62e13dd6e19de5d88e3c33c07ce767ed67e7dd7e902b5b1 \
-                        size    12270538
+    checksums           rmd160  221cb8d3e68bf8cb322c23d64ecf01ecb68eee2b \
+                        sha256  2100d674b9f3789a5579ffc5ed8471a0118fae5ecbab07f4548fa68938864061 \
+                        size    12304893
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.15.0

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
