### PR TITLE
tree-sitter: update to 0.26.5

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -10,7 +10,7 @@ bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ve
 name                emacs-mac-app
 conflicts           emacs-app emacs-app-devel
 version             ${emacs_mac_ver}
-revision            2
+revision            3
 categories          aqua editors
 maintainers         {amake @amake} openmaintainer
 
@@ -97,7 +97,7 @@ subport ${name}-devel {
     set date            2025-09-20
 
     version         [string map {- {}} ${date}]
-    revision        0
+    revision        1
 
     long_description \
         ${name} is the \"Mac port\" of GNU Emacs ${emacs_version}. \

--- a/devel/tree-sitter/Portfile
+++ b/devel/tree-sitter/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        tree-sitter tree-sitter 0.25.2 v
+github.setup        tree-sitter tree-sitter 0.26.5 v
 github.tarball_from archive
 revision            0
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 dist_subdir         ${name}/${version}_${revision}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ffe9b54797bec0bd7e333a99feb6540253f5caa5 \
-                    sha256  26791f69182192fef179cd58501c3226011158823557a86fe42682cb4a138523 \
-                    size    855826
+                    rmd160  6512dae4cb71da8e4f6be4f1604d8f587dcab24f \
+                    sha256  8e012493b2103e0471d3aba8048b73bc1a3138132974e2fd8bfb89a63e62f478 \
+                    size    905701
 
 use_configure       no
 

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -116,7 +116,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         30.2
-    revision        2
+    revision        3
     checksums       rmd160  fefdd3fcd453d733114f609a3e122b2529cc7410 \
                     sha256  1d79a4ba4d6596f302a7146843fe59cf5caec798190bcc07c907e7ba244b076d \
                     size    83059014
@@ -133,7 +133,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     github.tarball_from archive
     epoch           5
     version         20250924
-    revision        0
+    revision        1
 
     master_sites    ${github.master_sites}
 

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -65,7 +65,7 @@ if {${subport} eq ${name}} {
 
     github.setup        neovim neovim 0.11.6 v
     github.tarball_from archive
-    revision            0
+    revision            1
     conflicts           neovim-devel
 
     # cat cmake.deps/deps.txt \
@@ -114,7 +114,7 @@ if {${subport} eq ${name}} {
     github.setup        neovim neovim 28c294363f37d013af69e2779d734c132037f73f
     github.tarball_from archive
     version             20260131-[string range ${github.version} 0 6]
-    revision            0
+    revision            1
     conflicts           neovim
     github.livecheck.branch \
                         nightly

--- a/editors/step-writer/Portfile
+++ b/editors/step-writer/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        BrianAnakPintar step-writer 15b02568f7ec731215eb717b076a77f61e6e080a
 version             2024.11.16
-revision            0
+revision            1
 categories          editors
 license             MIT
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update tree-sitter to 0.26.5.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.3 24G419 x86_64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
