### PR TITLE
fpc-cross-m68k-*: add new subports

### DIFF
--- a/cross/m68k-binutils/Portfile
+++ b/cross/m68k-binutils/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           crossbinutils 1.0
+
+name                m68k-binutils
+version             2.46.0
+revision            0
+maintainers         {@kamischi web.de:karl-michael.schindler} \
+                    openmaintainer
+
+if {$subport eq $name} {
+    # Download sources and install docs for all subports
+    crossbinutils.setup m68k ${version}
+    depends_build
+    depends_lib
+    platforms           any
+    supported_archs     noarch
+    use_configure       no
+    build               {}
+    destroot            {}
+}
+
+# tried, but not working targets: amigaos atari openbsd
+# freepascal probably needs palm binutils from here:
+# https://github.com/chainq/prc-tools-remix
+foreach ostarget {linux freebsd netbsd} {
+    subport m68k-${ostarget}-binutils {
+        crossbinutils.setup     m68k-${ostarget} ${version}
+        # Depend on base package for installing the docs
+        depends_lib-append      port:$name
+        configure.args-append   --disable-werror
+        if {${ostarget} eq "linux"} {
+            depends_build-append    port:bison
+        }
+        # Delete docs since already installed by the base package
+        # Resolves clash about identical docs from each subport
+        post-destroot {
+            delete ${destroot}${prefix}/share/doc/m68k-binutils
+        }
+    }
+}
+
+subport m68k-embedded-binutils {
+    crossbinutils.setup     m68k-embedded ${version}
+    depends_lib-append      port:$name
+    configure.args-append \
+        --target=m68k-unknown-elf \
+        --disable-werror
+
+    post-destroot {
+        # See comment above about deleting docs
+        delete      ${destroot}${prefix}/share/doc/m68k-binutils
+        file rename ${destroot}${prefix}/m68k-unknown-elf/bin \
+                    ${destroot}${prefix}/m68k-embedded
+        file rename ${destroot}${prefix}/m68k-unknown-elf/lib \
+                    ${destroot}${prefix}/m68k-embedded
+        file delete ${destroot}${prefix}/m68k-unknown-elf
+    }
+}

--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -390,6 +390,44 @@ foreach ostarget {linux netbsd} {
     }
 }
 
+# may also support: amiga atari MacOSClassic palmos
+foreach ostarget {linux netbsd embedded} {
+    subport "${name}-cross-m68k-$ostarget" {
+        revision                0
+        categories-append       cross
+        supported_archs         noarch
+        worksrcdir              fpcbuild-${version}/fpcsrc
+        use_parallel_build      no
+        use_configure           no
+        depends_build-append    port:${name} port:${name}-cross port:m68k-${ostarget}-binutils
+        build.target            rtl packages
+        destroot.target         rtl_install packages_install
+        test.target
+
+# target specifics
+        description     FPC cross-compiler for m68k-$ostarget
+        long_description \
+            This Pascal crosscompiler produces m68k executables, \
+            which run natively on m68k-$ostarget systems. \n \
+            Get help with: \n \
+            fpc -h \n \
+            Compile and link a Pascal file with: \n \
+            \n \
+            fpc -Pm68k -T$ostarget FILENAME
+
+        build.args      PP=ppc68k CPU_TARGET=m68k OS_TARGET=$ostarget \
+                        OPT="-ap -v0"
+        destroot.args   CPU_TARGET=m68k OS_TARGET=$ostarget CROSSINSTALL=1 \
+                        INSTALL_PREFIX=${destroot}${prefix}/libexec/fpc/
+
+# remove duplicate doc and bin files
+        post-destroot   {
+            file delete -force ${destroot}${prefix}/libexec/fpc/share
+            file delete -force ${destroot}${prefix}/libexec/fpc/bin
+        }
+    }
+}
+
 if {${subport} eq "${name}"} {
     revision            3
 


### PR DESCRIPTION
#### Description

Add a series of cross compilers for m68k cpus, which require corresponding binutils.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.4 25E246 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
