### PR TITLE
xapian-core: update to 2.1.0 ; added: php8[45] , perl5.40 , python314

### DIFF
--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                xapian-core
-version             1.4.27
+version             2.0.0
 categories          devel
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             GPL-2+
@@ -29,9 +29,9 @@ if {${subport} eq ${name}} {
     # version.h does not get generated properly when there are multiple -arch flags
     PortGroup                   muniversal 1.0
 
-    checksums                   rmd160  344e11ede45691dd6f76a35690838acbd6ad216b \
-                                sha256  bcbc99cfbf16080119c2571fc296794f539bd542ca3926f17c2999600830ab61 \
-                                size    3246624
+    checksums                   rmd160  1e06d3189f19f2b52142633753b75d01b276ab08 \
+                                sha256  6cea3f49952a47224439a40bdb3608f928d121ad8721b9921cc42802d548ecf8 \
+                                size    3490804
 
     # TODO: Fix xapian-config to not require the .la file
     # /opt/local/bin/xapian-config --ltlibs --cxxflags
@@ -58,9 +58,9 @@ if {${subport} eq ${name}} {
 
 subport xapian-omega {
     revision                    0
-    checksums                   rmd160  bb9f9f8e497ac97fa506804114794799215de625 \
-                                sha256  1d193b3285ec150557257b049ee1d8c94c40bcde906ce0ba7f1a38a1a9a5a5c1 \
-                                size    583960
+    checksums                   rmd160  38e2c07a40bb7e6a4bc98b2c8288c387fd121b68 \
+                                sha256  85088a16cf64ea676d0856813244909f132e1b32013a56928c40a1e333a6734a \
+                                size    5823212
 
     description                 web application using the Xapian library
     long_description            Xapian Omega is an application built on the \
@@ -70,6 +70,8 @@ subport xapian-omega {
     homepage                    ${homepage}/docs/omega/overview.html
 
     distname                    xapian-omega-${version}
+
+    depends_build-append        path:bin/pkg-config:pkgconfig
 
     depends_lib                 port:libiconv \
                                 port:libmagic \
@@ -81,9 +83,9 @@ subport xapian-omega {
 }
 
 if {${subport} ni [list ${name} xapian-omega]} {
-    checksums                   rmd160  beec2bc2b651c54e97c2649db30c1c0240aedc72 \
-                                sha256  ba3b5e10809e579acd11bd165779ce3fd29a8904ea37968ef5b57ad97c3618ba \
-                                size    1116236
+    checksums                   rmd160  9987a1d09d44bca862d34b8cd99061c18184448d \
+                                sha256  9a544b69c31355a92edbcd4102cf0f1ec4407fd0a4645f4870fb52300b736910 \
+                                size    1123744
 
     homepage                    ${homepage}/docs/bindings/
 
@@ -130,7 +132,7 @@ subport xapian-bindings-java {
 }
 
 # Perl
-foreach v {5.28 5.30 5.32 5.34 5.36 5.38} {
+foreach v {5.28 5.30 5.32 5.34 5.36 5.38 5.40} {
     subport xapian-bindings-perl${v} "
         revision                0
 
@@ -149,7 +151,7 @@ foreach v {5.28 5.30 5.32 5.34 5.36 5.38} {
 }
 
 # PHP
-foreach v {8.0 8.1 8.2 8.3} {
+foreach v {8.0 8.1 8.2 8.3 8.4 8.5} {
     set v_no_dot [string map {. {}} ${v}]
     set php php${v_no_dot}
     subport ${php}-xapian "
@@ -177,7 +179,7 @@ foreach v {8.0 8.1 8.2 8.3} {
 }
 
 # Python
-foreach v {3.10 3.11 3.12 3.13} {
+foreach v {3.10 3.11 3.12 3.13 3.14} {
     set v_no_dot [string map {. {}} ${v}]
     if {[vercmp ${v} 3] >= 0} {
         set suffix 3
@@ -204,7 +206,8 @@ foreach v {3.10 3.11 3.12 3.13} {
 }
 
 # Ruby
-foreach v {2.7 3.0 3.1 3.2 3.3 3.4} {
+# 2.7 fails to build
+foreach v {3.0 3.1 3.2 3.3 3.4} {
     set v_no_dot [string map {. {}} ${v}]
     subport xapian-bindings-ruby${v_no_dot} "
         revision                0

--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                xapian-core
-version             1.4.27
+version             2.0.0
 categories          devel
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             GPL-2+
@@ -29,9 +29,9 @@ if {${subport} eq ${name}} {
     # version.h does not get generated properly when there are multiple -arch flags
     PortGroup                   muniversal 1.0
 
-    checksums                   rmd160  344e11ede45691dd6f76a35690838acbd6ad216b \
-                                sha256  bcbc99cfbf16080119c2571fc296794f539bd542ca3926f17c2999600830ab61 \
-                                size    3246624
+    checksums                   rmd160  1e06d3189f19f2b52142633753b75d01b276ab08 \
+                                sha256  6cea3f49952a47224439a40bdb3608f928d121ad8721b9921cc42802d548ecf8 \
+                                size    3490804
 
     # TODO: Fix xapian-config to not require the .la file
     # /opt/local/bin/xapian-config --ltlibs --cxxflags
@@ -58,9 +58,9 @@ if {${subport} eq ${name}} {
 
 subport xapian-omega {
     revision                    0
-    checksums                   rmd160  bb9f9f8e497ac97fa506804114794799215de625 \
-                                sha256  1d193b3285ec150557257b049ee1d8c94c40bcde906ce0ba7f1a38a1a9a5a5c1 \
-                                size    583960
+    checksums                   rmd160  38e2c07a40bb7e6a4bc98b2c8288c387fd121b68 \
+                                sha256  85088a16cf64ea676d0856813244909f132e1b32013a56928c40a1e333a6734a \
+                                size    5823212
 
     description                 web application using the Xapian library
     long_description            Xapian Omega is an application built on the \
@@ -70,6 +70,8 @@ subport xapian-omega {
     homepage                    ${homepage}/docs/omega/overview.html
 
     distname                    xapian-omega-${version}
+
+    depends_build-append        path:bin/pkg-config:pkgconfig
 
     depends_lib                 port:libiconv \
                                 port:libmagic \
@@ -81,9 +83,9 @@ subport xapian-omega {
 }
 
 if {${subport} ni [list ${name} xapian-omega]} {
-    checksums                   rmd160  beec2bc2b651c54e97c2649db30c1c0240aedc72 \
-                                sha256  ba3b5e10809e579acd11bd165779ce3fd29a8904ea37968ef5b57ad97c3618ba \
-                                size    1116236
+    checksums                   rmd160  9987a1d09d44bca862d34b8cd99061c18184448d \
+                                sha256  9a544b69c31355a92edbcd4102cf0f1ec4407fd0a4645f4870fb52300b736910 \
+                                size    1123744
 
     homepage                    ${homepage}/docs/bindings/
 
@@ -130,7 +132,7 @@ subport xapian-bindings-java {
 }
 
 # Perl
-foreach v {5.28 5.30 5.32 5.34 5.36 5.38} {
+foreach v {5.28 5.30 5.32 5.34 5.36 5.38 5.40} {
     subport xapian-bindings-perl${v} "
         revision                0
 
@@ -149,7 +151,7 @@ foreach v {5.28 5.30 5.32 5.34 5.36 5.38} {
 }
 
 # PHP
-foreach v {8.0 8.1 8.2 8.3} {
+foreach v {8.0 8.1 8.2 8.3 8.4 8.5 8.6} {
     set v_no_dot [string map {. {}} ${v}]
     set php php${v_no_dot}
     subport ${php}-xapian "
@@ -177,7 +179,7 @@ foreach v {8.0 8.1 8.2 8.3} {
 }
 
 # Python
-foreach v {3.10 3.11 3.12 3.13} {
+foreach v {3.10 3.11 3.12 3.13 3.14} {
     set v_no_dot [string map {. {}} ${v}]
     if {[vercmp ${v} 3] >= 0} {
         set suffix 3
@@ -204,7 +206,8 @@ foreach v {3.10 3.11 3.12 3.13} {
 }
 
 # Ruby
-foreach v {2.7 3.0 3.1 3.2 3.3 3.4} {
+# 2.7 fails to build
+foreach v {3.0 3.1 3.2 3.3 3.4} {
     set v_no_dot [string map {. {}} ${v}]
     subport xapian-bindings-ruby${v_no_dot} "
         revision                0

--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -3,7 +3,7 @@
 PortSystem                      1.0
 
 name                            xapian-core
-version                         1.4.27
+version                         2.1.0
 categories                      devel
 maintainers                     {ryandesign @ryandesign} openmaintainer
 license                         GPL-2+
@@ -27,9 +27,9 @@ if {${subport} eq ${name}} {
     # version.h does not get generated properly when there are multiple -arch flags
     PortGroup                   muniversal 1.0
 
-    checksums                   rmd160  344e11ede45691dd6f76a35690838acbd6ad216b \
-                                sha256  bcbc99cfbf16080119c2571fc296794f539bd542ca3926f17c2999600830ab61 \
-                                size    3246624
+    checksums                   rmd160  4ef04fb8b811ee0969f1b644983383525d20e2e4 \
+                                sha256  8e1259586d342e3d12b5e1f772e9185a10f2ba16e541566b5c3c239f71b8aacc \
+                                size    3521276
 
     # TODO: Fix xapian-config to not require the .la file
     # /opt/local/bin/xapian-config --ltlibs --cxxflags
@@ -56,9 +56,9 @@ if {${subport} eq ${name}} {
 
 subport xapian-omega {
     revision                    0
-    checksums                   rmd160  bb9f9f8e497ac97fa506804114794799215de625 \
-                                sha256  1d193b3285ec150557257b049ee1d8c94c40bcde906ce0ba7f1a38a1a9a5a5c1 \
-                                size    583960
+    checksums                   rmd160  468b58721e25bf200f2d6e39da07b5b37947574b \
+                                sha256  e3bcf29b5fcb790c28c3e90624ff9297a9a44914f0ba566cb3ee677a015097be \
+                                size    5834584
 
     description                 web application using the Xapian library
     long_description            Xapian Omega is an application built on the \
@@ -68,6 +68,8 @@ subport xapian-omega {
     homepage                    ${homepage}/docs/omega/overview.html
 
     distname                    xapian-omega-${version}
+
+    depends_build-append        path:bin/pkg-config:pkgconfig
 
     depends_lib                 port:libiconv \
                                 port:libmagic \
@@ -79,9 +81,9 @@ subport xapian-omega {
 }
 
 if {${subport} ni [list ${name} xapian-omega]} {
-    checksums                   rmd160  beec2bc2b651c54e97c2649db30c1c0240aedc72 \
-                                sha256  ba3b5e10809e579acd11bd165779ce3fd29a8904ea37968ef5b57ad97c3618ba \
-                                size    1116236
+    checksums                   rmd160  a4d11b5bc56e7625c734f1389b0b1ea7f2413e9d \
+                                sha256  f52ec189f13b4fa66ea625a6eb94bb32dd651b9ec806be6a911dda54cbe3875c \
+                                size    1124652
 
     homepage                    ${homepage}/docs/bindings/
 
@@ -128,7 +130,7 @@ subport xapian-bindings-java {
 }
 
 # Perl
-foreach v {5.28 5.30 5.32 5.34 5.36 5.38} {
+foreach v {5.28 5.30 5.32 5.34 5.36 5.38 5.40} {
     subport xapian-bindings-perl${v} "
         revision                0
 
@@ -147,7 +149,7 @@ foreach v {5.28 5.30 5.32 5.34 5.36 5.38} {
 }
 
 # PHP
-foreach v {8.0 8.1 8.2 8.3} {
+foreach v {8.0 8.1 8.2 8.3 8.4 8.5} {
     set v_no_dot [string map {. {}} ${v}]
     set php php${v_no_dot}
     subport ${php}-xapian "
@@ -175,7 +177,7 @@ foreach v {8.0 8.1 8.2 8.3} {
 }
 
 # Python
-foreach v {3.10 3.11 3.12 3.13} {
+foreach v {3.10 3.11 3.12 3.13 3.14} {
     set v_no_dot [string map {. {}} ${v}]
     if {[vercmp ${v} 3] >= 0} {
         set suffix 3
@@ -202,7 +204,8 @@ foreach v {3.10 3.11 3.12 3.13} {
 }
 
 # Ruby
-foreach v {2.7 3.0 3.1 3.2 3.3 3.4} {
+# 2.7 fails to build
+foreach v {3.0 3.1 3.2 3.3 3.4} {
     set v_no_dot [string map {. {}} ${v}]
     subport xapian-bindings-ruby${v_no_dot} "
         revision                0

--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -1,27 +1,25 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
+PortSystem                      1.0
 
-name                xapian-core
-version             1.4.27
-categories          devel
-maintainers         {ryandesign @ryandesign} openmaintainer
-license             GPL-2+
+name                            xapian-core
+version                         1.4.27
+categories                      devel
+maintainers                     {ryandesign @ryandesign} openmaintainer
+license                         GPL-2+
 
-description         Xapian search library
-long_description    Xapian is a highly adaptable toolkit which allows \
-                    developers to easily add advanced indexing and search \
-                    facilities to their own applications. It supports the \
-                    Probabilistic Information Retrieval model and also \
-                    supports a rich set of boolean query operators.
+description                     Xapian search library
+long_description \
+    Xapian is a highly adaptable toolkit which allows developers to easily add advanced indexing and search \
+    facilities to their own applications. It supports the Probabilistic Information Retrieval model and also \
+    supports a rich set of boolean query operators.
 
-homepage            https://xapian.org
-master_sites        https://oligarchy.co.uk/xapian/${version}/
-dist_subdir         xapian
-use_xz              yes
+homepage                        https://xapian.org
+master_sites                    https://oligarchy.co.uk/xapian/${version}/
+dist_subdir                     xapian
+use_xz                          yes
 
-compiler.cxx_standard \
-                    2011
+compiler.cxx_standard           2011
 
 if {${subport} eq ${name}} {
     revision                    0

--- a/kde/baloo/Portfile
+++ b/kde/baloo/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 name                baloo
 version             4.14.3
-revision            3
+revision            4
 categories          kde kde4
 maintainers         nomaintainer
 license             {LGPL-2 LGPL-2.1+ GPL-2+}

--- a/mail/mu/Portfile
+++ b/mail/mu/Portfile
@@ -10,7 +10,7 @@ github.tarball_from archive
 checksums           rmd160  bb16b2715a6c659f56c8b94b1390044662a14fa5 \
                     sha256  bc7c4dc1a3c86498efcbc9d61b4ff8c38630153c4a8f7e3af39c7f03c1c049bc \
                     size    1033829
-revision            0
+revision            1
 
 categories          mail
 license             GPL-3

--- a/mail/muchsync/Portfile
+++ b/mail/muchsync/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                muchsync
 version             7
+revision            1
 categories          mail
 platforms           darwin
 license             GPL-2+

--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5                       1.0
 
 name                notmuch
 version             0.38.3
-revision            1
+revision            2
 checksums           rmd160  5dec7b4dc2db2c731ad106ab1f15c6b911fb4a40 \
                     sha256  9af46cc80da58b4301ca2baefcc25a40d112d0315507e632c0f3f0f08328d054 \
                     size    805416

--- a/textproc/recoll/Portfile
+++ b/textproc/recoll/Portfile
@@ -8,6 +8,7 @@ qt5.depends_component qtwebkit
 
 name                recoll
 version             1.31.6
+revision            1
 categories          textproc
 platforms           darwin
 license             GPL-2+


### PR DESCRIPTION

###### Tested on
```
Model Identifier: MacPro5,1
macOS 15.7.4 24G517 x86_64
Xcode 26.3 17C529
Command Line Tools 26.2.0.0.1.1764812424
```
###### Verification <!-- (delete not applicable items) -->
Have you
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
```
declare devDIR='/Volumes/Bjarne4TB/Users/Bjarne/BDMdata/GitMacintosh/MacPorts'

declare -a subPorts=( xapian-core xapian-omega xapian-bindings-java xapian-bindings-perl5.28 xapian-bindings-perl5.30 xapian-bindings-perl5.32 \
                      xapian-bindings-perl5.34 xapian-bindings-perl5.36 xapian-bindings-perl5.38 xapian-bindings-perl5.40 php80-xapian \
                      php81-xapian php82-xapian php83-xapian php84-xapian php85-xapian xapian-bindings-python310 xapian-bindings-python311 \
                      xapian-bindings-python312 xapian-bindings-python313 xapian-bindings-python314 xapian-bindings-ruby27 xapian-bindings-ruby30 \
                      xapian-bindings-ruby31 xapian-bindings-ruby32 xapian-bindings-ruby33 xapian-bindings-ruby34 )

for xapian in "${subPorts[@]}"
do
    port clean --work    "${xapian}"
    port -cuNf uninstall "${xapian}" 2>/dev/null
done

for xapian in "${subPorts[@]}"
do
    port info --conflicts "${xapian}" \
    | awk '{sub($1 FS,"")}1' \
    | xargs port -cuNfp deactivate 2>/dev/null

    port -cuNd   install "${xapian}" 2>&1 \
    | tee    "${devDIR}/logs/${xapian}_main.log"

    port -cuNd  contents "${xapian}" 2>&1 \
    | tee -a "${devDIR}/logs/${xapian}_main.log"
done

```