### PR TITLE
ollama: Update to 0.20.5, enable MLX on arm64 only

### DIFF
--- a/llm/ollama/Portfile
+++ b/llm/ollama/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ollama/ollama 0.20.2 v
+go.setup            github.com/ollama/ollama 0.20.5 v
 github.tarball_from archive
 revision            0
 
@@ -17,15 +17,13 @@ description         ${name} runs and manages LLMs
 long_description    Get up and running with large language models easily
 homepage            https://ollama.com
 
-checksums           rmd160  214a25cda3d9498d7daa98bbc9dce5640f057323 \
-                    sha256  53a8eb37cb99279d6d8f5e8c94cda3119119fb75f4f35a3b8cc39b0232478bef \
-                    size    26443000
+checksums           rmd160  e8a8f21857db3aefba9b16687410afaa35f5ac08 \
+                    sha256  5bc50226f3cd3a29861fe1af6f007be27d2bdfa3ec002788189364b774fec291 \
+                    size    26470263
 
 # See https://github.com/ollama/ollama/pull/6854
 patchfiles-append   patch-NO_MMAP_ENV.diff
 patch.args          -p1
-
-depends_lib-append  port:mlx-c
 
 go.offline_build    no
 build.post_args     -ldflags \"-s -w \
@@ -95,6 +93,15 @@ variant completion description "Install bash completion for ${name}" {
     # Use this until upstream has implemented proper shell completions
     depends_run-append \
                     port:ollama-bash-completion-plugin
+}
+
+variant mlx description "Support acceleration with Apple's MLX library" {
+    depends_lib-append  port:mlx-c
+}
+
+platform darwin arm {
+    default_variants-append \
+        +mlx
 }
 
 default_variants-append \


### PR DESCRIPTION
#### Description

Move MLX support to a variant, enable it by default on ARM only.

Closes: https://trac.macports.org/ticket/73802

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
