### PR TITLE
lang/ferrumc: new port 0.3.0

### DIFF
--- a/lang/ferrumc/Portfile
+++ b/lang/ferrumc/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        Ferrum-Language Ferrum 0.3.0 v
+github.tarball_from archive
 name                ferrumc
 categories          lang
 maintainers         nomaintainer

--- a/lang/ferrumc/Portfile
+++ b/lang/ferrumc/Portfile
@@ -6,7 +6,7 @@ name                ferrumc
 version             0.3.0
 categories          lang
 maintainers         nomaintainer
-license             MIT
+license GPL-3
 homepage            https://ferrum-language.github.io/Ferrum/
 description         Ferrum-language compiler with compile-time memory safety
 long_description    Ferrum-language is a systems programming language with C syntax and \

--- a/lang/ferrumc/Portfile
+++ b/lang/ferrumc/Portfile
@@ -1,12 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
+github.setup        Ferrum-Language Ferrum 0.3.0 v
 name                ferrumc
-version             0.3.0
 categories          lang
 maintainers         nomaintainer
-license GPL-3
+license             GPL-3
 homepage            https://ferrum-language.github.io/Ferrum/
 description         Ferrum-language compiler with compile-time memory safety
 long_description    Ferrum-language is a systems programming language with C syntax and \
@@ -16,10 +17,10 @@ long_description    Ferrum-language is a systems programming language with C syn
 platforms           darwin
 
 if {${build_arch} eq "arm64"} {
-    distname        ferrumc-v${version}-macos-arm64
+    distfiles       ferrumc-v${version}-macos-arm64.tar.gz
     checksums       sha256 dd299666b2f859ff1f07fc7494d8dffe4b9f568e132168531ab5636b9011f520
 } else {
-    distname        ferrumc-v${version}-macos-x86_64
+    distfiles       ferrumc-v${version}-macos-x86_64.tar.gz
     checksums       sha256 bc22feaf923829d4c8f18ff2b69ab4ed369b52b2d84244301167be4801c5082f
 }
 

--- a/lang/ferrumc/Portfile
+++ b/lang/ferrumc/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                ferrumc
+version             0.3.0
+categories          lang
+maintainers         nomaintainer
+license             MIT
+homepage            https://ferrum-language.github.io/Ferrum/
+description         Ferrum-language compiler with compile-time memory safety
+long_description    Ferrum-language is a systems programming language with C syntax and \
+                    compile-time memory safety via a borrow checker and ownership model. \
+                    Compiled to native code through LLVM 18.
+
+platforms           darwin
+
+if {${build_arch} eq "arm64"} {
+    distname        ferrumc-v${version}-macos-arm64
+    checksums       sha256 dd299666b2f859ff1f07fc7494d8dffe4b9f568e132168531ab5636b9011f520
+} else {
+    distname        ferrumc-v${version}-macos-x86_64
+    checksums       sha256 bc22feaf923829d4c8f18ff2b69ab4ed369b52b2d84244301167be4801c5082f
+}
+
+master_sites        https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/
+extract.suffix      .tar.gz
+use_configure       no
+
+build {}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/ferrumc ${destroot}${prefix}/bin/ferrumc
+}

--- a/lang/ferrumc/Portfile
+++ b/lang/ferrumc/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           cmake 1.1
 
 github.setup        Ferrum-Language Ferrum 0.3.0 v
 name                ferrumc
@@ -14,22 +15,20 @@ long_description    Ferrum-language is a systems programming language with C syn
                     compile-time memory safety via a borrow checker and ownership model. \
                     Compiled to native code through LLVM 18.
 
-platforms           darwin
+checksums           rmd160  0bd5dc52ad8bb042323d2aac9f1a0eae18039b3e \
+                    sha256  3a6f76e2c3a9cbb6b89910fca1d5d5c09f8074da2bbb233299e91c022e2f26d6 \
+                    size    94231
 
-if {${build_arch} eq "arm64"} {
-    distfiles       ferrumc-v${version}-macos-arm64.tar.gz
-    checksums       sha256 dd299666b2f859ff1f07fc7494d8dffe4b9f568e132168531ab5636b9011f520
-} else {
-    distfiles       ferrumc-v${version}-macos-x86_64.tar.gz
-    checksums       sha256 bc22feaf923829d4c8f18ff2b69ab4ed369b52b2d84244301167be4801c5082f
-}
+depends_build-append \
+                    port:ninja
 
-master_sites        https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/
-extract.suffix      .tar.gz
-use_configure       no
+depends_lib-append \
+                    port:llvm-18
 
-build {}
+configure.args-append \
+                    -DLLVM_DIR=${prefix}/libexec/llvm-18/lib/cmake/llvm \
+                    -DCMAKE_DISABLE_FIND_PACKAGE_LibEdit=TRUE
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/ferrumc ${destroot}${prefix}/bin/ferrumc
+    xinstall -m 755 ${build.dir}/ferrumc ${destroot}${prefix}/bin/ferrumc
 }

--- a/lang/ferrumc/Portfile
+++ b/lang/ferrumc/Portfile
@@ -1,13 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           github 1.0
 
 github.setup        Ferrum-Language Ferrum 0.3.0 v
 github.tarball_from archive
 name                ferrumc
-categories          lang
+revision            0
+categories          lang devel
 maintainers         nomaintainer
 license             GPL-3
 homepage            https://ferrum-language.github.io/Ferrum/
@@ -20,16 +21,29 @@ checksums           rmd160  0bd5dc52ad8bb042323d2aac9f1a0eae18039b3e \
                     sha256  3a6f76e2c3a9cbb6b89910fca1d5d5c09f8074da2bbb233299e91c022e2f26d6 \
                     size    94231
 
-depends_build-append \
-                    port:ninja
+set llvm_version    18
 
-depends_lib-append \
-                    port:llvm-18
+depends_lib-append  port:libffi \
+                    port:ncurses \
+                    port:zstd \
+                    port:zlib
+
+compiler.whitelist-append \
+                    macports-clang-${llvm_version}
+
+cmake.module_path-append \
+                    ${prefix}/libexec/llvm-${llvm_version}/lib/cmake/llvm
 
 configure.args-append \
-                    -DLLVM_DIR=${prefix}/libexec/llvm-18/lib/cmake/llvm \
                     -DCMAKE_DISABLE_FIND_PACKAGE_LibEdit=TRUE
 
+# CMakeLists.txt only declares CXX but configure checks also need C
+post-patch {
+    reinplace "s|LANGUAGES CXX|LANGUAGES C CXX|" ${worksrcpath}/CMakeLists.txt
+}
+
 destroot {
-    xinstall -m 755 ${build.dir}/ferrumc ${destroot}${prefix}/bin/ferrumc
+    xinstall -m 755 ${build.dir}/${name} ${destroot}${prefix}/bin/${name}
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 ${worksrcpath}/LICENSE ${destroot}${prefix}/share/doc/${name}/COPYING
 }


### PR DESCRIPTION
**New port: lang/ferrumc — Ferrum-language compiler 0.3.0**

Ferrum-language is a systems programming language with C syntax and compile-time memory safety via a borrow checker and ownership model, compiled to native code through LLVM 18.

- License: MIT
- Homepage: https://ferrum-language.github.io/Ferrum/
- Upstream: https://github.com/Ferrum-Language/Ferrum/releases/tag/v0.3.0
- Supports arm64 and x86_64 (separate prebuilt binaries per arch)

SHA256:
- arm64:  `dd299666b2f859ff1f07fc7494d8dffe4b9f568e132168531ab5636b9011f520`
- x86_64: `bc22feaf923829d4c8f18ff2b69ab4ed369b52b2d84244301167be4801c5082f`