### PR TITLE
tkimg: Update to 1.4.17, use 7z distfile, do out-of-source build, fix livecheck

### DIFF
--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -3,8 +3,12 @@
 PortSystem              1.0
 
 name                    tkimg
-version                 1.4.16
-revision                1
+version                 1.4.17
+revision                0
+checksums               rmd160  cd1a130eb937385862f2f12dba0c82315e1f5e6d \
+                        sha256  aeab762f5c11979508974b35c354559a8ffb99404438f38dfd295e70abecc1cf \
+                        size    6695711
+
 categories              graphics
 license                 Tcl/Tk
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} {gmx.us:chrischavez @chrstphrchvz} openmaintainer
@@ -13,18 +17,14 @@ description             adds a lot of image formats to Tcl/Tk
 long_description        The \"Img\" package adds a lot of image formats to Tcl/Tk.
 
 master_sites            sourceforge:tkimg/tkimg/[join [lrange [split ${version} .] 0 1] .]/tkimg%20${version}
-distname                Img-${version}-Source
-extract.rename          yes
-
-checksums               rmd160  6b4fb4bd3558990ffc8aa4bb30246973027b5a7c \
-                        sha256  d99af4835fe3e20960817c7a1b5235dcfaa97c642593cce50bdb64c5827cd321 \
-                        size    12129708
+distname                Img-${version}
+use_7z                  yes
 
 post-extract {
-    # Copy "group" permission to "others", which is empty.
+    # All files in the 7z archive have 0644 permission
+    # and all directories have 0700 permission. Brilliant!
     fs-traverse item ${worksrcpath} {
-        set p [file attributes ${item} -permissions]
-        file attributes ${item} -permissions [format {0%o} [expr {(${p} >> 3 & 7) | ${p}}]]
+        file attributes ${item} -permissions 0755
     }
 
     # DOS to UNIX line endings so we can patch.

--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -53,6 +53,14 @@ depends_build-append    port:tcllib
 depends_lib-append      port:tcl \
                         port:zlib
 
+# Do an out-of-source build.
+build.dir               ${workpath}/build
+configure.dir           ${build.dir}
+configure.cmd           ${worksrcpath}/configure
+pre-configure {
+    file mkdir ${build.dir}
+}
+
 configure.args-append   --with-tcl=${prefix}/lib
 
 destroot.destdir        INSTALL_ROOT=${destroot}

--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -80,5 +80,6 @@ variant x11 conflicts {*}${x11conflicts} {
                             --with-tkinclude=${prefix}/include/tk-x11
 }
 
-livecheck.url           https://wiki.tcl-lang.org/page/Img
-livecheck.regex         {>(\d+\.\d+\.\d+)<}
+livecheck.type          regex
+livecheck.url           ${homepage}
+livecheck.regex         {>Version +(\d+\.\d+\.\d+)}


### PR DESCRIPTION
#### Description

tkimg:

* Update to 1.4.17
* Use 7z distfile because it's smaller
* Do out-of-source build just for fun
* Fix livecheck

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.5 21H1222 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
