### PR TITLE
wolfssl: fix build on macOS <10.14

### DIFF
--- a/devel/wolfssl/Portfile
+++ b/devel/wolfssl/Portfile
@@ -39,11 +39,10 @@ configure.args      --enable-all \
 compiler.blacklist-append \
                     {clang < 1000}
 
-# Enabling this option does not work at least on 10.6:
-# src/internal.c:41288: error: 'errSecSuccess' undeclared (first use in this function)
+# src/internal.c:42797:24: error: call to undeclared function
+# 'SecTrustEvaluateWithError' on macOS <10.14
 # Arguably we do not need archaic system certificates anyway.
-# OS version threshold is set according to system git being functional.
-if {${os.platform} eq "darwin" && ${os.major} < 14} {
+if {${os.platform} eq "darwin" && ${os.major} < 18} {
     configure.args-append \
                     --disable-sys-ca-certs
 }


### PR DESCRIPTION
https://build.macports.org/builders/ports-10.13_x86_64-builder/builds/283491/steps/install-port/logs/stdio

###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?