### PR TITLE
vala: update to 0.56.19

### DIFF
--- a/lang/vala/Portfile
+++ b/lang/vala/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                vala
 conflicts           vala-devel
 set my_name         vala
-version             0.56.18
+version             0.56.19
 revision            0
 
 categories          lang
@@ -25,9 +25,9 @@ dist_subdir         ${my_name}
 distname            ${my_name}-${version}
 use_xz              yes
 
-checksums           rmd160  a4d3ded63aa60f5aac44c60c3c7c7289e9fd9175 \
-                    sha256  f2affe7d40ab63db8e7b9ecc3f6bdc9c2fc7e3134c84ff2d795f482fe926a382 \
-                    size    3995244
+checksums           rmd160  62cd33aa1fa25202f8a7bf59424adbcf734eaf55 \
+                    sha256  5ad7cbbfcc0de61b403d6797c9ef60455bfbebd8e162aec33b5b0b097adfb9d5 \
+                    size    4007612
 
 if { [string match *clang* ${configure.compiler}] } {
     # Quiet warnings


### PR DESCRIPTION
#### Description

Following #32084

vala-devel is building fine on older macOS so it is safe to merge:

<img width="374" height="716" alt="Captura de Tela 2026-04-07 às 21 53 57" src="https://github.com/user-attachments/assets/5681f3c1-cf3e-4f56-b13b-723a04b30fb6" />


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Command Line Tools 26.4.0.0.1774242506

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (already failing on .18 and still failing on .19)
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? (tested +valadoc)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
