### PR TITLE
mysql55: fix build

### DIFF
--- a/databases/mysql55/Portfile
+++ b/databases/mysql55/Portfile
@@ -34,8 +34,13 @@ if {$subport eq $name} {
     cmake.out_of_source yes
     use_parallel_build  yes
 
+    # Will not compile with C++17; force earlier standard
+    configure.args-append -DCMAKE_CXX_STANDARD=98
+
     patch.pre_args-replace  -p0 -p1
     patchfiles          patch-cmake-install_layout.cmake.diff
+
+    patchfiles-append   Ventura-and-arm64.patch
 
     checksums           rmd160  4b6fdfc37dc87fdabb2b944b695d5b9e687e22f2 \
                         sha256  b1e7853bc1f04aabf6771e0ad947f35ac8d237f4b35d0706d1095c9526ff99d7 \

--- a/databases/mysql55/files/Ventura-and-arm64.patch
+++ b/databases/mysql55/files/Ventura-and-arm64.patch
@@ -1,0 +1,27 @@
+diff --git a/include/my_global.h b/include/my_global.h
+index 01a1dca..04c487e 100644
+--- a/include/my_global.h
++++ b/include/my_global.h
+@@ -174,7 +174,7 @@
+ #  if defined(__i386__) || defined(__ppc__)
+ #    define SIZEOF_CHARP 4
+ #    define SIZEOF_LONG 4
+-#  elif defined(__x86_64__) || defined(__ppc64__)
++#  elif defined(__x86_64__) || defined(__ppc64__) || defined(__aarch64__) || defined(__arm64__)
+ #    define SIZEOF_CHARP 8
+ #    define SIZEOF_LONG 8
+ #  else
+diff --git a/storage/perfschema/CMakeLists.txt b/storage/perfschema/CMakeLists.txt
+index f8ee1ca..3445c40 100644
+--- a/storage/perfschema/CMakeLists.txt
++++ b/storage/perfschema/CMakeLists.txt
+@@ -13,8 +13,7 @@
+ # along with this program; if not, write to the Free Software Foundation,
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA
+ 
+-INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}
+-                    ${CMAKE_SOURCE_DIR}/include
++INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include
+                     ${CMAKE_SOURCE_DIR}/sql
+                     ${CMAKE_SOURCE_DIR}/regex
+                     ${CMAKE_SOURCE_DIR}/extra/yassl/include)


### PR DESCRIPTION
#### Description
Fix build errors on ARM64, compilers which default to C++17, and due to VERSION file conflict.
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15 Intel + MacPorts LLVM Clang 19

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
Only tested through build phase.
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
