### PR TITLE
betterleaks: new port (v1.1.1)

### DIFF
--- a/security/betterleaks/Portfile
+++ b/security/betterleaks/Portfile
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/betterleaks/betterleaks 1.1.1 v
+go.offline_build    no
+revision            0
+
+homepage            https://betterleaks.com/
+
+description         \
+    A Better Secrets Scanner built for configurability and speed
+
+long_description    \
+    Betterleaks is a tool for detecting secrets like passwords, API keys, and \
+    tokens in git repos, files, and whatever else you wanna throw at it via \
+    stdin.
+
+categories          security
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  86260ea706330aacda794d5cd371c50c50dba208 \
+                    sha256  1014a8213fe6d2375a09231c7243ada5f59097f1f766307bdef0d566820c480b \
+                    size    520770
+
+build.cmd           make
+build.pre_args-append \
+                    VERSION=${github.tag_prefix}${version}
+build.args          build
+
+post-build {
+    system -W ${worksrcpath} "./${name} completion bash > ${name}.bash"
+    system -W ${worksrcpath} "./${name} completion fish > ${name}.fish"
+    system -W ${worksrcpath} "./${name} completion zsh > ${name}.zsh"
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    set bash_completions_dir share/bash-completion/completions
+    xinstall -d ${destroot}${prefix}/${bash_completions_dir}
+    xinstall -m 0644 ${worksrcpath}/${name}.bash \
+        ${destroot}${prefix}/${bash_completions_dir}/${name}
+
+    set fish_completions_dir share/fish/vendor_completions.d
+    xinstall -d ${destroot}${prefix}/${fish_completions_dir}
+    xinstall -m 0644 ${worksrcpath}/${name}.fish \
+        ${destroot}${prefix}/${fish_completions_dir}
+
+    set zsh_completions_dir share/zsh/site-functions
+    xinstall -d ${destroot}${prefix}/${zsh_completions_dir}
+    xinstall -m 0644 ${worksrcpath}/${name}.zsh \
+        ${destroot}${prefix}/${zsh_completions_dir}/_${name}
+}


### PR DESCRIPTION
https://betterleaks.com/

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
