### PR TITLE
mediainfolib: Remove graphviz dependency

### DIFF
--- a/devel/mediainfolib/Portfile
+++ b/devel/mediainfolib/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 
 # update along with mediainfo
 github.setup        MediaArea MediaInfoLib 26.01 v
+revision            1
 github.tarball_from archive
 checksums           rmd160  ba06cdbfe9f4d99fa76ea4c630fcaac570b862eb \
                     sha256  941daa01fce4595bd7b56c4d2db166f58e2bb2362dcb9636b952ee29b64db986 \
@@ -22,7 +23,6 @@ license             BSD
 depends_build       path:bin/pkg-config:pkgconfig
 
 depends_lib         port:curl \
-                    port:graphviz \
                     port:tinyxml2 \
                     port:zenlib \
                     port:zlib
@@ -37,5 +37,4 @@ compiler.blacklist-append   {clang < 900}
 use_autoreconf      yes
 configure.args      --enable-static \
                     --with-libcurl \
-                    --with-libtinyxml2 \
-                    --with-graphviz
+                    --with-libtinyxml2


### PR DESCRIPTION
graphviz pulls in a lot of other dependencies, some of which can cause problems, e.g. the quartz variant of glib2 is not available as an archive.

It should at most be a non-default variant.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
