### PR TITLE
gdcm: Update to 3.2.2

### DIFF
--- a/science/gdcm/Portfile
+++ b/science/gdcm/Portfile
@@ -8,7 +8,7 @@ PortGroup               legacysupport 1.1
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup            malaterre GDCM 3.0.26 v
+github.setup            malaterre GDCM 3.2.2 v
 revision                0
 
 name                    gdcm
@@ -18,13 +18,14 @@ maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 description             a C++ library for DICOM medical files
 long_description        Grassroots DiCoM is a C++ library for DICOM medical files.
 
+# Home page on Sourceforge, but new releases found only on Github mirror.
 homepage                https://sourceforge.net/projects/gdcm/
 
 github.tarball_from     archive
 
-checksums               rmd160  2d28b702c10014f4649514e01b09304fb61372e1 \
-                        sha256  376ecb26ed524d885ec0469312e4b9ca4d970f88f820e55bb647adb1022fc91c \
-                        size    4096002
+checksums               rmd160  67b22151c5b1b46c249fb4d4d0caf957ab2dd5a0 \
+                        sha256  133078bfff4fe850a1faaea44b0a907ba93579fd16f34c956f4d665b24b590e5 \
+                        size    4091233
 
 compiler.cxx_standard   2014
 


### PR DESCRIPTION
#### Description

Update gdcm 3.0.26 --> 3.2.2.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?