### PR TITLE
vhs: update to 0.11.0

### DIFF
--- a/graphics/vhs/Portfile
+++ b/graphics/vhs/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/charmbracelet/vhs 0.10.0 v
+go.setup            github.com/charmbracelet/vhs 0.11.0 v
 go.offline_build    no
 revision            0
 
@@ -19,9 +19,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  6030a752572942f8b4fe8979f2530264e0c431dc \
-                    sha256  ae37fe7e52ade753f850ab81c7d5344f8e540ab6886f877bf5b613620c909893 \
-                    size    135426
+checksums           rmd160  bea958d598ee80c438a72fd18b8169b60b488547 \
+                    sha256  c08b8502989fe7e9626c02938f3fc512c2a4ba21f839f455d20d7eb1da7bc39f \
+                    size    136991
 
 depends_run-append  path:bin/ffmpeg:ffmpeg \
                     path:bin/ttyd:ttyd


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
