### PR TITLE
llvm: update {10..22} conflicts_build libuuid

### DIFF
--- a/lang/llvm-10/Portfile
+++ b/lang/llvm-10/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
+PortGroup conflicts_build   1.0
 
 set llvm_version        10
 set llvm_version_no_dot 10
@@ -82,6 +83,9 @@ use_xz                  yes
 extract.suffix          .tar.xz
 distfiles               llvm-${version}.src${extract.suffix}
 worksrcdir              llvm-${version}.src
+
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 if {${distfiles} ne ""} {
     if {${subport} eq "llvm-${llvm_version}"} {

--- a/lang/llvm-11/Portfile
+++ b/lang/llvm-11/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 PortGroup active_variants 1.1
 PortGroup cmake         1.0
 PortGroup legacysupport 1.0
+PortGroup conflicts_build   1.0
 
 # link legacysupport statically for compilers
 legacysupport.use_static yes
@@ -106,6 +107,9 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
 worksrcdir              llvm-project/llvm
 patch.dir               ${workpath}/llvm-project/llvm
+
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 post-extract {
     ln -s ${workpath}/${distname} ${workpath}/llvm-project

--- a/lang/llvm-12/Portfile
+++ b/lang/llvm-12/Portfile
@@ -4,6 +4,7 @@ PortSystem                            1.0
 PortGroup active_variants             1.1
 PortGroup cmake                       1.1
 PortGroup legacysupport               1.0
+PortGroup conflicts_build             1.0
 
 # Do not propagate c/c++ standards as set by base
 cmake.set_c_standard     no
@@ -36,6 +37,9 @@ dist_subdir             llvm
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 worksrcdir              ${worksrcdir}/llvm
+
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*

--- a/lang/llvm-13/Portfile
+++ b/lang/llvm-13/Portfile
@@ -4,6 +4,7 @@ PortSystem                            1.0
 PortGroup active_variants             1.1
 PortGroup cmake                       1.1
 PortGroup legacysupport               1.1
+PortGroup conflicts_build             1.0
 
 # Do not propagate c/c++ standards as set by base
 cmake.set_c_standard     no
@@ -40,6 +41,9 @@ dist_subdir             llvm
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 worksrcdir              ${worksrcdir}/llvm
+
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*

--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -4,6 +4,7 @@ PortSystem                            1.0
 PortGroup active_variants             1.1
 PortGroup cmake                       1.1
 PortGroup legacysupport               1.1
+PortGroup conflicts_build             1.0
 
 # Do not propagate c/c++ standards as set by base
 cmake.set_c_standard     no
@@ -41,6 +42,9 @@ dist_subdir             llvm
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 worksrcdir              ${worksrcdir}/llvm
+
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*

--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -4,6 +4,7 @@ PortSystem                            1.0
 PortGroup active_variants             1.1
 PortGroup cmake                       1.1
 PortGroup legacysupport               1.1
+PortGroup conflicts_build             1.0
 
 # Do not propagate c/c++ standards as set by base
 cmake.set_c_standard     no
@@ -41,6 +42,9 @@ dist_subdir             llvm
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 worksrcdir              ${worksrcdir}/llvm
+
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*

--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -4,6 +4,7 @@ PortSystem                            1.0
 PortGroup active_variants             1.1
 PortGroup cmake                       1.1
 PortGroup legacysupport               1.1
+PortGroup conflicts_build             1.0
 
 # Do not propagate c/c++ standards as set by base
 cmake.set_c_standard                  no
@@ -41,6 +42,9 @@ dist_subdir             llvm
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 worksrcdir              ${worksrcdir}/llvm
+
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*

--- a/lang/llvm-17/Portfile
+++ b/lang/llvm-17/Portfile
@@ -5,6 +5,7 @@ PortGroup active_variants             1.1
 PortGroup cmake                       1.1
 PortGroup legacysupport               1.1
 PortGroup conflicts_build             1.0
+PortGroup conflicts_build             1.0
 
 # Do not propagate c/c++ standards as set by base
 cmake.set_c_standard                  no
@@ -43,6 +44,9 @@ dist_subdir             llvm
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 worksrcdir              ${worksrcdir}/llvm
+
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # https://github.com/macports/macports-ports/commit/a83a493bc21cbe7e14b1f5884379649ec8f31bae#commitcomment-132530885
 conflicts_build-append  libunwind libunwind-headers

--- a/lang/llvm-18/Portfile
+++ b/lang/llvm-18/Portfile
@@ -46,6 +46,8 @@ worksrcdir              ${worksrcdir}/llvm
 
 # https://github.com/macports/macports-ports/commit/a83a493bc21cbe7e14b1f5884379649ec8f31bae#commitcomment-132530885
 conflicts_build-append  libunwind libunwind-headers
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*

--- a/lang/llvm-19/Portfile
+++ b/lang/llvm-19/Portfile
@@ -46,6 +46,8 @@ worksrcdir              ${worksrcdir}/llvm
 
 # https://github.com/macports/macports-ports/commit/a83a493bc21cbe7e14b1f5884379649ec8f31bae#commitcomment-132530885
 conflicts_build-append  libunwind libunwind-headers
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*

--- a/lang/llvm-20/Portfile
+++ b/lang/llvm-20/Portfile
@@ -48,6 +48,8 @@ worksrcdir              ${worksrcdir}/llvm
 conflicts_build-append  libunwind libunwind-headers
 # https://trac.macports.org/ticket/72695
 conflicts_build-append  ocaml-findlib
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*

--- a/lang/llvm-21/Portfile
+++ b/lang/llvm-21/Portfile
@@ -48,6 +48,8 @@ worksrcdir              ${worksrcdir}/llvm
 conflicts_build-append  libunwind libunwind-headers
 # https://trac.macports.org/ticket/72695
 conflicts_build-append  ocaml-findlib
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*

--- a/lang/llvm-22/Portfile
+++ b/lang/llvm-22/Portfile
@@ -48,6 +48,8 @@ worksrcdir              ${worksrcdir}/llvm
 conflicts_build-append  libunwind libunwind-headers
 # https://trac.macports.org/ticket/72695
 conflicts_build-append  ocaml-findlib
+# https://trac.macports.org/ticket/73620
+conflicts_build-append  libuuid
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*


### PR DESCRIPTION
#### Description

added this to all the Ports
```
PortGroup conflicts_build             1.0
# https://trac.macports.org/ticket/73620
conflicts_build-append  libuuid
```

closes  [ticket 73620](https://trac.macports.org/ticket/73620)

```
llvm-22                : fix for 'conflicts_build libuuid'
llvm-21                : fix for 'conflicts_build libuuid'
llvm-20                : fix for 'conflicts_build libuuid'
llvm-19                : fix for 'conflicts_build libuuid'
llvm-18                : fix for 'conflicts_build libuuid'
llvm-17                : fix for 'conflicts_build libuuid'
llvm-16                : fix for 'conflicts_build libuuid'
llvm-15                : fix for 'conflicts_build libuuid'
llvm-14                : fix for 'conflicts_build libuuid'
llvm-13                : fix for 'conflicts_build libuuid'
llvm-12                : fix for 'conflicts_build libuuid'
llvm-11                : fix for 'conflicts_build libuuid'
llvm-10                : fix for 'conflicts_build libuuid'
```