### PR TITLE
ghidra: fix installs x86_64 binary when build_arch is arm64

### DIFF
--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -7,6 +7,7 @@ PortGroup           app 1.0
 
 github.setup        NationalSecurityAgency ghidra 12.0.4 Ghidra_ _build
 github.tarball_from archive
+revision            1
 checksums           rmd160  bb6b1efb6a5074d346fc4c28e933a794f15ecddb \
                     sha256  2650b5c5f2615883db347157f88d15f6f06cd14e223156cd6b6034264081f5b4 \
                     size    78597407
@@ -32,7 +33,7 @@ configure.pre_args  ""
 configure.cmd       gradle -I gradle/support/fetchDependencies.gradle
 build.env-append    GRADLE_USER_HOME=${worksrcpath}
 build.env-append    _JAVA_OPTIONS=-Duser.home=${worksrcpath}
-build.cmd           gradle
+build.cmd           gradle -x FileFormats:extractSevenZipNativeLibs
 build.target        buildGhidra
 
 set ghidra_copy_list \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/73610

#### Description

fix https://trac.macports.org/ticket/73610

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Xcode 26.3 17C529


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
