### PR TITLE
boost192: new port

### DIFF
--- a/devel/boost188/Portfile
+++ b/devel/boost188/Portfile
@@ -439,9 +439,7 @@ if {$subport eq $name} {
         }
     }
 
-    livecheck.type  regex
-    livecheck.url   https://www.boost.org/users/download/
-    livecheck.regex Version (\\d+\\.\\d+\\.\\d+)</h2>
+    livecheck.type  none
 } else {
     post-destroot {
         move {*}[glob ${destroot}${bprefix}/lib/libboost_numpy*] ${destroot}${bprefix}

--- a/devel/boost189/Portfile
+++ b/devel/boost189/Portfile
@@ -1,0 +1,537 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                              1.0
+PortGroup                               active_variants 1.1
+PortGroup                               legacysupport 1.1
+PortGroup                               mpi 1.0
+
+# Needed for: TARGET_OS_IOS, dirfd
+legacysupport.newest_darwin_requires_legacy 14
+
+version                                 1.89.0
+
+set branch                              [join [lrange [split ${version} .] 0 1] .]
+set tag                                 [string map {. {}} ${branch}]
+
+name                                    boost${tag}
+
+# Revision is set below in the `if {$subport eq $name} { ... }` statement
+# The boost-numpy subport has its own revision number
+
+checksums                               rmd160  8ff46b8e8abf26bee85dc9f55512e5df7f5d9fab \
+                                        sha256  85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a \
+                                        size    154699732
+
+license                                 Boost-1
+categories                              devel
+maintainers                             {@BjarneDMat mathiesen.info:macintosh} openmaintainer
+
+
+description                             Collection of portable C++ source libraries
+long_description \
+    Boost provides free portable peer-reviewed C++ libraries. \
+    The emphasis is on portable libraries which work well with the C++ Standard Library.
+
+homepage                                https://www.boost.org
+master_sites                            https://archives.boost.io/release/${version}/source
+set distver                             [join [split ${version} .] _]
+distname                                boost_${distver}
+use_bzip2                               yes
+
+compiler.blacklist-append {clang < 1000}
+
+depends_lib-append                      port:bzip2 \
+                                        port:expat \
+                                        path:lib/pkgconfig/icu-uc.pc:icu \
+                                        port:libiconv \
+                                        port:lzma \
+                                        port:zlib \
+                                        port:zstd
+
+post-extract {
+    fs-traverse dir ${workpath} {
+        if {[file isdirectory ${dir}]} {
+            file attributes ${dir} -permissions a+rx
+        }
+    }
+    # Enforce correct compiler and flags are used to build b2
+    xinstall -m 755 -d ${workpath}/bin
+
+    if {[string match *clang* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/clang++
+        ln -s ${configure.cc}  ${workpath}/bin/clang
+    } elseif {[string match *gcc* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/g++
+        ln -s ${configure.cc}  ${workpath}/bin/gcc
+    }
+}
+configure.env-append                    PATH=${workpath}/bin:$env(PATH)
+build.env-append                        PATH=${workpath}/bin:$env(PATH)
+
+# Install prefix for this port
+set  bprefix  ${prefix}/libexec/boost/${branch}
+
+# libcxxabi installed by the libcxx port on the buildbot does not
+# have the cxa_thread_atexit support, so until this is fixed
+# we have to force thread_local off on < 10.7 when using libc++
+platform darwin {
+    if {${os.major} < 11} {
+        patchfiles-append patch-boost-libcpp-force-thread-local-off.diff
+    }
+}
+
+# temporary patch to fix: explicit template instanciations in
+# boost::serialization don't get exported with all compilers; this fix
+# is already in the boost repo & will be part of a future release. See
+# also the following tickets:
+# https://trac.macports.org/ticket/48717
+# https://svn.boost.org/trac/boost/ticket/11671
+patchfiles-append                       patch-export_serialization_explicit_template_instantiations.diff
+
+# revert the default tagged library name changes in 1.69.0 <
+# libboost_<component>-<threading>-<arch>.dylib > back to 1.68.0
+# format: libboost_<component>-<threading>.dylib; where <component> is
+# the component name (e.g., system, thread), <threading> is either mt
+# or st (multi or single), and <arch> is the build arch (x86, x64,
+# p64, p32).
+# patchfiles-append                       patch-revert-lib-name-tagged.diff
+
+# Availability.h -> AvailabilityMacros.h on Tiger
+# The attempted fix:
+# https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
+# is insufficient because GCC 6/7 still defines __cpp_lib_uncaught_exceptions
+# in the absence of __STRICT_ANSI__
+platform darwin 8 {
+    patchfiles-append                   patch-tiger-availability.diff
+}
+
+# posix_memalign introduced in 10.6
+platform darwin {
+    if {${os.major} < 10} {
+        patchfiles-append               patch-boost-aligned-alloc.diff
+    }
+}
+
+# see https://trac.macports.org/wiki/UsingTheRightCompiler
+patchfiles-append patch-compiler.diff
+post-patch {
+    reinplace   "s|__MACPORTS_CXX__|${configure.cxx}|g" \
+                ${worksrcpath}/tools/build/src/tools/clang-darwin.jam
+}
+
+# Build issue on some older systems
+# ld: warning: option -s is obsolete and being ignored
+# ld: internal error: atom not found in symbolIndex(__ZNSt3__1plIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_12basic_stringIT_T0_T1_EERKS9_SB_) for architecture x86_64
+# patchfiles-append                       patch-b2-build-older-OSes.diff
+
+# https://github.com/boostorg/gil/pull/767
+# patchfiles-append patch-boost-gil.diff
+
+# Fixes: https://github.com/boostorg/atomic/issues/79
+patchfiles-append patch-powerpc-atomic.diff
+
+proc write_jam s {
+    global  worksrcpath
+    set     config  [open ${worksrcpath}/user-config.jam a]
+    puts    ${config}  ${s}
+    close   ${config}
+}
+
+compilers.choose                        cc cxx
+mpi.setup                               -gcc
+
+# NOTE: although technically Boost does not require C++11 compliance
+# for building, doing so allows for building on more OSs than without.
+# Further: Building Boost using C++11 compliance does not seem to then
+# require ports depending on Boost to also require C++11 compliance,
+# and requiring it does make such building easier for those ports.
+configure.cxxflags-append               -std=gnu++17
+# ICU requires C++17
+compiler.cxx_standard                   2017
+
+# This flag fixes the return type of unsetenv(3)
+# See: https://trac.macports.org/ticket/63121
+platform darwin 8 {
+    configure.cxxflags-append           -D__DARWIN_UNIX03=1
+}
+
+# It turns out that ccache and distcc can produce boost libraries that, although they
+# compile without warning, have all sorts of runtime errors especially with pointer corruption.
+# Since most people will now use MacPorts' pre-compiled boost, this should not be a problem.
+configure.ccache                        no
+configure.distcc                        no
+
+configure.cmd                           ./bootstrap.sh
+configure.args                          --without-libraries=python \
+                                        --without-libraries=mpi \
+                                        --with-icu=${prefix}
+
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    patchfiles-append                   patch-legacysupport.diff
+
+    post-patch {
+        reinplace   "s|@PREFIX@|${prefix}|"  ${worksrcpath}/bootstrap.sh
+    }
+}
+
+# boost build scripts default to clang on darwin
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.args-append --with-toolset=gcc
+}
+
+# Boost's PPC32 ASM code in the context module was only recently fixed (see
+# patch above). PPC64 is still broken.
+platform darwin {
+    if {${build_arch} eq "ppc64"} {
+        configure.args-append           --without-libraries=context \
+                                        --without-libraries=coroutine
+    }
+}
+
+configure.universal_args
+
+post-configure {
+
+    reinplace -E "s|-install_name \"|&${bprefix}/lib/|" \
+        ${worksrcpath}/tools/build/src/tools/darwin.jam
+
+    set compileflags ""
+    if {[string length ${configure.sdkroot}] != 0} {
+        set compileflags "<compileflags>\"-isysroot ${configure.sdkroot}\""
+    }
+
+    set cxx_stdlibflags {}
+    if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
+        set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+    }
+
+    # see https://trac.macports.org/ticket/55857
+    # see https://svn.boost.org/trac10/ticket/13454
+    write_jam "using darwin : : ${configure.cxx} : <asmflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cxxflags>\"${configure.cxxflags} [get_canonical_archflags cxx] ${cxx_stdlibflags}\" ${compileflags} <linkflags>\"${configure.ldflags} ${cxx_stdlibflags}\" : ;"
+
+}
+
+build.cmd                               ${worksrcpath}/b2
+build.target
+build.args                              -d2 \
+                                        --layout=tagged \
+                                        --debug-configuration \
+                                        --user-config=user-config.jam \
+                                        -sBZIP2_INCLUDE=${prefix}/include \
+                                        -sBZIP2_LIBPATH=${prefix}/lib \
+                                        -sEXPAT_INCLUDE=${prefix}/include \
+                                        -sEXPAT_LIBPATH=${prefix}/lib \
+                                        -sZLIB_INCLUDE=${prefix}/include \
+                                        -sZLIB_LIBPATH=${prefix}/lib \
+                                        -sICU_PATH=${prefix} \
+                                        variant=release \
+                                        threading=single,multi \
+                                        link=static,shared \
+                                        runtime-link=shared \
+                                        -j${build.jobs}
+
+destroot.cmd                            ${worksrcpath}/b2
+destroot.post_args
+
+pre-destroot {
+    destroot.args  {*}${build.args}  --prefix=${destroot}${bprefix}
+    system  "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
+}
+
+proc boost_docs_install {} {
+    global bprefix destroot worksrcpath name
+
+    set docdir ${bprefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    set l [expr [string length ${worksrcpath}] + 1]
+    fs-traverse f [glob -directory ${worksrcpath} *] {
+        set dest ${destroot}${docdir}/[string range ${f} ${l} end]
+        if {[file isdirectory ${f}]} {
+            if {[file tail ${f}] eq "example"} {
+                copy ${f} ${dest}
+                continue
+            }
+            xinstall -d ${dest}
+        } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
+            xinstall -m 644 ${f} ${dest}
+        }
+    }
+}
+
+post-destroot {
+    if {[variant_isset docs]} {
+        boost_docs_install
+    }
+}
+
+set pythons_versions {2.7 3.10 3.11 3.12 3.13 3.14}
+
+set pythons_ports {}
+foreach v ${pythons_versions} {
+    lappend pythons_ports python[string map {. {}} ${v}]
+}
+
+proc python_dir {} {
+    global pythons_versions
+    foreach p ${pythons_versions} {
+        set s [string map {. {}} ${p}]
+        if {[variant_isset python${s}]} {
+            return [file normalize [exec ${p} -c "import sys; print(sys.prefix)"]/lib/${p}/site-packages]
+        }
+    }
+    error "Python support not enabled."
+}
+
+foreach v ${pythons_versions} {
+    set s [string map {. {}} ${v}]
+    set p python${s}
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    if { ${s} > 30 } { set bppatch "patch-boost-python3.diff" } else { set bppatch "" }
+    variant ${p} description "Build Boost.Python for Python ${v}" conflicts {*}${c} debug "
+
+        # There is a conflict with python and debug support, so we should really change the 'variant' line above
+        # to end with 'conflicts ${c} debug' above. However, we leave it enabled for those who want to try it.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+
+        depends_lib-append              port:${p}
+        configure.args-delete           --without-libraries=python
+        configure.args-append           --with-python=${prefix}/bin/python${v} --with-python-root=${prefix}/bin/python${v}
+
+        patchfiles-append               ${bppatch} patch-tools-build-src-tools-python.jam.diff \
+                                        patch-tools-build-src-tools-python-2.jam.diff
+
+        post-patch {
+            reinplace s|@FRAMEWORKS_DIR@|${frameworks_dir}| ${worksrcpath}/tools/build/src/tools/python.jam
+        }
+    "
+}
+
+if {![variant_isset debug]} {
+    set selected_python python314
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            set selected_python python${s}
+        }
+    }
+    default_variants +${selected_python}
+}
+
+post-destroot {
+    # To avoid checking for all Python variants, don't fail if no libs exist
+    foreach f [glob -nocomplain ${destroot}${bprefix}/lib/*python*.dylib] {
+        set tf [file tail ${f}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python3" ${tf}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python"  ${tf}]
+    }
+}
+
+default_variants +no_single +no_static
+
+variant debug description {Builds debug versions of the libraries as well} {
+    build.args-delete                   variant=release
+    build.args-append                   variant=debug,release
+}
+
+variant no_static description {Disable building static libraries} {
+    build.args-delete                   link=static,shared
+    build.args-append                   link=shared
+}
+
+variant no_single description {Disable building single-threaded libraries} {
+    build.args-delete                   threading=single,multi
+    build.args-append                   threading=multi
+}
+
+subport ${name}-numpy {
+    revision    0
+
+    description Boost.Numpy library
+    long_description {*}${description}
+
+    depends_lib port:boost${tag}
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            depends_lib-append port:py${s}-numpy
+            require_active_variants boost python${s}
+        }
+    }
+    if {[variant_isset no_static]} {
+        require_active_variants boost no_static
+    } else {
+        require_active_variants boost "" no_static
+    }
+    if {[variant_isset no_single]} {
+        require_active_variants boost no_single
+    } else {
+        require_active_variants boost "" no_single
+    }
+}
+
+if {$subport eq $name} {
+    revision    0
+
+    patchfiles-append patch-disable-numpy-extension.diff
+
+    variant regex_match_extra description \
+        "Enable access to extended capture information of submatches in Boost.Regex" {
+        notes-append "
+        You enabled the +regex_match_extra variant\; see the following page for\
+        an exhaustive list of the consequences of this feature:
+
+        http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
+        "
+
+        post-patch {
+            reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
+                ${worksrcpath}/boost/regex/user.hpp
+        }
+    }
+
+    variant docs description {Enable building documentation} {
+        # No configure changes, etc; we simply check 'variant_isset' elsewhere
+    }
+
+    post-destroot {
+        delete file {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*]
+    }
+
+    if {[mpi_variant_isset]} {
+
+        # see https://trac.macports.org/ticket/49748
+        # see http://www.openradar.me/25313838
+        configure.ldflags-append -Lstage/lib
+
+        # There is a conflict with debug support.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+        if {[variant_isset debug]} {
+            return -code error "+debug variant conflicts with mpi"
+        }
+
+        configure.args-delete           --without-libraries=mpi
+
+        post-configure {
+            write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
+        }
+
+        if {![catch python_dir]} {
+
+            patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
+
+            post-destroot {
+                set site_packages [python_dir]
+                xinstall -d ${destroot}${site_packages}/boost
+                xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
+                    ${destroot}${site_packages}/boost
+
+                set f ${destroot}${bprefix}/lib/mpi.so
+                if {[info exists ${f}]} {
+                    set l ${site_packages}/boost/mpi.so
+                    move ${f} ${destroot}${l}
+                    system "install_name_tool -id ${l} ${destroot}${l}"
+                }
+            }
+
+        }
+    }
+
+    livecheck.type                      regex
+    livecheck.url                       https://www.boost.org/users/download/
+    livecheck.regex                     Version (\\d+\\.\\d+\\.\\d+)</h2>
+} else {
+    post-destroot {
+        move {*}[glob ${destroot}${bprefix}/lib/libboost_numpy*] ${destroot}${bprefix}
+        move {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*] ${destroot}${bprefix}
+        file mkdir ${destroot}${bprefix}/cmake
+        move {*}[glob ${destroot}${bprefix}/lib/cmake/boost_numpy*/libboost*] ${destroot}${bprefix}/cmake
+        # if an mpi variant *and* a python variant is selected, then a binary
+        # python module called mpi.so gets installed, so delete ${frameworks_dir}
+        delete ${destroot}${bprefix}${frameworks_dir} \
+            ${destroot}${bprefix}/include \
+            ${destroot}${bprefix}/lib \
+            ${destroot}${bprefix}/share
+        file mkdir ${destroot}${bprefix}/lib ${destroot}${bprefix}/include/boost/python \
+            ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+        move {*}[glob ${destroot}${bprefix}/libboost_numpy*] ${destroot}${bprefix}/lib
+        move {*}[glob ${destroot}${bprefix}/numpy*] ${destroot}${bprefix}/include/boost/python
+        move {*}[glob ${destroot}${bprefix}/cmake/*] ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+    }
+
+    livecheck.type                      none
+}
+
+if {!${universal_possible} || ![variant_isset universal]} {
+    if {[lsearch ${build_arch} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm
+    } else {
+        if {[lsearch ${build_arch} ppc*] != -1} {
+            build.args-append architecture=power
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            if {[lsearch ${build_arch} *86*] != -1} {
+                build.args-append architecture=x86
+            } else {
+                pre-fetch {
+                    error "Current value of 'build_arch' (${build_arch}) is not supported."
+                }
+            }
+            if {[lsearch ${build_arch} *64] != -1} {
+                build.args-append address-model=64
+            } else {
+                build.args-append address-model=32
+            }
+        }
+    }
+}
+
+variant universal {
+    build.args-append                   pch=off
+
+    if {[lsearch ${configure.universal_archs} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm+x86
+    } else {
+        if {[lsearch ${configure.universal_archs} ppc*] != -1} {
+            if {[lsearch ${configure.universal_archs} *86*] != -1} {
+                build.args-append architecture=arm+x86
+            } else {
+                build.args-append architecture=power
+            }
+            if {${os.arch} ne "powerpc"} {
+                build.args-append       --disable-long-double
+            }
+        } else {
+            build.args-append architecture=x86
+        }
+        if {[lsearch ${configure.universal_archs} *64] != -1} {
+            if {[lsearch ${configure.universal_archs} i386] != -1 || [lsearch ${configure.universal_archs} ppc] != -1} {
+                build.args-append address-model=32_64
+                if {[lsearch ${configure.universal_archs} ppc64] == -1} {
+                    post-patch {
+                        reinplace "/local support-ppc64 =/s/= 1/= /" ${worksrcpath}/tools/build/src/tools/darwin.jam
+                    }
+                }
+            } else {
+                build.args-append       address-model=64
+            }
+        } else {
+            build.args-append           address-model=32
+        }
+    }
+}
+
+# TODO: Is this even needed? Is this correct for ppc64?
+platform powerpc {
+    build.args-append                   --disable-long-double
+}
+
+platform darwin 8 powerpc {
+    if {[variant_isset universal]} {
+        build.args-append               macosx-version=10.4
+    }
+}

--- a/devel/boost189/files/patch-b2-build-older-OSes.diff
+++ b/devel/boost189/files/patch-b2-build-older-OSes.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/engine/build.sh.orig	2024-12-04 19:53:38.000000000 -0500
++++ tools/build/src/engine/build.sh	2024-12-30 13:06:10.000000000 -0500
+@@ -391,7 +391,7 @@
+ 
+     clang|clang-*)
+         CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
+-        B2_CXXFLAGS_RELEASE="-O3 -s -Wno-deprecated-declarations"
++        B2_CXXFLAGS_RELEASE="-O3 -Wno-deprecated-declarations"
+         B2_CXXFLAGS_DEBUG="-O0 -fno-inline -g -Wno-deprecated-declarations"
+     ;;
+ 

--- a/devel/boost189/files/patch-boost-aligned-alloc.diff
+++ b/devel/boost189/files/patch-boost-aligned-alloc.diff
@@ -1,0 +1,17 @@
+posix_memalign introduced in 10.6
+
+--- ./boost/align/detail/aligned_alloc_posix.hpp.orig
++++ ./boost/align/detail/aligned_alloc_posix.hpp
+@@ -23,8 +23,10 @@
+         alignment = sizeof(void*);
+     }
+     void* p;
+-    if (::posix_memalign(&p, alignment, size) != 0) {
+-        p = 0;
++    if (alignment <= 16) {
++        p = ::malloc(size);
++    } else {
++        p = ::valloc(size);
+     }
+     return p;
+ }

--- a/devel/boost189/files/patch-boost-gil.diff
+++ b/devel/boost189/files/patch-boost-gil.diff
@@ -1,0 +1,20 @@
+--- boost/gil/algorithm.hpp.orig
++++ boost/gil/algorithm.hpp
+@@ -1238,7 +1238,7 @@
+         BinaryOperation2 binary_op2)
+     {
+         init = binary_op1(init, binary_op2(*first1, *first2));
+-        return inner_product_k_t<Size - 1>::template apply(
++        return inner_product_k_t<Size - 1>::apply(
+             first1 + 1, first2 + 1, init, binary_op1, binary_op2);
+     }
+ };
+@@ -1285,7 +1285,7 @@
+     BinaryOperation1 binary_op1,
+     BinaryOperation2 binary_op2)
+ {
+-    return detail::inner_product_k_t<Size>::template apply(
++    return detail::inner_product_k_t<Size>::apply(
+         first1, first2, init, binary_op1, binary_op2);
+ }
+ 

--- a/devel/boost189/files/patch-boost-libcpp-force-thread-local-off.diff
+++ b/devel/boost189/files/patch-boost-libcpp-force-thread-local-off.diff
@@ -1,0 +1,13 @@
+--- boost/config/stdlib/libcpp.hpp.orig
++++ boost/config/stdlib/libcpp.hpp
+@@ -15,6 +15,10 @@
+ #  endif
+ #endif
+ 
++#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
++#  define BOOST_NO_CXX11_THREAD_LOCAL
++#endif
++
+ #define BOOST_STDLIB "libc++ version " BOOST_STRINGIZE(_LIBCPP_VERSION)
+ 
+ #define BOOST_HAS_THREADS

--- a/devel/boost189/files/patch-boost-python3.diff
+++ b/devel/boost189/files/patch-boost-python3.diff
@@ -1,0 +1,13 @@
+--- libs/mpi/src/python/datatypes.cpp.orig
++++ libs/mpi/src/python/datatypes.cpp
+@@ -13,6 +13,10 @@
+ #include <boost/mpi/python/serialize.hpp>
+ #include <boost/mpi.hpp>
+ 
++#if PY_MAJOR_VERSION >= 3
++#define PyInt_Type PyLong_Type
++#endif
++
+ namespace boost { namespace mpi { namespace python {
+ 
+ void export_datatypes()

--- a/devel/boost189/files/patch-compiler.diff
+++ b/devel/boost189/files/patch-compiler.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/clang-darwin.jam.orig
++++ tools/build/src/tools/clang-darwin.jam
+@@ -51,7 +51,7 @@
+ #   compile and link options allow you to specify addition command line options for each version
+ rule init ( version ? :  command * : options * )
+ {
+-    command = [ common.find-compiler clang-darwin : clang++ : $(version) : $(command)
++    command = [ common.find-compiler clang-darwin : __MACPORTS_CXX__ : $(version) : $(command)
+                 : /usr/bin /usr/local/bin ] ;
+     local command-string = [ common.make-command-string $(command) ] ;
+     if ! $(version) { # ?= operator does not short-circuit

--- a/devel/boost189/files/patch-disable-numpy-extension.diff
+++ b/devel/boost189/files/patch-disable-numpy-extension.diff
@@ -1,0 +1,22 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -852,18 +852,7 @@
+     local full-cmd = $(interpreter-cmd)" -c \"$(full-cmd)\"" ;
+     debug-message "running command '$(full-cmd)'" ;
+     local result = [ SHELL $(full-cmd) : strip-eol : exit-status ] ;
+-    if $(result[2]) = 0
+-    {
+-        .numpy = true ;
+-        .numpy-include = $(result[1]) ;
+-        debug-message "NumPy enabled" ;
+-    }
+-    else
+-    {
+-        debug-message "NumPy disabled. Reason:" ;
+-        debug-message "  $(full-cmd) aborted with " ;
+-        debug-message "  $(result[1])" ;
+-    }
++    debug-message "NumPy disabled." ;
+ 
+     #
+     # End autoconfiguration sequence.

--- a/devel/boost189/files/patch-export_serialization_explicit_template_instantiations.diff
+++ b/devel/boost189/files/patch-export_serialization_explicit_template_instantiations.diff
@@ -1,0 +1,512 @@
+--- libs/serialization/src/basic_text_iprimitive.cpp.orig
++++ libs/serialization/src/basic_text_iprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_iprimitive<std::istream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::istream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_oprimitive.cpp.orig
++++ libs/serialization/src/basic_text_oprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_oprimitive<std::ostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::ostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_wiprimitive.cpp.orig
++++ libs/serialization/src/basic_text_wiprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_iprimitive<std::wistream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::wistream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_woprimitive.cpp.orig
++++ libs/serialization/src/basic_text_woprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_oprimitive<std::wostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::wostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_xml_grammar.ipp.orig
++++ libs/serialization/src/basic_xml_grammar.ipp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ #include <algorithm>
+ #include <boost/config.hpp> // typename
+ 
+--- libs/serialization/src/binary_iarchive.cpp.orig
++++ libs/serialization/src/binary_iarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -23,14 +27,14 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of stream
+-template class detail::archive_serializer_map<binary_iarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_iarchive,
+     std::istream::char_type, 
+     std::istream::traits_type
+ >;
+-template class basic_binary_iarchive<binary_iarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_iarchive, 
+     std::istream::char_type, 
+     std::istream::traits_type
+--- libs/serialization/src/binary_oarchive.cpp.orig
++++ libs/serialization/src/binary_oarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of binary stream
+@@ -23,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_oarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+ >;
+-template class basic_binary_oarchive<binary_oarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+--- libs/serialization/src/binary_wiarchive.cpp.orig
++++ libs/serialization/src/binary_wiarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,14 +29,14 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class detail::archive_serializer_map<binary_wiarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_wiarchive,
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_iarchive<binary_wiarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_wiarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/binary_woarchive.cpp.orig
++++ libs/serialization/src/binary_woarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_woarchive.hpp>
++#pragma GCC visibility pop
+ 
+ // explicitly instantiate for this type of text stream
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -25,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_woarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_oarchive<binary_woarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/polymorphic_iarchive.cpp.orig
++++ libs/serialization/src/polymorphic_iarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_iarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_iarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_iarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/polymorphic_oarchive.cpp.orig
++++ libs/serialization/src/polymorphic_oarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_oarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_oarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_oarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/text_iarchive.cpp.orig
++++ libs/serialization/src/text_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_iarchive>;
+-template class basic_text_iarchive<text_iarchive> ;
+-template class text_iarchive_impl<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_iarchive_impl<text_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_oarchive.cpp.orig
++++ libs/serialization/src/text_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace archive {
+ 
+ //template class basic_text_oprimitive<std::ostream> ;
+-template class detail::archive_serializer_map<text_oarchive>;
+-template class basic_text_oarchive<text_oarchive> ;
+-template class text_oarchive_impl<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_oarchive_impl<text_oarchive> ;
+ 
+ } // namespace serialization
+ } // namespace boost
+--- libs/serialization/src/text_wiarchive.cpp.orig
++++ libs/serialization/src/text_wiarchive.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,9 +29,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_wiarchive>;
+-template class basic_text_iarchive<text_wiarchive> ;
+-template class text_wiarchive_impl<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_wiarchive_impl<text_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_woarchive.cpp.orig
++++ libs/serialization/src/text_woarchive.cpp
+@@ -15,7 +15,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_woarchive>;
+-template class basic_text_oarchive<text_woarchive> ;
+-template class text_woarchive_impl<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_woarchive_impl<text_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_grammar.cpp.orig
++++ libs/serialization/src/xml_grammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -67,7 +69,7 @@
+ namespace archive {
+ 
+ // explicit instantiation of xml for 8 bit characters
+-template class basic_xml_grammar<char>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<char>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_iarchive.cpp.orig
++++ libs/serialization/src/xml_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_iarchive>;
+-template class basic_xml_iarchive<xml_iarchive> ;
+-template class xml_iarchive_impl<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_iarchive_impl<xml_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_oarchive.cpp.orig
++++ libs/serialization/src/xml_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_oarchive>;
+-template class basic_xml_oarchive<xml_oarchive> ;
+-template class xml_oarchive_impl<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_oarchive_impl<xml_oarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wgrammar.cpp.orig
++++ libs/serialization/src/xml_wgrammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -149,7 +151,7 @@
+ namespace archive {
+ 
+ // explicit instantiation of xml for wide characters
+-template class basic_xml_grammar<wchar_t>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<wchar_t>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wiarchive.cpp.orig
++++ libs/serialization/src/xml_wiarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_wiarchive>;
+-template class basic_xml_iarchive<xml_wiarchive> ;
+-template class xml_wiarchive_impl<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_wiarchive_impl<xml_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_woarchive.cpp.orig
++++ libs/serialization/src/xml_woarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_woarchive>;
+-template class basic_xml_oarchive<xml_woarchive> ;
+-template class xml_woarchive_impl<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_woarchive_impl<xml_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost

--- a/devel/boost189/files/patch-legacysupport.diff
+++ b/devel/boost189/files/patch-legacysupport.diff
@@ -1,0 +1,11 @@
+--- bootstrap.sh.orig	2024-12-05 08:53:27.000000000 +0800
++++ bootstrap.sh	2025-01-17 13:16:35.000000000 +0800
+@@ -226,7 +226,7 @@
+ if test "x$BJAM" = x; then
+   $ECHO "Building B2 engine.."
+   pwd=`pwd`
+-  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" ${TOOLSET}
++  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" --cxxflags="-isystem@PREFIX@/include/LegacySupport -Wl,-lMacportsLegacySupport" ${TOOLSET}
+   if [ $? -ne 0 ]; then
+       echo
+       echo "Failed to build B2 build engine"

--- a/devel/boost189/files/patch-libs-mpi-build-Jamfile.v2.diff
+++ b/devel/boost189/files/patch-libs-mpi-build-Jamfile.v2.diff
@@ -1,0 +1,26 @@
+--- libs/mpi/build/Jamfile.v2.orig
++++ libs/mpi/build/Jamfile.v2
+@@ -49,6 +49,7 @@
+     <link>shared:<define>BOOST_MPI_DYN_LINK=1
+   : # Default build
+     <link>shared
++    <threading>multi
+   : # Usage requirements
+     <library>../../serialization/build//boost_serialization
+     <library>/mpi//mpi [ mpi.extra-requirements ]
+@@ -95,6 +96,7 @@
+                 <python>$(py$(N)-version)
+               : # Default build
+                 <link>shared
++                <threading>multi
+               : # Usage requirements
+                 <library>/mpi//mpi [ mpi.extra-requirements ]
+               ;
+@@ -122,6 +124,7 @@
+                 <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
+                 <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
+                 <link>shared <runtime-link>shared
++                <threading>multi
+                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+                 <python>$(py$(N)-version)
+               ;

--- a/devel/boost189/files/patch-powerpc-atomic.diff
+++ b/devel/boost189/files/patch-powerpc-atomic.diff
@@ -1,0 +1,28 @@
+From 5342c1b562fc014b2f0dd53850c9cf3eb8888402 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sat, 13 Dec 2025 21:33:23 +0800
+Subject: [PATCH] thread_pause: use correct assembler syntax on
+ powerpc*-apple-darwin
+
+Fixes: https://github.com/boostorg/atomic/issues/79
+---
+ include/boost/atomic/thread_pause.hpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/include/boost/atomic/thread_pause.hpp b/include/boost/atomic/thread_pause.hpp
+index 7926a95..5bfa894 100644
+--- boost/atomic/thread_pause.hpp
++++ boost/atomic/thread_pause.hpp
+@@ -75,7 +75,11 @@ BOOST_FORCEINLINE void thread_pause() noexcept
+ #elif (defined(__ARM_ARCH) && __ARM_ARCH >= 8) || defined(__ARM_ARCH_8A__)
+     __asm__ __volatile__("yield" : : : "memory");
+ #elif (defined(__POWERPC__) || defined(__PPC__))
+-    __asm__ __volatile__("or 27,27,27" : : : "memory"); // yield pseudo-instruction
++    #ifdef __APPLE__
++        __asm__ __volatile__("or r27,r27,r27" : : : "memory"); // yield pseudo-instruction
++    #else
++        __asm__ __volatile__("or 27,27,27" : : : "memory"); // yield pseudo-instruction
++    #endif
+ #elif defined(__riscv) && (__riscv_xlen == 64)
+ #if defined(__riscv_zihintpause)
+     __asm__ __volatile__("pause" : : : "memory");

--- a/devel/boost189/files/patch-process-PROC_PPID_ONLY.diff
+++ b/devel/boost189/files/patch-process-PROC_PPID_ONLY.diff
@@ -1,0 +1,33 @@
+From 0ca663c8262b65ccee9a4e6abbafaef710f6b36f Mon Sep 17 00:00:00 2001
+From: Klemens Morgenstern <klemens.morgenstern@gmx.net>
+Date: Sun, 26 Jan 2025 21:49:25 +0800
+Subject: [PATCH] Set ENOTSUP when PROC_PPID_ONLY is undefined
+
+closes #452
+---
+ src/pid.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/pid.cpp b/src/pid.cpp
+index 7fa5f822c..322405907 100644
+--- libs/process/src/pid.cpp
++++ libs/process/src/pid.cpp
+@@ -178,6 +178,8 @@ pid_type parent_pid(pid_type pid, error_code & ec)
+ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+ {
+     std::vector<pid_type> vec;
++#if defined(PROC_PPID_ONLY)
++
+     vec.resize(proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, nullptr, 0) / sizeof(pid_type));
+     const auto sz = proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, &vec[0], sizeof(pid_type) * vec.size());
+     if (sz < 0)
+@@ -186,6 +188,9 @@ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+         return {};
+     }
+     vec.resize(sz);
++#else
++    BOOST_PROCESS_V2_ASSIGN_EC(ec, ENOTSUP, system_category());
++#endif
+     return vec;
+ }
+ 

--- a/devel/boost189/files/patch-revert-lib-name-tagged.diff
+++ b/devel/boost189/files/patch-revert-lib-name-tagged.diff
@@ -1,0 +1,11 @@
+--- boostcpp.jam.orig
++++ boostcpp.jam
+@@ -163,7 +163,7 @@
+             <base> <threading> <runtime> ;
+     case 1.69 :
+         .format-name-args =
+-            <base> <threading> <runtime> <arch-and-model> ;
++            <base> <threading> <runtime> ;
+     }
+ }
+ else if $(layout) = system

--- a/devel/boost189/files/patch-tiger-availability.diff
+++ b/devel/boost189/files/patch-tiger-availability.diff
@@ -1,0 +1,11 @@
+--- boost/core/uncaught_exceptions.hpp.orig
++++ boost/core/uncaught_exceptions.hpp
+@@ -27,7 +27,7 @@
+ #endif
+ 
+ #if defined(__APPLE__)
+-#include <Availability.h>
++#include <AvailabilityMacros.h>
+ // Apple systems only support std::uncaught_exceptions starting with specific versions:
+ // - Mac OS >= 10.12
+ // - iOS >= 10.0

--- a/devel/boost189/files/patch-tools-build-src-tools-python-2.jam.diff
+++ b/devel/boost189/files/patch-tools-build-src-tools-python-2.jam.diff
@@ -1,0 +1,16 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -545,6 +545,13 @@
+         libraries ?= $(default-library-path) ;
+         includes ?= $(default-include-path) ;
+     }
++    else if $(target-os) = darwin
++    {
++        includes ?= $(prefix)/Headers ;
++
++        local lib = $(exec-prefix)/lib ;
++        libraries ?= $(lib)/python$(version)/config $(lib) ;
++    }
+     else
+     {
+         local default-include-path = $(prefix)/include/python$(version) ;

--- a/devel/boost189/files/patch-tools-build-src-tools-python.jam.diff
+++ b/devel/boost189/files/patch-tools-build-src-tools-python.jam.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -434,7 +434,7 @@
+     version ?= $(.version-countdown) ;
+ 
+     local prefix
+-      = [ GLOB /System/Library/Frameworks /Library/Frameworks
++      = [ GLOB @FRAMEWORKS_DIR@
+           : Python.framework ] ;
+ 
+     return $(prefix)/Versions/$(version)/bin/python ;

--- a/devel/boost190/Portfile
+++ b/devel/boost190/Portfile
@@ -1,0 +1,538 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       active_variants 1.1
+PortGroup       legacysupport 1.1
+PortGroup       mpi 1.0
+
+# Needed for: TARGET_OS_IOS, dirfd
+legacysupport.newest_darwin_requires_legacy 14
+
+version         1.90.0
+
+set branch      [join [lrange [split ${version} .] 0 1] .]
+set tag         [string map {. {}} ${branch}]
+
+name            boost${tag}
+
+# Revision is set below in the `if {$subport eq $name} { ... }` statement
+# The boost-numpy subport has its own revision number
+
+checksums       rmd160  5a7ef8942487fdcdd3586e6a1667bf60e1c7a267 \
+                sha256  49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305 \
+                size    170662122
+
+license         Boost-1
+categories      devel
+maintainers     {michaelld @michaelld} \
+                {mascguy @mascguy} \
+                openmaintainer
+
+description     Collection of portable C++ source libraries
+
+long_description \
+    Boost provides free portable peer-reviewed C++ \
+    libraries. The emphasis is on portable libraries \
+    which work well with the C++ Standard Library.
+
+homepage        https://www.boost.org
+master_sites    https://archives.boost.io/release/${version}/source
+set distver     [join [split ${version} .] _]
+distname        boost_${distver}
+use_bzip2       yes
+
+compiler.blacklist-append {clang < 1000}
+
+depends_lib-append \
+                port:bzip2 \
+                port:expat \
+                path:lib/pkgconfig/icu-uc.pc:icu \
+                port:libiconv \
+                port:lzma \
+                port:zlib \
+                port:zstd
+
+post-extract {
+    fs-traverse dir ${workpath} {
+        if {[file isdirectory ${dir}]} {
+            file attributes ${dir} -permissions a+rx
+        }
+    }
+    # Enforce correct compiler and flags are used to build b2
+    xinstall -m 755 -d ${workpath}/bin
+
+    if {[string match *clang* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/clang++
+        ln -s ${configure.cc}  ${workpath}/bin/clang
+    } elseif {[string match *gcc* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/g++
+        ln -s ${configure.cc}  ${workpath}/bin/gcc
+    }
+}
+configure.env-append  PATH=${workpath}/bin:$env(PATH)
+build.env-append      PATH=${workpath}/bin:$env(PATH)
+
+# Install prefix for this port
+set bprefix ${prefix}/libexec/boost/${branch}
+
+# libcxxabi installed by the libcxx port on the buildbot does not
+# have the cxa_thread_atexit support, so until this is fixed
+# we have to force thread_local off on < 10.7 when using libc++
+patchfiles-append patch-boost-libcpp-force-thread-local-off.diff
+
+# temporary patch to fix: explicit template instanciations in
+# boost::serialization don't get exported with all compilers; this fix
+# is already in the boost repo & will be part of a future release. See
+# also the following tickets:
+# https://trac.macports.org/ticket/48717
+# https://svn.boost.org/trac/boost/ticket/11671
+patchfiles-append patch-export_serialization_explicit_template_instantiations.diff
+
+# revert the default tagged library name changes in 1.69.0 <
+# libboost_<component>-<threading>-<arch>.dylib > back to 1.68.0
+# format: libboost_<component>-<threading>.dylib; where <component> is
+# the component name (e.g., system, thread), <threading> is either mt
+# or st (multi or single), and <arch> is the build arch (x86, x64,
+# p64, p32).
+patchfiles-append patch-revert-lib-name-tagged.diff
+
+# Availability.h -> AvailabilityMacros.h on Tiger
+# The attempted fix:
+# https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
+# is insufficient because GCC 6/7 still defines __cpp_lib_uncaught_exceptions
+# in the absence of __STRICT_ANSI__
+platform darwin 8 {
+    patchfiles-append patch-tiger-availability.diff
+}
+
+# posix_memalign introduced in 10.6
+platform darwin {
+    if {${os.major} < 10} {
+        patchfiles-append patch-boost-aligned-alloc.diff
+    }
+}
+
+# see https://trac.macports.org/wiki/UsingTheRightCompiler
+patchfiles-append patch-compiler.diff
+post-patch {
+    reinplace "s|__MACPORTS_CXX__|${configure.cxx}|g" ${worksrcpath}/tools/build/src/tools/clang-darwin.jam
+}
+
+# Build issue on some older systems
+# ld: warning: option -s is obsolete and being ignored
+# ld: internal error: atom not found in symbolIndex(__ZNSt3__1plIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_12basic_stringIT_T0_T1_EERKS9_SB_) for architecture x86_64
+patchfiles-append patch-b2-build-older-OSes.diff
+
+# Fixes: https://github.com/boostorg/atomic/issues/79
+patchfiles-append patch-powerpc-atomic.diff
+
+# Fixes: https://github.com/chriskohlhoff/asio/issues/1711
+# [Boost version] Bad detection of std::aligned_alloc for XCode 12.2 with -std=c++1z
+patchfiles-append patch-boost_asio_detail_config.hpp.diff
+
+proc write_jam s {
+    global worksrcpath
+    set config [open ${worksrcpath}/user-config.jam a]
+    puts ${config} ${s}
+    close ${config}
+}
+
+compilers.choose   cc cxx
+mpi.setup          -gcc
+
+# NOTE: although technically Boost does not require C++11 compliance
+# for building, doing so allows for building on more OSs than without.
+# Further: Building Boost using C++11 compliance does not seem to then
+# require ports depending on Boost to also require C++11 compliance,
+# and requiring it does make such building easier for those ports.
+configure.cxxflags-append -std=gnu++17
+# ICU requires C++17
+compiler.cxx_standard   2017
+
+# This flag fixes the return type of unsetenv(3)
+# See: https://trac.macports.org/ticket/63121
+platform darwin 8 {
+    configure.cxxflags-append -D__DARWIN_UNIX03=1
+}
+
+# It turns out that ccache and distcc can produce boost libraries that, although they
+# compile without warning, have all sorts of runtime errors especially with pointer corruption.
+# Since most people will now use MacPorts' pre-compiled boost, this should not be a problem.
+configure.ccache    no
+configure.distcc    no
+
+configure.cmd       ./bootstrap.sh
+configure.args      --without-libraries=python \
+                    --without-libraries=mpi \
+                    --with-icu=${prefix}
+
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    patchfiles-append \
+                    patch-legacysupport.diff
+
+    post-patch {
+        reinplace "s|@PREFIX@|${prefix}|" ${worksrcpath}/bootstrap.sh
+    }
+}
+
+# boost build scripts default to clang on darwin
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.args-append --with-toolset=gcc
+}
+
+# Boost's PPC32 ASM code in the context module was only recently fixed (see
+# patch above). PPC64 is still broken.
+platform darwin {
+    if {${build_arch} eq "ppc64"} {
+        configure.args-append   --without-libraries=context \
+                                --without-libraries=coroutine
+    }
+}
+
+configure.universal_args
+
+post-configure {
+
+    reinplace -E "s|-install_name \"|&${bprefix}/lib/|" \
+        ${worksrcpath}/tools/build/src/tools/darwin.jam
+
+    set compileflags ""
+    if {[string length ${configure.sdkroot}] != 0} {
+        set compileflags "<compileflags>\"-isysroot ${configure.sdkroot}\""
+    }
+
+    set cxx_stdlibflags {}
+    if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
+        set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+    }
+
+    # see https://trac.macports.org/ticket/55857
+    # see https://svn.boost.org/trac10/ticket/13454
+    write_jam "using darwin : : ${configure.cxx} : <asmflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cxxflags>\"${configure.cxxflags} [get_canonical_archflags cxx] ${cxx_stdlibflags}\" ${compileflags} <linkflags>\"${configure.ldflags} ${cxx_stdlibflags}\" : ;"
+
+}
+
+build.cmd       ${worksrcpath}/b2
+build.target
+build.args      -d2 \
+                --layout=tagged \
+                --debug-configuration \
+                --user-config=user-config.jam \
+                -sBZIP2_INCLUDE=${prefix}/include \
+                -sBZIP2_LIBPATH=${prefix}/lib \
+                -sEXPAT_INCLUDE=${prefix}/include \
+                -sEXPAT_LIBPATH=${prefix}/lib \
+                -sZLIB_INCLUDE=${prefix}/include \
+                -sZLIB_LIBPATH=${prefix}/lib \
+                -sICU_PATH=${prefix} \
+                variant=release \
+                threading=single,multi \
+                link=static,shared \
+                runtime-link=shared \
+                -j${build.jobs}
+
+destroot.cmd    ${worksrcpath}/b2
+destroot.post_args
+
+pre-destroot {
+    destroot.args {*}${build.args} --prefix=${destroot}${bprefix}
+    system "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
+}
+
+proc boost_docs_install {} {
+    global bprefix destroot worksrcpath name
+
+    set docdir ${bprefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    set l [expr [string length ${worksrcpath}] + 1]
+    fs-traverse f [glob -directory ${worksrcpath} *] {
+        set dest ${destroot}${docdir}/[string range ${f} ${l} end]
+        if {[file isdirectory ${f}]} {
+            if {[file tail ${f}] eq "example"} {
+                copy ${f} ${dest}
+                continue
+            }
+            xinstall -d ${dest}
+        } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
+            xinstall -m 644 ${f} ${dest}
+        }
+    }
+}
+
+post-destroot {
+    if {[variant_isset docs]} {
+        boost_docs_install
+    }
+}
+
+set pythons_versions {2.7 3.10 3.11 3.12 3.13 3.14}
+
+set pythons_ports {}
+foreach v ${pythons_versions} {
+    lappend pythons_ports python[string map {. {}} ${v}]
+}
+
+proc python_dir {} {
+    global pythons_versions
+    foreach p ${pythons_versions} {
+        set s [string map {. {}} ${p}]
+        if {[variant_isset python${s}]} {
+            return [file normalize [exec ${p} -c "import sys; print(sys.prefix)"]/lib/${p}/site-packages]
+        }
+    }
+    error "Python support not enabled."
+}
+
+foreach v ${pythons_versions} {
+    set s [string map {. {}} ${v}]
+    set p python${s}
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    if { ${s} > 30 } { set bppatch "patch-boost-python3.diff" } else { set bppatch "" }
+    variant ${p} description "Build Boost.Python for Python ${v}" conflicts {*}${c} debug "
+
+        # There is a conflict with python and debug support, so we should really change the 'variant' line above
+        # to end with 'conflicts ${c} debug' above. However, we leave it enabled for those who want to try it.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+
+        depends_lib-append      port:${p}
+        configure.args-delete   --without-libraries=python
+        configure.args-append   --with-python=${prefix}/bin/python${v} --with-python-root=${prefix}/bin/python${v}
+
+        patchfiles-append   ${bppatch} patch-tools-build-src-tools-python.jam.diff \
+                            patch-tools-build-src-tools-python-2.jam.diff
+
+        post-patch {
+            reinplace s|@FRAMEWORKS_DIR@|${frameworks_dir}| ${worksrcpath}/tools/build/src/tools/python.jam
+        }
+    "
+}
+
+if {![variant_isset debug]} {
+    set selected_python python314
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            set selected_python python${s}
+        }
+    }
+    default_variants +${selected_python}
+}
+
+post-destroot {
+    # To avoid checking for all Python variants, don't fail if no libs exist
+    foreach f [glob -nocomplain ${destroot}${bprefix}/lib/*python*.dylib] {
+        set tf [file tail ${f}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python3" ${tf}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python"  ${tf}]
+    }
+}
+
+default_variants +no_single +no_static
+
+variant debug description {Builds debug versions of the libraries as well} {
+    build.args-delete   variant=release
+    build.args-append   variant=debug,release
+}
+
+variant no_static description {Disable building static libraries} {
+    build.args-delete   link=static,shared
+    build.args-append   link=shared
+}
+
+variant no_single description {Disable building single-threaded libraries} {
+    build.args-delete   threading=single,multi
+    build.args-append   threading=multi
+}
+
+subport ${name}-numpy {
+    revision 1
+
+    description Boost.Numpy library
+    long_description {*}${description}
+
+    depends_lib port:boost${tag}
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            depends_lib-append port:py${s}-numpy
+            require_active_variants boost python${s}
+        }
+    }
+    if {[variant_isset no_static]} {
+        require_active_variants boost no_static
+    } else {
+        require_active_variants boost "" no_static
+    }
+    if {[variant_isset no_single]} {
+        require_active_variants boost no_single
+    } else {
+        require_active_variants boost "" no_single
+    }
+}
+
+if {$subport eq $name} {
+    revision 2
+
+    patchfiles-append patch-disable-numpy-extension.diff
+
+    variant regex_match_extra description \
+        "Enable access to extended capture information of submatches in Boost.Regex" {
+        notes-append "
+        You enabled the +regex_match_extra variant\; see the following page for\
+        an exhaustive list of the consequences of this feature:
+
+        http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
+        "
+
+        post-patch {
+            reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
+                ${worksrcpath}/boost/regex/user.hpp
+        }
+    }
+
+    variant docs description {Enable building documentation} {
+        # No configure changes, etc; we simply check 'variant_isset' elsewhere
+    }
+
+    post-destroot {
+        delete file {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*]
+    }
+
+    if {[mpi_variant_isset]} {
+
+        # see https://trac.macports.org/ticket/49748
+        # see http://www.openradar.me/25313838
+        configure.ldflags-append -Lstage/lib
+
+        # There is a conflict with debug support.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+        if {[variant_isset debug]} {
+            return -code error "+debug variant conflicts with mpi"
+        }
+
+        configure.args-delete   --without-libraries=mpi
+
+        post-configure {
+            write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
+        }
+
+        if {![catch python_dir]} {
+
+            patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
+
+            post-destroot {
+                set site_packages [python_dir]
+                xinstall -d ${destroot}${site_packages}/boost
+                xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
+                    ${destroot}${site_packages}/boost
+
+                set f ${destroot}${bprefix}/lib/mpi.so
+                if {[info exists ${f}]} {
+                    set l ${site_packages}/boost/mpi.so
+                    move ${f} ${destroot}${l}
+                    system "install_name_tool -id ${l} ${destroot}${l}"
+                }
+            }
+
+        }
+    }
+
+    livecheck.type  regex
+    livecheck.url   https://www.boost.org/users/download/
+    livecheck.regex Version (\\d+\\.\\d+\\.\\d+)</h2>
+} else {
+    post-destroot {
+        move {*}[glob ${destroot}${bprefix}/lib/libboost_numpy*] ${destroot}${bprefix}
+        move {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*] ${destroot}${bprefix}
+        file mkdir ${destroot}${bprefix}/cmake
+        move {*}[glob ${destroot}${bprefix}/lib/cmake/boost_numpy*/libboost*] ${destroot}${bprefix}/cmake
+        # if an mpi variant *and* a python variant is selected, then a binary
+        # python module called mpi.so gets installed, so delete ${frameworks_dir}
+        delete ${destroot}${bprefix}${frameworks_dir} \
+            ${destroot}${bprefix}/include \
+            ${destroot}${bprefix}/lib \
+            ${destroot}${bprefix}/share
+        file mkdir ${destroot}${bprefix}/lib ${destroot}${bprefix}/include/boost/python \
+            ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+        move {*}[glob ${destroot}${bprefix}/libboost_numpy*] ${destroot}${bprefix}/lib
+        move {*}[glob ${destroot}${bprefix}/numpy*] ${destroot}${bprefix}/include/boost/python
+        move {*}[glob ${destroot}${bprefix}/cmake/*] ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+    }
+
+    livecheck.type  none
+}
+
+if {!${universal_possible} || ![variant_isset universal]} {
+    if {[lsearch ${build_arch} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm
+    } else {
+        if {[lsearch ${build_arch} ppc*] != -1} {
+            build.args-append architecture=power
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            if {[lsearch ${build_arch} *86*] != -1} {
+                build.args-append architecture=x86
+            } else {
+                pre-fetch {
+                    error "Current value of 'build_arch' (${build_arch}) is not supported."
+                }
+            }
+            if {[lsearch ${build_arch} *64] != -1} {
+                build.args-append address-model=64
+            } else {
+                build.args-append address-model=32
+            }
+        }
+    }
+}
+
+variant universal {
+    build.args-append   pch=off
+
+    if {[lsearch ${configure.universal_archs} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm+x86
+    } else {
+        if {[lsearch ${configure.universal_archs} ppc*] != -1} {
+            if {[lsearch ${configure.universal_archs} *86*] != -1} {
+                build.args-append architecture=arm+x86
+            } else {
+                build.args-append architecture=power
+            }
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            build.args-append architecture=x86
+        }
+        if {[lsearch ${configure.universal_archs} *64] != -1} {
+            if {[lsearch ${configure.universal_archs} i386] != -1 || [lsearch ${configure.universal_archs} ppc] != -1} {
+                build.args-append address-model=32_64
+                if {[lsearch ${configure.universal_archs} ppc64] == -1} {
+                    post-patch {
+                        reinplace "/local support-ppc64 =/s/= 1/= /" ${worksrcpath}/tools/build/src/tools/darwin.jam
+                    }
+                }
+            } else {
+                build.args-append address-model=64
+            }
+        } else {
+            build.args-append address-model=32
+        }
+    }
+}
+
+# TODO: Is this even needed? Is this correct for ppc64?
+platform powerpc {
+    build.args-append   --disable-long-double
+}
+
+platform darwin 8 powerpc {
+    if {[variant_isset universal]} {
+        build.args-append   macosx-version=10.4
+    }
+}

--- a/devel/boost190/Portfile
+++ b/devel/boost190/Portfile
@@ -1,0 +1,541 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                              1.0
+PortGroup                               active_variants 1.1
+PortGroup                               legacysupport 1.1
+PortGroup                               mpi 1.0
+
+# Needed for: TARGET_OS_IOS, dirfd
+legacysupport.newest_darwin_requires_legacy 14
+
+version                                 1.90.0
+
+set branch                              [join [lrange [split ${version} .] 0 1] .]
+set tag                                 [string map {. {}} ${branch}]
+
+name                                    boost${tag}
+
+# Revision is set below in the `if {$subport eq $name} { ... }` statement
+# The boost-numpy subport has its own revision number
+
+checksums                               rmd160  5a7ef8942487fdcdd3586e6a1667bf60e1c7a267 \
+                                        sha256  49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305 \
+                                        size    170662122
+
+license                                 Boost-1
+categories                              devel
+maintainers                             {@BjarneDMat mathiesen.info:macintosh} openmaintainer
+
+
+description                             Collection of portable C++ source libraries
+long_description \
+    Boost provides free portable peer-reviewed C++ libraries. \
+    The emphasis is on portable libraries which work well with the C++ Standard Library.
+
+homepage                                https://www.boost.org
+master_sites                            https://archives.boost.io/release/${version}/source
+set distver                             [join [split ${version} .] _]
+distname                                boost_${distver}
+use_bzip2                               yes
+
+compiler.blacklist-append {clang < 1000}
+
+depends_lib-append                      port:bzip2 \
+                                        port:expat \
+                                        path:lib/pkgconfig/icu-uc.pc:icu \
+                                        port:libiconv \
+                                        port:lzma \
+                                        port:zlib \
+                                        port:zstd
+
+post-extract {
+    fs-traverse dir ${workpath} {
+        if {[file isdirectory ${dir}]} {
+            file attributes ${dir} -permissions a+rx
+        }
+    }
+    # Enforce correct compiler and flags are used to build b2
+    xinstall -m 755 -d ${workpath}/bin
+
+    if {[string match *clang* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/clang++
+        ln -s ${configure.cc}  ${workpath}/bin/clang
+    } elseif {[string match *gcc* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/g++
+        ln -s ${configure.cc}  ${workpath}/bin/gcc
+    }
+}
+configure.env-append                    PATH=${workpath}/bin:$env(PATH)
+build.env-append                        PATH=${workpath}/bin:$env(PATH)
+
+# Install prefix for this port
+set  bprefix  ${prefix}/libexec/boost/${branch}
+
+# libcxxabi installed by the libcxx port on the buildbot does not
+# have the cxa_thread_atexit support, so until this is fixed
+# we have to force thread_local off on < 10.7 when using libc++
+platform darwin {
+    if {${os.major} < 11} {
+        patchfiles-append patch-boost-libcpp-force-thread-local-off.diff
+    }
+}
+
+# temporary patch to fix: explicit template instanciations in
+# boost::serialization don't get exported with all compilers; this fix
+# is already in the boost repo & will be part of a future release. See
+# also the following tickets:
+# https://trac.macports.org/ticket/48717
+# https://svn.boost.org/trac/boost/ticket/11671
+# patchfiles-append                       patch-export_serialization_explicit_template_instantiations.diff
+
+# revert the default tagged library name changes in 1.69.0 <
+# libboost_<component>-<threading>-<arch>.dylib > back to 1.68.0
+# format: libboost_<component>-<threading>.dylib; where <component> is
+# the component name (e.g., system, thread), <threading> is either mt
+# or st (multi or single), and <arch> is the build arch (x86, x64,
+# p64, p32).
+# patchfiles-append                       patch-revert-lib-name-tagged.diff
+
+# Availability.h -> AvailabilityMacros.h on Tiger
+# The attempted fix:
+# https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
+# is insufficient because GCC 6/7 still defines __cpp_lib_uncaught_exceptions
+# in the absence of __STRICT_ANSI__
+platform darwin 8 {
+    patchfiles-append                   patch-tiger-availability.diff
+}
+
+# posix_memalign introduced in 10.6
+platform darwin {
+    if {${os.major} < 10} {
+        patchfiles-append               patch-boost-aligned-alloc.diff
+    }
+}
+
+# see https://trac.macports.org/wiki/UsingTheRightCompiler
+patchfiles-append patch-compiler.diff
+post-patch {
+    reinplace   "s|__MACPORTS_CXX__|${configure.cxx}|g" \
+                ${worksrcpath}/tools/build/src/tools/clang-darwin.jam
+}
+
+# Build issue on some older systems
+# ld: warning: option -s is obsolete and being ignored
+# ld: internal error: atom not found in symbolIndex(__ZNSt3__1plIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_12basic_stringIT_T0_T1_EERKS9_SB_) for architecture x86_64
+# patchfiles-append                       patch-b2-build-older-OSes.diff
+
+# https://github.com/boostorg/gil/pull/767
+# patchfiles-append patch-boost-gil.diff
+
+# Fixes: https://github.com/boostorg/atomic/issues/79
+# patchfiles-append patch-powerpc-atomic.diff
+
+# Fixes: https://github.com/chriskohlhoff/asio/issues/1711
+# [Boost version] Bad detection of std::aligned_alloc for XCode 12.2 with -std=c++1z
+patchfiles-append                       patch-boost_asio_detail_config.hpp.diff
+
+proc write_jam s {
+    global  worksrcpath
+    set     config  [open ${worksrcpath}/user-config.jam a]
+    puts    ${config}  ${s}
+    close   ${config}
+}
+
+compilers.choose                        cc cxx
+mpi.setup                               -gcc
+
+# NOTE: although technically Boost does not require C++11 compliance
+# for building, doing so allows for building on more OSs than without.
+# Further: Building Boost using C++11 compliance does not seem to then
+# require ports depending on Boost to also require C++11 compliance,
+# and requiring it does make such building easier for those ports.
+configure.cxxflags-append               -std=gnu++17
+# ICU requires C++17
+compiler.cxx_standard                   2017
+
+# This flag fixes the return type of unsetenv(3)
+# See: https://trac.macports.org/ticket/63121
+platform darwin 8 {
+    configure.cxxflags-append           -D__DARWIN_UNIX03=1
+}
+
+# It turns out that ccache and distcc can produce boost libraries that, although they
+# compile without warning, have all sorts of runtime errors especially with pointer corruption.
+# Since most people will now use MacPorts' pre-compiled boost, this should not be a problem.
+configure.ccache                        no
+configure.distcc                        no
+
+configure.cmd                           ./bootstrap.sh
+configure.args                          --without-libraries=python \
+                                        --without-libraries=mpi \
+                                        --with-icu=${prefix}
+
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    patchfiles-append                   patch-legacysupport.diff
+
+    post-patch {
+        reinplace   "s|@PREFIX@|${prefix}|"  ${worksrcpath}/bootstrap.sh
+    }
+}
+
+# boost build scripts default to clang on darwin
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.args-append --with-toolset=gcc
+}
+
+# Boost's PPC32 ASM code in the context module was only recently fixed (see
+# patch above). PPC64 is still broken.
+platform darwin {
+    if {${build_arch} eq "ppc64"} {
+        configure.args-append           --without-libraries=context \
+                                        --without-libraries=coroutine
+    }
+}
+
+configure.universal_args
+
+post-configure {
+
+    reinplace -E "s|-install_name \"|&${bprefix}/lib/|" \
+        ${worksrcpath}/tools/build/src/tools/darwin.jam
+
+    set compileflags ""
+    if {[string length ${configure.sdkroot}] != 0} {
+        set compileflags "<compileflags>\"-isysroot ${configure.sdkroot}\""
+    }
+
+    set cxx_stdlibflags {}
+    if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
+        set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+    }
+
+    # see https://trac.macports.org/ticket/55857
+    # see https://svn.boost.org/trac10/ticket/13454
+    write_jam "using darwin : : ${configure.cxx} : <asmflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cxxflags>\"${configure.cxxflags} [get_canonical_archflags cxx] ${cxx_stdlibflags}\" ${compileflags} <linkflags>\"${configure.ldflags} ${cxx_stdlibflags}\" : ;"
+
+}
+
+build.cmd                               ${worksrcpath}/b2
+build.target
+build.args                              -d2 \
+                                        --layout=tagged \
+                                        --debug-configuration \
+                                        --user-config=user-config.jam \
+                                        -sBZIP2_INCLUDE=${prefix}/include \
+                                        -sBZIP2_LIBPATH=${prefix}/lib \
+                                        -sEXPAT_INCLUDE=${prefix}/include \
+                                        -sEXPAT_LIBPATH=${prefix}/lib \
+                                        -sZLIB_INCLUDE=${prefix}/include \
+                                        -sZLIB_LIBPATH=${prefix}/lib \
+                                        -sICU_PATH=${prefix} \
+                                        variant=release \
+                                        threading=single,multi \
+                                        link=static,shared \
+                                        runtime-link=shared \
+                                        -j${build.jobs}
+
+destroot.cmd                            ${worksrcpath}/b2
+destroot.post_args
+
+pre-destroot {
+    destroot.args  {*}${build.args}  --prefix=${destroot}${bprefix}
+    system  "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
+}
+
+proc boost_docs_install {} {
+    global bprefix destroot worksrcpath name
+
+    set docdir ${bprefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    set l [expr [string length ${worksrcpath}] + 1]
+    fs-traverse f [glob -directory ${worksrcpath} *] {
+        set dest ${destroot}${docdir}/[string range ${f} ${l} end]
+        if {[file isdirectory ${f}]} {
+            if {[file tail ${f}] eq "example"} {
+                copy ${f} ${dest}
+                continue
+            }
+            xinstall -d ${dest}
+        } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
+            xinstall -m 644 ${f} ${dest}
+        }
+    }
+}
+
+post-destroot {
+    if {[variant_isset docs]} {
+        boost_docs_install
+    }
+}
+
+set pythons_versions {2.7 3.10 3.11 3.12 3.13 3.14}
+
+set pythons_ports {}
+foreach v ${pythons_versions} {
+    lappend pythons_ports python[string map {. {}} ${v}]
+}
+
+proc python_dir {} {
+    global pythons_versions
+    foreach p ${pythons_versions} {
+        set s [string map {. {}} ${p}]
+        if {[variant_isset python${s}]} {
+            return [file normalize [exec ${p} -c "import sys; print(sys.prefix)"]/lib/${p}/site-packages]
+        }
+    }
+    error "Python support not enabled."
+}
+
+foreach v ${pythons_versions} {
+    set s [string map {. {}} ${v}]
+    set p python${s}
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    if { ${s} > 30 } { set bppatch "patch-boost-python3.diff" } else { set bppatch "" }
+    variant ${p} description "Build Boost.Python for Python ${v}" conflicts {*}${c} debug "
+
+        # There is a conflict with python and debug support, so we should really change the 'variant' line above
+        # to end with 'conflicts ${c} debug' above. However, we leave it enabled for those who want to try it.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+
+        depends_lib-append              port:${p}
+        configure.args-delete           --without-libraries=python
+        configure.args-append           --with-python=${prefix}/bin/python${v} --with-python-root=${prefix}/bin/python${v}
+
+        patchfiles-append               ${bppatch} patch-tools-build-src-tools-python.jam.diff \
+                                        patch-tools-build-src-tools-python-2.jam.diff
+
+        post-patch {
+            reinplace s|@FRAMEWORKS_DIR@|${frameworks_dir}| ${worksrcpath}/tools/build/src/tools/python.jam
+        }
+    "
+}
+
+if {![variant_isset debug]} {
+    set selected_python python314
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            set selected_python python${s}
+        }
+    }
+    default_variants +${selected_python}
+}
+
+post-destroot {
+    # To avoid checking for all Python variants, don't fail if no libs exist
+    foreach f [glob -nocomplain ${destroot}${bprefix}/lib/*python*.dylib] {
+        set tf [file tail ${f}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python3" ${tf}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python"  ${tf}]
+    }
+}
+
+default_variants +no_single +no_static
+
+variant debug description {Builds debug versions of the libraries as well} {
+    build.args-delete                   variant=release
+    build.args-append                   variant=debug,release
+}
+
+variant no_static description {Disable building static libraries} {
+    build.args-delete                   link=static,shared
+    build.args-append                   link=shared
+}
+
+variant no_single description {Disable building single-threaded libraries} {
+    build.args-delete                   threading=single,multi
+    build.args-append                   threading=multi
+}
+
+subport ${name}-numpy {
+    revision    0
+
+    description Boost.Numpy library
+    long_description {*}${description}
+
+    depends_lib port:boost${tag}
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            depends_lib-append port:py${s}-numpy
+            require_active_variants boost python${s}
+        }
+    }
+    if {[variant_isset no_static]} {
+        require_active_variants boost no_static
+    } else {
+        require_active_variants boost "" no_static
+    }
+    if {[variant_isset no_single]} {
+        require_active_variants boost no_single
+    } else {
+        require_active_variants boost "" no_single
+    }
+}
+
+if {$subport eq $name} {
+    revision    0
+
+    patchfiles-append patch-disable-numpy-extension.diff
+
+    variant regex_match_extra description \
+        "Enable access to extended capture information of submatches in Boost.Regex" {
+        notes-append "
+        You enabled the +regex_match_extra variant\; see the following page for\
+        an exhaustive list of the consequences of this feature:
+
+        http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
+        "
+
+        post-patch {
+            reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
+                ${worksrcpath}/boost/regex/user.hpp
+        }
+    }
+
+    variant docs description {Enable building documentation} {
+        # No configure changes, etc; we simply check 'variant_isset' elsewhere
+    }
+
+    post-destroot {
+        delete file {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*]
+    }
+
+    if {[mpi_variant_isset]} {
+
+        # see https://trac.macports.org/ticket/49748
+        # see http://www.openradar.me/25313838
+        configure.ldflags-append -Lstage/lib
+
+        # There is a conflict with debug support.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+        if {[variant_isset debug]} {
+            return -code error "+debug variant conflicts with mpi"
+        }
+
+        configure.args-delete           --without-libraries=mpi
+
+        post-configure {
+            write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
+        }
+
+        if {![catch python_dir]} {
+
+            patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
+
+            post-destroot {
+                set site_packages [python_dir]
+                xinstall -d ${destroot}${site_packages}/boost
+                xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
+                    ${destroot}${site_packages}/boost
+
+                set f ${destroot}${bprefix}/lib/mpi.so
+                if {[info exists ${f}]} {
+                    set l ${site_packages}/boost/mpi.so
+                    move ${f} ${destroot}${l}
+                    system "install_name_tool -id ${l} ${destroot}${l}"
+                }
+            }
+
+        }
+    }
+
+    livecheck.type                      regex
+    livecheck.url                       https://www.boost.org/users/download/
+    livecheck.regex                     Version (\\d+\\.\\d+\\.\\d+)</h2>
+} else {
+    post-destroot {
+        move {*}[glob ${destroot}${bprefix}/lib/libboost_numpy*] ${destroot}${bprefix}
+        move {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*] ${destroot}${bprefix}
+        file mkdir ${destroot}${bprefix}/cmake
+        move {*}[glob ${destroot}${bprefix}/lib/cmake/boost_numpy*/libboost*] ${destroot}${bprefix}/cmake
+        # if an mpi variant *and* a python variant is selected, then a binary
+        # python module called mpi.so gets installed, so delete ${frameworks_dir}
+        delete ${destroot}${bprefix}${frameworks_dir} \
+            ${destroot}${bprefix}/include \
+            ${destroot}${bprefix}/lib \
+            ${destroot}${bprefix}/share
+        file mkdir ${destroot}${bprefix}/lib ${destroot}${bprefix}/include/boost/python \
+            ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+        move {*}[glob ${destroot}${bprefix}/libboost_numpy*] ${destroot}${bprefix}/lib
+        move {*}[glob ${destroot}${bprefix}/numpy*] ${destroot}${bprefix}/include/boost/python
+        move {*}[glob ${destroot}${bprefix}/cmake/*] ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+    }
+
+    livecheck.type                      none
+}
+
+if {!${universal_possible} || ![variant_isset universal]} {
+    if {[lsearch ${build_arch} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm
+    } else {
+        if {[lsearch ${build_arch} ppc*] != -1} {
+            build.args-append architecture=power
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            if {[lsearch ${build_arch} *86*] != -1} {
+                build.args-append architecture=x86
+            } else {
+                pre-fetch {
+                    error "Current value of 'build_arch' (${build_arch}) is not supported."
+                }
+            }
+            if {[lsearch ${build_arch} *64] != -1} {
+                build.args-append address-model=64
+            } else {
+                build.args-append address-model=32
+            }
+        }
+    }
+}
+
+variant universal {
+    build.args-append                   pch=off
+
+    if {[lsearch ${configure.universal_archs} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm+x86
+    } else {
+        if {[lsearch ${configure.universal_archs} ppc*] != -1} {
+            if {[lsearch ${configure.universal_archs} *86*] != -1} {
+                build.args-append architecture=arm+x86
+            } else {
+                build.args-append architecture=power
+            }
+            if {${os.arch} ne "powerpc"} {
+                build.args-append       --disable-long-double
+            }
+        } else {
+            build.args-append architecture=x86
+        }
+        if {[lsearch ${configure.universal_archs} *64] != -1} {
+            if {[lsearch ${configure.universal_archs} i386] != -1 || [lsearch ${configure.universal_archs} ppc] != -1} {
+                build.args-append address-model=32_64
+                if {[lsearch ${configure.universal_archs} ppc64] == -1} {
+                    post-patch {
+                        reinplace "/local support-ppc64 =/s/= 1/= /" ${worksrcpath}/tools/build/src/tools/darwin.jam
+                    }
+                }
+            } else {
+                build.args-append       address-model=64
+            }
+        } else {
+            build.args-append           address-model=32
+        }
+    }
+}
+
+# TODO: Is this even needed? Is this correct for ppc64?
+platform powerpc {
+    build.args-append                   --disable-long-double
+}
+
+platform darwin 8 powerpc {
+    if {[variant_isset universal]} {
+        build.args-append               macosx-version=10.4
+    }
+}

--- a/devel/boost190/files/patch-b2-build-older-OSes.diff
+++ b/devel/boost190/files/patch-b2-build-older-OSes.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/engine/build.sh.orig	2024-12-04 19:53:38.000000000 -0500
++++ tools/build/src/engine/build.sh	2024-12-30 13:06:10.000000000 -0500
+@@ -391,7 +391,7 @@
+ 
+     clang|clang-*)
+         CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
+-        B2_CXXFLAGS_RELEASE="-O3 -s -Wno-deprecated-declarations"
++        B2_CXXFLAGS_RELEASE="-O3 -Wno-deprecated-declarations"
+         B2_CXXFLAGS_DEBUG="-O0 -fno-inline -g -Wno-deprecated-declarations"
+     ;;
+ 

--- a/devel/boost190/files/patch-boost-aligned-alloc.diff
+++ b/devel/boost190/files/patch-boost-aligned-alloc.diff
@@ -1,0 +1,17 @@
+posix_memalign introduced in 10.6
+
+--- ./boost/align/detail/aligned_alloc_posix.hpp.orig
++++ ./boost/align/detail/aligned_alloc_posix.hpp
+@@ -23,8 +23,10 @@
+         alignment = sizeof(void*);
+     }
+     void* p;
+-    if (::posix_memalign(&p, alignment, size) != 0) {
+-        p = 0;
++    if (alignment <= 16) {
++        p = ::malloc(size);
++    } else {
++        p = ::valloc(size);
+     }
+     return p;
+ }

--- a/devel/boost190/files/patch-boost-gil.diff
+++ b/devel/boost190/files/patch-boost-gil.diff
@@ -1,0 +1,20 @@
+--- boost/gil/algorithm.hpp.orig
++++ boost/gil/algorithm.hpp
+@@ -1238,7 +1238,7 @@
+         BinaryOperation2 binary_op2)
+     {
+         init = binary_op1(init, binary_op2(*first1, *first2));
+-        return inner_product_k_t<Size - 1>::template apply(
++        return inner_product_k_t<Size - 1>::apply(
+             first1 + 1, first2 + 1, init, binary_op1, binary_op2);
+     }
+ };
+@@ -1285,7 +1285,7 @@
+     BinaryOperation1 binary_op1,
+     BinaryOperation2 binary_op2)
+ {
+-    return detail::inner_product_k_t<Size>::template apply(
++    return detail::inner_product_k_t<Size>::apply(
+         first1, first2, init, binary_op1, binary_op2);
+ }
+ 

--- a/devel/boost190/files/patch-boost-libcpp-force-thread-local-off.diff
+++ b/devel/boost190/files/patch-boost-libcpp-force-thread-local-off.diff
@@ -1,0 +1,13 @@
+--- boost/config/stdlib/libcpp.hpp.orig
++++ boost/config/stdlib/libcpp.hpp
+@@ -15,6 +15,10 @@
+ #  endif
+ #endif
+ 
++#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
++#  define BOOST_NO_CXX11_THREAD_LOCAL
++#endif
++
+ #define BOOST_STDLIB "libc++ version " BOOST_STRINGIZE(_LIBCPP_VERSION)
+ 
+ #define BOOST_HAS_THREADS

--- a/devel/boost190/files/patch-boost-python3.diff
+++ b/devel/boost190/files/patch-boost-python3.diff
@@ -1,0 +1,13 @@
+--- libs/mpi/src/python/datatypes.cpp.orig
++++ libs/mpi/src/python/datatypes.cpp
+@@ -13,6 +13,10 @@
+ #include <boost/mpi/python/serialize.hpp>
+ #include <boost/mpi.hpp>
+ 
++#if PY_MAJOR_VERSION >= 3
++#define PyInt_Type PyLong_Type
++#endif
++
+ namespace boost { namespace mpi { namespace python {
+ 
+ void export_datatypes()

--- a/devel/boost190/files/patch-boost_asio_detail_config.hpp.diff
+++ b/devel/boost190/files/patch-boost_asio_detail_config.hpp.diff
@@ -1,0 +1,14 @@
+https://github.com/chriskohlhoff/asio/issues/1711
+[Boost version] Bad detection of std::aligned_alloc for XCode 12.2 with -std=c++1z
+
+--- boost/asio/detail/config.hpp	2026-03-03 16:20:41
++++ boost/asio/detail/config.hpp	2026-03-03 16:20:41
+@@ -373,7 +373,7 @@
+ #  if (__cplusplus >= 201703)
+ #   if defined(__clang__)
+ #    if defined(BOOST_ASIO_HAS_CLANG_LIBCXX)
+-#     if (_LIBCPP_STD_VER > 14)
++#     if (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC)
+ #      if defined(__FreeBSD__) || defined(__Fuchsia__) || defined(__wasi__) \
+          || defined(__NetBSD__) || defined(__OpenBSD__)
+ #       define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1

--- a/devel/boost190/files/patch-compiler.diff
+++ b/devel/boost190/files/patch-compiler.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/clang-darwin.jam.orig
++++ tools/build/src/tools/clang-darwin.jam
+@@ -51,7 +51,7 @@
+ #   compile and link options allow you to specify addition command line options for each version
+ rule init ( version ? :  command * : options * )
+ {
+-    command = [ common.find-compiler clang-darwin : clang++ : $(version) : $(command)
++    command = [ common.find-compiler clang-darwin : __MACPORTS_CXX__ : $(version) : $(command)
+                 : /usr/bin /usr/local/bin ] ;
+     local command-string = [ common.make-command-string $(command) ] ;
+     if ! $(version) { # ?= operator does not short-circuit

--- a/devel/boost190/files/patch-disable-numpy-extension.diff
+++ b/devel/boost190/files/patch-disable-numpy-extension.diff
@@ -1,0 +1,22 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -852,18 +852,7 @@
+     local full-cmd = $(interpreter-cmd)" -c \"$(full-cmd)\"" ;
+     debug-message "running command '$(full-cmd)'" ;
+     local result = [ SHELL $(full-cmd) : strip-eol : exit-status ] ;
+-    if $(result[2]) = 0
+-    {
+-        .numpy = true ;
+-        .numpy-include = $(result[1]) ;
+-        debug-message "NumPy enabled" ;
+-    }
+-    else
+-    {
+-        debug-message "NumPy disabled. Reason:" ;
+-        debug-message "  $(full-cmd) aborted with " ;
+-        debug-message "  $(result[1])" ;
+-    }
++    debug-message "NumPy disabled." ;
+ 
+     #
+     # End autoconfiguration sequence.

--- a/devel/boost190/files/patch-export_serialization_explicit_template_instantiations.diff
+++ b/devel/boost190/files/patch-export_serialization_explicit_template_instantiations.diff
@@ -1,0 +1,512 @@
+--- libs/serialization/src/basic_text_iprimitive.cpp.orig
++++ libs/serialization/src/basic_text_iprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_iprimitive<std::istream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::istream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_oprimitive.cpp.orig
++++ libs/serialization/src/basic_text_oprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_oprimitive<std::ostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::ostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_wiprimitive.cpp.orig
++++ libs/serialization/src/basic_text_wiprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_iprimitive<std::wistream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::wistream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_woprimitive.cpp.orig
++++ libs/serialization/src/basic_text_woprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_oprimitive<std::wostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::wostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_xml_grammar.ipp.orig
++++ libs/serialization/src/basic_xml_grammar.ipp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ #include <algorithm>
+ #include <boost/config.hpp> // typename
+ 
+--- libs/serialization/src/binary_iarchive.cpp.orig
++++ libs/serialization/src/binary_iarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -23,14 +27,14 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of stream
+-template class detail::archive_serializer_map<binary_iarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_iarchive,
+     std::istream::char_type, 
+     std::istream::traits_type
+ >;
+-template class basic_binary_iarchive<binary_iarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_iarchive, 
+     std::istream::char_type, 
+     std::istream::traits_type
+--- libs/serialization/src/binary_oarchive.cpp.orig
++++ libs/serialization/src/binary_oarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of binary stream
+@@ -23,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_oarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+ >;
+-template class basic_binary_oarchive<binary_oarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+--- libs/serialization/src/binary_wiarchive.cpp.orig
++++ libs/serialization/src/binary_wiarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,14 +29,14 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class detail::archive_serializer_map<binary_wiarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_wiarchive,
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_iarchive<binary_wiarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_wiarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/binary_woarchive.cpp.orig
++++ libs/serialization/src/binary_woarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_woarchive.hpp>
++#pragma GCC visibility pop
+ 
+ // explicitly instantiate for this type of text stream
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -25,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_woarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_oarchive<binary_woarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/polymorphic_iarchive.cpp.orig
++++ libs/serialization/src/polymorphic_iarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_iarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_iarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_iarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/polymorphic_oarchive.cpp.orig
++++ libs/serialization/src/polymorphic_oarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_oarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_oarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_oarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/text_iarchive.cpp.orig
++++ libs/serialization/src/text_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_iarchive>;
+-template class basic_text_iarchive<text_iarchive> ;
+-template class text_iarchive_impl<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_iarchive_impl<text_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_oarchive.cpp.orig
++++ libs/serialization/src/text_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace archive {
+ 
+ //template class basic_text_oprimitive<std::ostream> ;
+-template class detail::archive_serializer_map<text_oarchive>;
+-template class basic_text_oarchive<text_oarchive> ;
+-template class text_oarchive_impl<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_oarchive_impl<text_oarchive> ;
+ 
+ } // namespace serialization
+ } // namespace boost
+--- libs/serialization/src/text_wiarchive.cpp.orig
++++ libs/serialization/src/text_wiarchive.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,9 +29,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_wiarchive>;
+-template class basic_text_iarchive<text_wiarchive> ;
+-template class text_wiarchive_impl<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_wiarchive_impl<text_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_woarchive.cpp.orig
++++ libs/serialization/src/text_woarchive.cpp
+@@ -15,7 +15,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_woarchive>;
+-template class basic_text_oarchive<text_woarchive> ;
+-template class text_woarchive_impl<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_woarchive_impl<text_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_grammar.cpp.orig
++++ libs/serialization/src/xml_grammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -67,7 +69,7 @@
+ namespace archive {
+ 
+ // explicit instantiation of xml for 8 bit characters
+-template class basic_xml_grammar<char>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<char>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_iarchive.cpp.orig
++++ libs/serialization/src/xml_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_iarchive>;
+-template class basic_xml_iarchive<xml_iarchive> ;
+-template class xml_iarchive_impl<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_iarchive_impl<xml_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_oarchive.cpp.orig
++++ libs/serialization/src/xml_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_oarchive>;
+-template class basic_xml_oarchive<xml_oarchive> ;
+-template class xml_oarchive_impl<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_oarchive_impl<xml_oarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wgrammar.cpp.orig
++++ libs/serialization/src/xml_wgrammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -149,7 +151,7 @@
+ namespace archive {
+ 
+ // explicit instantiation of xml for wide characters
+-template class basic_xml_grammar<wchar_t>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<wchar_t>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wiarchive.cpp.orig
++++ libs/serialization/src/xml_wiarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_wiarchive>;
+-template class basic_xml_iarchive<xml_wiarchive> ;
+-template class xml_wiarchive_impl<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_wiarchive_impl<xml_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_woarchive.cpp.orig
++++ libs/serialization/src/xml_woarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_woarchive>;
+-template class basic_xml_oarchive<xml_woarchive> ;
+-template class xml_woarchive_impl<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_woarchive_impl<xml_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost

--- a/devel/boost190/files/patch-legacysupport.diff
+++ b/devel/boost190/files/patch-legacysupport.diff
@@ -1,0 +1,11 @@
+--- bootstrap.sh.orig	2024-12-05 08:53:27.000000000 +0800
++++ bootstrap.sh	2025-01-17 13:16:35.000000000 +0800
+@@ -226,7 +226,7 @@
+ if test "x$BJAM" = x; then
+   $ECHO "Building B2 engine.."
+   pwd=`pwd`
+-  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" ${TOOLSET}
++  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" --cxxflags="-isystem@PREFIX@/include/LegacySupport -Wl,-lMacportsLegacySupport" ${TOOLSET}
+   if [ $? -ne 0 ]; then
+       echo
+       echo "Failed to build B2 build engine"

--- a/devel/boost190/files/patch-libs-mpi-build-Jamfile.v2.diff
+++ b/devel/boost190/files/patch-libs-mpi-build-Jamfile.v2.diff
@@ -1,0 +1,26 @@
+--- libs/mpi/build/Jamfile.v2.orig
++++ libs/mpi/build/Jamfile.v2
+@@ -49,6 +49,7 @@
+     <link>shared:<define>BOOST_MPI_DYN_LINK=1
+   : # Default build
+     <link>shared
++    <threading>multi
+   : # Usage requirements
+     <library>../../serialization/build//boost_serialization
+     <library>/mpi//mpi [ mpi.extra-requirements ]
+@@ -95,6 +96,7 @@
+                 <python>$(py$(N)-version)
+               : # Default build
+                 <link>shared
++                <threading>multi
+               : # Usage requirements
+                 <library>/mpi//mpi [ mpi.extra-requirements ]
+               ;
+@@ -122,6 +124,7 @@
+                 <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
+                 <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
+                 <link>shared <runtime-link>shared
++                <threading>multi
+                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+                 <python>$(py$(N)-version)
+               ;

--- a/devel/boost190/files/patch-powerpc-atomic.diff
+++ b/devel/boost190/files/patch-powerpc-atomic.diff
@@ -1,0 +1,28 @@
+From 5342c1b562fc014b2f0dd53850c9cf3eb8888402 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sat, 13 Dec 2025 21:33:23 +0800
+Subject: [PATCH] thread_pause: use correct assembler syntax on
+ powerpc*-apple-darwin
+
+Fixes: https://github.com/boostorg/atomic/issues/79
+---
+ include/boost/atomic/thread_pause.hpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/include/boost/atomic/thread_pause.hpp b/include/boost/atomic/thread_pause.hpp
+index 7926a95..5bfa894 100644
+--- boost/atomic/thread_pause.hpp
++++ boost/atomic/thread_pause.hpp
+@@ -75,7 +75,11 @@ BOOST_FORCEINLINE void thread_pause() noexcept
+ #elif (defined(__ARM_ARCH) && __ARM_ARCH >= 8) || defined(__ARM_ARCH_8A__)
+     __asm__ __volatile__("yield" : : : "memory");
+ #elif (defined(__POWERPC__) || defined(__PPC__))
+-    __asm__ __volatile__("or 27,27,27" : : : "memory"); // yield pseudo-instruction
++    #ifdef __APPLE__
++        __asm__ __volatile__("or r27,r27,r27" : : : "memory"); // yield pseudo-instruction
++    #else
++        __asm__ __volatile__("or 27,27,27" : : : "memory"); // yield pseudo-instruction
++    #endif
+ #elif defined(__riscv) && (__riscv_xlen == 64)
+ #if defined(__riscv_zihintpause)
+     __asm__ __volatile__("pause" : : : "memory");

--- a/devel/boost190/files/patch-process-PROC_PPID_ONLY.diff
+++ b/devel/boost190/files/patch-process-PROC_PPID_ONLY.diff
@@ -1,0 +1,33 @@
+From 0ca663c8262b65ccee9a4e6abbafaef710f6b36f Mon Sep 17 00:00:00 2001
+From: Klemens Morgenstern <klemens.morgenstern@gmx.net>
+Date: Sun, 26 Jan 2025 21:49:25 +0800
+Subject: [PATCH] Set ENOTSUP when PROC_PPID_ONLY is undefined
+
+closes #452
+---
+ src/pid.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/pid.cpp b/src/pid.cpp
+index 7fa5f822c..322405907 100644
+--- libs/process/src/pid.cpp
++++ libs/process/src/pid.cpp
+@@ -178,6 +178,8 @@ pid_type parent_pid(pid_type pid, error_code & ec)
+ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+ {
+     std::vector<pid_type> vec;
++#if defined(PROC_PPID_ONLY)
++
+     vec.resize(proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, nullptr, 0) / sizeof(pid_type));
+     const auto sz = proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, &vec[0], sizeof(pid_type) * vec.size());
+     if (sz < 0)
+@@ -186,6 +188,9 @@ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+         return {};
+     }
+     vec.resize(sz);
++#else
++    BOOST_PROCESS_V2_ASSIGN_EC(ec, ENOTSUP, system_category());
++#endif
+     return vec;
+ }
+ 

--- a/devel/boost190/files/patch-revert-lib-name-tagged.diff
+++ b/devel/boost190/files/patch-revert-lib-name-tagged.diff
@@ -1,0 +1,11 @@
+--- boostcpp.jam.orig
++++ boostcpp.jam
+@@ -163,7 +163,7 @@
+             <base> <threading> <runtime> ;
+     case 1.69 :
+         .format-name-args =
+-            <base> <threading> <runtime> <arch-and-model> ;
++            <base> <threading> <runtime> ;
+     }
+ }
+ else if $(layout) = system

--- a/devel/boost190/files/patch-tiger-availability.diff
+++ b/devel/boost190/files/patch-tiger-availability.diff
@@ -1,0 +1,11 @@
+--- boost/core/uncaught_exceptions.hpp.orig
++++ boost/core/uncaught_exceptions.hpp
+@@ -27,7 +27,7 @@
+ #endif
+ 
+ #if defined(__APPLE__)
+-#include <Availability.h>
++#include <AvailabilityMacros.h>
+ // Apple systems only support std::uncaught_exceptions starting with specific versions:
+ // - Mac OS >= 10.12
+ // - iOS >= 10.0

--- a/devel/boost190/files/patch-tools-build-src-tools-python-2.jam.diff
+++ b/devel/boost190/files/patch-tools-build-src-tools-python-2.jam.diff
@@ -1,0 +1,16 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -545,6 +545,13 @@
+         libraries ?= $(default-library-path) ;
+         includes ?= $(default-include-path) ;
+     }
++    else if $(target-os) = darwin
++    {
++        includes ?= $(prefix)/Headers ;
++
++        local lib = $(exec-prefix)/lib ;
++        libraries ?= $(lib)/python$(version)/config $(lib) ;
++    }
+     else
+     {
+         local default-include-path = $(prefix)/include/python$(version) ;

--- a/devel/boost190/files/patch-tools-build-src-tools-python.jam.diff
+++ b/devel/boost190/files/patch-tools-build-src-tools-python.jam.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -434,7 +434,7 @@
+     version ?= $(.version-countdown) ;
+ 
+     local prefix
+-      = [ GLOB /System/Library/Frameworks /Library/Frameworks
++      = [ GLOB @FRAMEWORKS_DIR@
+           : Python.framework ] ;
+ 
+     return $(prefix)/Versions/$(version)/bin/python ;

--- a/devel/boost191/Portfile
+++ b/devel/boost191/Portfile
@@ -1,0 +1,541 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                              1.0
+PortGroup                               active_variants 1.1
+PortGroup                               legacysupport 1.1
+PortGroup                               mpi 1.0
+
+# Needed for: TARGET_OS_IOS, dirfd
+legacysupport.newest_darwin_requires_legacy 14
+
+version                                 1.91.0
+
+set branch                              [join [lrange [split ${version} .] 0 1] .]
+set tag                                 [string map {. {}} ${branch}]
+
+name                                    boost${tag}
+
+# Revision is set below in the `if {$subport eq $name} { ... }` statement
+# The boost-numpy subport has its own revision number
+
+checksums                               rmd160  9049a9814030e0875938c7127ad4500eb7ff1b9a \
+                                        sha256  de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5 \
+                                        size    204579466
+
+license                                 Boost-1
+categories                              devel
+maintainers                             {@BjarneDMat mathiesen.info:macintosh} openmaintainer
+
+
+description                             Collection of portable C++ source libraries
+long_description \
+    Boost provides free portable peer-reviewed C++ libraries. \
+    The emphasis is on portable libraries which work well with the C++ Standard Library.
+
+homepage                                https://www.boost.org
+master_sites                            https://archives.boost.io/release/${version}/source
+set distver                             [join [split ${version} .] _]
+distname                                boost_${distver}
+use_bzip2                               yes
+
+compiler.blacklist-append {clang < 1000}
+
+depends_lib-append                      port:bzip2 \
+                                        port:expat \
+                                        path:lib/pkgconfig/icu-uc.pc:icu \
+                                        port:libiconv \
+                                        port:lzma \
+                                        port:zlib \
+                                        port:zstd
+
+post-extract {
+    fs-traverse dir ${workpath} {
+        if {[file isdirectory ${dir}]} {
+            file attributes ${dir} -permissions a+rx
+        }
+    }
+    # Enforce correct compiler and flags are used to build b2
+    xinstall -m 755 -d ${workpath}/bin
+
+    if {[string match *clang* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/clang++
+        ln -s ${configure.cc}  ${workpath}/bin/clang
+    } elseif {[string match *gcc* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/g++
+        ln -s ${configure.cc}  ${workpath}/bin/gcc
+    }
+}
+configure.env-append                    PATH=${workpath}/bin:$env(PATH)
+build.env-append                        PATH=${workpath}/bin:$env(PATH)
+
+# Install prefix for this port
+set  bprefix  ${prefix}/libexec/boost/${branch}
+
+# libcxxabi installed by the libcxx port on the buildbot does not
+# have the cxa_thread_atexit support, so until this is fixed
+# we have to force thread_local off on < 10.7 when using libc++
+platform darwin {
+    if {${os.major} < 11} {
+        patchfiles-append patch-boost-libcpp-force-thread-local-off.diff
+    }
+}
+
+# temporary patch to fix: explicit template instanciations in
+# boost::serialization don't get exported with all compilers; this fix
+# is already in the boost repo & will be part of a future release. See
+# also the following tickets:
+# https://trac.macports.org/ticket/48717
+# https://svn.boost.org/trac/boost/ticket/11671
+# patchfiles-append                       patch-export_serialization_explicit_template_instantiations.diff
+
+# revert the default tagged library name changes in 1.69.0 <
+# libboost_<component>-<threading>-<arch>.dylib > back to 1.68.0
+# format: libboost_<component>-<threading>.dylib; where <component> is
+# the component name (e.g., system, thread), <threading> is either mt
+# or st (multi or single), and <arch> is the build arch (x86, x64,
+# p64, p32).
+# patchfiles-append                       patch-revert-lib-name-tagged.diff
+
+# https://github.com/boostorg/process/issues/452
+# patchfiles-append patch-process-PROC_PPID_ONLY.diff
+
+# Availability.h -> AvailabilityMacros.h on Tiger
+# The attempted fix:
+# https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
+# is insufficient because GCC 6/7 still defines __cpp_lib_uncaught_exceptions
+# in the absence of __STRICT_ANSI__
+platform darwin 8 {
+    patchfiles-append                   patch-tiger-availability.diff
+}
+
+# posix_memalign introduced in 10.6
+platform darwin {
+    if {${os.major} < 10} {
+        patchfiles-append               patch-boost-aligned-alloc.diff
+    }
+}
+
+# see https://trac.macports.org/wiki/UsingTheRightCompiler
+patchfiles-append patch-compiler.diff
+post-patch {
+    reinplace   "s|__MACPORTS_CXX__|${configure.cxx}|g" \
+                ${worksrcpath}/tools/build/src/tools/clang-darwin.jam
+}
+
+# Build issue on some older systems
+# ld: warning: option -s is obsolete and being ignored
+# ld: internal error: atom not found in symbolIndex(__ZNSt3__1plIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_12basic_stringIT_T0_T1_EERKS9_SB_) for architecture x86_64
+# patchfiles-append                       patch-b2-build-older-OSes.diff
+
+# https://github.com/boostorg/gil/pull/767
+# patchfiles-append patch-boost-gil.diff
+
+# Fixes: https://github.com/chriskohlhoff/asio/issues/1711
+# [Boost version] Bad detection of std::aligned_alloc for XCode 12.2 with -std=c++1z
+patchfiles-append                       patch-boost_asio_detail_config.hpp.diff
+
+proc write_jam s {
+    global  worksrcpath
+    set     config  [open ${worksrcpath}/user-config.jam a]
+    puts    ${config}  ${s}
+    close   ${config}
+}
+
+compilers.choose                        cc cxx
+mpi.setup                               -gcc
+
+# NOTE: although technically Boost does not require C++11 compliance
+# for building, doing so allows for building on more OSs than without.
+# Further: Building Boost using C++11 compliance does not seem to then
+# require ports depending on Boost to also require C++11 compliance,
+# and requiring it does make such building easier for those ports.
+configure.cxxflags-append               -std=gnu++17
+# ICU requires C++17
+compiler.cxx_standard                   2017
+
+# This flag fixes the return type of unsetenv(3)
+# See: https://trac.macports.org/ticket/63121
+platform darwin 8 {
+    configure.cxxflags-append           -D__DARWIN_UNIX03=1
+}
+
+# It turns out that ccache and distcc can produce boost libraries that, although they
+# compile without warning, have all sorts of runtime errors especially with pointer corruption.
+# Since most people will now use MacPorts' pre-compiled boost, this should not be a problem.
+configure.ccache                        no
+configure.distcc                        no
+
+configure.cmd                           ./bootstrap.sh
+configure.args                          --without-libraries=python \
+                                        --without-libraries=mpi \
+                                        --with-icu=${prefix}
+
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    patchfiles-append                   patch-legacysupport.diff
+
+    post-patch {
+        reinplace   "s|@PREFIX@|${prefix}|"  ${worksrcpath}/bootstrap.sh
+    }
+}
+
+# boost build scripts default to clang on darwin
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.args-append --with-toolset=gcc
+}
+
+# Boost's PPC32 ASM code in the context module was only recently fixed (see
+# patch above). PPC64 is still broken.
+platform darwin {
+    if {${build_arch} eq "ppc64"} {
+        configure.args-append           --without-libraries=context \
+                                        --without-libraries=coroutine
+    }
+}
+
+configure.universal_args
+
+post-configure {
+
+    reinplace -E "s|-install_name \"|&${bprefix}/lib/|" \
+        ${worksrcpath}/tools/build/src/tools/darwin.jam
+
+    set compileflags ""
+    if {[string length ${configure.sdkroot}] != 0} {
+        set compileflags "<compileflags>\"-isysroot ${configure.sdkroot}\""
+    }
+
+    set cxx_stdlibflags {}
+    if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
+        set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+    }
+
+    # see https://trac.macports.org/ticket/55857
+    # see https://svn.boost.org/trac10/ticket/13454
+    write_jam "using darwin : : ${configure.cxx} : <asmflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cxxflags>\"${configure.cxxflags} [get_canonical_archflags cxx] ${cxx_stdlibflags}\" ${compileflags} <linkflags>\"${configure.ldflags} ${cxx_stdlibflags}\" : ;"
+
+}
+
+build.cmd                               ${worksrcpath}/b2
+build.target
+build.args                              -d2 \
+                                        --layout=tagged \
+                                        --debug-configuration \
+                                        --user-config=user-config.jam \
+                                        -sBZIP2_INCLUDE=${prefix}/include \
+                                        -sBZIP2_LIBPATH=${prefix}/lib \
+                                        -sEXPAT_INCLUDE=${prefix}/include \
+                                        -sEXPAT_LIBPATH=${prefix}/lib \
+                                        -sZLIB_INCLUDE=${prefix}/include \
+                                        -sZLIB_LIBPATH=${prefix}/lib \
+                                        -sICU_PATH=${prefix} \
+                                        variant=release \
+                                        threading=single,multi \
+                                        link=static,shared \
+                                        runtime-link=shared \
+                                        -j${build.jobs}
+
+destroot.cmd                            ${worksrcpath}/b2
+destroot.post_args
+
+pre-destroot {
+    destroot.args  {*}${build.args}  --prefix=${destroot}${bprefix}
+    system  "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
+}
+
+proc boost_docs_install {} {
+    global bprefix destroot worksrcpath name
+
+    set docdir ${bprefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    set l [expr [string length ${worksrcpath}] + 1]
+    fs-traverse f [glob -directory ${worksrcpath} *] {
+        set dest ${destroot}${docdir}/[string range ${f} ${l} end]
+        if {[file isdirectory ${f}]} {
+            if {[file tail ${f}] eq "example"} {
+                copy ${f} ${dest}
+                continue
+            }
+            xinstall -d ${dest}
+        } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
+            xinstall -m 644 ${f} ${dest}
+        }
+    }
+}
+
+post-destroot {
+    if {[variant_isset docs]} {
+        boost_docs_install
+    }
+}
+
+set pythons_versions {2.7 3.10 3.11 3.12 3.13 3.14}
+
+set pythons_ports {}
+foreach v ${pythons_versions} {
+    lappend pythons_ports python[string map {. {}} ${v}]
+}
+
+proc python_dir {} {
+    global pythons_versions
+    foreach p ${pythons_versions} {
+        set s [string map {. {}} ${p}]
+        if {[variant_isset python${s}]} {
+            return [file normalize [exec ${p} -c "import sys; print(sys.prefix)"]/lib/${p}/site-packages]
+        }
+    }
+    error "Python support not enabled."
+}
+
+foreach v ${pythons_versions} {
+    set s [string map {. {}} ${v}]
+    set p python${s}
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    if { ${s} > 30 } { set bppatch "patch-boost-python3.diff" } else { set bppatch "" }
+    variant ${p} description "Build Boost.Python for Python ${v}" conflicts {*}${c} debug "
+
+        # There is a conflict with python and debug support, so we should really change the 'variant' line above
+        # to end with 'conflicts ${c} debug' above. However, we leave it enabled for those who want to try it.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+
+        depends_lib-append              port:${p}
+        configure.args-delete           --without-libraries=python
+        configure.args-append           --with-python=${prefix}/bin/python${v} --with-python-root=${prefix}/bin/python${v}
+
+        patchfiles-append               ${bppatch} patch-tools-build-src-tools-python.jam.diff \
+                                        patch-tools-build-src-tools-python-2.jam.diff
+
+        post-patch {
+            reinplace s|@FRAMEWORKS_DIR@|${frameworks_dir}| ${worksrcpath}/tools/build/src/tools/python.jam
+        }
+    "
+}
+
+if {![variant_isset debug]} {
+    set selected_python python314
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            set selected_python python${s}
+        }
+    }
+    default_variants +${selected_python}
+}
+
+post-destroot {
+    # To avoid checking for all Python variants, don't fail if no libs exist
+    foreach f [glob -nocomplain ${destroot}${bprefix}/lib/*python*.dylib] {
+        set tf [file tail ${f}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python3" ${tf}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python"  ${tf}]
+    }
+}
+
+default_variants +no_single +no_static
+
+variant debug description {Builds debug versions of the libraries as well} {
+    build.args-delete                   variant=release
+    build.args-append                   variant=debug,release
+}
+
+variant no_static description {Disable building static libraries} {
+    build.args-delete                   link=static,shared
+    build.args-append                   link=shared
+}
+
+variant no_single description {Disable building single-threaded libraries} {
+    build.args-delete                   threading=single,multi
+    build.args-append                   threading=multi
+}
+
+subport ${name}-numpy {
+    revision    0
+
+    description Boost.Numpy library
+    long_description {*}${description}
+
+    depends_lib port:boost${tag}
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            depends_lib-append port:py${s}-numpy
+            require_active_variants boost python${s}
+        }
+    }
+    if {[variant_isset no_static]} {
+        require_active_variants boost no_static
+    } else {
+        require_active_variants boost "" no_static
+    }
+    if {[variant_isset no_single]} {
+        require_active_variants boost no_single
+    } else {
+        require_active_variants boost "" no_single
+    }
+}
+
+if {$subport eq $name} {
+    revision    0
+
+    patchfiles-append patch-disable-numpy-extension.diff
+
+    variant regex_match_extra description \
+        "Enable access to extended capture information of submatches in Boost.Regex" {
+        notes-append "
+        You enabled the +regex_match_extra variant\; see the following page for\
+        an exhaustive list of the consequences of this feature:
+
+        http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
+        "
+
+        post-patch {
+            reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
+                ${worksrcpath}/boost/regex/user.hpp
+        }
+    }
+
+    variant docs description {Enable building documentation} {
+        # No configure changes, etc; we simply check 'variant_isset' elsewhere
+    }
+
+    post-destroot {
+        delete file {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*]
+    }
+
+    if {[mpi_variant_isset]} {
+
+        # see https://trac.macports.org/ticket/49748
+        # see http://www.openradar.me/25313838
+        configure.ldflags-append -Lstage/lib
+
+        # There is a conflict with debug support.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+        if {[variant_isset debug]} {
+            return -code error "+debug variant conflicts with mpi"
+        }
+
+        configure.args-delete           --without-libraries=mpi
+
+        post-configure {
+            write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
+        }
+
+        if {![catch python_dir]} {
+
+            patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
+
+            post-destroot {
+                set site_packages [python_dir]
+                xinstall -d ${destroot}${site_packages}/boost
+                xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
+                    ${destroot}${site_packages}/boost
+
+                set f ${destroot}${bprefix}/lib/mpi.so
+                if {[info exists ${f}]} {
+                    set l ${site_packages}/boost/mpi.so
+                    move ${f} ${destroot}${l}
+                    system "install_name_tool -id ${l} ${destroot}${l}"
+                }
+            }
+
+        }
+    }
+
+    livecheck.type                      regex
+    livecheck.url                       https://www.boost.org/users/download/
+    livecheck.regex                     Version (\\d+\\.\\d+\\.\\d+)</h2>
+} else {
+    post-destroot {
+        move {*}[glob ${destroot}${bprefix}/lib/libboost_numpy*] ${destroot}${bprefix}
+        move {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*] ${destroot}${bprefix}
+        file mkdir ${destroot}${bprefix}/cmake
+        move {*}[glob ${destroot}${bprefix}/lib/cmake/boost_numpy*/libboost*] ${destroot}${bprefix}/cmake
+        # if an mpi variant *and* a python variant is selected, then a binary
+        # python module called mpi.so gets installed, so delete ${frameworks_dir}
+        delete ${destroot}${bprefix}${frameworks_dir} \
+            ${destroot}${bprefix}/include \
+            ${destroot}${bprefix}/lib \
+            ${destroot}${bprefix}/share
+        file mkdir ${destroot}${bprefix}/lib ${destroot}${bprefix}/include/boost/python \
+            ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+        move {*}[glob ${destroot}${bprefix}/libboost_numpy*] ${destroot}${bprefix}/lib
+        move {*}[glob ${destroot}${bprefix}/numpy*] ${destroot}${bprefix}/include/boost/python
+        move {*}[glob ${destroot}${bprefix}/cmake/*] ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+    }
+
+    livecheck.type                      none
+}
+
+if {!${universal_possible} || ![variant_isset universal]} {
+    if {[lsearch ${build_arch} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm
+    } else {
+        if {[lsearch ${build_arch} ppc*] != -1} {
+            build.args-append architecture=power
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            if {[lsearch ${build_arch} *86*] != -1} {
+                build.args-append architecture=x86
+            } else {
+                pre-fetch {
+                    error "Current value of 'build_arch' (${build_arch}) is not supported."
+                }
+            }
+            if {[lsearch ${build_arch} *64] != -1} {
+                build.args-append address-model=64
+            } else {
+                build.args-append address-model=32
+            }
+        }
+    }
+}
+
+variant universal {
+    build.args-append                   pch=off
+
+    if {[lsearch ${configure.universal_archs} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm+x86
+    } else {
+        if {[lsearch ${configure.universal_archs} ppc*] != -1} {
+            if {[lsearch ${configure.universal_archs} *86*] != -1} {
+                build.args-append architecture=arm+x86
+            } else {
+                build.args-append architecture=power
+            }
+            if {${os.arch} ne "powerpc"} {
+                build.args-append       --disable-long-double
+            }
+        } else {
+            build.args-append architecture=x86
+        }
+        if {[lsearch ${configure.universal_archs} *64] != -1} {
+            if {[lsearch ${configure.universal_archs} i386] != -1 || [lsearch ${configure.universal_archs} ppc] != -1} {
+                build.args-append address-model=32_64
+                if {[lsearch ${configure.universal_archs} ppc64] == -1} {
+                    post-patch {
+                        reinplace "/local support-ppc64 =/s/= 1/= /" ${worksrcpath}/tools/build/src/tools/darwin.jam
+                    }
+                }
+            } else {
+                build.args-append       address-model=64
+            }
+        } else {
+            build.args-append           address-model=32
+        }
+    }
+}
+
+# TODO: Is this even needed? Is this correct for ppc64?
+platform powerpc {
+    build.args-append                   --disable-long-double
+}
+
+platform darwin 8 powerpc {
+    if {[variant_isset universal]} {
+        build.args-append               macosx-version=10.4
+    }
+}

--- a/devel/boost191/files/patch-b2-build-older-OSes.diff
+++ b/devel/boost191/files/patch-b2-build-older-OSes.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/engine/build.sh.orig	2024-12-04 19:53:38.000000000 -0500
++++ tools/build/src/engine/build.sh	2024-12-30 13:06:10.000000000 -0500
+@@ -391,7 +391,7 @@
+ 
+     clang|clang-*)
+         CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
+-        B2_CXXFLAGS_RELEASE="-O3 -s -Wno-deprecated-declarations"
++        B2_CXXFLAGS_RELEASE="-O3 -Wno-deprecated-declarations"
+         B2_CXXFLAGS_DEBUG="-O0 -fno-inline -g -Wno-deprecated-declarations"
+     ;;
+ 

--- a/devel/boost191/files/patch-boost-aligned-alloc.diff
+++ b/devel/boost191/files/patch-boost-aligned-alloc.diff
@@ -1,0 +1,17 @@
+posix_memalign introduced in 10.6
+
+--- ./boost/align/detail/aligned_alloc_posix.hpp.orig
++++ ./boost/align/detail/aligned_alloc_posix.hpp
+@@ -23,8 +23,10 @@
+         alignment = sizeof(void*);
+     }
+     void* p;
+-    if (::posix_memalign(&p, alignment, size) != 0) {
+-        p = 0;
++    if (alignment <= 16) {
++        p = ::malloc(size);
++    } else {
++        p = ::valloc(size);
+     }
+     return p;
+ }

--- a/devel/boost191/files/patch-boost-gil.diff
+++ b/devel/boost191/files/patch-boost-gil.diff
@@ -1,0 +1,20 @@
+--- boost/gil/algorithm.hpp.orig
++++ boost/gil/algorithm.hpp
+@@ -1238,7 +1238,7 @@
+         BinaryOperation2 binary_op2)
+     {
+         init = binary_op1(init, binary_op2(*first1, *first2));
+-        return inner_product_k_t<Size - 1>::template apply(
++        return inner_product_k_t<Size - 1>::apply(
+             first1 + 1, first2 + 1, init, binary_op1, binary_op2);
+     }
+ };
+@@ -1285,7 +1285,7 @@
+     BinaryOperation1 binary_op1,
+     BinaryOperation2 binary_op2)
+ {
+-    return detail::inner_product_k_t<Size>::template apply(
++    return detail::inner_product_k_t<Size>::apply(
+         first1, first2, init, binary_op1, binary_op2);
+ }
+ 

--- a/devel/boost191/files/patch-boost-libcpp-force-thread-local-off.diff
+++ b/devel/boost191/files/patch-boost-libcpp-force-thread-local-off.diff
@@ -1,0 +1,13 @@
+--- boost/config/stdlib/libcpp.hpp.orig
++++ boost/config/stdlib/libcpp.hpp
+@@ -15,6 +15,10 @@
+ #  endif
+ #endif
+ 
++#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
++#  define BOOST_NO_CXX11_THREAD_LOCAL
++#endif
++
+ #define BOOST_STDLIB "libc++ version " BOOST_STRINGIZE(_LIBCPP_VERSION)
+ 
+ #define BOOST_HAS_THREADS

--- a/devel/boost191/files/patch-boost-python3.diff
+++ b/devel/boost191/files/patch-boost-python3.diff
@@ -1,0 +1,13 @@
+--- libs/mpi/src/python/datatypes.cpp.orig
++++ libs/mpi/src/python/datatypes.cpp
+@@ -13,6 +13,10 @@
+ #include <boost/mpi/python/serialize.hpp>
+ #include <boost/mpi.hpp>
+ 
++#if PY_MAJOR_VERSION >= 3
++#define PyInt_Type PyLong_Type
++#endif
++
+ namespace boost { namespace mpi { namespace python {
+ 
+ void export_datatypes()

--- a/devel/boost191/files/patch-boost_asio_detail_config.hpp.diff
+++ b/devel/boost191/files/patch-boost_asio_detail_config.hpp.diff
@@ -1,0 +1,14 @@
+https://github.com/chriskohlhoff/asio/issues/1711
+[Boost version] Bad detection of std::aligned_alloc for XCode 12.2 with -std=c++1z
+
+--- boost/asio/detail/config.hpp	2026-03-03 16:20:41
++++ boost/asio/detail/config.hpp	2026-03-03 16:20:41
+@@ -373,7 +373,7 @@
+ #  if (__cplusplus >= 201703)
+ #   if defined(__clang__)
+ #    if defined(BOOST_ASIO_HAS_CLANG_LIBCXX)
+-#     if (_LIBCPP_STD_VER > 14)
++#     if (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC)
+ #      if defined(__FreeBSD__) || defined(__Fuchsia__) || defined(__wasi__) \
+          || defined(__NetBSD__) || defined(__OpenBSD__)
+ #       define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1

--- a/devel/boost191/files/patch-compiler.diff
+++ b/devel/boost191/files/patch-compiler.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/clang-darwin.jam.orig
++++ tools/build/src/tools/clang-darwin.jam
+@@ -51,7 +51,7 @@
+ #   compile and link options allow you to specify addition command line options for each version
+ rule init ( version ? :  command * : options * )
+ {
+-    command = [ common.find-compiler clang-darwin : clang++ : $(version) : $(command)
++    command = [ common.find-compiler clang-darwin : __MACPORTS_CXX__ : $(version) : $(command)
+                 : /usr/bin /usr/local/bin ] ;
+     local command-string = [ common.make-command-string $(command) ] ;
+     if ! $(version) { # ?= operator does not short-circuit

--- a/devel/boost191/files/patch-disable-numpy-extension.diff
+++ b/devel/boost191/files/patch-disable-numpy-extension.diff
@@ -1,0 +1,22 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -852,18 +852,7 @@
+     local full-cmd = $(interpreter-cmd)" -c \"$(full-cmd)\"" ;
+     debug-message "running command '$(full-cmd)'" ;
+     local result = [ SHELL $(full-cmd) : strip-eol : exit-status ] ;
+-    if $(result[2]) = 0
+-    {
+-        .numpy = true ;
+-        .numpy-include = $(result[1]) ;
+-        debug-message "NumPy enabled" ;
+-    }
+-    else
+-    {
+-        debug-message "NumPy disabled. Reason:" ;
+-        debug-message "  $(full-cmd) aborted with " ;
+-        debug-message "  $(result[1])" ;
+-    }
++    debug-message "NumPy disabled." ;
+ 
+     #
+     # End autoconfiguration sequence.

--- a/devel/boost191/files/patch-export_serialization_explicit_template_instantiations.diff
+++ b/devel/boost191/files/patch-export_serialization_explicit_template_instantiations.diff
@@ -1,0 +1,512 @@
+--- libs/serialization/src/basic_text_iprimitive.cpp.orig
++++ libs/serialization/src/basic_text_iprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_iprimitive<std::istream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::istream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_oprimitive.cpp.orig
++++ libs/serialization/src/basic_text_oprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_oprimitive<std::ostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::ostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_wiprimitive.cpp.orig
++++ libs/serialization/src/basic_text_wiprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_iprimitive<std::wistream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::wistream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_woprimitive.cpp.orig
++++ libs/serialization/src/basic_text_woprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_oprimitive<std::wostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::wostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_xml_grammar.ipp.orig
++++ libs/serialization/src/basic_xml_grammar.ipp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ #include <algorithm>
+ #include <boost/config.hpp> // typename
+ 
+--- libs/serialization/src/binary_iarchive.cpp.orig
++++ libs/serialization/src/binary_iarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -23,14 +27,14 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of stream
+-template class detail::archive_serializer_map<binary_iarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_iarchive,
+     std::istream::char_type, 
+     std::istream::traits_type
+ >;
+-template class basic_binary_iarchive<binary_iarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_iarchive, 
+     std::istream::char_type, 
+     std::istream::traits_type
+--- libs/serialization/src/binary_oarchive.cpp.orig
++++ libs/serialization/src/binary_oarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of binary stream
+@@ -23,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_oarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+ >;
+-template class basic_binary_oarchive<binary_oarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+--- libs/serialization/src/binary_wiarchive.cpp.orig
++++ libs/serialization/src/binary_wiarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,14 +29,14 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class detail::archive_serializer_map<binary_wiarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_wiarchive,
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_iarchive<binary_wiarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_wiarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/binary_woarchive.cpp.orig
++++ libs/serialization/src/binary_woarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_woarchive.hpp>
++#pragma GCC visibility pop
+ 
+ // explicitly instantiate for this type of text stream
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -25,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_woarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_oarchive<binary_woarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/polymorphic_iarchive.cpp.orig
++++ libs/serialization/src/polymorphic_iarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_iarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_iarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_iarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/polymorphic_oarchive.cpp.orig
++++ libs/serialization/src/polymorphic_oarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_oarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_oarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_oarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/text_iarchive.cpp.orig
++++ libs/serialization/src/text_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_iarchive>;
+-template class basic_text_iarchive<text_iarchive> ;
+-template class text_iarchive_impl<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_iarchive_impl<text_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_oarchive.cpp.orig
++++ libs/serialization/src/text_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace archive {
+ 
+ //template class basic_text_oprimitive<std::ostream> ;
+-template class detail::archive_serializer_map<text_oarchive>;
+-template class basic_text_oarchive<text_oarchive> ;
+-template class text_oarchive_impl<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_oarchive_impl<text_oarchive> ;
+ 
+ } // namespace serialization
+ } // namespace boost
+--- libs/serialization/src/text_wiarchive.cpp.orig
++++ libs/serialization/src/text_wiarchive.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,9 +29,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_wiarchive>;
+-template class basic_text_iarchive<text_wiarchive> ;
+-template class text_wiarchive_impl<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_wiarchive_impl<text_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_woarchive.cpp.orig
++++ libs/serialization/src/text_woarchive.cpp
+@@ -15,7 +15,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_woarchive>;
+-template class basic_text_oarchive<text_woarchive> ;
+-template class text_woarchive_impl<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_woarchive_impl<text_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_grammar.cpp.orig
++++ libs/serialization/src/xml_grammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -67,7 +69,7 @@
+ namespace archive {
+ 
+ // explicit instantiation of xml for 8 bit characters
+-template class basic_xml_grammar<char>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<char>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_iarchive.cpp.orig
++++ libs/serialization/src/xml_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_iarchive>;
+-template class basic_xml_iarchive<xml_iarchive> ;
+-template class xml_iarchive_impl<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_iarchive_impl<xml_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_oarchive.cpp.orig
++++ libs/serialization/src/xml_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_oarchive>;
+-template class basic_xml_oarchive<xml_oarchive> ;
+-template class xml_oarchive_impl<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_oarchive_impl<xml_oarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wgrammar.cpp.orig
++++ libs/serialization/src/xml_wgrammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -149,7 +151,7 @@
+ namespace archive {
+ 
+ // explicit instantiation of xml for wide characters
+-template class basic_xml_grammar<wchar_t>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<wchar_t>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wiarchive.cpp.orig
++++ libs/serialization/src/xml_wiarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_wiarchive>;
+-template class basic_xml_iarchive<xml_wiarchive> ;
+-template class xml_wiarchive_impl<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_wiarchive_impl<xml_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_woarchive.cpp.orig
++++ libs/serialization/src/xml_woarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_woarchive>;
+-template class basic_xml_oarchive<xml_woarchive> ;
+-template class xml_woarchive_impl<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_woarchive_impl<xml_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost

--- a/devel/boost191/files/patch-legacysupport.diff
+++ b/devel/boost191/files/patch-legacysupport.diff
@@ -1,0 +1,11 @@
+--- bootstrap.sh.orig	2024-12-05 08:53:27.000000000 +0800
++++ bootstrap.sh	2025-01-17 13:16:35.000000000 +0800
+@@ -226,7 +226,7 @@
+ if test "x$BJAM" = x; then
+   $ECHO "Building B2 engine.."
+   pwd=`pwd`
+-  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" ${TOOLSET}
++  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" --cxxflags="-isystem@PREFIX@/include/LegacySupport -Wl,-lMacportsLegacySupport" ${TOOLSET}
+   if [ $? -ne 0 ]; then
+       echo
+       echo "Failed to build B2 build engine"

--- a/devel/boost191/files/patch-libs-mpi-build-Jamfile.v2.diff
+++ b/devel/boost191/files/patch-libs-mpi-build-Jamfile.v2.diff
@@ -1,0 +1,26 @@
+--- libs/mpi/build/Jamfile.v2.orig
++++ libs/mpi/build/Jamfile.v2
+@@ -49,6 +49,7 @@
+     <link>shared:<define>BOOST_MPI_DYN_LINK=1
+   : # Default build
+     <link>shared
++    <threading>multi
+   : # Usage requirements
+     <library>../../serialization/build//boost_serialization
+     <library>/mpi//mpi [ mpi.extra-requirements ]
+@@ -95,6 +96,7 @@
+                 <python>$(py$(N)-version)
+               : # Default build
+                 <link>shared
++                <threading>multi
+               : # Usage requirements
+                 <library>/mpi//mpi [ mpi.extra-requirements ]
+               ;
+@@ -122,6 +124,7 @@
+                 <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
+                 <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
+                 <link>shared <runtime-link>shared
++                <threading>multi
+                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+                 <python>$(py$(N)-version)
+               ;

--- a/devel/boost191/files/patch-process-PROC_PPID_ONLY.diff
+++ b/devel/boost191/files/patch-process-PROC_PPID_ONLY.diff
@@ -1,0 +1,33 @@
+From 0ca663c8262b65ccee9a4e6abbafaef710f6b36f Mon Sep 17 00:00:00 2001
+From: Klemens Morgenstern <klemens.morgenstern@gmx.net>
+Date: Sun, 26 Jan 2025 21:49:25 +0800
+Subject: [PATCH] Set ENOTSUP when PROC_PPID_ONLY is undefined
+
+closes #452
+---
+ src/pid.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/pid.cpp b/src/pid.cpp
+index 7fa5f822c..322405907 100644
+--- libs/process/src/pid.cpp
++++ libs/process/src/pid.cpp
+@@ -178,6 +178,8 @@ pid_type parent_pid(pid_type pid, error_code & ec)
+ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+ {
+     std::vector<pid_type> vec;
++#if defined(PROC_PPID_ONLY)
++
+     vec.resize(proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, nullptr, 0) / sizeof(pid_type));
+     const auto sz = proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, &vec[0], sizeof(pid_type) * vec.size());
+     if (sz < 0)
+@@ -186,6 +188,9 @@ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+         return {};
+     }
+     vec.resize(sz);
++#else
++    BOOST_PROCESS_V2_ASSIGN_EC(ec, ENOTSUP, system_category());
++#endif
+     return vec;
+ }
+ 

--- a/devel/boost191/files/patch-revert-lib-name-tagged.diff
+++ b/devel/boost191/files/patch-revert-lib-name-tagged.diff
@@ -1,0 +1,11 @@
+--- boostcpp.jam.orig
++++ boostcpp.jam
+@@ -163,7 +163,7 @@
+             <base> <threading> <runtime> ;
+     case 1.69 :
+         .format-name-args =
+-            <base> <threading> <runtime> <arch-and-model> ;
++            <base> <threading> <runtime> ;
+     }
+ }
+ else if $(layout) = system

--- a/devel/boost191/files/patch-tiger-availability.diff
+++ b/devel/boost191/files/patch-tiger-availability.diff
@@ -1,0 +1,11 @@
+--- boost/core/uncaught_exceptions.hpp.orig
++++ boost/core/uncaught_exceptions.hpp
+@@ -27,7 +27,7 @@
+ #endif
+ 
+ #if defined(__APPLE__)
+-#include <Availability.h>
++#include <AvailabilityMacros.h>
+ // Apple systems only support std::uncaught_exceptions starting with specific versions:
+ // - Mac OS >= 10.12
+ // - iOS >= 10.0

--- a/devel/boost191/files/patch-tools-build-src-tools-python-2.jam.diff
+++ b/devel/boost191/files/patch-tools-build-src-tools-python-2.jam.diff
@@ -1,0 +1,16 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -545,6 +545,13 @@
+         libraries ?= $(default-library-path) ;
+         includes ?= $(default-include-path) ;
+     }
++    else if $(target-os) = darwin
++    {
++        includes ?= $(prefix)/Headers ;
++
++        local lib = $(exec-prefix)/lib ;
++        libraries ?= $(lib)/python$(version)/config $(lib) ;
++    }
+     else
+     {
+         local default-include-path = $(prefix)/include/python$(version) ;

--- a/devel/boost191/files/patch-tools-build-src-tools-python.jam.diff
+++ b/devel/boost191/files/patch-tools-build-src-tools-python.jam.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -434,7 +434,7 @@
+     version ?= $(.version-countdown) ;
+ 
+     local prefix
+-      = [ GLOB /System/Library/Frameworks /Library/Frameworks
++      = [ GLOB @FRAMEWORKS_DIR@
+           : Python.framework ] ;
+ 
+     return $(prefix)/Versions/$(version)/bin/python ;

--- a/devel/boost192/Portfile
+++ b/devel/boost192/Portfile
@@ -1,0 +1,541 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                              1.0
+PortGroup                               active_variants 1.1
+PortGroup                               legacysupport 1.1
+PortGroup                               mpi 1.0
+
+# Needed for: TARGET_OS_IOS, dirfd
+legacysupport.newest_darwin_requires_legacy 14
+
+version                                 1.92.0
+
+set branch                              [join [lrange [split ${version} .] 0 1] .]
+set tag                                 [string map {. {}} ${branch}]
+
+name                                    boost${tag}
+
+# Revision is set below in the `if {$subport eq $name} { ... }` statement
+# The boost-numpy subport has its own revision number
+
+checksums                               rmd160  667d5fc380101d6ab9061b0e7219b8bc3d425ba7 \
+                                        sha256  5c1d40cb8e19adbf740a4ec2da35b3e58f3f5804b1dce44deb53df72193cbc6c \
+                                        size    199030664
+
+license                                 Boost-1
+categories                              devel
+maintainers                             {@BjarneDMat mathiesen.info:macintosh} openmaintainer
+
+
+description                             Collection of portable C++ source libraries
+long_description \
+    Boost provides free portable peer-reviewed C++ libraries. \
+    The emphasis is on portable libraries which work well with the C++ Standard Library.
+
+homepage                                https://www.boost.org
+master_sites                            https://archives.boost.io/release/${version}/source
+set distver                             [join [split ${version} .] _]
+distname                                boost_${distver}
+use_bzip2                               yes
+
+compiler.blacklist-append {clang < 1000}
+
+depends_lib-append                      port:bzip2 \
+                                        port:expat \
+                                        path:lib/pkgconfig/icu-uc.pc:icu \
+                                        port:libiconv \
+                                        port:lzma \
+                                        port:zlib \
+                                        port:zstd
+
+post-extract {
+    fs-traverse dir ${workpath} {
+        if {[file isdirectory ${dir}]} {
+            file attributes ${dir} -permissions a+rx
+        }
+    }
+    # Enforce correct compiler and flags are used to build b2
+    xinstall -m 755 -d ${workpath}/bin
+
+    if {[string match *clang* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/clang++
+        ln -s ${configure.cc}  ${workpath}/bin/clang
+    } elseif {[string match *gcc* ${configure.compiler}]} {
+        ln -s ${configure.cxx} ${workpath}/bin/g++
+        ln -s ${configure.cc}  ${workpath}/bin/gcc
+    }
+}
+configure.env-append                    PATH=${workpath}/bin:$env(PATH)
+build.env-append                        PATH=${workpath}/bin:$env(PATH)
+
+# Install prefix for this port
+set  bprefix  ${prefix}/libexec/boost/${branch}
+
+# libcxxabi installed by the libcxx port on the buildbot does not
+# have the cxa_thread_atexit support, so until this is fixed
+# we have to force thread_local off on < 10.7 when using libc++
+platform darwin {
+    if {${os.major} < 11} {
+        patchfiles-append patch-boost-libcpp-force-thread-local-off.diff
+    }
+}
+
+# temporary patch to fix: explicit template instanciations in
+# boost::serialization don't get exported with all compilers; this fix
+# is already in the boost repo & will be part of a future release. See
+# also the following tickets:
+# https://trac.macports.org/ticket/48717
+# https://svn.boost.org/trac/boost/ticket/11671
+# patchfiles-append                       patch-export_serialization_explicit_template_instantiations.diff
+
+# revert the default tagged library name changes in 1.69.0 <
+# libboost_<component>-<threading>-<arch>.dylib > back to 1.68.0
+# format: libboost_<component>-<threading>.dylib; where <component> is
+# the component name (e.g., system, thread), <threading> is either mt
+# or st (multi or single), and <arch> is the build arch (x86, x64,
+# p64, p32).
+# patchfiles-append                       patch-revert-lib-name-tagged.diff
+
+# https://github.com/boostorg/process/issues/452
+# patchfiles-append patch-process-PROC_PPID_ONLY.diff
+
+# Availability.h -> AvailabilityMacros.h on Tiger
+# The attempted fix:
+# https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
+# is insufficient because GCC 6/7 still defines __cpp_lib_uncaught_exceptions
+# in the absence of __STRICT_ANSI__
+platform darwin 8 {
+    patchfiles-append                   patch-tiger-availability.diff
+}
+
+# posix_memalign introduced in 10.6
+platform darwin {
+    if {${os.major} < 10} {
+        patchfiles-append               patch-boost-aligned-alloc.diff
+    }
+}
+
+# see https://trac.macports.org/wiki/UsingTheRightCompiler
+patchfiles-append patch-compiler.diff
+post-patch {
+    reinplace   "s|__MACPORTS_CXX__|${configure.cxx}|g" \
+                ${worksrcpath}/tools/build/src/tools/clang-darwin.jam
+}
+
+# Build issue on some older systems
+# ld: warning: option -s is obsolete and being ignored
+# ld: internal error: atom not found in symbolIndex(__ZNSt3__1plIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_12basic_stringIT_T0_T1_EERKS9_SB_) for architecture x86_64
+# patchfiles-append                       patch-b2-build-older-OSes.diff
+
+# https://github.com/boostorg/gil/pull/767
+# patchfiles-append patch-boost-gil.diff
+
+# Fixes: https://github.com/chriskohlhoff/asio/issues/1711
+# [Boost version] Bad detection of std::aligned_alloc for XCode 12.2 with -std=c++1z
+patchfiles-append                       patch-boost_asio_detail_config.hpp.diff
+
+proc write_jam s {
+    global  worksrcpath
+    set     config  [open ${worksrcpath}/user-config.jam a]
+    puts    ${config}  ${s}
+    close   ${config}
+}
+
+compilers.choose                        cc cxx
+mpi.setup                               -gcc
+
+# NOTE: although technically Boost does not require C++11 compliance
+# for building, doing so allows for building on more OSs than without.
+# Further: Building Boost using C++11 compliance does not seem to then
+# require ports depending on Boost to also require C++11 compliance,
+# and requiring it does make such building easier for those ports.
+configure.cxxflags-append               -std=gnu++17
+# ICU requires C++17
+compiler.cxx_standard                   2017
+
+# This flag fixes the return type of unsetenv(3)
+# See: https://trac.macports.org/ticket/63121
+platform darwin 8 {
+    configure.cxxflags-append           -D__DARWIN_UNIX03=1
+}
+
+# It turns out that ccache and distcc can produce boost libraries that, although they
+# compile without warning, have all sorts of runtime errors especially with pointer corruption.
+# Since most people will now use MacPorts' pre-compiled boost, this should not be a problem.
+configure.ccache                        no
+configure.distcc                        no
+
+configure.cmd                           ./bootstrap.sh
+configure.args                          --without-libraries=python \
+                                        --without-libraries=mpi \
+                                        --with-icu=${prefix}
+
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    patchfiles-append                   patch-legacysupport.diff
+
+    post-patch {
+        reinplace   "s|@PREFIX@|${prefix}|"  ${worksrcpath}/bootstrap.sh
+    }
+}
+
+# boost build scripts default to clang on darwin
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.args-append --with-toolset=gcc
+}
+
+# Boost's PPC32 ASM code in the context module was only recently fixed (see
+# patch above). PPC64 is still broken.
+platform darwin {
+    if {${build_arch} eq "ppc64"} {
+        configure.args-append           --without-libraries=context \
+                                        --without-libraries=coroutine
+    }
+}
+
+configure.universal_args
+
+post-configure {
+
+    reinplace -E "s|-install_name \"|&${bprefix}/lib/|" \
+        ${worksrcpath}/tools/build/src/tools/darwin.jam
+
+    set compileflags ""
+    if {[string length ${configure.sdkroot}] != 0} {
+        set compileflags "<compileflags>\"-isysroot ${configure.sdkroot}\""
+    }
+
+    set cxx_stdlibflags {}
+    if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
+        set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+    }
+
+    # see https://trac.macports.org/ticket/55857
+    # see https://svn.boost.org/trac10/ticket/13454
+    write_jam "using darwin : : ${configure.cxx} : <asmflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cflags>\"${configure.cflags} [get_canonical_archflags cc]\" <cxxflags>\"${configure.cxxflags} [get_canonical_archflags cxx] ${cxx_stdlibflags}\" ${compileflags} <linkflags>\"${configure.ldflags} ${cxx_stdlibflags}\" : ;"
+
+}
+
+build.cmd                               ${worksrcpath}/b2
+build.target
+build.args                              -d2 \
+                                        --layout=tagged \
+                                        --debug-configuration \
+                                        --user-config=user-config.jam \
+                                        -sBZIP2_INCLUDE=${prefix}/include \
+                                        -sBZIP2_LIBPATH=${prefix}/lib \
+                                        -sEXPAT_INCLUDE=${prefix}/include \
+                                        -sEXPAT_LIBPATH=${prefix}/lib \
+                                        -sZLIB_INCLUDE=${prefix}/include \
+                                        -sZLIB_LIBPATH=${prefix}/lib \
+                                        -sICU_PATH=${prefix} \
+                                        variant=release \
+                                        threading=single,multi \
+                                        link=static,shared \
+                                        runtime-link=shared \
+                                        -j${build.jobs}
+
+destroot.cmd                            ${worksrcpath}/b2
+destroot.post_args
+
+pre-destroot {
+    destroot.args  {*}${build.args}  --prefix=${destroot}${bprefix}
+    system  "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
+}
+
+proc boost_docs_install {} {
+    global bprefix destroot worksrcpath name
+
+    set docdir ${bprefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    set l [expr [string length ${worksrcpath}] + 1]
+    fs-traverse f [glob -directory ${worksrcpath} *] {
+        set dest ${destroot}${docdir}/[string range ${f} ${l} end]
+        if {[file isdirectory ${f}]} {
+            if {[file tail ${f}] eq "example"} {
+                copy ${f} ${dest}
+                continue
+            }
+            xinstall -d ${dest}
+        } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
+            xinstall -m 644 ${f} ${dest}
+        }
+    }
+}
+
+post-destroot {
+    if {[variant_isset docs]} {
+        boost_docs_install
+    }
+}
+
+set pythons_versions {2.7 3.10 3.11 3.12 3.13 3.14}
+
+set pythons_ports {}
+foreach v ${pythons_versions} {
+    lappend pythons_ports python[string map {. {}} ${v}]
+}
+
+proc python_dir {} {
+    global pythons_versions
+    foreach p ${pythons_versions} {
+        set s [string map {. {}} ${p}]
+        if {[variant_isset python${s}]} {
+            return [file normalize [exec ${p} -c "import sys; print(sys.prefix)"]/lib/${p}/site-packages]
+        }
+    }
+    error "Python support not enabled."
+}
+
+foreach v ${pythons_versions} {
+    set s [string map {. {}} ${v}]
+    set p python${s}
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    if { ${s} > 30 } { set bppatch "patch-boost-python3.diff" } else { set bppatch "" }
+    variant ${p} description "Build Boost.Python for Python ${v}" conflicts {*}${c} debug "
+
+        # There is a conflict with python and debug support, so we should really change the 'variant' line above
+        # to end with 'conflicts ${c} debug' above. However, we leave it enabled for those who want to try it.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+
+        depends_lib-append              port:${p}
+        configure.args-delete           --without-libraries=python
+        configure.args-append           --with-python=${prefix}/bin/python${v} --with-python-root=${prefix}/bin/python${v}
+
+        patchfiles-append               ${bppatch} patch-tools-build-src-tools-python.jam.diff \
+                                        patch-tools-build-src-tools-python-2.jam.diff
+
+        post-patch {
+            reinplace s|@FRAMEWORKS_DIR@|${frameworks_dir}| ${worksrcpath}/tools/build/src/tools/python.jam
+        }
+    "
+}
+
+if {![variant_isset debug]} {
+    set selected_python python314
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            set selected_python python${s}
+        }
+    }
+    default_variants +${selected_python}
+}
+
+post-destroot {
+    # To avoid checking for all Python variants, don't fail if no libs exist
+    foreach f [glob -nocomplain ${destroot}${bprefix}/lib/*python*.dylib] {
+        set tf [file tail ${f}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python3" ${tf}]
+        ln -s ${tf} ${destroot}${bprefix}/lib/[string map "${selected_python} python"  ${tf}]
+    }
+}
+
+default_variants +no_single +no_static
+
+variant debug description {Builds debug versions of the libraries as well} {
+    build.args-delete                   variant=release
+    build.args-append                   variant=debug,release
+}
+
+variant no_static description {Disable building static libraries} {
+    build.args-delete                   link=static,shared
+    build.args-append                   link=shared
+}
+
+variant no_single description {Disable building single-threaded libraries} {
+    build.args-delete                   threading=single,multi
+    build.args-append                   threading=multi
+}
+
+subport ${name}-numpy {
+    revision    0
+
+    description Boost.Numpy library
+    long_description {*}${description}
+
+    depends_lib port:boost${tag}
+    foreach v ${pythons_versions} {
+        set s [string map {. {}} ${v}]
+        if {[variant_isset python${s}]} {
+            depends_lib-append port:py${s}-numpy
+            require_active_variants boost python${s}
+        }
+    }
+    if {[variant_isset no_static]} {
+        require_active_variants boost no_static
+    } else {
+        require_active_variants boost "" no_static
+    }
+    if {[variant_isset no_single]} {
+        require_active_variants boost no_single
+    } else {
+        require_active_variants boost "" no_single
+    }
+}
+
+if {$subport eq $name} {
+    revision    0
+
+    patchfiles-append patch-disable-numpy-extension.diff
+
+    variant regex_match_extra description \
+        "Enable access to extended capture information of submatches in Boost.Regex" {
+        notes-append "
+        You enabled the +regex_match_extra variant\; see the following page for\
+        an exhaustive list of the consequences of this feature:
+
+        http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub_match.html
+        "
+
+        post-patch {
+            reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
+                ${worksrcpath}/boost/regex/user.hpp
+        }
+    }
+
+    variant docs description {Enable building documentation} {
+        # No configure changes, etc; we simply check 'variant_isset' elsewhere
+    }
+
+    post-destroot {
+        delete file {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*]
+    }
+
+    if {[mpi_variant_isset]} {
+
+        # see https://trac.macports.org/ticket/49748
+        # see http://www.openradar.me/25313838
+        configure.ldflags-append -Lstage/lib
+
+        # There is a conflict with debug support.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+        if {[variant_isset debug]} {
+            return -code error "+debug variant conflicts with mpi"
+        }
+
+        configure.args-delete           --without-libraries=mpi
+
+        post-configure {
+            write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
+        }
+
+        if {![catch python_dir]} {
+
+            patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
+
+            post-destroot {
+                set site_packages [python_dir]
+                xinstall -d ${destroot}${site_packages}/boost
+                xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
+                    ${destroot}${site_packages}/boost
+
+                set f ${destroot}${bprefix}/lib/mpi.so
+                if {[info exists ${f}]} {
+                    set l ${site_packages}/boost/mpi.so
+                    move ${f} ${destroot}${l}
+                    system "install_name_tool -id ${l} ${destroot}${l}"
+                }
+            }
+
+        }
+    }
+
+    livecheck.type                      regex
+    livecheck.url                       https://www.boost.org/users/download/
+    livecheck.regex                     Version (\\d+\\.\\d+\\.\\d+)</h2>
+} else {
+    post-destroot {
+        move {*}[glob ${destroot}${bprefix}/lib/libboost_numpy*] ${destroot}${bprefix}
+        move {*}[glob ${destroot}${bprefix}/include/boost/python/numpy*] ${destroot}${bprefix}
+        file mkdir ${destroot}${bprefix}/cmake
+        move {*}[glob ${destroot}${bprefix}/lib/cmake/boost_numpy*/libboost*] ${destroot}${bprefix}/cmake
+        # if an mpi variant *and* a python variant is selected, then a binary
+        # python module called mpi.so gets installed, so delete ${frameworks_dir}
+        delete ${destroot}${bprefix}${frameworks_dir} \
+            ${destroot}${bprefix}/include \
+            ${destroot}${bprefix}/lib \
+            ${destroot}${bprefix}/share
+        file mkdir ${destroot}${bprefix}/lib ${destroot}${bprefix}/include/boost/python \
+            ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+        move {*}[glob ${destroot}${bprefix}/libboost_numpy*] ${destroot}${bprefix}/lib
+        move {*}[glob ${destroot}${bprefix}/numpy*] ${destroot}${bprefix}/include/boost/python
+        move {*}[glob ${destroot}${bprefix}/cmake/*] ${destroot}${bprefix}/lib/cmake/boost_numpy-${version}
+    }
+
+    livecheck.type                      none
+}
+
+if {!${universal_possible} || ![variant_isset universal]} {
+    if {[lsearch ${build_arch} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm
+    } else {
+        if {[lsearch ${build_arch} ppc*] != -1} {
+            build.args-append architecture=power
+            if {${os.arch} ne "powerpc"} {
+                build.args-append --disable-long-double
+            }
+        } else {
+            if {[lsearch ${build_arch} *86*] != -1} {
+                build.args-append architecture=x86
+            } else {
+                pre-fetch {
+                    error "Current value of 'build_arch' (${build_arch}) is not supported."
+                }
+            }
+            if {[lsearch ${build_arch} *64] != -1} {
+                build.args-append address-model=64
+            } else {
+                build.args-append address-model=32
+            }
+        }
+    }
+}
+
+variant universal {
+    build.args-append                   pch=off
+
+    if {[lsearch ${configure.universal_archs} arm*] != -1} {
+        build.args-append address-model=64 architecture=arm+x86
+    } else {
+        if {[lsearch ${configure.universal_archs} ppc*] != -1} {
+            if {[lsearch ${configure.universal_archs} *86*] != -1} {
+                build.args-append architecture=arm+x86
+            } else {
+                build.args-append architecture=power
+            }
+            if {${os.arch} ne "powerpc"} {
+                build.args-append       --disable-long-double
+            }
+        } else {
+            build.args-append architecture=x86
+        }
+        if {[lsearch ${configure.universal_archs} *64] != -1} {
+            if {[lsearch ${configure.universal_archs} i386] != -1 || [lsearch ${configure.universal_archs} ppc] != -1} {
+                build.args-append address-model=32_64
+                if {[lsearch ${configure.universal_archs} ppc64] == -1} {
+                    post-patch {
+                        reinplace "/local support-ppc64 =/s/= 1/= /" ${worksrcpath}/tools/build/src/tools/darwin.jam
+                    }
+                }
+            } else {
+                build.args-append       address-model=64
+            }
+        } else {
+            build.args-append           address-model=32
+        }
+    }
+}
+
+# TODO: Is this even needed? Is this correct for ppc64?
+platform powerpc {
+    build.args-append                   --disable-long-double
+}
+
+platform darwin 8 powerpc {
+    if {[variant_isset universal]} {
+        build.args-append               macosx-version=10.4
+    }
+}

--- a/devel/boost192/files/patch-b2-build-older-OSes.diff
+++ b/devel/boost192/files/patch-b2-build-older-OSes.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/engine/build.sh.orig	2024-12-04 19:53:38.000000000 -0500
++++ tools/build/src/engine/build.sh	2024-12-30 13:06:10.000000000 -0500
+@@ -391,7 +391,7 @@
+ 
+     clang|clang-*)
+         CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
+-        B2_CXXFLAGS_RELEASE="-O3 -s -Wno-deprecated-declarations"
++        B2_CXXFLAGS_RELEASE="-O3 -Wno-deprecated-declarations"
+         B2_CXXFLAGS_DEBUG="-O0 -fno-inline -g -Wno-deprecated-declarations"
+     ;;
+ 

--- a/devel/boost192/files/patch-boost-aligned-alloc.diff
+++ b/devel/boost192/files/patch-boost-aligned-alloc.diff
@@ -1,0 +1,17 @@
+posix_memalign introduced in 10.6
+
+--- ./boost/align/detail/aligned_alloc_posix.hpp.orig
++++ ./boost/align/detail/aligned_alloc_posix.hpp
+@@ -23,8 +23,10 @@
+         alignment = sizeof(void*);
+     }
+     void* p;
+-    if (::posix_memalign(&p, alignment, size) != 0) {
+-        p = 0;
++    if (alignment <= 16) {
++        p = ::malloc(size);
++    } else {
++        p = ::valloc(size);
+     }
+     return p;
+ }

--- a/devel/boost192/files/patch-boost-gil.diff
+++ b/devel/boost192/files/patch-boost-gil.diff
@@ -1,0 +1,20 @@
+--- boost/gil/algorithm.hpp.orig
++++ boost/gil/algorithm.hpp
+@@ -1238,7 +1238,7 @@
+         BinaryOperation2 binary_op2)
+     {
+         init = binary_op1(init, binary_op2(*first1, *first2));
+-        return inner_product_k_t<Size - 1>::template apply(
++        return inner_product_k_t<Size - 1>::apply(
+             first1 + 1, first2 + 1, init, binary_op1, binary_op2);
+     }
+ };
+@@ -1285,7 +1285,7 @@
+     BinaryOperation1 binary_op1,
+     BinaryOperation2 binary_op2)
+ {
+-    return detail::inner_product_k_t<Size>::template apply(
++    return detail::inner_product_k_t<Size>::apply(
+         first1, first2, init, binary_op1, binary_op2);
+ }
+ 

--- a/devel/boost192/files/patch-boost-libcpp-force-thread-local-off.diff
+++ b/devel/boost192/files/patch-boost-libcpp-force-thread-local-off.diff
@@ -1,0 +1,13 @@
+--- boost/config/stdlib/libcpp.hpp.orig
++++ boost/config/stdlib/libcpp.hpp
+@@ -15,6 +15,10 @@
+ #  endif
+ #endif
+ 
++#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
++#  define BOOST_NO_CXX11_THREAD_LOCAL
++#endif
++
+ #define BOOST_STDLIB "libc++ version " BOOST_STRINGIZE(_LIBCPP_VERSION)
+ 
+ #define BOOST_HAS_THREADS

--- a/devel/boost192/files/patch-boost-python3.diff
+++ b/devel/boost192/files/patch-boost-python3.diff
@@ -1,0 +1,13 @@
+--- libs/mpi/src/python/datatypes.cpp.orig
++++ libs/mpi/src/python/datatypes.cpp
+@@ -13,6 +13,10 @@
+ #include <boost/mpi/python/serialize.hpp>
+ #include <boost/mpi.hpp>
+ 
++#if PY_MAJOR_VERSION >= 3
++#define PyInt_Type PyLong_Type
++#endif
++
+ namespace boost { namespace mpi { namespace python {
+ 
+ void export_datatypes()

--- a/devel/boost192/files/patch-boost_asio_detail_config.hpp.diff
+++ b/devel/boost192/files/patch-boost_asio_detail_config.hpp.diff
@@ -1,0 +1,14 @@
+https://github.com/chriskohlhoff/asio/issues/1711
+[Boost version] Bad detection of std::aligned_alloc for XCode 12.2 with -std=c++1z
+
+--- boost/asio/detail/config.hpp	2026-03-03 16:20:41
++++ boost/asio/detail/config.hpp	2026-03-03 16:20:41
+@@ -373,7 +373,7 @@
+ #  if (__cplusplus >= 201703)
+ #   if defined(__clang__)
+ #    if defined(BOOST_ASIO_HAS_CLANG_LIBCXX)
+-#     if (_LIBCPP_STD_VER > 14)
++#     if (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC)
+ #      if defined(__FreeBSD__) || defined(__Fuchsia__) || defined(__wasi__) \
+          || defined(__NetBSD__) || defined(__OpenBSD__)
+ #       define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1

--- a/devel/boost192/files/patch-compiler.diff
+++ b/devel/boost192/files/patch-compiler.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/clang-darwin.jam.orig
++++ tools/build/src/tools/clang-darwin.jam
+@@ -51,7 +51,7 @@
+ #   compile and link options allow you to specify addition command line options for each version
+ rule init ( version ? :  command * : options * )
+ {
+-    command = [ common.find-compiler clang-darwin : clang++ : $(version) : $(command)
++    command = [ common.find-compiler clang-darwin : __MACPORTS_CXX__ : $(version) : $(command)
+                 : /usr/bin /usr/local/bin ] ;
+     local command-string = [ common.make-command-string $(command) ] ;
+     if ! $(version) { # ?= operator does not short-circuit

--- a/devel/boost192/files/patch-disable-numpy-extension.diff
+++ b/devel/boost192/files/patch-disable-numpy-extension.diff
@@ -1,0 +1,22 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -852,18 +852,7 @@
+     local full-cmd = $(interpreter-cmd)" -c \"$(full-cmd)\"" ;
+     debug-message "running command '$(full-cmd)'" ;
+     local result = [ SHELL $(full-cmd) : strip-eol : exit-status ] ;
+-    if $(result[2]) = 0
+-    {
+-        .numpy = true ;
+-        .numpy-include = $(result[1]) ;
+-        debug-message "NumPy enabled" ;
+-    }
+-    else
+-    {
+-        debug-message "NumPy disabled. Reason:" ;
+-        debug-message "  $(full-cmd) aborted with " ;
+-        debug-message "  $(result[1])" ;
+-    }
++    debug-message "NumPy disabled." ;
+ 
+     #
+     # End autoconfiguration sequence.

--- a/devel/boost192/files/patch-export_serialization_explicit_template_instantiations.diff
+++ b/devel/boost192/files/patch-export_serialization_explicit_template_instantiations.diff
@@ -1,0 +1,512 @@
+--- libs/serialization/src/basic_text_iprimitive.cpp.orig
++++ libs/serialization/src/basic_text_iprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_iprimitive<std::istream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::istream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_oprimitive.cpp.orig
++++ libs/serialization/src/basic_text_oprimitive.cpp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
+@@ -23,7 +25,7 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class basic_text_oprimitive<std::ostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::ostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_wiprimitive.cpp.orig
++++ libs/serialization/src/basic_text_wiprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_iprimitive<std::wistream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_iprimitive<std::wistream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_text_woprimitive.cpp.orig
++++ libs/serialization/src/basic_text_woprimitive.cpp
+@@ -8,7 +8,9 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #include <boost/config.hpp>
+ 
+@@ -28,7 +30,7 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class basic_text_oprimitive<std::wostream> ;
++template class BOOST_SYMBOL_VISIBLE basic_text_oprimitive<std::wostream> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/basic_xml_grammar.ipp.orig
++++ libs/serialization/src/basic_xml_grammar.ipp
+@@ -12,7 +12,9 @@
+ #  pragma warning (disable : 4786) // too long name, harmless warning
+ #endif
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ #include <algorithm>
+ #include <boost/config.hpp> // typename
+ 
+--- libs/serialization/src/binary_iarchive.cpp.orig
++++ libs/serialization/src/binary_iarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <istream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -23,14 +27,14 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of stream
+-template class detail::archive_serializer_map<binary_iarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_iarchive,
+     std::istream::char_type, 
+     std::istream::traits_type
+ >;
+-template class basic_binary_iarchive<binary_iarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_iarchive, 
+     std::istream::char_type, 
+     std::istream::traits_type
+--- libs/serialization/src/binary_oarchive.cpp.orig
++++ libs/serialization/src/binary_oarchive.cpp
+@@ -8,11 +8,15 @@
+ 
+ //  See http://www.boost.org for updates, documentation, and revision history.
+ 
++#pragma GCC visibility push(default)
+ #include <ostream>
++#pragma GCC visibility pop
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of binary stream
+@@ -23,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_oarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+ >;
+-template class basic_binary_oarchive<binary_oarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_oarchive, 
+     std::ostream::char_type, 
+     std::ostream::traits_type
+--- libs/serialization/src/binary_wiarchive.cpp.orig
++++ libs/serialization/src/binary_wiarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,14 +29,14 @@
+ namespace archive {
+ 
+ // explicitly instantiate for this type of text stream
+-template class detail::archive_serializer_map<binary_wiarchive>;
+-template class basic_binary_iprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_iprimitive<
+     binary_wiarchive,
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_iarchive<binary_wiarchive> ;
+-template class binary_iarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_iarchive<binary_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_iarchive_impl<
+     binary_wiarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/binary_woarchive.cpp.orig
++++ libs/serialization/src/binary_woarchive.cpp
+@@ -15,7 +15,9 @@
+ #else
+ 
+ #define BOOST_WARCHIVE_SOURCE
++#pragma GCC visibility push(default)
+ #include <boost/archive/binary_woarchive.hpp>
++#pragma GCC visibility pop
+ 
+ // explicitly instantiate for this type of text stream
+ #include <boost/archive/impl/archive_serializer_map.ipp>
+@@ -25,14 +27,14 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<binary_woarchive>;
+-template class basic_binary_oprimitive<
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<binary_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_binary_oprimitive<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+ >;
+-template class basic_binary_oarchive<binary_woarchive> ;
+-template class binary_oarchive_impl<
++template class BOOST_SYMBOL_VISIBLE basic_binary_oarchive<binary_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE binary_oarchive_impl<
+     binary_woarchive, 
+     wchar_t, 
+     std::char_traits<wchar_t> 
+--- libs/serialization/src/polymorphic_iarchive.cpp.orig
++++ libs/serialization/src/polymorphic_iarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_iarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_iarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_iarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/polymorphic_oarchive.cpp.orig
++++ libs/serialization/src/polymorphic_oarchive.cpp
+@@ -17,13 +17,15 @@
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ #include <boost/archive/impl/archive_serializer_map.ipp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/polymorphic_oarchive.hpp>
++#pragma GCC visibility pop
+ 
+ namespace boost {
+ namespace archive {
+ namespace detail {
+ 
+-template class archive_serializer_map<polymorphic_oarchive>;
++template class BOOST_SYMBOL_VISIBLE archive_serializer_map<polymorphic_oarchive>;
+ 
+ } // detail
+ } // archive
+--- libs/serialization/src/text_iarchive.cpp.orig
++++ libs/serialization/src/text_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_iarchive>;
+-template class basic_text_iarchive<text_iarchive> ;
+-template class text_iarchive_impl<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_iarchive_impl<text_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_oarchive.cpp.orig
++++ libs/serialization/src/text_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace archive {
+ 
+ //template class basic_text_oprimitive<std::ostream> ;
+-template class detail::archive_serializer_map<text_oarchive>;
+-template class basic_text_oarchive<text_oarchive> ;
+-template class text_oarchive_impl<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_oarchive_impl<text_oarchive> ;
+ 
+ } // namespace serialization
+ } // namespace boost
+--- libs/serialization/src/text_wiarchive.cpp.orig
++++ libs/serialization/src/text_wiarchive.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -27,9 +29,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_wiarchive>;
+-template class basic_text_iarchive<text_wiarchive> ;
+-template class text_wiarchive_impl<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_iarchive<text_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_wiarchive_impl<text_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/text_woarchive.cpp.orig
++++ libs/serialization/src/text_woarchive.cpp
+@@ -15,7 +15,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/text_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -26,9 +28,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<text_woarchive>;
+-template class basic_text_oarchive<text_woarchive> ;
+-template class text_woarchive_impl<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<text_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_text_oarchive<text_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE text_woarchive_impl<text_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_grammar.cpp.orig
++++ libs/serialization/src/xml_grammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -67,7 +69,7 @@
+ namespace archive {
+ 
+ // explicit instantiation of xml for 8 bit characters
+-template class basic_xml_grammar<char>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<char>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_iarchive.cpp.orig
++++ libs/serialization/src/xml_iarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_iarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_iarchive>;
+-template class basic_xml_iarchive<xml_iarchive> ;
+-template class xml_iarchive_impl<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_iarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_iarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_iarchive_impl<xml_iarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_oarchive.cpp.orig
++++ libs/serialization/src/xml_oarchive.cpp
+@@ -14,7 +14,9 @@
+ 
+ #define BOOST_ARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_oarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -25,9 +27,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_oarchive>;
+-template class basic_xml_oarchive<xml_oarchive> ;
+-template class xml_oarchive_impl<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_oarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_oarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_oarchive_impl<xml_oarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wgrammar.cpp.orig
++++ libs/serialization/src/xml_wgrammar.cpp
+@@ -16,7 +16,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/impl/basic_xml_grammar.hpp>
++#pragma GCC visibility pop
+ 
+ using namespace boost::spirit::classic;
+ 
+@@ -149,7 +151,7 @@
+ namespace archive {
+ 
+ // explicit instantiation of xml for wide characters
+-template class basic_xml_grammar<wchar_t>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_grammar<wchar_t>;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_wiarchive.cpp.orig
++++ libs/serialization/src/xml_wiarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_wiarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of xml stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_wiarchive>;
+-template class basic_xml_iarchive<xml_wiarchive> ;
+-template class xml_wiarchive_impl<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_wiarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_iarchive<xml_wiarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_wiarchive_impl<xml_wiarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost
+--- libs/serialization/src/xml_woarchive.cpp.orig
++++ libs/serialization/src/xml_woarchive.cpp
+@@ -19,7 +19,9 @@
+ 
+ #define BOOST_WARCHIVE_SOURCE
+ #include <boost/serialization/config.hpp>
++#pragma GCC visibility push(default)
+ #include <boost/archive/xml_woarchive.hpp>
++#pragma GCC visibility pop
+ #include <boost/archive/detail/archive_serializer_map.hpp>
+ 
+ // explicitly instantiate for this type of text stream
+@@ -30,9 +32,9 @@
+ namespace boost {
+ namespace archive {
+ 
+-template class detail::archive_serializer_map<xml_woarchive>;
+-template class basic_xml_oarchive<xml_woarchive> ;
+-template class xml_woarchive_impl<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE detail::archive_serializer_map<xml_woarchive>;
++template class BOOST_SYMBOL_VISIBLE basic_xml_oarchive<xml_woarchive> ;
++template class BOOST_SYMBOL_VISIBLE xml_woarchive_impl<xml_woarchive> ;
+ 
+ } // namespace archive
+ } // namespace boost

--- a/devel/boost192/files/patch-legacysupport.diff
+++ b/devel/boost192/files/patch-legacysupport.diff
@@ -1,0 +1,11 @@
+--- bootstrap.sh.orig	2024-12-05 08:53:27.000000000 +0800
++++ bootstrap.sh	2025-01-17 13:16:35.000000000 +0800
+@@ -226,7 +226,7 @@
+ if test "x$BJAM" = x; then
+   $ECHO "Building B2 engine.."
+   pwd=`pwd`
+-  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" ${TOOLSET}
++  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" --cxxflags="-isystem@PREFIX@/include/LegacySupport -Wl,-lMacportsLegacySupport" ${TOOLSET}
+   if [ $? -ne 0 ]; then
+       echo
+       echo "Failed to build B2 build engine"

--- a/devel/boost192/files/patch-libs-mpi-build-Jamfile.v2.diff
+++ b/devel/boost192/files/patch-libs-mpi-build-Jamfile.v2.diff
@@ -1,0 +1,26 @@
+--- libs/mpi/build/Jamfile.v2.orig
++++ libs/mpi/build/Jamfile.v2
+@@ -49,6 +49,7 @@
+     <link>shared:<define>BOOST_MPI_DYN_LINK=1
+   : # Default build
+     <link>shared
++    <threading>multi
+   : # Usage requirements
+     <library>../../serialization/build//boost_serialization
+     <library>/mpi//mpi [ mpi.extra-requirements ]
+@@ -95,6 +96,7 @@
+                 <python>$(py$(N)-version)
+               : # Default build
+                 <link>shared
++                <threading>multi
+               : # Usage requirements
+                 <library>/mpi//mpi [ mpi.extra-requirements ]
+               ;
+@@ -122,6 +124,7 @@
+                 <link>shared:<define>BOOST_MPI_PYTHON_DYN_LINK=1
+                 <link>shared:<define>BOOST_PYTHON_DYN_LINK=1
+                 <link>shared <runtime-link>shared
++                <threading>multi
+                 <python-debugging>on:<define>BOOST_DEBUG_PYTHON
+                 <python>$(py$(N)-version)
+               ;

--- a/devel/boost192/files/patch-process-PROC_PPID_ONLY.diff
+++ b/devel/boost192/files/patch-process-PROC_PPID_ONLY.diff
@@ -1,0 +1,33 @@
+From 0ca663c8262b65ccee9a4e6abbafaef710f6b36f Mon Sep 17 00:00:00 2001
+From: Klemens Morgenstern <klemens.morgenstern@gmx.net>
+Date: Sun, 26 Jan 2025 21:49:25 +0800
+Subject: [PATCH] Set ENOTSUP when PROC_PPID_ONLY is undefined
+
+closes #452
+---
+ src/pid.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/pid.cpp b/src/pid.cpp
+index 7fa5f822c..322405907 100644
+--- libs/process/src/pid.cpp
++++ libs/process/src/pid.cpp
+@@ -178,6 +178,8 @@ pid_type parent_pid(pid_type pid, error_code & ec)
+ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+ {
+     std::vector<pid_type> vec;
++#if defined(PROC_PPID_ONLY)
++
+     vec.resize(proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, nullptr, 0) / sizeof(pid_type));
+     const auto sz = proc_listpids(PROC_PPID_ONLY, (uint32_t)pid, &vec[0], sizeof(pid_type) * vec.size());
+     if (sz < 0)
+@@ -186,6 +188,9 @@ std::vector<pid_type> child_pids(pid_type pid, error_code & ec)
+         return {};
+     }
+     vec.resize(sz);
++#else
++    BOOST_PROCESS_V2_ASSIGN_EC(ec, ENOTSUP, system_category());
++#endif
+     return vec;
+ }
+ 

--- a/devel/boost192/files/patch-revert-lib-name-tagged.diff
+++ b/devel/boost192/files/patch-revert-lib-name-tagged.diff
@@ -1,0 +1,11 @@
+--- boostcpp.jam.orig
++++ boostcpp.jam
+@@ -163,7 +163,7 @@
+             <base> <threading> <runtime> ;
+     case 1.69 :
+         .format-name-args =
+-            <base> <threading> <runtime> <arch-and-model> ;
++            <base> <threading> <runtime> ;
+     }
+ }
+ else if $(layout) = system

--- a/devel/boost192/files/patch-tiger-availability.diff
+++ b/devel/boost192/files/patch-tiger-availability.diff
@@ -1,0 +1,11 @@
+--- boost/core/uncaught_exceptions.hpp.orig
++++ boost/core/uncaught_exceptions.hpp
+@@ -27,7 +27,7 @@
+ #endif
+ 
+ #if defined(__APPLE__)
+-#include <Availability.h>
++#include <AvailabilityMacros.h>
+ // Apple systems only support std::uncaught_exceptions starting with specific versions:
+ // - Mac OS >= 10.12
+ // - iOS >= 10.0

--- a/devel/boost192/files/patch-tools-build-src-tools-python-2.jam.diff
+++ b/devel/boost192/files/patch-tools-build-src-tools-python-2.jam.diff
@@ -1,0 +1,16 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -545,6 +545,13 @@
+         libraries ?= $(default-library-path) ;
+         includes ?= $(default-include-path) ;
+     }
++    else if $(target-os) = darwin
++    {
++        includes ?= $(prefix)/Headers ;
++
++        local lib = $(exec-prefix)/lib ;
++        libraries ?= $(lib)/python$(version)/config $(lib) ;
++    }
+     else
+     {
+         local default-include-path = $(prefix)/include/python$(version) ;

--- a/devel/boost192/files/patch-tools-build-src-tools-python.jam.diff
+++ b/devel/boost192/files/patch-tools-build-src-tools-python.jam.diff
@@ -1,0 +1,11 @@
+--- tools/build/src/tools/python.jam.orig
++++ tools/build/src/tools/python.jam
+@@ -434,7 +434,7 @@
+     version ?= $(.version-countdown) ;
+ 
+     local prefix
+-      = [ GLOB /System/Library/Frameworks /Library/Frameworks
++      = [ GLOB @FRAMEWORKS_DIR@
+           : Python.framework ] ;
+ 
+     return $(prefix)/Versions/$(version)/bin/python ;


### PR DESCRIPTION
#### Description

###### Tested on
```
Model Identifier: MacPro5,1     macOS 15.7.8 24G824 x86_64
Xcode 26.3 17C529               Command Line Tools 26.3.0.0.1.1771626560

Model Identifier: Macmini6,1    macOS 10.15.8 19H2036 x86_64
Xcode 12.4 12D4e                Command Line Tools 12.4.0.0.1.161013581

Model Identifier: Mac14,3       macOS 26.6.2 25G83 arm64
Xcode not installed             Command Line Tools 26.6.0.0.1781586589
```

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

