### PR TITLE
vtk deps: Rev bumps for update

### DIFF
--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -17,7 +17,7 @@ gitlab.setup            nektar nektar 5.9.0 v
 boost.version           1.87
 
 name                    nektarpp
-revision                0
+revision                1
 
 categories              science
 license                 MIT

--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -17,7 +17,7 @@ gitlab.setup            nektar nektar 5.9.0 v
 boost.version           1.87
 
 name                    nektarpp
-revision                1
+revision                0
 
 categories              science
 license                 MIT

--- a/science/openEMS/Portfile
+++ b/science/openEMS/Portfile
@@ -9,7 +9,7 @@ boost.version       1.81
 
 github.setup        thliebig openEMS 32c5c6b537b33a8b70f9ba4f5c9a8ecbb12777b3
 version             20260122-[string range ${github.version} 0 7]
-revision            0
+revision            1
 
 checksums           rmd160  8824177c39eaea6a8a3a1ad0d766bca276b0f5e2 \
                     sha256  fc2b44c4817bca4085ac7166d000394cfbaa3313bffb8fd9401d7173f3bbab43 \

--- a/textproc/CSXCAD/Portfile
+++ b/textproc/CSXCAD/Portfile
@@ -12,7 +12,7 @@ version             20260207-0.6.3-[string range ${github.version} 0 7]
 checksums           rmd160  58617d9251d6b834677f1d0a8539456c25e25ff3 \
                     sha256  45816ea46cc4e9f6cd5e90f2835c04c09d3ce20bc699ae3af9c7bb16d09b88e5 \
                     size    207477
-revision            0
+revision            1
 
 platforms           darwin macosx
 categories          textproc


### PR DESCRIPTION
##### Description

* 3 port rev bumps for vtk update.
* Update:  Port `nektarpp` failed.  Reducing to 2 port rev bumps.
* Skipped other broken ports.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?