### PR TITLE
vapoursynth: use patch instead of legacysupport for std::iochars

### DIFF
--- a/multimedia/vapoursynth/Portfile
+++ b/multimedia/vapoursynth/Portfile
@@ -2,11 +2,10 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
-PortGroup               legacysupport 1.1
 
 github.setup            vapoursynth vapoursynth 73 R
 github.tarball_from     archive
-revision                0
+revision                1
 
 description             A video processing framework with simplicity in mind
 
@@ -28,19 +27,14 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
 compiler.cxx_standard   2014
 compiler.thread_local_storage yes
 
-# VapourSynth 73 uses floating-point std::to_chars, which the system
-# libc++ does not provide cleanly on Darwin 22 and earlier.
-legacysupport.newest_darwin_requires_legacy \
-                        22
-legacysupport.use_mp_libcxx \
-                        yes
-
 set python_branch       3.14
 set python_version      [string map {. {}} ${python_branch}]
 
 use_autoreconf          yes
 autoreconf.cmd          ./autogen.sh
 autoreconf.args
+
+patchfiles-append       patch-src-vspipe-double-to-string.diff
 
 depends_build-append    port:autoconf \
                         port:automake \

--- a/multimedia/vapoursynth/files/patch-src-vspipe-double-to-string.diff
+++ b/multimedia/vapoursynth/files/patch-src-vspipe-double-to-string.diff
@@ -1,0 +1,67 @@
+--- src/vspipe/vsjson.cpp.orig
++++ src/vspipe/vsjson.cpp
+@@ -21,4 +21,8 @@
+ #include "vsjson.h"
+ #include <charconv>
++#include <iomanip>
++#include <limits>
++#include <locale>
++#include <sstream>
+ 
+ static bool isAsciiPrintable(const std::string &s) {
+@@ -31,5 +35,21 @@ static bool isAsciiPrintable(const std::string &s) {
+ static std::string doubleToString(double v) {
++#if defined(__APPLE__) && defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 130300
++    std::ostringstream stream;
++    stream.imbue(std::locale::classic());
++    stream << std::fixed << std::setprecision(std::numeric_limits<double>::max_digits10) << v;
++
++    std::string result = stream.str();
++    if (const auto dot = result.find('.'); dot != std::string::npos) {
++        result.erase(result.find_last_not_of('0') + 1);
++        if (!result.empty() && result.back() == '.')
++            result.pop_back();
++    }
++    if (result == "-0")
++        result = "0";
++    return result;
++#else
+     char buffer[100];
+     auto res = std::to_chars(buffer, buffer + sizeof(buffer), v, std::chars_format::fixed);
+     return std::string(buffer, res.ptr - buffer);
++#endif
+ }
+--- src/vspipe/vspipe.cpp.orig
++++ src/vspipe/vspipe.cpp
+@@ -32,5 +32,9 @@
+ #include <algorithm>
+ #include <chrono>
+ #include <charconv>
++#include <iomanip>
++#include <limits>
++#include <locale>
++#include <sstream>
+ #include <filesystem>
+ #include "../common/wave.h"
+@@ -282,5 +286,21 @@ static void outputFrame(const VSFrame *frame, VSPipeOutputData *data) {
+ static std::string doubleToString(double v) {
++#if defined(__APPLE__) && defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 130300
++    std::ostringstream stream;
++    stream.imbue(std::locale::classic());
++    stream << std::fixed << std::setprecision(std::numeric_limits<double>::max_digits10) << v;
++
++    std::string result = stream.str();
++    if (const auto dot = result.find('.'); dot != std::string::npos) {
++        result.erase(result.find_last_not_of('0') + 1);
++        if (!result.empty() && result.back() == '.')
++            result.pop_back();
++    }
++    if (result == "-0")
++        result = "0";
++    return result;
++#else
+     char buffer[100];
+     auto res = std::to_chars(buffer, buffer + sizeof(buffer), v, std::chars_format::fixed);
+     return std::string(buffer, res.ptr - buffer);
++#endif
+ }


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
