### PR TITLE
macports-libcxx: add +experimental variant

### DIFF
--- a/lang/macports-libcxx/Portfile
+++ b/lang/macports-libcxx/Portfile
@@ -16,10 +16,30 @@ long_description    This port installs a recent libc++ from llvm \
 # for now, we will leverage the already-built libc++ in the appropriate clang port
 # later, we can build this independently if we choose to do so, much like libtapi
 
-# the clang-11 version in use when this port is updated will be used
 version             11.1.0
-set clangversion    11
 revision            0
+
+master_sites
+distfiles
+use_configure no
+build {}
+variant universal {}
+
+variant experimental description {Install LLVM 16-based libc++ (experimental)} {}
+
+set clangversion ""
+set llvm_include_path ""
+set llvm_libcxx_path ""
+# the clang-11 version in use when this port is updated will be used
+if {[variant_isset experimental]} {
+    set clangversion 16
+    set llvm_include_path include/c++/v1
+    set llvm_libcxx_path lib/libc++
+} else {
+    set clangversion 11
+    set llvm_include_path lib/c++/v1
+    set llvm_libcxx_path lib
+}
 
 depends_build       port:clang-${clangversion}
 
@@ -37,40 +57,38 @@ if {[string match ${configure.compiler} "macports-clang-${clangversion}"]} {
     configure.compiler  cc
 }
 
-master_sites
-distfiles
-fetch {}
-checksum {}
-use_configure no
-build {}
-variant universal {}
-
 destroot {
 
     xinstall -d ${destroot}${prefix}/include/libcxx
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/c++/v1 ${destroot}${prefix}/include/libcxx/
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_include_path} ${destroot}${prefix}/include/libcxx/
 
     # disable Apple libc++ availability tests, as we're using a new libc++ with these headers
     system -W ${destroot}${prefix}/include/libcxx/v1 "patch -p0 < ${filespath}/patch-disable-availabilty.diff"
 
     xinstall -d ${destroot}${prefix}/lib/libcxx
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++.1.0.dylib
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++.1.0.dylib
     system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -id ${prefix}/lib/libcxx/libc++.1.0.dylib libc++.1.0.dylib"
-    system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++.1.0.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -change @rpath/libc++abi.1.dylib ${prefix}/lib/libcxx/libc++abi.1.dylib libc++.1.0.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++.1.0.dylib libc++.1.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++.1.dylib libc++.dylib"
 
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++abi.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++abi.1.0.dylib
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++abi.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++abi.1.0.dylib
     system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -id ${prefix}/lib/libcxx/libc++abi.1.0.dylib libc++abi.1.0.dylib"
-    system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++abi.1.0.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++abi.1.0.dylib libc++abi.1.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++abi.1.dylib libc++abi.dylib"
 
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++.a ${destroot}${prefix}/lib/libcxx/libc++.a
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++abi.a ${destroot}${prefix}/lib/libcxx/libc++abi.a
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++experimental.a ${destroot}${prefix}/lib/libcxx/libc++experimental.a
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++.a ${destroot}${prefix}/lib/libcxx/libc++.a
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++abi.a ${destroot}${prefix}/lib/libcxx/libc++abi.a
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++experimental.a ${destroot}${prefix}/lib/libcxx/libc++experimental.a
 
+}
+
+# LLVM 16's libc++ may not have rpaths to delete
+if {![variant_isset experimental]} {
+    post-destroot {
+        system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++.1.0.dylib"
+        system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++abi.1.0.dylib"
+    }
 }
 
 notes "

--- a/lang/macports-libcxx/Portfile
+++ b/lang/macports-libcxx/Portfile
@@ -16,10 +16,30 @@ long_description    This port installs a recent libc++ from llvm \
 # for now, we will leverage the already-built libc++ in the appropriate clang port
 # later, we can build this independently if we choose to do so, much like libtapi
 
-# the clang-11 version in use when this port is updated will be used
 version             11.1.0
-set clangversion    11
-revision            0
+revision            1
+
+master_sites
+distfiles
+use_configure no
+build {}
+variant universal {}
+
+variant experimental description {Install LLVM 16-based libc++ (experimental)} {}
+
+set clangversion ""
+set llvm_include_path ""
+set llvm_libcxx_path ""
+# the clang-11 version in use when this port is updated will be used
+if {[variant_isset experimental]} {
+    set clangversion 16
+    set llvm_include_path include/c++/v1
+    set llvm_libcxx_path lib/libc++
+} else {
+    set clangversion 11
+    set llvm_include_path lib/c++/v1
+    set llvm_libcxx_path lib
+}
 
 depends_build       port:clang-${clangversion}
 
@@ -37,40 +57,42 @@ if {[string match ${configure.compiler} "macports-clang-${clangversion}"]} {
     configure.compiler  cc
 }
 
-master_sites
-distfiles
-fetch {}
-checksum {}
-use_configure no
-build {}
-variant universal {}
-
 destroot {
 
     xinstall -d ${destroot}${prefix}/include/libcxx
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/c++/v1 ${destroot}${prefix}/include/libcxx/
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_include_path} ${destroot}${prefix}/include/libcxx/
 
     # disable Apple libc++ availability tests, as we're using a new libc++ with these headers
     system -W ${destroot}${prefix}/include/libcxx/v1 "patch -p0 < ${filespath}/patch-disable-availabilty.diff"
 
     xinstall -d ${destroot}${prefix}/lib/libcxx
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++.1.0.dylib
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++.1.0.dylib
     system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -id ${prefix}/lib/libcxx/libc++.1.0.dylib libc++.1.0.dylib"
-    system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++.1.0.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -change @rpath/libc++abi.1.dylib ${prefix}/lib/libcxx/libc++abi.1.dylib libc++.1.0.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++.1.0.dylib libc++.1.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++.1.dylib libc++.dylib"
 
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++abi.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++abi.1.0.dylib
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++abi.1.0.dylib ${destroot}${prefix}/lib/libcxx/libc++abi.1.0.dylib
     system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -id ${prefix}/lib/libcxx/libc++abi.1.0.dylib libc++abi.1.0.dylib"
-    system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++abi.1.0.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++abi.1.0.dylib libc++abi.1.dylib"
     system -W  ${destroot}${prefix}/lib/libcxx/  "ln -s libc++abi.1.dylib libc++abi.dylib"
 
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++.a ${destroot}${prefix}/lib/libcxx/libc++.a
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++abi.a ${destroot}${prefix}/lib/libcxx/libc++abi.a
-    copy  ${prefix}/libexec/llvm-${clangversion}/lib/libc++experimental.a ${destroot}${prefix}/lib/libcxx/libc++experimental.a
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++.a ${destroot}${prefix}/lib/libcxx/libc++.a
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++abi.a ${destroot}${prefix}/lib/libcxx/libc++abi.a
+    copy  ${prefix}/libexec/llvm-${clangversion}/${llvm_libcxx_path}/libc++experimental.a ${destroot}${prefix}/lib/libcxx/libc++experimental.a
 
+}
+
+# LLVM 16's libc++ may not have rpaths to delete
+if {![variant_isset experimental]} {
+    post-destroot {
+        system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++.1.0.dylib"
+        system -W  ${destroot}${prefix}/lib/libcxx/  "install_name_tool -delete_rpath @loader_path/../lib libc++abi.1.0.dylib"
+    }
+}
+
+if {${configure.build_arch} in {"x86_64" "i386"}} {
+    default_variants +experimental
 }
 
 notes "


### PR DESCRIPTION
Using this variant I successfully built ccache and poppler locally.
I decided to use LLVM 16 because it’s the latest version that runs on Snow Leopard, although basic C++23 features are implemented in version 18.
GitHub Actions builders won’t be able to build this PR, since Clang 11 isn’t compatible with the latest versions of macOS.

CC @reneeotten @jmroot @ryandesign

###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
