### PR TITLE
fftw-3{,-single,-long}: build with OpenMP support enabled by default

### DIFF
--- a/math/fftw-3/Portfile
+++ b/math/fftw-3/Portfile
@@ -7,7 +7,7 @@ PortGroup       xcode_workaround 1.0
 
 name            fftw-3
 version         3.3.10
-revision        0
+revision        1
 
 checksums       rmd160  067dd44017c42bf7f702ee66ea4f8c309624134d \
                 sha256  56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467 \
@@ -15,7 +15,6 @@ checksums       rmd160  067dd44017c42bf7f702ee66ea4f8c309624134d \
 
 categories      math
 license         GPL-2+
-platforms       darwin
 maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 homepage        http://www.fftw.org/
 distname        fftw-${version}
@@ -29,31 +28,36 @@ description \
     Fast C routines to compute the Discrete Fourier Transform
 
 long_description \
-    FFTW is a C subroutine library for computing the \
-    Discrete Fourier Transform (DFT) in one or more \
-    dimensions, of both real and complex data, and of \
-    arbitrary input size. We believe that FFTW, which is \
-    free software, should become the FFT library of choice \
-    for most applications. Our benchmarks, performed on a \
-    variety of platforms, show that FFTW's performance is \
-    typically superior to that of other publicly available \
-    FFT software. Moreover, FFTW's performance is portable: \
-    the program will perform well on most architectures \
-    without modification. \
-    This port is of fftw version 3.x. It has many \
-    improvements relative to 2.x, but is not backwardly \
-    compatible.
-
-compilers.setup default_fortran
+    Fastest Fourier Transform in the West (FFTW) is a C subroutine \
+    library for computing the Discrete Fourier Transform (DFT) in one \
+    or more dimensions, of both real and complex data, and of \
+    arbitrary input size. We believe that FFTW, which is free \
+    software, should become the FFT library of choice for most \
+    applications. Our benchmarks, performed on a variety of platforms, \
+    show that FFTW's performance is typically superior to that of \
+    other publicly available FFT software. Moreover, FFTW's \
+    performance is portable: the program will perform well on most \
+    architectures without modification. \
+    \
+    \n\nThis port is of fftw version 3.x. It has many improvements \
+    relative to 2.x, but is not backwardly compatible. If you are \
+    interested in fftw version 2.x, please see the 'fftw' port.
 
 # see https://trac.macports.org/ticket/59678
 xcode_workaround.fixed_xcode_version 11.2
 
 variant openmp description {Add OpenMP support} {
     configure.args-append --enable-openmp
+
+    if {[string match *clang* ${configure.compiler}]} {
+        depends_lib-append  port:libomp
+    }
 }
-variant threads description {Legacy compatibility variant} requires openmp {
+
+variant threads requires openmp \
+    description {Legacy compatibility variant} {
 }
+
 if {[variant_isset openmp] && ![c_variant_isset]} {
     compiler.openmp_version 2.5
 }
@@ -74,6 +78,8 @@ variant pfft_patches description {Apply patches recommended for use as dependenc
     use_autoreconf yes
 }
 
+default_variants-append +openmp
+
 # don't change configure.cc, etc. since we'll take care of that manually with
 # MPICC env var
 mpi.setup
@@ -82,6 +88,10 @@ mpi.setup
 compiler.blacklist-append {clang <= 211.10.1} gcc-4.2
 # see https://trac.macports.org/ticket/60145
 compiler.blacklist-append *gcc-3.* *gcc-4.*
+# Xcode Clang does not support OpenMP
+if {[variant_isset openmp]} {
+    compiler.blacklist-append clang
+}
 
 configure.args \
     --enable-threads \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/64432

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

We have been firmly in the era of multi-core, multi-threaded hardware for a couple of decades now, so there's really no reason why OpenMP support shouldn't be enabled by default, especially for math libraries such as `fftw-3`. In fact, some ports, such as `rawtherapee`, require OpenMP support to be enabled in `fftw-3`; otherwise, performance of the application is severely degraded.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.14.6 18G9323 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
