### PR TITLE
cmake: Update to 3.31.11

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -35,12 +35,12 @@ set base_long_description \
 homepage            https://cmake.org
 platforms           darwin freebsd
 
-github.setup        Kitware CMake 3.31.10 v
+github.setup        Kitware CMake 3.31.11 v
 github.tarball_from releases
 distname            ${my_name}-${version}
-checksums           rmd160  ada1620363f97dd5ea58c6de3ffa60f6374dcb98 \
-                    sha256  cf06fadfd6d41fa8e1ade5099e54976d1d844fd1487ab99942341f91b13d3e29 \
-                    size    11715172
+checksums           rmd160  6a72426e7801f28cef72beff701c1db22f184d64 \
+                    sha256  c0a3b3f2912b2166f522d5010ffb6029d8454ee635f5ad7a3247e0be7f9a15c9 \
+                    size    11715545
 revision            0
 
 dist_subdir         ${my_name}
@@ -387,8 +387,9 @@ if {${subport} eq ${name}} {
     test.run                yes
     test.target             test
 
+    # Restrict to CMake version 3.x ONLY.  For 4.x, go to cmake-devel.
     # Ignore RC versions
-    github.livecheck.regex  {([0-9.]+)}
+    github.livecheck.regex  {(3.[0-9.]+)}
 } else {
     livecheck.type          none
 }


### PR DESCRIPTION
#### Description

* Update CMake 3.31.10 --> 3.31.11.
* Restrict livecheck to 3.x only.
* For 4.x, go to cmake-devel port.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?