### PR TITLE
GPXSee: update to 15.6

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 15.5
+github.setup        tumic0 GPXSee 15.6
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  44c2f586181db9fcd478373c4c26977fa82f6e56 \
-                    sha256  ad102091f471b92fc5eb8a21dbd9b6b80efbd3e6f16343aaa24ec5b4353c9b3d \
-                    size    6556226
+checksums           rmd160  4c29041331e3a74b49c6b2510ffe60daa370e616 \
+                    sha256  652a8c04f344d28b88791f4f303b5e6be6e02c3d04a93464e6906018d28ac68f \
+                    size    6562993
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
