### PR TITLE
telepathy-mission-control: use Python 3.14 for build

### DIFF
--- a/comms/telepathy-mission-control/Portfile
+++ b/comms/telepathy-mission-control/Portfile
@@ -23,8 +23,8 @@ checksums       sha256  2df8ae3995e919a7670e01aa3568215ef0777e34961ace1cac1c6477
 
 depends_build   port:pkgconfig \
                 port:libxslt \
-                port:dbus-python39 \
-                port:py39-gobject
+                port:dbus-python314 \
+                port:python314
 
 depends_lib     port:telepathy-glib
 
@@ -32,7 +32,7 @@ patchfiles      patch-configure.diff \
                 dynamic_lookup-11.patch
 
 configure.python \
-                ${prefix}/bin/python3.9
+                ${prefix}/bin/python3.14
 
 configure.args  --disable-libaccounts-sso \
                 --disable-upower \


### PR DESCRIPTION
#### Description
- remove redundant py-gobject dependency ; build works fine without

@dbevans I am trying to get rid of all py39-subports as that Python versions is EOL. The build lists py39-gobject as a dependency but that seems unneeded as the build works fine without. Also, the build finishes fine with Python 3.14 so use that one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.4 25E246 x86_64
Xcode 26.0.1 17A400

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
