### PR TITLE
emacs/emacs-mac: Fix tree-sitter build issue

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -175,8 +175,10 @@ variant nativecomp description {Builds emacs with native compilation support} {
 variant treesitter description {Builds emacs with tree-sitter support} {
     configure.args-delete   --without-tree-sitter
     configure.args-append   --with-tree-sitter
-    configure.cflags-append -Dts_language_version=ts_language_abi_version
     depends_lib-append  port:tree-sitter
+
+    # TODO: This will become unnecessary in Emacs 31
+    configure.cflags-append -Dts_language_version=ts_language_abi_version
 
     lappend rpaths ${prefix}/lib
 

--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -10,7 +10,7 @@ bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ve
 name                emacs-mac-app
 conflicts           emacs-app emacs-app-devel
 version             ${emacs_mac_ver}
-revision            3
+revision            4
 categories          aqua editors
 maintainers         {amake @amake} openmaintainer
 
@@ -102,7 +102,7 @@ subport ${name}-devel {
     set date            2025-09-20
 
     version         [string map {- {}} ${date}]
-    revision        1
+    revision        2
 
     long_description \
         ${name} is the \"Mac port\" of GNU Emacs ${emacs_version}. \
@@ -175,6 +175,7 @@ variant nativecomp description {Builds emacs with native compilation support} {
 variant treesitter description {Builds emacs with tree-sitter support} {
     configure.args-delete   --without-tree-sitter
     configure.args-append   --with-tree-sitter
+    configure.cflags-append -Dts_language_version=ts_language_abi_version
     depends_lib-append  port:tree-sitter
 
     lappend rpaths ${prefix}/lib

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -137,17 +137,17 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs db3d6f06c389e06922964fb4869d19ba9040c16e
+    github.setup    emacs-mirror emacs 7ce60be53e7ffbc1972dd8e98744adf6103eee9e
     github.tarball_from archive
     epoch           5
-    version         20250924
-    revision        2
+    version         20260406
+    revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  591d36fc54fc696d35e026f6d8a80d0230ed1394 \
-                    sha256  664d4fa8443c884ecbbddebfc799f9142dada9911eaff7b0fb116a4b0c63c2fe \
-                    size    52379510
+    checksums       rmd160  6496eb0f56b2250840049c249dea73310feb9244 \
+                    sha256  4dc00f6615292c0d6fccd330260bf2b06abbe84d4a27c469be8a914c0faa1ed5 \
+                    size    53052187
 
     livecheck.type none
 
@@ -307,8 +307,12 @@ variant nativecomp description {Builds emacs with native compilation support} {
 variant treesitter description {Builds emacs with tree-sitter support} {
     configure.args-delete   --without-tree-sitter
     configure.args-append   --with-tree-sitter
-    configure.cflags-append -Dts_language_version=ts_language_abi_version
     depends_lib-append      port:tree-sitter
+
+    # TODO: This will become unnecessary in Emacs 31
+    if {$subport eq $name || $subport eq "emacs-app"} {
+        configure.cflags-append -Dts_language_version=ts_language_abi_version
+    }
 
     if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
         lappend rpaths ${prefix}/lib

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -124,7 +124,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         30.2
-    revision        3
+    revision        4
     checksums       rmd160  fefdd3fcd453d733114f609a3e122b2529cc7410 \
                     sha256  1d79a4ba4d6596f302a7146843fe59cf5caec798190bcc07c907e7ba244b076d \
                     size    83059014
@@ -141,7 +141,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     github.tarball_from archive
     epoch           5
     version         20250924
-    revision        1
+    revision        2
 
     master_sites    ${github.master_sites}
 
@@ -307,6 +307,7 @@ variant nativecomp description {Builds emacs with native compilation support} {
 variant treesitter description {Builds emacs with tree-sitter support} {
     configure.args-delete   --without-tree-sitter
     configure.args-append   --with-tree-sitter
+    configure.cflags-append -Dts_language_version=ts_language_abi_version
     depends_lib-append      port:tree-sitter
 
     if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4 25E246 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

build details: 
```
# port -v rev-upgrade
--->  Scanning binaries for linking errors
Could not open /opt/local/lib/libtree-sitter.0.25.dylib: Error opening or reading file (referenced from /opt/local/bin/emacs-30.2)
--->  Found 1 broken file, matching files to ports
--->  Found 1 broken port, determining rebuild order
You can always run 'port rev-upgrade' again to fix errors.
The following ports will be rebuilt: emacs @30.2+nativecomp+treesitter

And recompiling emacs doesn’t work:

treesit.c:749:21: error: use of undeclared identifier 'ts_language_version'; did you mean 'ts_language_abi_version'?
  749 |                             make_fixnum (ts_language_version (lang)));
      |                                          ^~~~~~~~~~~~~~~~~~~
      |                                          ts_language_abi_version
/opt/local/include/tree_sitter/api.h:1268:10: note: 'ts_language_abi_version' declared here
 1268 | uint32_t ts_language_abi_version(const TSLanguage *self);
      |          ^
/usr/bin/clang -std=gnu23 -c -isystem/opt/local/include -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk -Demacs  -I. -I. -I../lib -I../lib         -I/opt/local/include/libxml2 -I/opt/local/include/gcc15                -MMD -MF deps/lastfile.d -MP    -I/opt/local/include/p11-kit-1              -Wno-pointer-sign -Wno-string-plus-int -Wno-unknown-attributes -Wno-unknown-pragmas -Wno-initializer-overrides -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-deprecated-declarations -pipe -Os -Wno-attributes -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk -arch arm64  lastfile.c
treesit.c:820:27: error: use of undeclared identifier 'ts_language_version'; did you mean 'ts_language_abi_version'?
  820 |       uint32_t version =  ts_language_version (ts_language);
      |                           ^~~~~~~~~~~~~~~~~~~
      |                           ts_language_abi_version
/opt/local/include/tree_sitter/api.h:1268:10: note: 'ts_language_abi_version' declared here
 1268 | uint32_t ts_language_abi_version(const TSLanguage *self);
      |          ^
2 errors generated.
make[2]: *** [treesit.o] Error 1
```
