### PR TITLE
libjpeg-turbo-devel: sync with libjpeg-turbo port

### DIFF
--- a/graphics/libjpeg-turbo-devel/Portfile
+++ b/graphics/libjpeg-turbo-devel/Portfile
@@ -10,14 +10,14 @@ PortGroup           muniversal 1.0
 name                libjpeg-turbo-devel
 conflicts           libjpeg-turbo mozjpeg
 set my_name         libjpeg-turbo
-version             3.1.1
+version             3.1.4.1
 revision            0
 github.setup        ${my_name} ${my_name} ${version}
-github.tarball_from archive
+github.tarball_from releases
 
 categories          graphics
 license             BSD
-maintainers         {mascguy @mascguy} openmaintainer
+maintainers         {larryv @larryv} {mascguy @mascguy} {jmr @jmroot}
 
 description         SIMD-accelerated libjpeg-compatible JPEG codec \
                     library
@@ -36,9 +36,9 @@ homepage            https://www.${my_name}.org
 
 dist_subdir         ${my_name}
 
-checksums           rmd160  ceafe9b5a25b92d2b6bd6f88f5aaa38ed10086be \
-                    sha256  304165ae11e64ab752e9cfc07c37bfdc87abd0bfe4bc699e59f34036d9c84f72 \
-                    size    2506010
+checksums           rmd160 7b86748e079ac56c996259de772f70cfd72fcde8 \
+                    sha256 ecae8008e2cc9ade2f2c1bb9d5e6d4fb73e7c433866a056bd82980741571a022 \
+                    size   2528617
 
 configure.args-append \
                     -DENABLE_SHARED:BOOL=ON \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
