### PR TITLE
iTerm2: Update to 3.4.22

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -5,7 +5,17 @@ PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
 
-if {${os.major} > 17} {
+if {${os.major} > 18} {
+    version             3.4.22
+    revision            0
+    checksums           rmd160  ddde0c508c47d82daebdf53b8de890c9383a40d7 \
+                        sha256  2729de014a1fef8b5bf30b6f4ed5f7717b211c553d6fd7761aa3ecaaa173d0ec \
+                        size    28779538
+    patchfiles          patch-Makefile-XC10.diff \
+                        patch-remove-sparkle-3.4.diff \
+                        patch-nsur.diff \
+                        patch-xcode12.diff
+} elseif {${os.major} > 17} {
     version             3.4.21
     revision            1
     checksums           rmd160  00cc53ced493db0be593d730f518f56ba0ebe5a3 \

--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -7,7 +7,7 @@ PortGroup           xcodeversion 1.0
 
 if {${os.major} > 17} {
     version             3.4.21
-    revision            0
+    revision            1
     checksums           rmd160  00cc53ced493db0be593d730f518f56ba0ebe5a3 \
                         sha256  175b03c9ab41b7c3a5c62967c442fa306639effb5641554c5f6ae739198e0be3 \
                         size    28781228
@@ -61,6 +61,7 @@ post-patch {
     # macOS 13/Xcode 14 seems to be requiring code signing (macOS 12 with XC14 now requires the same)
     if {${os.major} >= 21} {
         reinplace "s|CODE_SIGN_IDENTITY = \".*\";|CODE_SIGN_IDENTITY = \"-\";|g" ${worksrcpath}/iTerm2.xcodeproj/project.pbxproj
+        reinplace "s|ENABLE_HARDENED_RUNTIME = .*;|ENABLE_HARDENED_RUNTIME = NO;|g" ${worksrcpath}/iTerm2.xcodeproj/project.pbxproj
     } else {
         reinplace "s|CODE_SIGN_IDENTITY = \".*\";|CODE_SIGN_IDENTITY = \"\";|g" ${worksrcpath}/iTerm2.xcodeproj/project.pbxproj
     }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Resolves long-standing issues with iTerm2 as packaged by MacPorts on macOS versions that support Apple's hardened runtime.

These two commits are logically linked to resolve two related issues that are the cause of runtime crashes upon attempted load reported on Trac with the current packaged iTerm2 3.4.21-0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3 (25D125) ASi
Xcode 26.1.1 (17B100)

macOS 15.7.4 (24G517) x86-64
Xcode 16.0 (16A242d)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
