### PR TITLE
llvm-mingw: new port

### DIFF
--- a/cross/llvm-mingw/Portfile
+++ b/cross/llvm-mingw/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        mstorsjo llvm-mingw 20251216
+github.tarball_from releases
+platforms           {darwin any >= 15}
+categories          cross
+supported_archs     arm64 x86_64
+license             NCSA
+maintainers         {@Gcenx}
+
+description         {An LLVM/Clang/LLD based mingw-64 toolchain}
+long_description    ${description}
+
+distname            ${github.project}-${version}-ucrt-macos-universal
+use_xz              yes
+
+checksums           sha256  38bb5e48ec3e0ce95fb901f4efff0bd6ffa966d1b32539a6510af816a959d160 \
+                    rmd160  e8e68695812b30dcae40e3aeb46dc29d510449f3 \
+                    size    119178172
+
+use_configure       no
+build {}
+
+destroot {
+    xinstall -d     ${destroot}${prefix}/libexec/llvm-mingw
+    system -W ${workpath} "mv ${workpath}/${distname}/* ${destroot}${prefix}/libexec/llvm-mingw/"
+}
+
+if {[llength ${supported_archs}] > 1} {
+    configure.universal_archs {*}${supported_archs}
+    variant universal {}
+}


### PR DESCRIPTION
#### Description

This port would be used by wine instead of mingw-w64 as it supports all the desired cross targets. If merged I plan to use this over mingw-w64 going forward.

This became fully supported as of wine-11.1, it’s easy to patch wine-11.0 for llvm-mingw.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.3 24G419 x86_64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
