### PR TITLE
ocaml-not-ocamlfind: update to 0.14

### DIFF
--- a/lang/camlp5/Portfile
+++ b/lang/camlp5/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 github.setup        camlp5 camlp5 8.03.01
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            0
+revision            1
 categories          lang ocaml
 license             BSD
 maintainers         {pmetzger @pmetzger} openmaintainer

--- a/ocaml/ocaml-camlp5-buildscripts/Portfile
+++ b/ocaml/ocaml-camlp5-buildscripts/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        camlp5 camlp5-buildscripts 0.06
 github.tarball_from archive
 name                ocaml-camlp5-buildscripts
-revision            0
+revision            1
 categories          ocaml devel
 maintainers         {pguyot @pguyot} openmaintainer
 license             BSD

--- a/ocaml/ocaml-not-ocamlfind/Portfile
+++ b/ocaml/ocaml-not-ocamlfind/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           ocaml 1.1
 PortGroup           github 1.0
 
-github.setup        chetmurthy not-ocamlfind 0.13
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        chetmurthy not-ocamlfind 0.14
+github.tarball_from archive
 name                ocaml-not-ocamlfind
 revision            0
 categories          ocaml devel
@@ -16,16 +15,14 @@ license             MIT
 description         A small frontend for ocamlfind that adds a few useful commands
 long_description    {*}${description}
 
-checksums           rmd160  29a6b4ef6f3db3241d1d80efb3d4769eea743c6c \
-                    sha256  1192728dd4faa44ce7f1d14028828f68aad7dc2f70e8feb042e3159fcf24f2ce \
-                    size    290986
+checksums           rmd160  cad9df3626dc275b8b64818e39adb890c4977cf4 \
+                    sha256  5d5b38a0f307a2a464f7305e6e6bb1f9f26c44b8b121848b0aa7227cb0af94ae \
+                    size    189973
 
 depends_lib-append  port:ocaml-camlp-streams \
                     port:ocaml-fmt \
                     port:ocaml-ocamlgraph \
                     port:ocaml-rresult
-
-patchfiles          patch-Makefile.diff
 
 configure.args      -bindir ${prefix}/bin \
                     -mandir ${prefix}/share/man \
@@ -36,6 +33,6 @@ configure.pre_args
 
 use_parallel_build  no
 
-# use_findlib does OCAMLFIND_DESTDIR but not OCAMLFIND_BINDIR which may be specific to not-ocamlfind
+# use_findlib does OCAMLFIND_DESTDIR but not OCAMLFIND_BIN which may be specific to not-ocamlfind
 ocaml.use_findlib   yes
-destroot.env-append OCAMLFIND_BINDIR=${destroot}${prefix}/bin
+destroot.args-append OCAMLFIND_BIN=${destroot}${prefix}/bin


### PR DESCRIPTION
Remove patch-Makefile.diff (no longer applies, the OCAMLFIND_BINDIR variable was removed). Use destroot.args-append to override OCAMLFIND_BIN instead of env-append.

Revbump ocaml-camlp5-buildscripts and camlp5 for the dependency update.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D771280a x86_64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
