### PR TITLE
devel/llhttp, devel/icey: new ports

### DIFF
--- a/devel/icey/Portfile
+++ b/devel/icey/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+github.setup        nilstate icey 2.4.5
+github.tarball_from archive
+revision            0
+
+categories          devel multimedia net
+maintainers         nomaintainer
+license             LGPL-2.1+
+homepage            https://0state.com/icey/
+description         C++20 media stack and libwebrtc alternative for real-time video, signalling, TURN, and media servers
+long_description    ${description}
+
+checksums           rmd160  9a2f0145f1eea9a65d9289631a485c9436ee99dc \
+                    sha256  b8574956fcdd497b79cbb267935972348385b6c679d0239e0debc79afbedfbcf \
+                    size    6459512
+
+openssl.branch      3
+
+set ffmpeg_ver      8
+
+depends_lib-append  path:libexec/ffmpeg${ffmpeg_ver}/lib/libavcodec.dylib:ffmpeg${ffmpeg_ver} \
+                    port:libuv \
+                    port:llhttp \
+                    port:minizip \
+                    port:nlohmann-json \
+                    port:zlib
+
+configure.pkg_config_path-prepend \
+                    ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
+
+compiler.cxx_standard 2020
+
+# Upstream rejects the cmake PortGroup's default "MacPorts" build type.
+cmake.build_type    Release
+
+configure.args-append \
+                    -DBUILD_SHARED_LIBS=ON \
+                    -DUSE_SYSTEM_DEPS=ON \
+                    -DBUILD_TESTS=OFF \
+                    -DBUILD_SAMPLES=OFF \
+                    -DBUILD_APPLICATIONS=OFF \
+                    -DBUILD_FUZZERS=OFF \
+                    -DBUILD_BENCHMARKS=OFF \
+                    -DBUILD_PERF=OFF \
+                    -DBUILD_ALPHA=OFF \
+                    -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=TRUE \
+                    -DENABLE_NATIVE_ARCH=OFF \
+                    -DWITH_FFMPEG=ON \
+                    -DWITH_LIBDATACHANNEL=OFF \
+                    -DBUILD_MODULE_webrtc=OFF \
+                    -DWITH_OPENCV=OFF

--- a/devel/llhttp/Portfile
+++ b/devel/llhttp/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        nodejs llhttp 9.3.1 release/v
+github.tarball_from archive
+revision            0
+
+categories          devel
+maintainers         nomaintainer
+license             MIT
+homepage            https://llhttp.org/
+description         Fast HTTP message parser based on llparse
+long_description    {*}${description}
+
+checksums           rmd160  249f4ed62a7a8636a8c3bd0376ad38b8d37452f0 \
+                    sha256  c14a93f287d3dbd6580d08af968294f8bcc61e1e1e3c34301549d00f3cf09365 \
+                    size    39211
+
+# Upstream currently rejects the cmake PortGroup's default "MacPorts" build type.
+cmake.build_type    Release
+
+compiler.c_standard 1999


### PR DESCRIPTION
Adds two new ports:

- `devel/llhttp`: HTTP parser library used by `icey`
- `devel/icey`: C++20 real-time media/runtime library

Notes:
- `icey` uses the existing `minizip` subport from `archivers/zlib`
- WebRTC stays disabled in this first port because `libdatachannel` is not packaged here yet
- Formula metadata is pinned to the current `2.4.2` release tarball and checksums

Local validation on my side covered the release tarball metadata and dependency shape before opening this PR.