### PR TITLE
claude-code: update to 2.1.98

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.97
+version             2.1.98
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  905663a626838b8ae570c386c8a7c0840b397b5b \
-                 sha256  d6e6ee329dbf1cd0222cd710039086aab9621bc85d65d314adee421446dda08c \
-                 size    201052496
+    checksums    rmd160  8390eac95e50370f9c9a4b71f4878486ba17375f \
+                 sha256  f8b60f354ee058efccd3368cdee647b18da7c80b8f3b72a99815827297d1c1b0 \
+                 size    201977168
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  3ed1f5dd071c7e5e75f3c345a0b4fecd284a443d \
-                 sha256  9104eba60ca82c590ababc5eee0d01f2dc5440d7cf2d668e4c48d6485e41cfeb \
-                 size    199579088
+    checksums    rmd160  5f857879417e2671e2886f3c767d2ed84158edfc \
+                 sha256  db75cb2c3f5c5ad24dc29af5145fea39ef58fed0faea0a4a099cd5afb291482b \
+                 size    200503760
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.98.

###### Tested on

macOS 26.4 25E246 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?