### PR TITLE
kitty: update to version 0.43.1

### DIFF
--- a/aqua/kitty/Portfile
+++ b/aqua/kitty/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 # TODO: Test port on the macOS 10.12 - macOS 10.15. Because kitty replaces the
 # librsync with libxxhash, new versions can work
 # correctly again.
-github.setup        kovidgoyal kitty 0.41.1 v
+github.setup        kovidgoyal kitty 0.43.1 v
 github.tarball_from releases
 revision            0
 
@@ -23,9 +23,9 @@ homepage            https://sw.kovidgoyal.net/kitty/
 use_xz              yes
 
 checksums           ${distfiles} \
-                    rmd160  a73d7d502f48a3897565f50a9f4eb8dbfdc962d0 \
-                    sha256  e30150fad1bcc885a7adbd87380696ef7b67a62a38f74634efbc05c3745f26aa \
-                    size    8907984
+                    rmd160  2bfd8658b12a545c391c245ef50ac273d35f4934 \
+                    sha256  44a875e34e6a5f9b8f599b25b0796c07a1506fec2b2310573e03077ef1ae159f \
+                    size    12756968
 
 if {${os.major} <= 15} {
     # See https://github.com/kovidgoyal/kitty/issues/2700
@@ -115,7 +115,8 @@ post-destroot {
     platform darwin {
         if {${os.major} >= 22} {
             system -W ${destroot}${applications_dir} "/usr/bin/codesign --force -s - kitty.app/Contents/MacOS/kitten"
-            system -W ${destroot}${applications_dir} "/usr/bin/codesign --force -s- kitty.app/Contents/MacOS/kitty"
+            system -W ${destroot}${applications_dir} "/usr/bin/codesign --force -s - kitty.app/Contents/kitty-quick-access.app/Contents/MacOS/kitty-quick-access"
+            system -W ${destroot}${applications_dir} "/usr/bin/codesign --force -s - kitty.app/Contents/MacOS/kitty"
             system -W ${destroot}${applications_dir} "/usr/bin/codesign --force -s - kitty.app"
         }
     }

--- a/aqua/kitty/files/patch-kitty-no-deprecated-declarations.diff
+++ b/aqua/kitty/files/patch-kitty-no-deprecated-declarations.diff
@@ -1,11 +1,11 @@
 --- setup.py.orig
 +++ setup.py
-@@ -307,7 +307,7 @@
-     march = '-march=native' if native_optimizations else ''
+@@ -529,7 +529,7 @@ def init_env(
+ 
      cflags_ = os.environ.get(
          'OVERRIDE_CFLAGS', (
--            f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {std}'
-+            f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wno-deprecated-declarations -Wall -Wstrict-prototypes {std}'
+-            f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {c_std}'
++            f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wno-deprecated-declarations -Wall -Wstrict-prototypes {c_std}'
              f' {werror} {optimize} {sanitize_flag} -fwrapv {stack_protector} {missing_braces}'
-             f' -pipe {march} -fvisibility=hidden {fortify_source}'
+             f' -pipe -fvisibility=hidden {no_plt}'
          )


### PR DESCRIPTION
#### Description

Update kitty to version 0.43.1. I also adjust the patch to work with new version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.0.1 25A362 arm64
Xcode 26.0 17A324

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
