### PR TITLE
k9s: update to 0.50.15

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.50.14 v
+go.setup            github.com/derailed/k9s 0.50.15 v
 go.offline_build    no
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {breun @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  f4e6bd362e24ac17980ed1e09928d17abc45f308 \
-                    sha256  65429ba7f6170d707ca272c198d8d19f34ddf98b0e24931178ec530b42de7894 \
-                    size    6810204
+checksums           rmd160  e7a6ccb9f89ab8252a501cb4e67f635381d658e7 \
+                    sha256  f97774984c31bf9b64224b0ab5003072734420007d37c1ad2c92f1361de4f23d \
+                    size    6810231
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

Update to k9s 0.50.15.

###### Tested on

macOS 26.0.1 25A362 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?