### PR TITLE
symfony-cli: update to 5.15.1

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.15.0
+version             5.15.1
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,17 +44,17 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  92fb5871f6f89798c01e100a95efda99d4abd570 \
-                        sha256  504ee83ffc085adc5ecc5bf7e01ed029891c2854495a8ab2bc5874ff6e36997a \
-                        size    289965
+    checksums           rmd160  cec999b985fec6964ce61da253d58f6fb86813ae \
+                        sha256  101ef843524db069d54a2b8653a4757c856c6f89e3a40f40c6be8ccd8176aef4 \
+                        size    290450
 } else {
     build {}
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  221cb8d3e68bf8cb322c23d64ecf01ecb68eee2b \
-                        sha256  2100d674b9f3789a5579ffc5ed8471a0118fae5ecbab07f4548fa68938864061 \
-                        size    12304893
+    checksums           rmd160  ab01394ed1f8e5867a4b36e93891b0187727fb33 \
+                        sha256  b526b806fedb071511268e3e8fd00211f6d44f04f2fa0490cec3f52121530a40 \
+                        size    12218116
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.15.1

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
