### PR TITLE
pbsecret: Update to 20260406

### DIFF
--- a/sysutils/pbsecret/Portfile
+++ b/sysutils/pbsecret/Portfile
@@ -17,10 +17,10 @@ maintainers         {@midnightrocket} \
 platforms           macosx
 
 description         CLI util to write text to pasteboard as `org.nspasteboard.ConcealedType`
-long_description    \
-                    Copies data from STDIN to the general pasteboard as UTF-8 text. Copied \
+long_description    Copies data from STDIN to the general pasteboard as UTF-8 text. Copied \
                     data is tagged with "org.nspasteboard.ConcealedType" to prevent it from \
-                    being saved in the history of a clipboard manager, as per the spec at:
+                    being saved in the history of a clipboard manager, as per the spec at: \
+                    https://nspasteboard.org/
 
 license             MIT
 

--- a/sysutils/pbsecret/Portfile
+++ b/sysutils/pbsecret/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 
-github.setup        roosto pbsecret 9e91917de001a73fc01aa8ba96c5c83c4b7f5a34
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-version             20200219
+github.setup        roosto pbsecret 4e5c7146c9eb73e8cb977f2d0b49a4e0a1128b1c
+github.tarball_from archive
+version             20260406
 revision            0
 
 categories          sysutils
@@ -24,9 +23,9 @@ long_description    Copies data from STDIN to the general pasteboard as UTF-8 te
 
 license             MIT
 
-checksums           rmd160  e2402c186f6d67e4af66f83c183869706c226e93 \
-                    sha256  6d4b8ccca1bfc6a37102cf9b774d2b3e83037baed5600c7350d27209c7d688f3 \
-                    size    2365
+checksums           rmd160  10d30a57cf62b1754fcfc666fa675c7bec61f0da \
+                    sha256  a818e5c88cf2fea03ee029f12d29ccd526561c625a767ad6c6b36c4afc880e17 \
+                    size    2450
 
 
 destroot {

--- a/sysutils/pbsecret/Portfile
+++ b/sysutils/pbsecret/Portfile
@@ -1,32 +1,32 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem      1.0
-PortGroup       github 1.0
-PortGroup       makefile 1.0
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
 
-github.setup    roosto pbsecret 9e91917de001a73fc01aa8ba96c5c83c4b7f5a34
+github.setup        roosto pbsecret 9e91917de001a73fc01aa8ba96c5c83c4b7f5a34
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-version         20200219
-revision        0
+version             20200219
+revision            0
 
-categories      sysutils
-maintainers     {@midnightrocket} \
-                openmaintainer
+categories          sysutils
+maintainers         {@midnightrocket} \
+                    openmaintainer
 
-platforms       macosx
+platforms           macosx
 
-description     CLI util to write text to pasteboard as `org.nspasteboard.ConcealedType`
+description         CLI util to write text to pasteboard as `org.nspasteboard.ConcealedType`
 long_description    \
-                Copies data from STDIN to the general pasteboard as UTF-8 text. Copied \
-                data is tagged with "org.nspasteboard.ConcealedType" to prevent it from \
-                being saved in the history of a clipboard manager, as per the spec at:
+                    Copies data from STDIN to the general pasteboard as UTF-8 text. Copied \
+                    data is tagged with "org.nspasteboard.ConcealedType" to prevent it from \
+                    being saved in the history of a clipboard manager, as per the spec at:
 
-license         MIT
+license             MIT
 
-checksums       rmd160  e2402c186f6d67e4af66f83c183869706c226e93 \
-                sha256  6d4b8ccca1bfc6a37102cf9b774d2b3e83037baed5600c7350d27209c7d688f3 \
-                size    2365
+checksums           rmd160  e2402c186f6d67e4af66f83c183869706c226e93 \
+                    sha256  6d4b8ccca1bfc6a37102cf9b774d2b3e83037baed5600c7350d27209c7d688f3 \
+                    size    2365
 
 
 destroot {


### PR DESCRIPTION
#### Description
Update to newest commit https://github.com/roosto/pbsecret/commit/4e5c7146c9eb73e8cb977f2d0b49a4e0a1128b1c which prevents syncing copied content to iCloud devices. 

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4 25E246 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
