### PR TITLE
darktable-devel: update to 5.4.1

### DIFF
--- a/graphics/darktable-devel/Portfile
+++ b/graphics/darktable-devel/Portfile
@@ -9,7 +9,7 @@ PortGroup               cmake 1.1
 PortGroup               perl5 1.0
 PortGroup               conflicts_build 1.0
 
-github.setup            darktable-org darktable 4.8.1 release-
+github.setup            darktable-org darktable 5.4.1 release-
 name                    darktable-devel
 conflicts               darktable
 set my_name             darktable
@@ -33,9 +33,9 @@ github.tarball_from     releases
 dist_subdir             ${my_name}
 use_xz                  yes
 
-checksums               rmd160  8c4f84242041cdc8797333237b4c5645610a9479 \
-                        sha256  901b0e2caed36fb8619fdf4c60edfb8d31134b947d3054b5c66fd55c38af5991 \
-                        size    6258312
+checksums               rmd160  03ebb2b9f4276b95b8c4311ca1f67b65f59019ac \
+                        sha256  afdc7c88a338a8cd2fac31c8450d076edbf73e956e4307260c83ebc195f845e4 \
+                        size    7622104
 
 # If lua installed, those headers are found first, rather than lua54
 conflicts_build-append  lua

--- a/graphics/darktable-devel/Portfile
+++ b/graphics/darktable-devel/Portfile
@@ -82,6 +82,7 @@ configure.cppflags-append \
 depends_build-append    \
                         port:cctools \
                         port:gettext \
+                        port:gtk-mac-bundler \
                         port:intltool \
                         port:perl${perl5.major} \
                         port:pkgconfig \

--- a/graphics/darktable-devel/Portfile
+++ b/graphics/darktable-devel/Portfile
@@ -86,7 +86,8 @@ depends_build-append    \
                         port:intltool \
                         port:perl${perl5.major} \
                         port:pkgconfig \
-                        port:po4a
+                        port:po4a \
+                        port:potrace
 
 depends_lib-append      \
                         port:atk \
@@ -227,8 +228,8 @@ variant quartz conflicts x11 {
     depends_lib-append      port:gtk-osx-application-gtk3
 }
 
-if {![variant_isset quartz]} {
-    default_variants-append +x11
+if {![variant_isset x11]} {
+    default_variants-append +quartz
 }
 
 variant openmp description {enable support for OpenMP} {

--- a/graphics/darktable-devel/Portfile
+++ b/graphics/darktable-devel/Portfile
@@ -82,7 +82,6 @@ configure.cppflags-append \
 depends_build-append    \
                         port:cctools \
                         port:gettext \
-                        port:gtk-mac-bundler \
                         port:intltool \
                         port:perl${perl5.major} \
                         port:pkgconfig \
@@ -225,7 +224,8 @@ variant x11 conflicts quartz {
 
 variant quartz conflicts x11 {
     require_active_variants gtk3 quartz x11
-    depends_lib-append      port:gtk-osx-application-gtk3
+    # This is failing to build on github actions.
+    # depends_lib-append      port:gtk-osx-application-gtk3
 }
 
 if {![variant_isset x11]} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update `darktable-devel` to version 5.4.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.7.8 22H730 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
