### PR TITLE
lagrange: update to 1.19.3

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           gitea 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.19.2 v
+gitea.setup         gemini lagrange 1.19.3 v
 revision            0
 categories          net gemini
 license             BSD
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  9f28180be659cf53d6c73c788b30def4699d4283 \
-                    sha256  d2c84d4c7f07085a33a8565c53d259afd125827e4bdeef8e944638b7277c2cd0 \
-                    size    8928401
+checksums           rmd160  8c15530e6d8ab5ff02bb8f951465767e8ed7f181 \
+                    sha256  5a88854998e7c63ae1cb16be56882351d900a4dfeb82c11e2401530397d1794e \
+                    size    8930804
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://github.com/skyjake/lagrange/releases/tag/v1.19.3

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
