### PR TITLE
emacs-mac-app: add missing dependency

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -10,7 +10,7 @@ bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ve
 name                emacs-mac-app
 conflicts           emacs-app emacs-app-devel
 version             ${emacs_mac_ver}
-revision            1
+revision            2
 categories          aqua editors
 maintainers         {amake @amake} openmaintainer
 
@@ -31,7 +31,9 @@ depends_lib         port:ncurses \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
                     port:lcms2 \
                     port:gmp \
-                    port:jansson
+                    port:jansson \
+                    port:sqlite3 \
+                    port:webp
 
 patchfiles          patch-src_emacs.c.diff
 
@@ -53,9 +55,7 @@ depends_build       port:autoconf \
                     port:automake \
                     port:libtool \
                     path:bin/pkg-config:pkgconfig \
-                    port:texinfo \
-                    port:sqlite3 \
-                    port:webp
+                    port:texinfo
 
 set rpaths [list]
 


### PR DESCRIPTION
Increment revision number from 1 to 2 and add webp dependency.

#### Description

Port is build with `--with-webp` by default, but missing required dependency

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
