### PR TITLE
gh: update to 2.89.0

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             2.88.1
+version             2.89.0
 revision            0
 
 # Github CLI is failing to build on 10.12 and below.
@@ -54,9 +54,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  632a1f35f174d2f0c24f08fb4d0822f50c09c157 \
-                        sha256  79b9d8b6f45771188bcbe7de23e0300827b33454b811881522e20f6b48bb6e4c \
-                        size    14462686
+    checksums           rmd160  f9dc54cc50de8fa6d95ab98049c363e6ea8b82e1 \
+                        sha256  bc9c11f75e4aeb7e1f0bd5f543a3edabb8958655025f8cdc3d9bbe14435a7441 \
+                        size    14478004
 
     dist_subdir         ${name}
 
@@ -74,9 +74,9 @@ if ${source_build} {
 
     distname        gh_${version}_macOS_amd64
 
-    checksums       rmd160  3de4e4b9566463b94cf843355dbbabd7bb0461d3 \
-                    sha256  ff0fc4bdb9699f0c02e5bcdcbd09d0f8e4c4659aa5d30bcd39a3557ed7379b2e \
-                    size    14502719
+    checksums       rmd160  acd659104aba6b305470785f634cfd71325cbbae \
+                    sha256  862e21cac6a71f81e7cd6e5127e3cd344f8537441ad2db94cd208319dd17b6e9 \
+                    size    14898322
 
     use_configure   no
     use_zip         yes


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.5 24G624
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?