### PR TITLE
mle: update to 1.8.1

### DIFF
--- a/editors/mle/Portfile
+++ b/editors/mle/Portfile
@@ -8,10 +8,9 @@ PortGroup           makefile 1.0
 # _strndup, _memmem
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        adsr mle 1.7.2 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
-revision            1
+github.setup        adsr mle 1.8.1 v
+github.tarball_from archive
+revision            0
 
 categories          editors
 license             Apache-2
@@ -20,9 +19,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Small, flexible, terminal-based text editor
 long_description    {*}${description}
 
-checksums           rmd160  0e0381fa710a0ef2913f950796e2e155ee24e53e \
-                    sha256  6f2c7b51a04875e3e5087aefaca5ce7dd6de23b7f458806ef2c9928afbd06fa7 \
-                    size    143641
+checksums           rmd160  460e90ad8df716ce74d277240071b84a4d21609f \
+                    sha256  7ee33a695f801024254fc717b64aff6a7a4c274874fc4b83e1a23ccf1a74b9ca \
+                    size    167886
 
 post-patch {
     reinplace "s|-llua5.4|-llua|g" ${worksrcpath}/Makefile


### PR DESCRIPTION
#### Description
https://github.com/adsr/mle/blob/v1.8.1/CHANGELOG.md

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
