### PR TITLE
clang-{19,20}: unbreak on Darwin < 15

### DIFF
--- a/lang/llvm-19/Portfile
+++ b/lang/llvm-19/Portfile
@@ -258,8 +258,6 @@ if { ${subport} eq "clang-${llvm_version}" } {
 
     depends_run-append  port:clang_select-${llvm_version} port:cctools
 
-    platforms           {darwin >= 15}
-
     configure.args-append   \
         -DLLVM_ENABLE_PROJECTS="clang\;clang-tools-extra\;compiler-rt\;lld" \
         -DLLVM_ENABLE_RUNTIMES="libcxx\;libcxxabi\;libunwind" \
@@ -335,7 +333,8 @@ if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_versio
         # Extended to 10.11 and older, see https://trac.macports.org/ticket/65887
         configure.args-append    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
                                  -DCOMPILER_RT_BUILD_XRAY=OFF \
-                                 -DCOMPILER_RT_BUILD_MEMPROF=OFF
+                                 -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+                                 -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF
     }
 
     if {${os.platform} eq "darwin" && ${os.major} <= 11} {

--- a/lang/llvm-20/Portfile
+++ b/lang/llvm-20/Portfile
@@ -269,8 +269,6 @@ if { ${subport} eq "clang-${llvm_version}" } {
 
     depends_run-append  port:clang_select-${llvm_version} port:cctools
 
-    platforms           {darwin >= 15}
-
     configure.args-append   \
         -DLLVM_ENABLE_PROJECTS="clang\;clang-tools-extra\;lld" \
         -DLLVM_ENABLE_RUNTIMES="libcxx\;libcxxabi\;libunwind\;compiler-rt" \
@@ -349,7 +347,8 @@ if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_versio
         # Extend to 10.13 and older, see https://trac.macports.org/ticket/72150
         configure.args-append    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
                                  -DCOMPILER_RT_BUILD_XRAY=OFF \
-                                 -DCOMPILER_RT_BUILD_MEMPROF=OFF
+                                 -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+                                 -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF
     }
 
     if {${os.platform} eq "darwin" && ${os.major} <= 11} {


### PR DESCRIPTION
Unbreak Clang 19 and 20 on Darwin < 15 by disabling the CTX PROFILE option in Compiler-RT.

Clang 19.1.6 ran just fine on 10.9.5, but from 19.1.7 the sanitizers started depending on CTX PROFILE, breaking the build on older platforms. The requirement was subsequently raised to Darwin 15. Disabling CTX PROFILE  makes the build pass, meaning that the restriction on Clang can be removed.

Clang 20 can be supported by configuring in the same way, while Clang 21 has started using `shared_mutex` and thus cannot be linked against libc++ on 10.9. I assume that it can be solved using legacy-support, but I will look at that later and submit a separate PR if successful.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
