### PR TITLE
mariadb-10.6: update to 10.6.26 ; boost188

### DIFF
--- a/databases/mariadb-10.6/Portfile
+++ b/databases/mariadb-10.6/Portfile
@@ -7,25 +7,25 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-10.6
 set name_mysql      ${name}
-version             10.6.21
+version             10.6.25
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 1
+set revision_client 0
 set revision_server 0
 categories          databases
 homepage            https://mariadb.org/
-maintainers         {michaelld @michaelld} openmaintainer
+maintainers         {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 
 if {$subport eq $name} {
 
-    PortGroup           cmake 1.0
+    PortGroup           cmake 1.1
     PortGroup           select 1.0
     PortGroup           boost 1.0
     PortGroup           openssl 1.0
 
-    boost.version       1.78
+    boost.version       1.88
     compiler.cxx_standard 2011
 
     openssl.branch      3
@@ -39,13 +39,13 @@ if {$subport eq $name} {
     description         Multithreaded SQL database server
     long_description    Mariadb is a fork of the MySQL server, a multi-threaded SQL database.
 
-    cmake.out_of_source yes
-
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160  e70ac80ebd93515ff9373e3bba561568ecd06d31 \
-                    sha256  8d7f97169b3ba2044858965b8cfc254364400df43e905042f92e24b8fa7b0d96 \
-                    size    103982296
+    checksums       rmd160  0703bdecf5e794c55e6827a4b83458d6d57d43bc \
+                    sha256  ae221fbcaf3730070343e848e11e256092ba52c6fcf51a510374931720240a6c \
+                    size    108006288
+
+    cmake.build_type    Release
 
     depends_build-append port:bison
     depends_lib-append  port:curl \
@@ -54,6 +54,7 @@ if {$subport eq $name} {
                         port:ncurses \
                         port:pcre2 \
                         port:tcp_wrappers \
+                        port:lzo2 \
                         port:zlib
     depends_run-append  port:mysql_select
 
@@ -74,17 +75,16 @@ if {$subport eq $name} {
                    patch-libmariadb_libmariadb_CMakeLists.txt.diff \
                    patch-server_storage_perfschema_my_thread.h.diff \
                    patch-cmake_mysql_version.cmake.diff \
-                   patch-cmake_mysql_columnstore_version.cmake.diff
+                   patch-cmake_mysql_columnstore_version.cmake.diff \
+                   patch-client_mysqltest.cc.diff
     
     # temporary fix for C/C++ flag discovery
     patchfiles-append patch-fix-flag-discovery.diff
 
     post-patch {
         reinplace "s|@NAME@|${name_mysql}|g" \
-            ${worksrcpath}/cmake/install_layout.cmake
-        reinplace "s|@NAME@|${name_mysql}|g" \
-            ${worksrcpath}/libmariadb/cmake/install.cmake
-        reinplace "s|@NAME@|${name_mysql}|g" \
+            ${worksrcpath}/cmake/install_layout.cmake \
+            ${worksrcpath}/libmariadb/cmake/install.cmake \
             ${cmake.build_dir}/macports/macports-default.cnf \
             ${cmake.build_dir}/macports/my.cnf
         reinplace "s|@PREFIX@|${prefix}|g" \
@@ -107,10 +107,10 @@ if {$subport eq $name} {
                         -DWITH_EMBEDDED_SERVER:BOOL=ON \
                         -DWITH_ZLIB:STRING=system \
                         -DWITH_UNIT_TESTS:BOOL=ON \
-                        -DWITHOUT_CASSANDRA_STORAGE_ENGINE:BOOL=ON \
-                        -DWITHOUT_MROONGA_STORAGE_ENGINE:BOOL=ON \
-                        -DWITHOUT_ROCKSDB_STORAGE_ENGINE:BOOL=ON \
-                        -DWITHOUT_TOKUDB_STORAGE_ENGINE:BOOL=ON \
+                        -DPLUGIN_CASSANDRA=NO \
+                        -DPLUGIN_MROONGA=NO \
+                        -DPLUGIN_ROCKSDB=NO \
+                        -DPLUGIN_TOKUDB=NO \
                         -DENABLE_GCOV:BOOL=OFF \
                         -DENABLE_DTRACE:BOOL=OFF \
                         -DWITH_READLINE:BOOL=ON \
@@ -268,7 +268,7 @@ If this is a new install you might want to run:
 
 \$ sudo mkdir -p ${prefix}/var/db/${name_mysql}
 \$ sudo chown ${mysqluser}:${mysqluser} ${prefix}/var/db/${name_mysql}
-\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mariadb_install_db
+\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mariadb-install-db
 "
 
     livecheck.type          none

--- a/databases/mariadb-10.6/Portfile
+++ b/databases/mariadb-10.6/Portfile
@@ -7,25 +7,25 @@ legacysupport.newest_darwin_requires_legacy 15
 
 name                mariadb-10.6
 set name_mysql      ${name}
-version             10.6.21
+version             10.6.26
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 1
+set revision_client 0
 set revision_server 0
 categories          databases
 homepage            https://mariadb.org/
-maintainers         {michaelld @michaelld} openmaintainer
+maintainers         {mathiesen.info:macintosh @BjarneDMat} openmaintainer
 
 if {$subport eq $name} {
 
-    PortGroup           cmake 1.0
+    PortGroup           cmake 1.1
     PortGroup           select 1.0
     PortGroup           boost 1.0
     PortGroup           openssl 1.0
 
-    boost.version       1.78
+    boost.version       1.88
     compiler.cxx_standard 2011
 
     openssl.branch      3
@@ -39,13 +39,13 @@ if {$subport eq $name} {
     description         Multithreaded SQL database server
     long_description    Mariadb is a fork of the MySQL server, a multi-threaded SQL database.
 
-    cmake.out_of_source yes
-
     master_sites    https://downloads.mariadb.org/rest-api/mariadb/${version}/
     distname        mariadb-${version}
-    checksums       rmd160  e70ac80ebd93515ff9373e3bba561568ecd06d31 \
-                    sha256  8d7f97169b3ba2044858965b8cfc254364400df43e905042f92e24b8fa7b0d96 \
-                    size    103982296
+    checksums       rmd160  3fdc07f86469747f9a85276bdcd03168ae95a0ee \
+                    sha256  53b8852704e82ac09864c1f2da31b60519f824b3aac17ab9e22d3849fa712f6c \
+                    size    109044867
+
+    cmake.build_type    Release
 
     depends_build-append port:bison
     depends_lib-append  port:curl \
@@ -54,6 +54,7 @@ if {$subport eq $name} {
                         port:ncurses \
                         port:pcre2 \
                         port:tcp_wrappers \
+                        port:lzo2 \
                         port:zlib
     depends_run-append  port:mysql_select
 
@@ -74,17 +75,16 @@ if {$subport eq $name} {
                    patch-libmariadb_libmariadb_CMakeLists.txt.diff \
                    patch-server_storage_perfschema_my_thread.h.diff \
                    patch-cmake_mysql_version.cmake.diff \
-                   patch-cmake_mysql_columnstore_version.cmake.diff
+                   patch-cmake_mysql_columnstore_version.cmake.diff \
+                   patch-client_mysqltest.cc.diff
     
     # temporary fix for C/C++ flag discovery
     patchfiles-append patch-fix-flag-discovery.diff
 
     post-patch {
         reinplace "s|@NAME@|${name_mysql}|g" \
-            ${worksrcpath}/cmake/install_layout.cmake
-        reinplace "s|@NAME@|${name_mysql}|g" \
-            ${worksrcpath}/libmariadb/cmake/install.cmake
-        reinplace "s|@NAME@|${name_mysql}|g" \
+            ${worksrcpath}/cmake/install_layout.cmake \
+            ${worksrcpath}/libmariadb/cmake/install.cmake \
             ${cmake.build_dir}/macports/macports-default.cnf \
             ${cmake.build_dir}/macports/my.cnf
         reinplace "s|@PREFIX@|${prefix}|g" \
@@ -107,10 +107,10 @@ if {$subport eq $name} {
                         -DWITH_EMBEDDED_SERVER:BOOL=ON \
                         -DWITH_ZLIB:STRING=system \
                         -DWITH_UNIT_TESTS:BOOL=ON \
-                        -DWITHOUT_CASSANDRA_STORAGE_ENGINE:BOOL=ON \
-                        -DWITHOUT_MROONGA_STORAGE_ENGINE:BOOL=ON \
-                        -DWITHOUT_ROCKSDB_STORAGE_ENGINE:BOOL=ON \
-                        -DWITHOUT_TOKUDB_STORAGE_ENGINE:BOOL=ON \
+                        -DPLUGIN_CASSANDRA=NO \
+                        -DPLUGIN_MROONGA=NO \
+                        -DPLUGIN_ROCKSDB=NO \
+                        -DPLUGIN_TOKUDB=NO \
                         -DENABLE_GCOV:BOOL=OFF \
                         -DENABLE_DTRACE:BOOL=OFF \
                         -DWITH_READLINE:BOOL=ON \
@@ -268,7 +268,7 @@ If this is a new install you might want to run:
 
 \$ sudo mkdir -p ${prefix}/var/db/${name_mysql}
 \$ sudo chown ${mysqluser}:${mysqluser} ${prefix}/var/db/${name_mysql}
-\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mariadb_install_db
+\$ sudo -u ${mysqluser} ${prefix}/lib/${name_mysql}/bin/mariadb-install-db
 "
 
     livecheck.type          none

--- a/databases/mariadb-10.6/files/patch-client_mysqltest.cc.diff
+++ b/databases/mariadb-10.6/files/patch-client_mysqltest.cc.diff
@@ -1,0 +1,13 @@
+https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=293044
+https://jira.mariadb.org/browse/MDEV-38777
+
+--- a/client/mysqltest.cc.orig	2026-01-31 11:50:12.000000000 +0100
++++ b/client/mysqltest.cc	2026-02-08 10:42:07.309651000 +0100
+@@ -35,6 +35,7 @@
+ 
+ #define VER "3.5"
+ 
++#include <ctype.h>
+ #include "client_priv.h"
+ #include <mysql_version.h>
+ #include <mysqld_error.h>

--- a/databases/mariadb-10.6/files/patch-sql-my_json_writer.cc.diff
+++ b/databases/mariadb-10.6/files/patch-sql-my_json_writer.cc.diff
@@ -1,0 +1,25 @@
+# https://github.com/macports/macports-ports/pull/28680#issuecomment-3913517186
+--- a/sql/my_json_writer.cc	2026-02-17 17:18:40
++++ b/sql/my_json_writer.cc	2026-02-17 17:19:48
+@@ -234,8 +234,10 @@
+ 
+ void Json_writer::add_unquoted_str(const char* str, size_t len)
+ {
++#if !defined(NDEBUG) || defined(JSON_WRITER_UNIT_TEST)
+   VALIDITY_ASSERT(fmt_helper.is_making_writer_calls() ||
+                   got_name == named_item_expected());
++#endif
+   if (on_add_str(str, len))
+     return;
+ 
+@@ -267,8 +269,10 @@
+ 
+ void Json_writer::add_str(const char* str, size_t num_bytes)
+ {
++#if !defined(NDEBUG) || defined(JSON_WRITER_UNIT_TEST)
+   VALIDITY_ASSERT(fmt_helper.is_making_writer_calls() ||
+                   got_name == named_item_expected());
++#endif
+   if (on_add_str(str, num_bytes))
+     return;
+ 


### PR DESCRIPTION
for discussion see : 
- #28680 
###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix
###### Tested on
```
Model Identifier: MacPro5,1                 Model Identifier: Macmini6,1
macOS 15.7.4 24G517 x86_64                  macOS 10.15.8 19H2036 x86_64
Xcode 26.3 17C529                           Xcode 12.4 12D4e
Command Line Tools 26.2.0.0.1.1764812424    Command Line Tools 12.4.0.0.1.1610135815
```
