### PR TITLE
icu: Fix platform.h header for old clang

### DIFF
--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -25,7 +25,7 @@ set my_name         icu
 #  port file all | sort -u | xargs grep -El ':icu( |$)' | rev | cut -d / -f 2 | rev | xargs port info --name --subport | cut -d : -f 2 | tr ',' ' ' | grep -v '\-\-' | tr ' ' '\n' | sort -u
 
 github.setup        unicode-org ${my_name} 78.3 release-
-revision            0
+revision            1
 epoch               1
 subport             ${name}-docs         { revision 0 }
 subport             ${name}-lx           { revision 0 }
@@ -73,6 +73,7 @@ if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
 
     # fix rpath mess
     patchfiles-append patch-config-mh-darwin.diff
+    patchfiles-append   platform.h.patch
 
     compiler.cxx_standard   2017
 

--- a/devel/icu/files/patch-config-mh-darwin.diff
+++ b/devel/icu/files/patch-config-mh-darwin.diff
@@ -1,10 +1,9 @@
 With rpath disabled, the install_name is wrongly missing the path.
 
 With rpath enabled, the install_name is wrongly missing @rpath.
-
 --- config/mh-darwin.orig
 +++ config/mh-darwin
-@@ -30,9 +30,9 @@
+@@ -31,9 +31,9 @@
  
  ## Compiler switches to embed a library name and version information
  ifeq ($(ENABLE_RPATH),YES)
@@ -18,7 +17,7 @@ With rpath enabled, the install_name is wrongly missing @rpath.
  ## Compiler switch to embed a runtime search path
 --- config/mh-darwin-ppc.orig
 +++ config/mh-darwin-ppc
-@@ -30,9 +30,9 @@
+@@ -31,9 +31,9 @@
  
  ## Compiler switches to embed a library name and version information
  ifeq ($(ENABLE_RPATH),YES)

--- a/devel/icu/files/platform.h.patch
+++ b/devel/icu/files/platform.h.patch
@@ -1,0 +1,16 @@
+Work around bug in old clang versions that had __has_cpp_attribute defined even
+in C mode.
+
+https://discourse.llvm.org/t/possible-bug-with-has-cpp-attribute/36508/4
+https://bugs.llvm.org/show_bug.cgi?id=23435
+--- common/unicode/platform.h.orig	2026-03-17 12:44:50.000000000 -0500
++++ common/unicode/platform.h	2026-03-22 14:39:11.000000000 -0500
+@@ -388,7 +388,7 @@
+ #else
+ #   define UPRV_HAS_ATTRIBUTE(x) 0
+ #endif
+-#ifdef __has_cpp_attribute
++#if defined(__cplusplus) && defined(__has_cpp_attribute)
+ #   define UPRV_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+ #else
+ #   define UPRV_HAS_CPP_ATTRIBUTE(x) 0


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/73703

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix