### PR TITLE
ImageMagick, p5-perlmagick: Update to 6.9.13-43

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -13,12 +13,12 @@ legacysupport.newest_darwin_requires_legacy 10
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.13-40
-revision                    2
+version                     6.9.13-43
+revision                    0
 
-checksums                   rmd160  5b337b2895828c21756dc75af29699f76a18044d \
-                            sha256  bccce2de56b1e80ce20c25ccf2c85a669fc7e6815632bfa87cc52a83b6347a82 \
-                            size    9636924
+checksums                   rmd160  dab775ff5a70bc9cc0bbe9d58fc5654606203c25 \
+                            sha256  6fcd60539e788a9d51c5a5e59be51e6090cdbcf443b968560d632b4e2c42075c \
+                            size    9641712
 
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}
@@ -46,9 +46,13 @@ long_description            This is the legacy ImageMagick version 6.  For the \
                             PhotoCD and TIFF.
 
 homepage                    https://legacy.imagemagick.org
-master_sites                https://download.imagemagick.org/ImageMagick/download/releases/ \
+master_sites                https://imagemagick.org/archive/ \
+                            https://imagemagick.org/archive/releases/ \
+                            https://mirror.aarnet.edu.au/pub/imagemagick/ \
+                            https://ftp.icm.edu.pl/pub/unix/graphics/ImageMagick/ \
+                            https://mirror.accum.se/mirror/imagemagick.org/ftp/ \
+                            https://mirror.metanet.ch/imagemagick/ \
                             http://mirror.checkdomain.de/imagemagick/releases/ \
-                            ftp://ftp.u-aizu.ac.jp/pub/graphics/image/ImageMagick/imagemagick.org/releases/ \
                             ftp://sunsite.icm.edu.pl/packages/ImageMagick/releases/
 
 depends_lib                 port:bzip2 \
@@ -69,7 +73,6 @@ depends_lib                 port:bzip2 \
                             port:libiconv \
                             port:libtool \
                             port:openjpeg \
-                            port:openexr \
                             port:expat \
                             port:libxml2 \
                             port:libheif
@@ -85,7 +88,6 @@ configure.args              --enable-shared \
                             --enable-static \
                             --disable-silent-rules \
                             --with-frozenpaths \
-                            --with-openexr \
                             --disable-hdri \
                             --with-dps \
                             --with-bzlib \
@@ -110,6 +112,7 @@ configure.args              --enable-shared \
                             --without-wmf \
                             --without-gvc \
                             --without-rsvg \
+                            --without-openexr \
                             --without-lqr \
                             --without-pango \
                             --without-raqm \
@@ -149,6 +152,11 @@ variant lqr description {Support Liquid Rescale (experimental)} {
     configure.args-replace  --without-lqr --with-lqr
 }
 
+variant openexr description {Support OpenEXR} {
+    depends_lib-append      port:openexr
+    configure.args-replace  --without-openexr --with-openexr
+}
+
 variant pango description {Support Pango} {
     depends_lib-append      path:lib/pkgconfig/pango.pc:pango
     configure.args-replace  --without-pango --with-pango
@@ -171,7 +179,7 @@ variant x11 {
     configure.args-replace  --without-x --with-x
 }
 
-default_variants            +x11
+default_variants            +openexr +x11
 
 livecheck.type              regex
 livecheck.url               [lindex ${master_sites} 0]

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -7,12 +7,12 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         PerlMagick 6.9.13-40
+perl5.setup         PerlMagick 6.9.13-43
 revision            0
 
-checksums           rmd160  5b337b2895828c21756dc75af29699f76a18044d \
-                    sha256  bccce2de56b1e80ce20c25ccf2c85a669fc7e6815632bfa87cc52a83b6347a82 \
-                    size    9636924
+checksums           rmd160  dab775ff5a70bc9cc0bbe9d58fc5654606203c25 \
+                    sha256  6fcd60539e788a9d51c5a5e59be51e6090cdbcf443b968560d632b4e2c42075c \
+                    size    9641712
 
 set my_name         ImageMagick
 maintainers         {ryandesign @ryandesign}
@@ -25,9 +25,13 @@ use_xz              yes
 # ensure it will always match the ImageMagick version.
 
 homepage            https://legacy.imagemagick.org/script/perl-magick.php
-master_sites        https://imagemagick.org/download/releases/ \
+master_sites        https://imagemagick.org/archive/ \
+                    https://imagemagick.org/archive/releases/ \
+                    https://mirror.aarnet.edu.au/pub/imagemagick/ \
+                    https://ftp.icm.edu.pl/pub/unix/graphics/ImageMagick/ \
+                    https://mirror.accum.se/mirror/imagemagick.org/ftp/ \
+                    https://mirror.metanet.ch/imagemagick/ \
                     http://mirror.checkdomain.de/imagemagick/releases/ \
-                    ftp://ftp.u-aizu.ac.jp/pub/graphics/image/ImageMagick/imagemagick.org/releases/ \
                     ftp://sunsite.icm.edu.pl/packages/ImageMagick/releases/
 
 dist_subdir         ImageMagick


### PR DESCRIPTION
#### Description

* Update ImageMagick 6.9.13-40 --> 6.9.13-43.
* Synchronize p5-perlmagick with this update.
* Update mirror list.
* Add openexr variant, to enable opting out in case of errors, etc.

###### Type(s)

- [x] enhancement

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?