### PR TITLE
ruby-build: Update to 20260412

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20260327 v
+github.setup        rbenv ruby-build 20260412 v
 revision            0
 github.tarball_from archive
 categories          ruby
@@ -17,9 +17,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  6789111fd5b18bdd119ea18d3eb973a7ef6370b3 \
-                    sha256  33d48ec69ba998069f30939a2dfbe3ccdc52d4bc74f5709084e54fef95ccf510 \
-                    size    99451
+checksums           rmd160  2df5ea017d9488a6a4621290a70fc22374df6707 \
+                    sha256  7215fbadd7e57d9fa1b6939f478e50bb6929e9044226a50f405962c7aeb0c969 \
+                    size    99922
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20260412


##### Tested on

macOS 26.3.1 25D771280a arm64
Xcode 26.4 17E192


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
