### PR TITLE
py-wand: Update to 0.7.0

### DIFF
--- a/python/py-wand/Portfile
+++ b/python/py-wand/Portfile
@@ -5,25 +5,27 @@ PortGroup           python 1.0
 
 name                py-wand
 python.rootname     Wand
-version             0.6.13
+version             0.7.0
 revision            0
 categories-append   graphics
 license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     310 311 312
+python.versions     310 311 312 313 314
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Ctypes-based simple MagickWand API binding for Python
 long_description    {*}${description}
 
-homepage            http://wand-py.org/
+homepage            https://docs.wand-py.org/
 
-checksums           rmd160  b6e0df5816bed3602d179df75ff09bbeb13eb41c \
-                    sha256  f5013484eaf7a20eb22d1821aaefe60b50cc329722372b5f8565d46d4aaafcca \
-                    size    11883700
+distname            wand-${version}
+
+checksums           rmd160  6b3e18ab755734784f5f26eb7e0651f6eaf138d4 \
+                    sha256  e48f983cc248c23f752e5ba8a6aa1b09370c87d81425d2cc7474f4536c0740f9 \
+                    size    11888946
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:ImageMagick


### PR DESCRIPTION
#### Description

Update to new version of wand. Add support for Python 3.14

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 26.4 25E246 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X]  checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
