### PR TITLE
ccache: update to 4.14

### DIFF
--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -3,19 +3,16 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           legacysupport 1.1
-legacysupport.newest_darwin_requires_legacy 18
-legacysupport.use_mp_libcxx yes
 
 # src/third_party/blake3/CMakeLists.txt checks CMAKE_SIZEOF_VOID_P
 PortGroup           muniversal 1.0
 
-github.setup        ccache ccache 4.13.1 v
+github.setup        ccache ccache 4.13.2 v
 revision            0
 
-checksums           rmd160  7441461f9b34838d3dff7a3b42441266ce8d2e5f \
-                    sha256  85638df95c4d3907d9dd686583f2e0b2bd4c232d36e025a5c48e91524b491c4b \
-                    size    534316
+checksums           rmd160  d20e352148771bfab8ddd479a42bbb0f9f206435 \
+                    sha256  4a0d835f1b3fd7e2ac58a511718bbc902532941f377f7990a3d33b5cf8733ba6 \
+                    size    536304
 
 categories          devel
 platforms           darwin freebsd
@@ -47,6 +44,35 @@ depends_build-append \
 depends_lib-append  port:hiredis \
                     port:xxhashlib \
                     port:zstd
+
+# https://trac.macports.org/ticket/69805
+# https://github.com/macports/macports-ports/pull/31641
+# Unfortunately, the current version of
+# macports-libcxx lacks support for std::ranges
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # PowerPCs can use the fresh version of GCC
+    if {[string match *clang* ${configure.compiler}] && ${configure.cxx_stdlib} eq "libc++"} {
+        # use LLVM 16 for best compatibility
+        set llvmversion     16
+        configure.compiler  macports-clang-${llvmversion}
+        depends_lib-append  port:macports-libcxx
+
+        # https://trac.macports.org/ticket/71669
+        configure.cxxflags-append \
+            -isystem${workpath}/include/c++/v1 \
+            -nostdinc++ \
+            -stdlib=libc++
+        configure.ldflags-append \
+            -L${prefix}/lib/libcxx
+
+        post-extract {
+            file mkdir ${workpath}/include/c++
+            copy ${prefix}/libexec/llvm-${llvmversion}/include/c++/v1 ${workpath}/include/c++/
+            # disable Apple libc++ availability tests, as we're using a new libc++ with these headers
+            system -W ${workpath}/include/c++/v1 "patch -p0 < ${filespath}/patch-disable-availability.diff"
+        }
+    }
+}
 
 # Use bundled copies of these dependencies that aren't in MacPorts (or, in the
 # case of fmt, aren't in the standard location).

--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -3,19 +3,16 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           legacysupport 1.1
-legacysupport.newest_darwin_requires_legacy 18
-legacysupport.use_mp_libcxx yes
 
 # src/third_party/blake3/CMakeLists.txt checks CMAKE_SIZEOF_VOID_P
 PortGroup           muniversal 1.0
 
-github.setup        ccache ccache 4.13.1 v
+github.setup        ccache ccache 4.13.6 v
 revision            0
 
-checksums           rmd160  7441461f9b34838d3dff7a3b42441266ce8d2e5f \
-                    sha256  85638df95c4d3907d9dd686583f2e0b2bd4c232d36e025a5c48e91524b491c4b \
-                    size    534316
+checksums           rmd160  31eeb32ccaca42d943472800efb59138f5ae0f12 \
+                    sha256  a7de667ca08cf67c3c8af9f213f6aa701a1188a2b3163fb74483858ce5e79fbb \
+                    size    538628
 
 categories          devel
 platforms           darwin freebsd
@@ -47,6 +44,35 @@ depends_build-append \
 depends_lib-append  port:hiredis \
                     port:xxhashlib \
                     port:zstd
+
+# https://trac.macports.org/ticket/69805
+# https://github.com/macports/macports-ports/pull/31641
+# Unfortunately, the current version of
+# macports-libcxx lacks support for std::ranges
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # PowerPCs can use the fresh version of GCC
+    if {[string match *clang* ${configure.compiler}] && ${configure.cxx_stdlib} eq "libc++"} {
+        # use LLVM 16 for best compatibility
+        set llvmversion     16
+        configure.compiler  macports-clang-${llvmversion}
+        depends_lib-append  port:macports-libcxx
+
+        # https://trac.macports.org/ticket/71669
+        configure.cxxflags-append \
+            -isystem${workpath}/include/c++/v1 \
+            -nostdinc++ \
+            -stdlib=libc++
+        configure.ldflags-append \
+            -L${prefix}/lib/libcxx
+
+        post-extract {
+            file mkdir ${workpath}/include/c++
+            copy ${prefix}/libexec/llvm-${llvmversion}/include/c++/v1 ${workpath}/include/c++/
+            # disable Apple libc++ availability tests, as we're using a new libc++ with these headers
+            system -W ${workpath}/include/c++/v1 "patch -p0 < ${filespath}/patch-disable-availability.diff"
+        }
+    }
+}
 
 # Use bundled copies of these dependencies that aren't in MacPorts (or, in the
 # case of fmt, aren't in the standard location).

--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -3,19 +3,16 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           legacysupport 1.1
-legacysupport.newest_darwin_requires_legacy 18
-legacysupport.use_mp_libcxx yes
 
 # src/third_party/blake3/CMakeLists.txt checks CMAKE_SIZEOF_VOID_P
 PortGroup           muniversal 1.0
 
-github.setup        ccache ccache 4.13.1 v
+github.setup        ccache ccache 4.14 v
 revision            0
 
-checksums           rmd160  7441461f9b34838d3dff7a3b42441266ce8d2e5f \
-                    sha256  85638df95c4d3907d9dd686583f2e0b2bd4c232d36e025a5c48e91524b491c4b \
-                    size    534316
+checksums           rmd160  815929aa1b9e1b2d72f7b9a9f81a44a8724d7604 \
+                    sha256  b093ac5d38204cb4d9f29b0bbd570675aa5a592a78e6675b2c506dbe045234e7 \
+                    size    551012
 
 categories          devel
 platforms           darwin freebsd
@@ -47,6 +44,35 @@ depends_build-append \
 depends_lib-append  port:hiredis \
                     port:xxhashlib \
                     port:zstd
+
+# https://trac.macports.org/ticket/69805
+# https://github.com/macports/macports-ports/pull/31641
+# Unfortunately, the current version of
+# macports-libcxx lacks support for std::ranges
+if {${os.platform} eq "darwin" && ${os.major} < 19} {
+    # PowerPCs can use the fresh version of GCC
+    if {[string match *clang* ${configure.compiler}] && ${configure.cxx_stdlib} eq "libc++"} {
+        # use LLVM 16 for best compatibility
+        set llvmversion     16
+        configure.compiler  macports-clang-${llvmversion}
+        depends_lib-append  port:macports-libcxx
+
+        # https://trac.macports.org/ticket/71669
+        configure.cxxflags-append \
+            -isystem${workpath}/include/c++/v1 \
+            -nostdinc++ \
+            -stdlib=libc++
+        configure.ldflags-append \
+            -L${prefix}/lib/libcxx
+
+        post-extract {
+            file mkdir ${workpath}/include/c++
+            copy ${prefix}/libexec/llvm-${llvmversion}/include/c++/v1 ${workpath}/include/c++/
+            # disable Apple libc++ availability tests, as we're using a new libc++ with these headers
+            system -W ${workpath}/include/c++/v1 "patch -p0 < ${filespath}/patch-disable-availability.diff"
+        }
+    }
+}
 
 # Use bundled copies of these dependencies that aren't in MacPorts (or, in the
 # case of fmt, aren't in the standard location).

--- a/devel/ccache/files/patch-disable-availability.diff
+++ b/devel/ccache/files/patch-disable-availability.diff
@@ -1,0 +1,12 @@
+--- __config.orig	2023-11-28 17:52:28.000000000 +0900
++++ __config	2026-02-09 03:50:00.000000000 +0900
+@@ -33,6 +33,9 @@
+ #  define _LIBCPP_COMPILER_GCC
+ #endif
+ 
++// we are not going to use Apple Availability testing in these headers
++#define _LIBCPP_DISABLE_AVAILABILITY
++
+ #ifdef __cplusplus
+ 
+ // The attributes supported by clang are documented at https://clang.llvm.org/docs/AttributeReference.html


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?