### PR TITLE
age-plugin-yubikey: Update to 0.5.1.

### DIFF
--- a/security/age-plugin-yubikey/Portfile
+++ b/security/age-plugin-yubikey/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        str4d age-plugin-yubikey 0.5.0 v
+github.setup        str4d age-plugin-yubikey 0.5.1 v
 github.tarball_from archive
 revision            0
 categories          security
@@ -208,7 +208,7 @@ cargo.crates \
     reqwest                        0.11.27  dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62 \
     rfc6979                          0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
     roff                             0.1.0  e33e4fb37ba46888052c763e4ec2acfedd8f00f62897b630cadb6298b833675e \
-    rsa                        0.9.0-pre.0  a7bc1d34159d63536b4d89944e9ab5bb952f45db6fa0b8b03c2f8c09fb5b7171 \
+    rsa                           0.9.0-pre.0  a7bc1d34159d63536b4d89944e9ab5bb952f45db6fa0b8b03c2f8c09fb5b7171 \
     rust-embed                       8.3.0  fb78f46d0066053d16d4ca7b898e9343bc3530f71c61d5ad84cd404ada068745 \
     rust-embed-impl                  8.3.0  b91ac2a3c6c0520a3fb3dd89321177c3c692937c4eb21893378219da10c44fc8 \
     rust-embed-utils                 8.3.0  86f69089032567ffff4eada41c573fc43ff466c7db7c5688b2e7969584345581 \
@@ -291,7 +291,7 @@ cargo.crates \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
-    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
     wasm-bindgen                    0.2.92  4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8 \
     wasm-bindgen-backend            0.2.92  614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da \
     wasm-bindgen-futures            0.4.42  76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0 \
@@ -328,15 +328,15 @@ cargo.crates \
     winreg                          0.50.0  524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1 \
     x509                             0.2.0  ca3cec94c3999f31341553f358ef55f65fc031291a022cd42ec0ce7219560c76 \
     x509-parser                     0.14.0  e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8 \
-    yubikey                    0.8.0-pre.0  71240be97248417e072ab49076573dbf96e886478453497e02b49968c0273790 \
+    yubikey                       0.8.0-pre.0  71240be97248417e072ab49076573dbf96e886478453497e02b49968c0273790 \
     zerocopy                        0.7.35  1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0 \
     zerocopy-derive                 0.7.35  fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e \
     zeroize                          1.8.1  ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  fe4912d0586132a771708728ab6d6f3956df5bc1 \
-                    sha256  65807403f0098569a473ffa76302b205da148a7f46b61fd331b8e323959978ba \
-                    size    57426
+                    rmd160  df890c13f4d2610bd73f610611df15ec965bcd49 \
+                    sha256  51e4680ad7ad7f56535e4f3018531bd0196815659378709979617d4f17102700 \
+                    size    58018
 
 set cargo_builddir ${worksrcpath}/target/[cargo.rust_platform]/release
 


### PR DESCRIPTION
#### Description

Update `age-plugin-yubikey` to 0.5.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
