### PR TITLE
kubectl: update to 1.35.3, 1.34.6 & 1.33.10

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -44,11 +44,11 @@ subport kubectl-1.34 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     5
+    set patchNumber     6
     revision            0
-    checksums           rmd160  1dc077f716c6963a7200c8af1f918c9d6e738175 \
-                        sha256  43016323664abbf98e6e3612479b7264a5bf432e19d8031b681b16d68adb7b7f \
-                        size    38106927
+    checksums           rmd160  6cb47b8531b64b6df126b4f82c2d3359bdcc65f8 \
+                        sha256  cc88a9e51d05c048876a474feb6e353fd9e9fe64bb95f5cfced27a0b29d28790 \
+                        size    38100729
 }
 
 subport kubectl-1.33 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -57,11 +57,11 @@ subport kubectl-1.33 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     9
+    set patchNumber     10
     revision            0
-    checksums           rmd160  e295f2194aef2ab052ffc8981fe493e2e7604af8 \
-                        sha256  434059f69d49623bdd3b952bdd42b842c01016b3cad37f1a4b6226258751621b \
-                        size    37125913
+    checksums           rmd160  a7996b420f39ab7b87096a33bf51c0e5105572da \
+                        sha256  a4dd3abd7da2f4f50ffe79583682a1f990856903b5d200948c12e69e632dd8ff \
+                        size    37116163
 }
 
 subport kubectl-1.32 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -31,11 +31,11 @@ subport kubectl-1.35 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     2
+    set patchNumber     3
     revision            0
-    checksums           rmd160  e3c819bb6e53b0946bbacdabd43ad0a336eb768c \
-                        sha256  58d86b5cf71c9f9e9fb1f18f281f582d120a59452d64f9e8646278ee5fd619ed \
-                        size    38923701
+    checksums           rmd160  c3bc5c5fd8faa199100e55dad9ebe967d0bb1be4 \
+                        sha256  4374809bf135137568135384209f160acdab7372f2608fa60ca3513782db4f03 \
+                        size    38927893
 }
 
 subport kubectl-1.34 {
@@ -312,7 +312,7 @@ if {${subport} == ${name}} {
     PortGroup           obsolete 1.0
 
     replaced_by         ${latestVersion}
-    version             1.35.2
+    version             1.35.3
     revision            0
 
 } elseif {${subport} == "kubectl_select"} {


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
