### PR TITLE
Heimdall: Submission of a new port

### DIFF
--- a/comms/Heimdall/Portfile
+++ b/comms/Heimdall/Portfile
@@ -13,7 +13,8 @@ description         Tool to flash Samsung mobile phones
 long_description    Reverse-engineered tool from Samsung provided Odin that allows to flash all Samsung phones since around 2010.
 
 distname            ${version}
-worksrcdir          ${name}-${version}
+distname            v${version}
+worksrcdir          ${name}-${distname}
 
 homepage            https://git.sr.ht/~grimler/Heimdall
 master_sites        https://git.sr.ht/~grimler/Heimdall/archive/

--- a/comms/Heimdall/Portfile
+++ b/comms/Heimdall/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           qt6 1.0
+
+name                Heimdall
+version             v2.2.2
+categories          comms
+license             MIT
+maintainers         {@sumirati buggycode.net:sumirati} openmaintainer
+description         Tool to flash Samsung mobile phones
+long_description    Reverse-engineered tool from Samsung provided Odin that allows to flash all Samsung phones since around 2010.
+
+distname            ${version}
+worksrcdir          ${name}-${version}
+
+homepage            https://git.sr.ht/~grimler/Heimdall
+master_sites        https://git.sr.ht/~grimler/Heimdall/archive/
+
+checksums           rmd160  cade5ca1359af61e01a81d89123a67d9e3f6383f \
+                    sha256  7d01dd8bf9c2f93ea016ae8b059110c50cea49e78670e8a1333ebd5899cdaaa3 \
+                    size    68059
+
+depends_build       port:qt6-qtbase port:libusb port:cmake port:pkgconfig
+
+cmake_share_module_dir   ${prefix}/libexec/qt6/lib/cmake/Qt6Widgets/  

--- a/comms/Heimdall/Portfile
+++ b/comms/Heimdall/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           qt6 1.0
 
 name                Heimdall
-version             v2.2.2
+version             2.2.2
 categories          comms
 license             MIT
 maintainers         {@sumirati buggycode.net:sumirati} openmaintainer

--- a/comms/Heimdall/Portfile
+++ b/comms/Heimdall/Portfile
@@ -28,4 +28,4 @@ depends_build-append \
 
 depends_lib-append  port:libusb
 
-cmake_share_module_dir   ${prefix}/libexec/qt6/lib/cmake/Qt6Widgets/  
+cmake_share_module_dir   ${qt6.dir}/lib/cmake/Qt6Widgets/  

--- a/comms/Heimdall/Portfile
+++ b/comms/Heimdall/Portfile
@@ -23,6 +23,9 @@ checksums           rmd160  cade5ca1359af61e01a81d89123a67d9e3f6383f \
                     sha256  7d01dd8bf9c2f93ea016ae8b059110c50cea49e78670e8a1333ebd5899cdaaa3 \
                     size    68059
 
-depends_build       port:qt6-qtbase port:libusb port:cmake port:pkgconfig
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  port:libusb
 
 cmake_share_module_dir   ${prefix}/libexec/qt6/lib/cmake/Qt6Widgets/  

--- a/comms/Heimdall/Portfile
+++ b/comms/Heimdall/Portfile
@@ -12,7 +12,6 @@ maintainers         {@sumirati buggycode.net:sumirati} openmaintainer
 description         Tool to flash Samsung mobile phones
 long_description    Reverse-engineered tool from Samsung provided Odin that allows to flash all Samsung phones since around 2010.
 
-distname            ${version}
 distname            v${version}
 worksrcdir          ${name}-${distname}
 


### PR DESCRIPTION
* Adding the Portfile for the most current version v2.2.2

#### Description

Heimdall is an open source re-implementation of the Samsung tool, called Odin, used to flash Samsung smartphones since ca. 2010. It is required to load custom Android builds to Samsung phones - or official images.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 26.3 25D125 arm64
Xcode 26.2 17C52

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? `sudo port -vst install` fails, `sudo port -vs install` works
- [x] tested basic functionality of all binary files?
