### PR TITLE
inkscape: update Python dependency to 3.14

### DIFF
--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -14,7 +14,7 @@ set ver_hash        0d15f75042
 set ver_gal_item    58914
 version             ${ver_num}
 epoch               1
-revision            1
+revision            2
 
 categories          graphics gnome
 license             GPL-3+
@@ -39,7 +39,7 @@ checksums           rmd160  c467d4018561eb4fedef1c6284b9cd998ced5591 \
 cmake.generator     Ninja
 
 set python_major    3
-set python_minor    12
+set python_minor    14
 set python_version  ${python_major}${python_minor}
 
 # Fix for poppler >= 26.01.0: gfree -> g_free, reset -> rewind


### PR DESCRIPTION
Partially closes https://trac.macports.org/ticket/72167.

The two tests run against the installed inkscape binary:

1. SVG → PNG export — exercised the core rendering pipeline: `inkscape --export-type=png --export-filename=/tmp/test.png /opt/local/share/inkscape/paint/Decoratives.svg`
    - Result: produced a 71KB PNG successfully.
2. List input types — exercised the extension/plugin system (which uses the Python interpreter): `inkscape --list-input-types`
    - Result: listed ~50 formats (svg, pdf, png, dxf, etc.) without errors.

Both passed. There were some cosmetic glibmm warnings about PangoFT2FontMap and GtkRecentManager, but those are pre-existing and unrelated to the py314 change.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4 25E246 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
