### PR TITLE
py-altair: add py314 subport

### DIFF
--- a/python/py-altair/Portfile
+++ b/python/py-altair/Portfile
@@ -12,7 +12,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     310 311 312 313
+python.versions     310 311 312 313 314
 python.pep517_backend hatch
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -35,7 +35,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-toolz \
                         port:py${python.version}-packaging
 
-    if {${python.version} < 314} {
+    if {${python.version} < 315} {
         depends_lib-append  port:py${python.version}-typing_extensions
     }
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Altair 6.0.0 declares `typing-extensions>=4.12.0; python_version < '3.15'`, so py314-typing_extensions is still required.

Tested (just to make sure altair works with python3.14) with:

```shell
python3.14 -m venv /tmp/altair-test && /tmp/altair-test/bin/pip install altair && /tmp/altair-test/bin/python -c "import altair as alt; print(alt.__version__); c = alt.Chart({'values': [{'x': 1}]}).mark_point(); print('OK')"
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.4 25E246 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
