### PR TITLE
gnome-online-accounts: Re-enable backend

### DIFF
--- a/gnome/gnome-online-accounts/Portfile
+++ b/gnome/gnome-online-accounts/Portfile
@@ -5,7 +5,7 @@ PortGroup           gobject_introspection 1.0
 
 name                gnome-online-accounts
 version             3.44.0
-revision            2
+revision            3
 license             LGPL-2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Single sign-on framework for GNOME
@@ -43,6 +43,7 @@ gobject_introspection yes
 compiler.cxx_standard 2011
 
 patchfiles          gettext-1.0.patch \
+                    libxml2-2.12.patch \
                     patch-src-goaidentity-Makefile.am.diff
 
 use_parallel_build no
@@ -55,7 +56,6 @@ configure.cppflags-append \
 
 configure.args      --enable-compile-warnings=no \
                     --enable-gtk-doc \
-                    --disable-backend \
                     --disable-media-server \
                     --enable-exchange \
                     --enable-inspector \

--- a/gnome/gnome-online-accounts/files/libxml2-2.12.patch
+++ b/gnome/gnome-online-accounts/files/libxml2-2.12.patch
@@ -1,0 +1,15 @@
+Fix:
+
+goaewsclient.c:252:9: error: implicit declaration of function 'xmlReadMemory' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/commit/b9638e2418408be4906752297e700506766dcf20
+--- src/goabackend/goaewsclient.c.orig
++++ src/goabackend/goaewsclient.c
+@@ -27,6 +27,7 @@
+ #include <glib/gi18n-lib.h>
+ 
+ #include <libsoup/soup.h>
++#include <libxml/parser.h>
+ #include <libxml/xmlIO.h>
+ 
+ #include "goaewsclient.h"


### PR DESCRIPTION
#### Description

The backend had only been disabled (in c46244e6) because it didn't build with libxml2 2.12 or later. This re-enables it and adds a patch to let it build again.

Closes: https://trac.macports.org/ticket/70090

If there are other reasons why it's better to leave the backend disabled, then this PR and the ticket can just be closed.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
