### PR TITLE
wireguard-tools: update to 1.0.20260223

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             1.0.20250521
+version             1.0.20260223
 revision            0
-checksums           rmd160  dcf5c503db9c41c95f8fe99d7bb506fac9a2f485 \
-                    sha256  b6f2628b85b1b23cc06517ec9c74f82d52c4cdbd020f3dd2f00c972a1782950e \
-                    size    100340
+checksums           rmd160  68bf2d03e7d4a1831c49390e061b8724f4c44d11 \
+                    sha256  af459827b80bfd31b83b08077f4b5843acb7d18ad9a33a2ef532d3090f291fbf \
+                    size    100472
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
wireguard-tools: update to 1.0.20260223

###### Tested on
macOS 15.7.3 24G419 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?