### PR TITLE
gemini-cli: new port

### DIFF
--- a/llm/gemini-cli/Portfile
+++ b/llm/gemini-cli/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           npm 1.0
+
+name                gemini-cli
+version             0.7.0
+revision            0
+
+categories          llm
+platforms           any
+maintainers         {breun @breun} openmaintainer
+license             Apache-2
+supported_archs     noarch
+
+description         Use Google Gemini from your terminal
+long_description    Gemini CLI is an open-source AI agent that brings the power of Gemini directly into your terminal.
+
+homepage            https://google-gemini.github.io/gemini-cli/
+
+npm.rootname        @google/${name}
+distname            ${name}-${version}
+
+checksums           rmd160  5f26391c5204cef9f9a50eda2fc8150629c610c4 \
+                    sha256  a9cc6e57d470158b533b564f746f2d7409308870567ef2c9efd9b3a66b916741 \
+                    size    899069
+
+test.run    yes
+test.cmd    gemini
+test.target
+test.args   --version


### PR DESCRIPTION
#### Description

New port for [gemini-cli](https://google-gemini.github.io/gemini-cli/).

###### Tested on

macOS 26.0.1 25A362 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?