### PR TITLE
claude-code: update to 2.1.100

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.98
+version             2.1.100
 revision            0
 
 categories          llm
@@ -26,13 +26,13 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  8390eac95e50370f9c9a4b71f4878486ba17375f \
-                 sha256  f8b60f354ee058efccd3368cdee647b18da7c80b8f3b72a99815827297d1c1b0 \
+    checksums    rmd160  f1790824024e7c40c7bc85031a47e6dd641ab112 \
+                 sha256  8675f043a9c4102e460e485167d10ba04b463f5af91932765d45c27bf25f25ba \
                  size    201977168
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  5f857879417e2671e2886f3c767d2ed84158edfc \
-                 sha256  db75cb2c3f5c5ad24dc29af5145fea39ef58fed0faea0a4a099cd5afb291482b \
+    checksums    rmd160  d585cf3b9d84b35b5f039ac997575ae33ef8c629 \
+                 sha256  0c4d58bfdee338da47353eafd9f0db77ec7c4a30e6c5bea629c535f91ceba624 \
                  size    200503760
 } else {
     set arch_classifier unsupported_arch


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.100.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?