### PR TITLE
libsdl2: fix EGL library paths

### DIFF
--- a/devel/libsdl2/Portfile
+++ b/devel/libsdl2/Portfile
@@ -5,6 +5,7 @@ PortGroup       github 1.0
 
 name            libsdl2
 github.setup    libsdl-org SDL 2.32.10 release-
+revision        1
 categories      devel multimedia
 platforms       macosx freebsd
 license         zlib
@@ -21,11 +22,13 @@ homepage        https://www.libsdl.org/
 github.tarball_from releases
 distname        SDL2-${version}
 checksums       rmd160 4212372b886f8dbab92141c520951e245e0c9657 \
-                sha256 5f5993c530f084535c65a6879e9b26ad441169b3e25d789d83287040a9ca5165
+                sha256 5f5993c530f084535c65a6879e9b26ad441169b3e25d789d83287040a9ca5165 \
+                size   7630262
 
 depends_lib     port:libiconv
 
-patchfiles      available.patch
+patchfiles      available.patch \
+                prefix.patch
 
 configure.args  --without-x \
                 --disable-jack \
@@ -82,6 +85,10 @@ variant x11 {
 }
 if {${os.subplatform} ne "macosx"} {
     default_variants +x11
+}
+
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/src/video/SDL_egl.c
 }
 
 post-destroot {

--- a/devel/libsdl2/files/prefix.patch
+++ b/devel/libsdl2/files/prefix.patch
@@ -1,0 +1,17 @@
+--- src/video/SDL_egl.c.orig	2025-01-01 19:47:53
++++ src/video/SDL_egl.c	2025-10-24 21:12:41
+@@ -82,10 +82,10 @@
+ 
+ #elif defined(SDL_VIDEO_DRIVER_COCOA)
+ /* EGL AND OpenGL ES support via ANGLE */
+-#define DEFAULT_EGL        "libEGL.dylib"
+-#define DEFAULT_OGL_ES2    "libGLESv2.dylib"
+-#define DEFAULT_OGL_ES_PVR "libGLES_CM.dylib"   //???
+-#define DEFAULT_OGL_ES     "libGLESv1_CM.dylib" //???
++#define DEFAULT_EGL        "@PREFIX@/lib/libEGL.dylib"
++#define DEFAULT_OGL_ES2    "@PREFIX@/lib/libGLESv2.dylib"
++#define DEFAULT_OGL_ES_PVR "@PREFIX@/lib/libGLES_CM.dylib"   //???
++#define DEFAULT_OGL_ES     "@PREFIX@/lib/libGLESv1_CM.dylib" //???
+ 
+ #elif defined(__OpenBSD__)
+ /* OpenBSD */


### PR DESCRIPTION
#### Description

This makes it work with the angle port (see [example](https://github.com/erik-larsen/opengl-for-mac)).

###### Type(s)

- [x] bugfix

###### Tested on
macOS 15.7.1 24G231 arm64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?