### PR TITLE
Gemini cli 0.8.0

### DIFF
--- a/llm/gemini-cli/Portfile
+++ b/llm/gemini-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                gemini-cli
-version             0.7.0
+version             0.8.0
 revision            0
 
 categories          llm
@@ -21,9 +21,9 @@ homepage            https://google-gemini.github.io/gemini-cli/
 npm.rootname        @google/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  5f26391c5204cef9f9a50eda2fc8150629c610c4 \
-                    sha256  a9cc6e57d470158b533b564f746f2d7409308870567ef2c9efd9b3a66b916741 \
-                    size    899069
+checksums           rmd160  69ffbbfa61333363a2a643312f33046c2b99c59e \
+                    sha256  b270ce72e33f45dbc2ef99dea50b207cf51137ef02b4e5c578bd943546e6d694 \
+                    size    928599
 
 test.run    yes
 test.cmd    gemini

--- a/llm/gemini-cli/Portfile
+++ b/llm/gemini-cli/Portfile
@@ -14,7 +14,7 @@ license             Apache-2
 supported_archs     noarch
 
 description         Use Google Gemini from your terminal
-long_description    Gemini CLI is an open-source AI agent that brings the power of Gemini directly into your terminal.
+long_description    Gemini CLI is an open-source AI agent that brings the power of Google Gemini directly into your terminal.
 
 homepage            https://google-gemini.github.io/gemini-cli/
 


### PR DESCRIPTION
#### Description

Update to gemini-cli 0.8.0.

###### Tested on

macOS 26.0.1 25A362 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?