### PR TITLE
arduino-cli: update to 1.3.1

### DIFF
--- a/devel/arduino-cli/Portfile
+++ b/devel/arduino-cli/Portfile
@@ -3,9 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/arduino/arduino-cli 1.1.1 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+go.setup            github.com/arduino/arduino-cli 1.3.1 v
 revision            0
 
 categories          devel electronics
@@ -20,9 +18,9 @@ long_description    \
     or machine interfaces.
 homepage            https://arduino.github.io/arduino-cli
 
-checksums           rmd160  27a683a138e6e6ce33c17d2718e1defacb7aa78d \
-                    sha256  02d2a0adaefe13c82289a279d0addc071d9bb7b91a0ae65869796a3569ab4ac2 \
-                    size    10136227
+checksums           rmd160  50c544b7be5d19cef05a20848900431a4e588d95 \
+                    sha256  7977ef114eee32aec3eb2f371c6a5bbcf9b2238b1e923eb2d384c888ad1c1fe0 \
+                    size    10986096
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 go.offline_build no


### PR DESCRIPTION
#### Description

Update `Arduino-cli` to version release 1.3.1. Additionally, we no longer specify the `github.tarball_from` and instead use the default specified by the Golang PortGroup (of `archive`).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.0.1 25A362 arm64
Xcode 26.0.1 17A400 / Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
