### PR TITLE
qsv: update to 19.0.0

### DIFF
--- a/textproc/qsv/Portfile
+++ b/textproc/qsv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        dathere qsv 18.0.0
+github.setup        dathere qsv 19.0.0
 github.tarball_from archive
 revision            0
 
@@ -24,9 +24,9 @@ license             {public-domain MIT}
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  244c56d72828d6108b09c31ffdec594c6921349d \
-                    sha256  20ed71f0303478d05a87cdfcf79f96793e77d8dc4321bd12a13d89c5040c6233 \
-                    size    53148022
+checksums           rmd160  6e3d268fca412d4663f2e6e5a88215f4534a127a \
+                    sha256  b33887902348e454694ebe01c79a97c8babbf59ebba94386b7a749023ad7f1a7 \
+                    size    19593138
 
 depends_build-append \
                     path:bin/cmake:cmake


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.4 24G517 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
