### PR TITLE
vtk: Fix builds for 10.6

### DIFF
--- a/graphics/vtk/files/patch-use-x11.diff
+++ b/graphics/vtk/files/patch-use-x11.diff
@@ -16,16 +16,19 @@ Fix that in the patch. The following forces X11 on Apple and fixes linking.
  # For VTK 9.4.0:  It looks like upstream already fixed previous hunk #1
  # "elseif (VTK_USE_SDL2)".  Remove hunk #1, leave hunk #2 in place.
 
---- Rendering/OpenGL2/CMakeLists.txt.orig	2024-11-25 00:01:28
-+++ Rendering/OpenGL2/CMakeLists.txt		2024-11-26 18:50:58
-@@ -438,6 +438,7 @@
- if (VTK_USE_X)
-   vtk_module_find_package(PACKAGE X11)
-   vtk_module_link(VTK::RenderingOpenGL2 PUBLIC X11::X11)
-+  vtk_module_link(VTK::RenderingOpenGL2 PUBLIC GL)
-   if (TARGET X11::Xcursor)
-     vtk_module_link(VTK::RenderingOpenGL2 PRIVATE X11::Xcursor)
-   else()
+ # For VTK 9.6.1:  This hunk is broken.  Upstream changed the USE_X code.
+ # Disable for now.  See if build finishes, and whether X11 keeps working.
+
+#--- Rendering/OpenGL2/CMakeLists.txt.orig	2024-11-25 00:01:28
+#+++ Rendering/OpenGL2/CMakeLists.txt		2024-11-26 18:50:58
+#@@ -438,6 +438,7 @@ 
+# if (VTK_USE_X)
+#   vtk_module_find_package(PACKAGE X11)
+#   vtk_module_link(VTK::RenderingOpenGL2 PUBLIC X11::X11)
+#+  vtk_module_link(VTK::RenderingOpenGL2 PUBLIC GL)
+#   if (TARGET X11::Xcursor)
+#     vtk_module_link(VTK::RenderingOpenGL2 PRIVATE X11::Xcursor)
+#   else()
 
 --- CMake/vtkOpenGLOptions.cmake.orig	2024-11-25 00:01:28
 +++ CMake/vtkOpenGLOptions.cmake	2024-11-26 18:50:58


### PR DESCRIPTION
#### Description

Disable broken patch for 10.6 only; one hunk only.
Attempt to progress broken builds for 10.6.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.
Waiting for merge to check 10.6 builders.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?