### PR TITLE
nco: update to 5.3.7

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.3.6
+github.setup        nco nco 5.3.7
 github.tarball_from archive
 revision            0
 maintainers         {takeshi @tenomoto} \
@@ -21,9 +21,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  aef07fbce22532a4f4be01935d1bf45155eeb3cc \
-                    sha256  70d64f461a0d5262274495ee1a9d85735aa3115281fdf01df4f946a919f9f6ae \
-                    size    6882318
+checksums           rmd160  c7d2a4d3a123a5b4a79d938b94b83ec7aa37787d \
+                    sha256  f1103219bfddd838b80a326793c165a17f21ec612c9520342e34d556a6d012e5 \
+                    size    6892763
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Simple update to upstream version 5.3.7
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.4 24G517 x86_64
Command Line Tools 26.3.0.0.1.1771626560


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
