### PR TITLE
kubectl: update to 1.35.1, 1.34.4, 1.33.8 & 1.32.12

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -32,11 +32,11 @@ subport kubectl-1.35 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     0
+    set patchNumber     1
     revision            0
-    checksums           rmd160  06c6695cff5e467287d2c83c44fcea19c324d634 \
-                        sha256  ed32a4da18f41f8cde7d8484afafc76b6a008915425f69440228d8e63d3f420d \
-                        size    42076423
+    checksums           rmd160  bb46feb784ab4cc225d379b26142efc7d8edc887 \
+                        sha256  5b5952a974937c5a007d8bc11bb584aedc8d17f39c639e0fcc8f8676ca4e96e2 \
+                        size    38923942
 }
 
 subport kubectl-1.34 {
@@ -313,7 +313,7 @@ if {${subport} == ${name}} {
     PortGroup           obsolete 1.0
 
     replaced_by         ${latestVersion}
-    version             1.35.0
+    version             1.35.1
     revision            0
 
 } elseif {${subport} == "kubectl_select"} {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -58,11 +58,11 @@ subport kubectl-1.33 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     7
+    set patchNumber     8
     revision            0
-    checksums           rmd160  444999cb45da1bdf73267b8e93e69862ffd5fe62 \
-                        sha256  3387b8de7a7a4a466cc6b76a8bbcdb9c7b55f7252a99c6e651898b0411139bbb \
-                        size    37110661
+    checksums           rmd160  981e07093149e91160c3446c3ae4ec606f4395d3 \
+                        sha256  63ea80573bc49ac5a17810c25fbf345668b8cace4952a6f2881b36dbda446721 \
+                        size    37124284
 }
 
 subport kubectl-1.32 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -71,11 +71,11 @@ subport kubectl-1.32 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     11
+    set patchNumber     12
     revision            0
-    checksums           rmd160  41ad08dbcf4e4ba705776c84d0f6d630c0f296f7 \
-                        sha256  ea0c6f0664588d9b65d43d8936e8c7273275b431298f625be2da9a29b538da34 \
-                        size    36398817
+    checksums           rmd160  c12e97558320419100df17c3425ab5779db60ec9 \
+                        sha256  d933fc21a0c9861e06eed6f595b0a96df0b1c0bce9a6e0dc53ce94339ce3fe25 \
+                        size    36400756
 }
 
 subport kubectl-1.31 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -45,11 +45,11 @@ subport kubectl-1.34 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     3
+    set patchNumber     4
     revision            0
-    checksums           rmd160  7ba2b1a759da058351fb7e95c566cb7ac2f285d4 \
-                        sha256  d95f59700bf9d059b261ee2e0a34187301c734d596307e8dfe66c4c68c1a565d \
-                        size    38087990
+    checksums           rmd160  56c141bd14049d6975d993fbc5c9d459a773775e \
+                        sha256  365ca06d1dd2406246f55bc876383e96e3b028f987a7f60e473dafed0e920fc2 \
+                        size    38096650
 }
 
 subport kubectl-1.33 {


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
