### PR TITLE
opencode: update to 1.4.3

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.4.0
+version             1.4.3
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  0ede004e84cf93d6e6f1b8799859df7109b196e8 \
-                    sha256  339916d6078d6f219ed74cc42b7a3bb70bce47754bcc5cceb9542a7c3e80695b \
-                    size    3567
+checksums           rmd160  a5e42284b4ff4f7ac330344b4a3cc56526feac56 \
+                    sha256  24cfbdc020b289881782c07323e6585a82c1ea412e5ca83844ae832686694b23 \
+                    size    3565


### PR DESCRIPTION
#### Description

Update to OpenCode 1.4.3.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?