### PR TITLE
clang-16: fix support for macOS 26

### DIFF
--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -323,6 +323,12 @@ if { ${subport} eq "flang-${llvm_version}" } {
     depends_lib-append  port:clang-${llvm_version} port:mlir-${llvm_version}
     depends_run-append  port:bash
 
+    # Xcode Clang 16.3+ (macOS 15+) errors on template keyword without
+    # explicit template arguments in flang/runtime/reduction-templates.h
+    if {[string match *clang* ${configure.compiler}] && ${os.major} >= 24} {
+        configure.cxxflags-append -Wno-missing-template-arg-list-after-template-kw
+    }
+
     # https://trac.macports.org/ticket/72931
     build.mem_per_job   3072
 
@@ -334,7 +340,7 @@ if { ${subport} eq "flang-${llvm_version}" } {
 }
 
 if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_version}" } {
-    platforms {darwin < 25}
+    platforms {darwin < 26}
 
     depends_lib-append  port:libxml2 port:libomp port:llvm-${llvm_version}
     depends_run-append  port:ld64
@@ -372,6 +378,15 @@ if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_versio
         # might be fixable with the use of newer SDK and/or effort if motivated
         # all three toggles are needed to force them off
         # Extended to 10.11 and older, see https://trac.macports.org/ticket/65887
+        configure.args-append    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+                                 -DCOMPILER_RT_BUILD_XRAY=OFF \
+                                 -DCOMPILER_RT_BUILD_MEMPROF=OFF
+    }
+
+    if {${os.platform} eq "darwin" && ${os.major} >= 25} {
+        # tsan and other sanitizers fail to link on macOS 26+ (Darwin 25+) due to
+        # the new Apple ld-prime linker rejecting 32-bit relocations in 64-bit binaries
+        # e.g. tsan_rtl_aarch64.S: "ld: 32-bit pointer in 64-bit arch"
         configure.args-append    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
                                  -DCOMPILER_RT_BUILD_XRAY=OFF \
                                  -DCOMPILER_RT_BUILD_MEMPROF=OFF


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Fix compilation of clang-16 with darwin 25 (macOS 26) by disabling sanitizers that wouldn't link

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 x86_64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
