### PR TITLE
java/javacc/Portfile: version -6.0 +7.0.13 and related changes

### DIFF
--- a/java/javacc/Portfile
+++ b/java/javacc/Portfile
@@ -1,13 +1,15 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
-name                javacc
-version             6.0
-categories          java lang devel
-platforms           any
-supported_archs     noarch
-maintainers         nomaintainer
-license             BSD
+revision            4
+PortGroup           github 1.0
+
+use_zip             yes
+github.setup        javacc javacc 7.0.13
 description         Java Compiler Compiler, a parser generator for use with Java
+categories          java lang devel
+license             BSD
 long_description    Java Compiler Compiler (JavaCC) is the most popular \
     parser generator for use with Java applications. A parser generator is a \
     tool that reads a grammar specification and converts it to a Java program \
@@ -15,39 +17,40 @@ long_description    Java Compiler Compiler (JavaCC) is the most popular \
     generator itself, JavaCC provides other standard capabilities related to \
     parser generation such as tree building (via a tool called JJTree included \
     with JavaCC), actions, debugging, etc.
-
-homepage            https://javacc.org/
-master_sites        http://java.net/projects/javacc/downloads/download/
-checksums           rmd160  bac11ae2993642b254e4b90303e15de3599295eb \
-                    sha256  4147023112d0a959756e9cfab93c33b5d940b58692a39a6785897e4be85e16a6
-
-use_zip             yes
-
-post-extract {
-    # these wrappers are missing in the v6.0 zip-file
-    file copy ${filespath}/javacc ${filespath}/jjdoc ${filespath}/jjrun ${filespath}/jjtree \
-        ${worksrcpath}/bin
-}
+github.master_sites https://github.com/${github.author}/${name}/archive:source \
+                    https://repo1.maven.org/maven2/net/java/dev/${github.author}/${name}/${version}:binary
+distfiles           ${distname}${extract.suffix}:source \
+                    ${distname}.jar:binary
+platforms           any
+supported_archs     noarch
+maintainers         nomaintainer
+checksums           ${distname}${extract.suffix} \
+                        rmd160 b8ac61e85f3881d08cac08c40b6298e351e81d4e \
+                        sha256 735d39bca711aeb77ed3bc113747f97844ba29f5e91c78c8a6fc317068de3157 \
+                        size 3612611 \
+                    ${distname}.jar \
+                        rmd160 087ef8f84326064ac4503228f98b406be401e311 \
+                        sha256 a4ea46021ec567d89ca305763eedf738ba8a63601445e1aad08a329a6554502a \
+                        size 637847
+worksrcdir          ${github.author}-${github.project}-${github.version}
 
 configure {
-    reinplace "s|@JAR@|${prefix}/share/java/javacc.jar|g" \
-        ${worksrcpath}/bin/javacc ${worksrcpath}/bin/jjdoc ${worksrcpath}/bin/jjtree
+    reinplace "s|target|share/java|g" \
+        ${worksrcpath}/scripts/javacc \
+        ${worksrcpath}/scripts/jjdoc \
+        ${worksrcpath}/scripts/jjtree
 }
-    
+
 build {}
 
 destroot {
     xinstall -d -m 755 ${destroot}${prefix}/share/java \
         ${destroot}${prefix}/share/doc/
-    file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 ${worksrcpath}/bin/lib/javacc.jar \
-        ${destroot}${prefix}/share/java/
-    xinstall -m 755 -W ${worksrcpath}/bin javacc jjdoc jjtree jjrun \
+    file copy ${worksrcpath}/docs ${destroot}${prefix}/share/doc/${name}
+    file rename ${distpath}/${distname}.jar \
+        ${destroot}${prefix}/share/java/${name}.jar
+    xinstall -m 755 -W ${worksrcpath}/scripts javacc jjdoc jjtree jjrun \
         ${destroot}${prefix}/bin
     xinstall -m 644 -W ${worksrcpath} LICENSE \
         ${destroot}${prefix}/share/doc/${name}
 }
-
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     javacc-(\[0-9\.\]+).zip


### PR DESCRIPTION
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4 +
 PortSystem 1.0

-name                javacc
-version             6.0
+revision            4
+PortGroup           github 1.0
+
+use_zip             yes
+github.setup        javacc javacc 7.0.13
+description         Java Compiler Compiler, a parser generator for use with Java
 categories          java lang devel
-platforms           any
-supported_archs     noarch
-maintainers         nomaintainer
 license             BSD
-description         Java Compiler Compiler, a parser generator for use with Java
 long_description    Java Compiler Compiler (JavaCC) is the most popular \

     with JavaCC), actions, debugging, etc.
-
-homepage            https://javacc.org/
-master_sites        http://java.net/projects/javacc/downloads/download/
-checksums           rmd160  bac11ae2993642b254e4b90303e15de3599295eb \
-                    sha256  4147023112d0a959756e9cfab93c33b5d940b58692a39a6785897e4be85e16a6
-
-use_zip             yes
-
-post-extract {
-    # these wrappers are missing in the v6.0 zip-file
-    file copy ${filespath}/javacc ${filespath}/jjdoc ${filespath}/jjrun ${filespath}/jjtree \
-        ${worksrcpath}/bin
-}
+github.master_sites https://github.com/${github.author}/${name}/archive:source \
+                    https://repo1.maven.org/maven2/net/java/dev/${github.author}/${name}/${version}:binary
+distfiles           ${distname}${extract.suffix}:source \
+                    ${distname}.jar:binary
+platforms           any
+supported_archs     noarch
+maintainers         nomaintainer
+checksums           ${distname}${extract.suffix} \
+                        rmd160 b8ac61e85f3881d08cac08c40b6298e351e81d4e \
+                        sha256 735d39bca711aeb77ed3bc113747f97844ba29f5e91c78c8a6fc317068de3157 \
+                        size 3612611 \
+                    ${distname}.jar \
+                        rmd160 087ef8f84326064ac4503228f98b406be401e311 \
+                        sha256 a4ea46021ec567d89ca305763eedf738ba8a63601445e1aad08a329a6554502a \
+                        size 637847
+worksrcdir          ${github.author}-${github.project}-${github.version}

 configure {
-    reinplace "s|@JAR@|${prefix}/share/java/javacc.jar|g" \
-        ${worksrcpath}/bin/javacc ${worksrcpath}/bin/jjdoc ${worksrcpath}/bin/jjtree
+    reinplace "s|target|share/java|g" \
+        ${worksrcpath}/scripts/javacc \
+        ${worksrcpath}/scripts/jjdoc \
+        ${worksrcpath}/scripts/jjtree
 }
-
+
 build {}

 destroot {
     xinstall -d -m 755 ${destroot}${prefix}/share/java \
         ${destroot}${prefix}/share/doc/
-    file copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 ${worksrcpath}/bin/lib/javacc.jar \
-        ${destroot}${prefix}/share/java/
-    xinstall -m 755 -W ${worksrcpath}/bin javacc jjdoc jjtree jjrun \
+    file copy ${worksrcpath}/docs ${destroot}${prefix}/share/doc/${name}
+    file rename ${distpath}/${distname}.jar \
+        ${destroot}${prefix}/share/java/${name}.jar
+    xinstall -m 755 -W ${worksrcpath}/scripts javacc jjdoc jjtree jjrun \
         ${destroot}${prefix}/bin
     xinstall -m 644 -W ${worksrcpath} LICENSE \
         ${destroot}${prefix}/share/doc/${name}
 }
-
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     javacc-(\[0-9\.\]+).zip

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
