### PR TITLE
py{27,37}-lxml: Add missing revbumps and dep

### DIFF
--- a/python/py-altgraph/Portfile
+++ b/python/py-altgraph/Portfile
@@ -25,7 +25,7 @@ checksums           md5 103802ef2ad240dfa98886a909cc54d2 \
                     rmd160 3f6cc99212babb09ead8a0b1ab1d74f8ea0b84db \
                     sha256 c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7
 
-python.versions     37 310 311 312 313 314
+python.versions     27 37 310 311 312 313 314
 
 if {$subport ne $name} {
     test.run        yes

--- a/python/py-lxml/Portfile
+++ b/python/py-lxml/Portfile
@@ -31,13 +31,16 @@ python.versions     27 37 310 311 312 313 314
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {
         version     5.0.2
-        revision    0
+        revision    1
         checksums   rmd160  edd377fe2e214c69db4e468583ac507cf71853a7 \
                     sha256  6399703c40ba53e2c3b72fdb56cb908d2b83c08082ecf17de839b27e68d1e598 \
                     size    3862433
+
+        depends_build-append \
+                        port:py${python.version}-modulegraph \
     } elseif {${python.version} == 37} {
         version     5.4.0
-        revision    0
+        revision    1
         checksums   rmd160  388615fe1ee020bdbc0fc6556a47a94843578e9d \
                     sha256  d12832e1dbea4be280b22fd0ea7c9b87f0d8fc51ba06e92dc62d52f804f78ebd \
                     size    3679479

--- a/python/py-modulegraph/Portfile
+++ b/python/py-modulegraph/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-modulegraph
 version             0.19.7
+revision            1
 categories-append   devel
 license             MIT
 maintainers         {jmr @jmroot} openmaintainer
@@ -25,13 +26,17 @@ checksums           md5 87234ee031830f93aaf175ea21e35013 \
                     rmd160 d0cc393f8c6a437a84c4b69550ebc7a3553c2b80 \
                     sha256 9ad8a81148ba1d90ade66617a153786f7d7cf6a88de83ee28e251183122c2a57
 
-python.versions     37 310 311 312 313 314
+python.versions     27 37 310 311 312 313 314
 
 if {$subport ne $name} {
     depends_lib-append  port:py${python.version}-altgraph
     if {${python.version} < 38} {
         # Needs pkg_resources at runtime when importlib.metadata is not available
         depends_lib-append  port:py${python.version}-setuptools
+    }
+    if {${python.version} < 33} {
+        # Byte-form string literals aren't available before Python 3.3
+        patchfiles-append       patch-norb.diff
     }
     test.run        yes
     python.test_framework   unittest

--- a/python/py-modulegraph/files/patch-norb.diff
+++ b/python/py-modulegraph/files/patch-norb.diff
@@ -1,0 +1,11 @@
+--- modulegraph/util.py.orig	2025-11-21 12:36:05.000000000 -0800
++++ modulegraph/util.py	2026-04-04 16:44:53.000000000 -0700
+@@ -115,7 +115,7 @@ def imp_walk(name):
+     raise ImportError("No module named %s" % (name,))
+ 
+ 
+-cookie_re = re.compile(rb"coding[:=]\s*([-\w.]+)")
++cookie_re = re.compile(r"coding[:=]\s*([-\w.]+)")
+ if sys.version_info[0] == 2:
+     default_encoding = "ascii"
+ else:


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.11 20G1443, x86_64, Xcode 13.2.1 13C100
macOS 11.7.11 20G1443, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.8 22H730, arm64, Xcode 15.2 15C500b
macOS 14.8.5 23J423, arm64, Xcode 16.2 16C5032a
macOS 15.7.5 24G624, arm64, Xcode 26.3 17C529
macOS 26.4 25E246, arm64, Xcode 26.4 17E192
```
Some subports have broken dependencies on <10.6.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? `*`
- [x] tried a full install with `sudo port -vst install`?
- [N/A] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - Tests pass on py*-altgraph and py*-lxml, though they're too quick to be real.
         Tests have failed on py*-modulegraph since their enablement.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
