### PR TITLE
python315-devel: blacklist clang < 900

### DIFF
--- a/lang/python315-devel/Portfile
+++ b/lang/python315-devel/Portfile
@@ -60,6 +60,12 @@ the 'python' or 'python3' commands), run one or both of:
 }
 
 compiler.c_standard 2011
+# https://github.com/python/cpython/commit/ad4ee7cb0f75d9c6615eaefe69692fc8e3ec553b
+# Python 3.15.0a7 has enabled portable SIMD by default for
+# x86-64/arm64, which increases the Clang version requirement.
+# TODO: need to add an option to disable this for older systems.
+compiler.blacklist-append \
+                    {clang < 900}
 
 configure.args      --enable-framework=${frameworks_dir} \
                     --enable-ipv6 \


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?