### PR TITLE
cclient: fix for changed definiton of scandir

### DIFF
--- a/mail/cclient/Portfile
+++ b/mail/cclient/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            cclient
 version         2007f
-revision        4
+revision        5
 checksums       rmd160  298b09c2da9650cb7bc70094da49bab57878ae20 \
                 sha256  53e15a2b5c1bc80161d42e9f69792a3fa18332b7b771910131004eb520004a28 \
                 size    1990304
@@ -71,6 +71,10 @@ destroot {
 
 if {${os.platform} eq "darwin" && ${os.major} >= 10} {
     patchfiles-append fix-pam-paths-for-10.6+.patch
+}
+
+if {${os.platform} eq "darwin" && ${os.major} >= 12} {
+    patchfiles-append scandir.patch
 }
 
 variant ssl_plaintext description {Allow plaintext passwords over SSL} {

--- a/mail/cclient/files/scandir.patch
+++ b/mail/cclient/files/scandir.patch
@@ -1,0 +1,166 @@
+Fix:
+The signature of the scandir function changed to include a const in OS X 10.8.
+https://trac.macports.org/ticket/71181#comment:4
+https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271539
+
+Patch derived from https://bugs.freebsd.org/bugzilla/attachment.cgi?id=242299&action=diff
+--- src/osdep/unix/mh.c.orig	2022-04-17 00:12:02 UTC
++++ src/osdep/unix/mh.c
+@@ -100,8 +100,8 @@ long mh_append (MAILSTREAM *stream,char *mailbox,appen
+ 	      long options);
+ long mh_append (MAILSTREAM *stream,char *mailbox,append_t af,void *data);
+ 
+-int mh_select (struct direct *name);
+-int mh_numsort (const void *d1,const void *d2);
++int mh_select (const struct direct *name);
++int mh_numsort (const struct direct **d1,const struct direct **d2);
+ char *mh_file (char *dst,char *name);
+ long mh_canonicalize (char *pattern,char *ref,char *pat);
+ void mh_setdate (char *file,MESSAGECACHE *elt);
+@@ -1191,7 +1191,7 @@ long mh_append (MAILSTREAM *stream,char *mailbox,appen
+  * Returns: T to use file name, NIL to skip it
+  */
+ 
+-int mh_select (struct direct *name)
++int mh_select (const struct direct *name)
+ {
+   char c;
+   char *s = name->d_name;
+@@ -1206,10 +1206,9 @@ int mh_select (struct direct *name)
+  * Returns: negative if d1 < d2, 0 if d1 == d2, postive if d1 > d2
+  */
+ 
+-int mh_numsort (const void *d1,const void *d2)
++int mh_numsort (const struct direct **d1,const struct direct **d2)
+ {
+-  return atoi ((*(struct direct **) d1)->d_name) -
+-    atoi ((*(struct direct **) d2)->d_name);
++  return atoi ((*d1)->d_name) - atoi ((*d2)->d_name);
+ }
+ 
+ 
+@ -0,0 +1,54 @@ 
+--- src/osdep/unix/mix.c.orig	2022-04-17 00:12:02 UTC
++++ src/osdep/unix/mix.c
+@@ -123,7 +123,7 @@ long mix_rename (MAILSTREAM *stream,char *old,char *ne
+ long mix_create (MAILSTREAM *stream,char *mailbox);
+ long mix_delete (MAILSTREAM *stream,char *mailbox);
+ long mix_rename (MAILSTREAM *stream,char *old,char *newname);
+-int mix_rselect (struct direct *name);
++int mix_rselect (const struct direct *name);
+ MAILSTREAM *mix_open (MAILSTREAM *stream);
+ void mix_close (MAILSTREAM *stream,long options);
+ void mix_abort (MAILSTREAM *stream);
+@@ -138,8 +138,8 @@ long mix_expunge (MAILSTREAM *stream,char *sequence,lo
+ long mix_ping (MAILSTREAM *stream);
+ void mix_check (MAILSTREAM *stream);
+ long mix_expunge (MAILSTREAM *stream,char *sequence,long options);
+-int mix_select (struct direct *name);
+-int mix_msgfsort (const void *d1,const void *d2);
++int mix_select (const struct direct *name);
++int mix_msgfsort (const struct direct **d1,const struct direct **d2);
+ long mix_addset (SEARCHSET **set,unsigned long start,unsigned long size);
+ long mix_burp (MAILSTREAM *stream,MIXBURP *burp,unsigned long *reclaimed);
+ long mix_burp_check (SEARCHSET *set,size_t size,char *file);
+@@ -585,7 +585,7 @@ long mix_rename (MAILSTREAM *stream,char *old,char *ne
+  * Returns: T if mix file name, NIL otherwise
+  */
+ 
+-int mix_rselect (struct direct *name)
++int mix_rselect (const struct direct *name)
+ {
+   return mix_dirfmttest (name->d_name);
+ }
+@@ -1150,7 +1150,7 @@ long mix_expunge (MAILSTREAM *stream,char *sequence,lo
+  * ".mix" with no suffix was used by experimental versions
+  */
+ 
+-int mix_select (struct direct *name)
++int mix_select (const struct direct *name)
+ {
+   char c,*s;
+ 				/* make sure name has prefix */
+@@ -1169,10 +1169,10 @@ int mix_select (struct direct *name)
+  * Returns: -1 if d1 < d2, 0 if d1 == d2, 1 d1 > d2
+  */
+ 
+-int mix_msgfsort (const void *d1,const void *d2)
++int mix_msgfsort (const struct direct **d1,const struct direct **d2)
+ {
+-  char *n1 = (*(struct direct **) d1)->d_name + sizeof (MIXNAME) - 1;
+-  char *n2 = (*(struct direct **) d2)->d_name + sizeof (MIXNAME) - 1;
++  char *n1 = (*d1)->d_name + sizeof (MIXNAME) - 1;
++  char *n2 = (*d2)->d_name + sizeof (MIXNAME) - 1;
+   return compare_ulong (*n1 ? strtoul (n1,NIL,16) : 0,
+ 			*n2 ? strtoul (n2,NIL,16) : 0);
+ }
+--- src/osdep/unix/mx.c.orig	2022-04-17 00:12:02 UTC
++++ src/osdep/unix/mx.c
+@@ -98,8 +98,8 @@ long mx_append_msg (MAILSTREAM *stream,char *flags,MES
+ long mx_append_msg (MAILSTREAM *stream,char *flags,MESSAGECACHE *elt,
+ 		    STRING *st,SEARCHSET *set);
+ 
+-int mx_select (struct direct *name);
+-int mx_numsort (const void *d1,const void *d2);
++int mx_select (const struct direct *name);
++int mx_numsort (const struct direct **d1,const struct direct **d2);
+ char *mx_file (char *dst,char *name);
+ long mx_lockindex (MAILSTREAM *stream);
+ void mx_unlockindex (MAILSTREAM *stream);
+@@ -1110,7 +1110,7 @@ long mx_append_msg (MAILSTREAM *stream,char *flags,MES
+  * Returns: T to use file name, NIL to skip it
+  */
+ 
+-int mx_select (struct direct *name)
++int mx_select (const struct direct *name)
+ {
+   char c;
+   char *s = name->d_name;
+@@ -1125,10 +1125,9 @@ int mx_select (struct direct *name)
+  * Returns: negative if d1 < d2, 0 if d1 == d2, postive if d1 > d2
+  */
+ 
+-int mx_numsort (const void *d1,const void *d2)
++int mx_numsort (const struct direct **d1,const struct direct **d2)
+ {
+-  return atoi ((*(struct direct **) d1)->d_name) -
+-    atoi ((*(struct direct **) d2)->d_name);
++  return atoi ((*d1)->d_name) - atoi ((*d2)->d_name);
+ }
+ 
+ 
+--- src/osdep/unix/news.c.orig	2022-04-17 00:12:02 UTC
++++ src/osdep/unix/news.c
+@@ -76,8 +76,8 @@ MAILSTREAM *news_open (MAILSTREAM *stream);
+ long news_delete (MAILSTREAM *stream,char *mailbox);
+ long news_rename (MAILSTREAM *stream,char *old,char *newname);
+ MAILSTREAM *news_open (MAILSTREAM *stream);
+-int news_select (struct direct *name);
+-int news_numsort (const void *d1,const void *d2);
++int news_select (const struct direct *name);
++int news_numsort (const struct direct **d1,const struct direct **d2);
+ void news_close (MAILSTREAM *stream,long options);
+ void news_fast (MAILSTREAM *stream,char *sequence,long flags);
+ void news_flags (MAILSTREAM *stream,char *sequence,long flags);
+@@ -402,7 +402,7 @@ MAILSTREAM *news_open (MAILSTREAM *stream)
+  * Returns: T to use file name, NIL to skip it
+  */
+ 
+-int news_select (struct direct *name)
++int news_select (const struct direct *name)
+ {
+   char c;
+   char *s = name->d_name;
+@@ -417,10 +417,9 @@ int news_select (struct direct *name)
+  * Returns: negative if d1 < d2, 0 if d1 == d2, postive if d1 > d2
+  */
+ 
+-int news_numsort (const void *d1,const void *d2)
++int news_numsort (const struct direct **d1,const struct direct **d2)
+ {
+-  return atoi ((*(struct direct **) d1)->d_name) -
+-    atoi ((*(struct direct **) d2)->d_name);
++  return atoi ((*d1)->d_name) - atoi ((*d2)->d_name);
+ }
+ 
+ 


### PR DESCRIPTION
Changes to be committed:
	modified:   mail/cclient/Portfile
	new file:   mail/cclient/files/scandir.patch

fixes: https://trac.macports.org/ticket/71181

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
```
Model Identifier: Macmini6,1                Model Identifier: MacPro5,1                 
macOS 10.15.7 19H2026 x86_64                macOS 14.7.7 23H723 x86_64                  
Xcode 12.4 12D4e                            Xcode 16.2 16C5032a                         
Command Line Tools 12.4.0.0.1.1610135815    Command Line Tools 16.2.0.0.1.1733547573    
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? 
