### PR TITLE
weechat: update to 4.8.1

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.7.1
+version             4.8.1
 revision            0
-checksums           rmd160  c8683962267f791620f688e7f14b98fa55b25504 \
-                    sha256  e83fb71ca251c5dd74bd9c5a6bd3f85dc2eb8ecec0955f43c07f3e0911edb7d3 \
-                    size    2768340
+checksums           rmd160  17f18ac16169d3443c13d66d029576304713f2eb \
+                    sha256  e7ac1fbcc71458ed647aada8747990905cb5bfb93fd8ccccbc2a969673a4285a \
+                    size    2789552
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 4.8.1

###### Tested on
macOS 15.7.1 24G231 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?