### PR TITLE
bstring: update to 1.1.0

### DIFF
--- a/textproc/bstring/Portfile
+++ b/textproc/bstring/Portfile
@@ -2,10 +2,13 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           meson 1.0
 
-github.setup        msteinert bstring 1.0.3 v
+github.setup        msteinert bstring 1.1.0 v
 github.tarball_from releases
 revision            0
+
+use_xz              yes
 
 categories          textproc devel
 license             BSD
@@ -14,29 +17,22 @@ maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
 description         The Better String Library for C
 long_description    ${name} is a fork of Paul Hsieh's Better String Library. \
                     It provides a comprehensive string library for C with \
-                    features like autotools build system, updated test suite \
-                    based on Check, Valgrind integration, and continuous \
+                    UTF-8 support, a meson build system, and continuous \
                     integration via GitHub Actions.
 
 homepage            https://github.com/msteinert/bstring
 
-checksums           rmd160  e43549dabb94d9b7703c7b762b5fba95f4b398ef \
-                    sha256  f6162a784beae8919fc60328a1bbe620573b31224d33c7d59583724f54646a3d \
-                    size    511108
+checksums           rmd160  cf8098657d90d894e911326891ab46696a174a54 \
+                    sha256  1b513965a658494193ab9431c229ea675a7b1c7c85de9d68b8cc089abfb82240 \
+                    size    121708
 
-depends_build       path:bin/pkg-config:pkgconfig
-
-use_autoreconf      yes
-
-variant tests description "Build and run tests" {
-    depends_lib-append  port:check
-    configure.args-append --enable-tests
-    test.run            yes
-    test.target         check
+variant tests description {Build and run tests} {
+    depends_build-append    port:check
+    configure.args-append   -Denable-tests=true
+    test.run                yes
 }
 
 post-destroot {
-    # Install documentation
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 644 -W ${worksrcpath} README.md COPYING \
         ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update bstring to 1.1.0. This release migrates the build system from
autotools to meson and adds UTF-8 support. The Portfile has been
updated to use the meson PortGroup and the tests variant updated
accordingly.

###### Tested on
macOS 26.4 25E246 arm64
Xcode 26.4 17E192

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?