### PR TITLE
XviD: set C version to 1999

### DIFF
--- a/multimedia/XviD/Portfile
+++ b/multimedia/XviD/Portfile
@@ -42,6 +42,10 @@ patchfiles          configure-CFLAGS.patch \
 
 use_autoreconf      yes
 
+# XviD is C99 code
+compiler.c_standard 1999
+configure.cflags-append -std=gnu99
+
 configure.universal_args-delete --disable-dependency-tracking
 
 set my_targets(arm64)   aarch64


### PR DESCRIPTION
In C23, bool is a built-in keyword. Guard the typedef int bool; in encoder.h so it is only used with older C standards.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
