### PR TITLE
poppler: update to 26.09.0

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -3,12 +3,11 @@
 PortSystem          1.0
 PortGroup           gobject_introspection 1.0
 PortGroup           cmake 1.1
-PortGroup           legacysupport 1.1
 
 name                poppler
 conflicts           poppler-devel xpdf-tools
 set my_name         poppler
-version             26.02.0
+version             26.04.0
 revision            0
 epoch               1
 
@@ -27,9 +26,9 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  b8fe92a99f44dcabfd09f4e52c574e646d679a31 \
-                    sha256  dded8621f7b2f695c91063aab1558691c8418374cd583501e89ed39487e7ab77 \
-                    size    2025588
+checksums           rmd160  2e796488708a82968509b526ff3237f1c475592e \
+                    sha256  b0955163114af96bc0106f68cb24daf973a629462453d8b82775f81b0d4e0693 \
+                    size    2032180
 
 set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
@@ -75,19 +74,34 @@ compiler.c_standard   2011
 compiler.thread_local_storage yes
 
 # https://trac.macports.org/ticket/73454
-# macports-libcxx is quite outdated and cannot properly support std::ranges
-# on macOS <10.15 compilation successful only with fresh GCC
+# https://trac.macports.org/ticket/69805
+# https://github.com/macports/macports-ports/pull/31641
+# Unfortunately, the current version of
+# macports-libcxx lacks support for std::ranges
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    if {${configure.build_arch} in {"x86_64" "i386"}} {
-        configure.compiler    macports-gcc-15
-        # ensure that macports-libstdc++ is used
-        # without this line linking will always fail
-        configure.cxx_stdlib  macports-libstdc++
+    # PowerPCs can use the fresh version of GCC
+    if {[string match *clang* ${configure.compiler}] && ${configure.cxx_stdlib} eq "libc++"} {
+        # use LLVM 16 for best compatibility
+        set llvmversion     16
+        configure.compiler  macports-clang-${llvmversion}
+        depends_lib-append  port:macports-libcxx
+
+        # https://trac.macports.org/ticket/71669
+        configure.cxxflags-append \
+            -isystem${workpath}/include/c++/v1 \
+            -nostdinc++ \
+            -stdlib=libc++
+        configure.ldflags-append \
+            -L${prefix}/lib/libcxx
+
+        post-extract {
+            file mkdir ${workpath}/include/c++
+            copy ${prefix}/libexec/llvm-${llvmversion}/include/c++/v1 ${workpath}/include/c++/
+            # disable Apple libc++ availability tests, as we're using a new libc++ with these headers
+            system -W ${workpath}/include/c++/v1 "patch -p0 < ${filespath}/patch-disable-availability.diff"
+        }
     }
 }
-
-legacysupport.newest_darwin_requires_legacy 18
-legacysupport.use_mp_libcxx yes
 
 # match clang, not strequal
 patchfiles-append   patch-cmake_modules_PopplerMacros.cmake.diff

--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -3,12 +3,11 @@
 PortSystem          1.0
 PortGroup           gobject_introspection 1.0
 PortGroup           cmake 1.1
-PortGroup           legacysupport 1.1
 
 name                poppler
 conflicts           poppler-devel xpdf-tools
 set my_name         poppler
-version             26.02.0
+version             26.07.0
 revision            0
 epoch               1
 
@@ -27,9 +26,9 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  b8fe92a99f44dcabfd09f4e52c574e646d679a31 \
-                    sha256  dded8621f7b2f695c91063aab1558691c8418374cd583501e89ed39487e7ab77 \
-                    size    2025588
+checksums           rmd160  765b66fca4afe96966a846bb3fc356ddbc20862b \
+                    sha256  304832f48f8a47fdca90c6b6d1f684e68f37c10c9a0726f345f4ca9df4ca01e2 \
+                    size    2027720
 
 set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
@@ -75,19 +74,34 @@ compiler.c_standard   2011
 compiler.thread_local_storage yes
 
 # https://trac.macports.org/ticket/73454
-# macports-libcxx is quite outdated and cannot properly support std::ranges
-# on macOS <10.15 compilation successful only with fresh GCC
+# https://trac.macports.org/ticket/69805
+# https://github.com/macports/macports-ports/pull/31641
+# Unfortunately, the current version of
+# macports-libcxx lacks support for std::ranges
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    if {${configure.build_arch} in {"x86_64" "i386"}} {
-        configure.compiler    macports-gcc-15
-        # ensure that macports-libstdc++ is used
-        # without this line linking will always fail
-        configure.cxx_stdlib  macports-libstdc++
+    # PowerPCs can use the fresh version of GCC
+    if {[string match *clang* ${configure.compiler}] && ${configure.cxx_stdlib} eq "libc++"} {
+        # use LLVM 16 for best compatibility
+        set llvmversion     16
+        configure.compiler  macports-clang-${llvmversion}
+        depends_lib-append  port:macports-libcxx
+
+        # https://trac.macports.org/ticket/71669
+        configure.cxxflags-append \
+            -isystem${workpath}/include/c++/v1 \
+            -nostdinc++ \
+            -stdlib=libc++
+        configure.ldflags-append \
+            -L${prefix}/lib/libcxx
+
+        post-extract {
+            file mkdir ${workpath}/include/c++
+            copy ${prefix}/libexec/llvm-${llvmversion}/include/c++/v1 ${workpath}/include/c++/
+            # disable Apple libc++ availability tests, as we're using a new libc++ with these headers
+            system -W ${workpath}/include/c++/v1 "patch -p0 < ${filespath}/patch-disable-availability.diff"
+        }
     }
 }
-
-legacysupport.newest_darwin_requires_legacy 18
-legacysupport.use_mp_libcxx yes
 
 # match clang, not strequal
 patchfiles-append   patch-cmake_modules_PopplerMacros.cmake.diff

--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -3,12 +3,11 @@
 PortSystem          1.0
 PortGroup           gobject_introspection 1.0
 PortGroup           cmake 1.1
-PortGroup           legacysupport 1.1
 
 name                poppler
 conflicts           poppler-devel xpdf-tools
 set my_name         poppler
-version             26.02.0
+version             26.09.0
 revision            0
 epoch               1
 
@@ -27,9 +26,9 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  b8fe92a99f44dcabfd09f4e52c574e646d679a31 \
-                    sha256  dded8621f7b2f695c91063aab1558691c8418374cd583501e89ed39487e7ab77 \
-                    size    2025588
+checksums           rmd160  cc62c518fe42ac338f81542c670e0f9983bde8e4 \
+                    sha256  8059eadb6805340768f138c465b57f8164c92b4a0773c37ef031ea6c0d987b2e \
+                    size    2041828
 
 set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
@@ -49,6 +48,7 @@ depends_lib-append \
                     port:gettext-runtime \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:gpgmepp \
+                    path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:lcms2 \
                     port:libiconv \
                     path:include/turbojpeg.h:libjpeg-turbo \
@@ -75,19 +75,34 @@ compiler.c_standard   2011
 compiler.thread_local_storage yes
 
 # https://trac.macports.org/ticket/73454
-# macports-libcxx is quite outdated and cannot properly support std::ranges
-# on macOS <10.15 compilation successful only with fresh GCC
+# https://trac.macports.org/ticket/69805
+# https://github.com/macports/macports-ports/pull/31641
+# Unfortunately, the current version of
+# macports-libcxx lacks support for std::ranges
 if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    if {${configure.build_arch} in {"x86_64" "i386"}} {
-        configure.compiler    macports-gcc-15
-        # ensure that macports-libstdc++ is used
-        # without this line linking will always fail
-        configure.cxx_stdlib  macports-libstdc++
+    # PowerPCs can use the fresh version of GCC
+    if {[string match *clang* ${configure.compiler}] && ${configure.cxx_stdlib} eq "libc++"} {
+        # use LLVM 16 for best compatibility
+        set llvmversion     16
+        configure.compiler  macports-clang-${llvmversion}
+        depends_lib-append  port:macports-libcxx
+
+        # https://trac.macports.org/ticket/71669
+        configure.cxxflags-append \
+            -isystem${workpath}/include/c++/v1 \
+            -nostdinc++ \
+            -stdlib=libc++
+        configure.ldflags-append \
+            -L${prefix}/lib/libcxx
+
+        post-extract {
+            file mkdir ${workpath}/include/c++
+            copy ${prefix}/libexec/llvm-${llvmversion}/include/c++/v1 ${workpath}/include/c++/
+            # disable Apple libc++ availability tests, as we're using a new libc++ with these headers
+            system -W ${workpath}/include/c++/v1 "patch -p0 < ${filespath}/patch-disable-availability.diff"
+        }
     }
 }
-
-legacysupport.newest_darwin_requires_legacy 18
-legacysupport.use_mp_libcxx yes
 
 # match clang, not strequal
 patchfiles-append   patch-cmake_modules_PopplerMacros.cmake.diff
@@ -169,7 +184,7 @@ if {${subport} ne ${name}} {
 
     post-extract {
         system -W ${workpath} \
-                    "${prefix}/bin/git clone --depth=1 https://anongit.freedesktop.org/git/poppler/test"
+                    "${prefix}/bin/git clone --depth=1 https://gitlab.freedesktop.org/poppler/test"
     }
 
 # currently poppler only provides unit tests for the Qt wrappers

--- a/graphics/poppler/files/patch-CMakeLists.txt-fix-boost.diff
+++ b/graphics/poppler/files/patch-CMakeLists.txt-fix-boost.diff
@@ -1,11 +1,11 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -233,7 +233,7 @@ add_definitions(-DQT_NO_KEYWORDS)
+@@ -235,7 +235,7 @@ add_definitions(-DQT_NO_KEYWORDS)
  macro_optional_find_package(Cairo ${CAIRO_VERSION})
  
  if (ENABLE_BOOST)
--  find_package(Boost 1.74.0 CONFIG)
-+  find_package(Boost 1.74.0 MODULE)
+-  find_package(Boost ${BOOST_VERSION} CONFIG)
++  find_package(Boost ${BOOST_VERSION} MODULE)
    if(Boost_FOUND)
      set(USE_BOOST_HEADERS ON)
    else()

--- a/graphics/poppler/files/patch-disable-availability.diff
+++ b/graphics/poppler/files/patch-disable-availability.diff
@@ -1,0 +1,12 @@
+--- __config.orig	2023-11-28 17:52:28.000000000 +0900
++++ __config	2026-02-09 03:50:00.000000000 +0900
+@@ -33,6 +33,9 @@
+ #  define _LIBCPP_COMPILER_GCC
+ #endif
+ 
++// we are not going to use Apple Availability testing in these headers
++#define _LIBCPP_DISABLE_AVAILABILITY
++
+ #ifdef __cplusplus
+ 
+ // The attributes supported by clang are documented at https://clang.llvm.org/docs/AttributeReference.html


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?