### PR TITLE
gemini-cli: update to 0.37.1

### DIFF
--- a/llm/gemini-cli/Portfile
+++ b/llm/gemini-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                gemini-cli
-version             0.36.0
+version             0.37.1
 revision            0
 
 categories          llm
@@ -21,9 +21,9 @@ homepage            https://geminicli.com
 npm.rootname        @google/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  66cbd3e0af4dfed1638da287e46521cc9b8c724c \
-                    sha256  6ad5100594adfb3a8bfc7cbca860052abb147e3307b0fbdedeede1f71a3f62ed \
-                    size    19616032
+checksums           rmd160  4b906fe81cef1c178af46414c23b8e1549106a30 \
+                    sha256  14a663bd41213590d65dfca795462532910bf24035ca70335e63a2bbb7c5b7ad \
+                    size    23300358
 
 post-destroot {
     set node_modules_dir ${destroot}${prefix}/lib/node_modules/${npm.rootname}/node_modules


### PR DESCRIPTION
#### Description

Update to Gemini CLI 0.37.1.

###### Tested on

macOS 26.4 25E246 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?