### PR TITLE
hdf5: Fix livecheck

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -206,7 +206,6 @@ if {[ mpi_variant_isset ]} {
     configure.args-append       --enable-parallel
 }
 
-
 notes-append {
 Mac users may need to set the environment variable "HDF5_USE_FILE_LOCKING"\
 to the five-character string "FALSE" when accessing network mounted files.\
@@ -215,7 +214,6 @@ Otherwise errors such as "unable to open file" or "HDF5 error" may be\
 encountered.
 }
 
-# Now attempting livecheck via github portgroup.
-#livecheck.type      regex
-#livecheck.url       https://www.hdfgroup.org/downloads/hdf5
-#livecheck.regex     hdf5-(\[0-9.-\]+)-Std
+# Livecheck on GitHub release tags only.  Exclude non-release tags.
+# Accept matches both with and without "hdf5_" or "hdf5-" prefix.
+livecheck.regex     releases/tag/\[hdf5_-\]*(\[0-9.-\]+)


### PR DESCRIPTION
#### Description

HDF5 distfile name changed in series 2.x.
hdf5_ prefix was dropped ... but not always.
Fix livecheck to pick up all variations, new and old.
No other functional changes to this port.  No rev bumps.

###### Type(s)

- [x] enhancement

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?