### PR TITLE
mabel: new port (v0.1.7)

### DIFF
--- a/net/mabel/Portfile
+++ b/net/mabel/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/smmr-software/mabel 0.1.7 v
+go.offline_build    no
+revision            0
+
+description         A fancy BitTorrent client for the terminal
+
+long_description    {*}${description}
+
+categories          net
+installs_libs       no
+license             GPL-3
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  2c643637254131ae648f01071dbefda529d170f1 \
+                    sha256  e39f0cc67d37455e06e1ed37948028293fdd13090586333fceebb5b8d075c7c1 \
+                    size    146782
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+notes "
+    ${name} requires installation of a Nerd Font: https://www.nerdfonts.com/
+"


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/73691

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
