### PR TITLE
mise: Update to 2026.4.10

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.4.4 v
+github.setup        jdx mise 2026.4.10 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  919a82d8c784932eecbd8f375032f61c2207ff02 \
-                    sha256  0369019f7c934116863bcb185c3e1c8aca1ebc0a7bb500bff8e208c8721ce84c \
-                    size    6705163
+                    rmd160  54ae44d56b673a7f2ec0d45b46d397ead5e6c8c3 \
+                    sha256  7b99d5eb931b348aa4c6fc5b457066ffd19d6979c1a6b9b62e4e5f66479b8615 \
+                    size    6750969
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -112,7 +112,7 @@ cargo.crates \
     asn1-rs-derive                       0.6.0  3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c \
     asn1-rs-impl                         0.2.0  7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7 \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
-    astral-tokio-tar                     0.5.6  ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5 \
+    astral-tokio-tar                     0.6.0  3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9 \
     astral_async_zip                    0.0.17  ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba \
     async-backtrace                      0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
     async-backtrace-attributes           0.2.7  affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7 \
@@ -122,6 +122,7 @@ cargo.crates \
     async-recursion                      1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
     async-spooled-tempfile               0.1.0  5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5 \
     async-trait                         0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
+    async_http_range_reader              0.9.1  2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197 \
     atomic-waker                         1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                              1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
     aws-config                          1.8.13  c456581cb3c77fafcc8c67204a70680d40b61112d6da78c77bd31d945b65f1b5 \
@@ -130,11 +131,11 @@ cargo.crates \
     aws-lc-rs                           1.16.2  a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc \
     aws-lc-sys                          0.39.1  83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399 \
     aws-runtime                          1.6.0  c635c2dc792cb4a11ce1a4f392a925340d1bdf499289b5ec1ec6810954eb43f5 \
-    aws-sdk-s3                         1.121.0  61948728b681f88a1e49b9500469cf9e36575a424e745e2c5a651a42386e7d9c \
+    aws-sdk-s3                         1.119.0  1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c \
     aws-sdk-sts                         1.97.0  e6443ccadc777095d5ed13e21f5c364878c9f5bad4e35187a6cdbd863b0afcad \
     aws-sigv4                            1.3.8  efa49f3c607b92daae0c078d48a4571f599f966dce3caee5f1ea55c4d9073f99 \
     aws-smithy-async                    1.2.11  52eec3db979d18cb807fc1070961cc51d87d069abe9ab57917769687368a8c6c \
-    aws-smithy-checksums               0.63.13  23374b9170cbbcc6f5df8dc5ebb9b6c5c28a3c8f599f0e8b8b10eb6f4a5c6e74 \
+    aws-smithy-checksums               0.63.12  87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae \
     aws-smithy-eventstream             0.60.18  35b9c7354a3b13c66f60fe4616d6d1969c9fd36b1b5333a5dfb3ee716b33c588 \
     aws-smithy-http                     0.62.6  826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b \
     aws-smithy-http                     0.63.3  630e67f2a31094ffa51b210ae030855cb8f3b7ee1329bdd8d085aaf61e8b97fc \
@@ -162,6 +163,7 @@ cargo.crates \
     beef                                 0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
     bindgen                             0.72.1  993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895 \
     binstall-tar                        0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
+    bisection                            0.1.0  021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3 \
     bit-set                              0.6.0  f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f \
     bit-set                              0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                              0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
@@ -171,6 +173,7 @@ cargo.crates \
     blake2                              0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
     blake3                               1.8.4  4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e \
     block-buffer                        0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    block-buffer                        0.12.0  cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be \
     block-padding                        0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
     blowfish                             0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
     bstr                                1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
@@ -188,7 +191,7 @@ cargo.crates \
     calm_io                              0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                       0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.59  b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283 \
+    cc                                  1.2.60  43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20 \
     cesu8                                1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
@@ -223,11 +226,12 @@ cargo.crates \
     compression-core                    0.4.31  75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d \
     concurrent-queue                     2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     configparser                         3.1.0  e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b \
-    confique                             0.3.1  33cbbbdc4e7bec8bd8a61bc21159fc79fa22004754feb0a83f78119b3918e0b3 \
-    confique-macro                      0.0.12  85d58122c074ab6431418377f20b74cac2d37be215a94784f1aa319e89200aab \
+    confique                             0.4.0  06b4f5ec222421e22bb0a8cbaa36b1d2b50fd45cdd30c915ded34108da78b29f \
+    confique-macro                      0.0.13  e4d1754680cd218e7bcb4c960cc9bae3444b5197d64563dccccfdf83cab9e1a7 \
     console                            0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
     console                             0.16.3  d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
     const-oid                            0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
+    const-oid                           0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
     const_format                        0.2.35  7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad \
     const_format_proc_macros            0.2.34  1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744 \
     constant_time_eq                     0.3.1  7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6 \
@@ -241,9 +245,9 @@ cargo.crates \
     countme                              3.0.1  7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636 \
     cpufeatures                         0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
     cpufeatures                          0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
-    crc                                  3.3.0  9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675 \
+    crc                                  3.4.0  5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d \
     crc-catalog                          2.4.0  19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5 \
-    crc-fast                             1.9.0  2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d \
+    crc-fast                             1.6.0  6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3 \
     crc32fast                            1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crossbeam-channel                   0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
     crossbeam-deque                      0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
@@ -253,9 +257,10 @@ cargo.crates \
     crossterm_winapi                     0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crypto-bigint                        0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
+    crypto-common                        0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
     crypto_secretbox                     0.1.1  b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1 \
-    ctor                                 0.4.3  ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6 \
-    ctor-proc-macro                      0.0.6  e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2 \
+    ctor                                 0.9.1  c1c888a2a4f677017373fb6c01e13e318dd9e78758445ed5eb985e355d3f8281 \
+    ctor-proc-macro                     0.0.12  a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive              0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
@@ -289,14 +294,15 @@ cargo.crates \
     deunicode                            1.6.2  abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04 \
     diff                                0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     digest                              0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    digest                              0.11.2  4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c \
     directories                          6.0.0  16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
     dirs                                 6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                             0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     displaydoc                           0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     document-features                   0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dotenvy                             0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
-    dtor                                 0.0.6  97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8 \
-    dtor-proc-macro                      0.0.5  7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055 \
+    dtor                                 0.6.0  30e4690622ab6700ced40fc370a3f07b7d111f0154bb6fb08f73b4c8834f75b6 \
+    dtor-proc-macro                     0.0.12  8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131 \
     duct                                0.13.7  e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c \
     duct                                 1.1.1  7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684 \
     dunce                                1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
@@ -326,9 +332,9 @@ cargo.crates \
     exec                                 0.3.1  886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615 \
     expr-lang                            1.1.1  e6e6e9a6990c24970375077a97a392146b5be2155a957d9a4e5337ca0bde0c26 \
     eyre                                0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
-    fancy-regex                         0.16.2  998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f \
+    fancy-regex                         0.17.0  72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8 \
     faster-hex                          0.10.0  7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73 \
-    fastrand                             2.4.0  a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f \
+    fastrand                             2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     ff                                  0.13.1  c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393 \
     fiat-crypto                          0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     file_url                             0.2.7  81d37aab514a05a249a5b15408dc74d716f5745a2c5daf22e40a245ffd38fa84 \
@@ -443,6 +449,7 @@ cargo.crates \
     hashbrown                           0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                           0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                           0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
+    hashbrown                           0.17.0  4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
     heapless                             0.8.0  0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad \
     heck                                 0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                           0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
@@ -457,12 +464,14 @@ cargo.crates \
     http-body                            1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                       0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     http-cache-semantics                 2.1.1  4311240f94cb6fe622337dc580b09ddd6ae4a891eb121dba20cf4f77ca4e7129 \
+    http-content-range                   0.2.4  66cdb727cec723cee65912a74a7f9f0c3ad0c6f9df4f03d05a5c7a15398bbad1 \
     http-serde                           2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
     httparse                            1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                             1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     human_format                         1.2.1  eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b \
     humansize                            2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
     humantime                            2.3.0  135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424 \
+    hybrid-array                        0.4.10  3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214 \
     hyper                              0.14.32  41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7 \
     hyper                                1.9.0  6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca \
     hyper-rustls                        0.24.2  ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590 \
@@ -493,7 +502,7 @@ cargo.crates \
     impl-tools-lib                      0.11.4  ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf \
     indenter                             0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
     indexmap                             1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                            2.13.1  45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff \
+    indexmap                            2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     indicatif                          0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
     indoc                                2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     inout                                0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
@@ -522,7 +531,7 @@ cargo.crates \
     jni-sys                              0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                       0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                           0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                              0.3.94  2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9 \
+    js-sys                              0.3.95  2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca \
     json-number                         0.4.10  479dfd2ad8e4b4ae076b031f72ef2f3791f65e2a0f51e5f3408dbf716c4c2f82 \
     json-patch                           4.1.0  f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90 \
     json-syntax                         0.12.5  044a68aba3f96d712f492b72be25e10f96201eaaca3207a7d6e68d6d5105fda9 \
@@ -549,7 +558,8 @@ cargo.crates \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
-    libredox                            0.1.15  7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08 \
+    libredox                            0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
+    link-section                        0.0.12  f52437d47b0358721ec869cc7374b2a21f7b2237af9b439c0391341a1fbfbf1b \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                              0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
@@ -561,7 +571,7 @@ cargo.crates \
     logos                               0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                        0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
     loom                                 0.5.6  ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5 \
-    lru                                 0.16.3  a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593 \
+    lru                                 0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
     lru-slab                             0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
     lua-src                            550.0.0  e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb \
     luajit-src                 210.6.6+707c12b  a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295 \
@@ -572,6 +582,7 @@ cargo.crates \
     matchers                             0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     maybe-async                         0.2.10  5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11 \
     md-5                                0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
+    md-5                                0.11.0  69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
     memchr                               2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
     memmap2                             0.9.10  714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3 \
     memoffset                            0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
@@ -644,7 +655,7 @@ cargo.crates \
     paste                               1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
     path-absolutize                      3.1.1  e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5 \
     path-dedot                           3.1.1  07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397 \
-    path_resolver                        0.2.5  d6a4d9af27fc7240c8270eff3eeaad11bc9ff950d37be041f3e3e7ad98d3d9db \
+    path_resolver                        0.2.7  59953de32542217edd1cc5fd52ac7ca2de57d7613a3a3e569370e5ea09231df3 \
     pbkdf2                              0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
     pem                                  3.0.6  1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
     pem-rfc7468                          0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
@@ -706,32 +717,32 @@ cargo.crates \
     r-efi                                6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radium                               0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
     rand                                 0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
-    rand                                 0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
-    rand                                0.10.0  bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8 \
+    rand                                 0.9.3  7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166 \
+    rand                                0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
     rand_chacha                          0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                          0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                            0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                            0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_core                           0.10.0  0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                            0.39.14  aa33859aa5310222070ed0d542fbaec201fc2cb2a203e36c2d4a41d81a8ce454 \
-    rattler_cache                       0.6.13  7fe24d25387a11f011f987e86ef85db3a5f966bdf75cc3c8bd0f4c8d44797fff \
-    rattler_conda_types                 0.43.4  4195ca32c110895ec622711fe6f2cacc3560cab0b0ef075677a0c6e480c2ad22 \
-    rattler_digest                       1.2.2  e4109fd4ea54f1e34812f9db9166013325418ba92ff5693136afe681a56039fe \
+    rattler                             0.40.5  d5e004d0371d9671efc0c41c9d5311a21479db551fd68236a3299b7d7b8447f0 \
+    rattler_cache                       0.6.20  1b829f276e98d7d670be90df8aebaac4ce92606d766e315c230ee4c1782ec9e4 \
+    rattler_conda_types                 0.44.5  251545c07ce023c159c6673e9e5da7f49ae9a5cc791d1f5dbb6067a00612550a \
+    rattler_digest                       1.2.3  fa6239d5be357419ba579b1cda7fe0e140a22134ebc999adb62b818989fbc7c7 \
     rattler_macros                      1.0.12  18d0d45ce3ae00333421569d2fafa4b877708a901c3cb217f8d4acfab4328df0 \
-    rattler_menuinst                    0.2.48  f7bbf3ac0ca5c3416ed3d95228f426cd5be045ce4554d94c89a55107cdb25205 \
-    rattler_networking                  0.26.1  c8ebcccad5b14e122a0ddd03a8d4e9810c50e17ec23d5d5354fd6394218cc6db \
-    rattler_package_streaming           0.24.1  7bd3dce7e4f4e2031aa809daa049bc1a5ca9e712ca202cc84f69f2b0128008e8 \
+    rattler_menuinst                    0.2.55  be28b61681374a243151224f09d8691ef59db158001f075b64ef60f26622cc1a \
+    rattler_networking                  0.26.8  6c737c889ed175f55fb86986694a916a58f97bb22cf466169abd9c1dd363712e \
+    rattler_package_streaming           0.24.8  b9cf2ab39920b58ac3cd41a23ef4ec40ab9fdc4a3645c045f5de6b2677b1398f \
     rattler_pty                          0.2.9  ec435d69bcc064b5cb0f6a49d8cfc1dbed93f0ec233d4499156ae7c3bc7f90d7 \
     rattler_redaction                   0.1.13  961121cad9792daafc176a7f4caafc0fc889fb17507c23a4c86e1777a8b5e179 \
-    rattler_repodata_gateway            0.26.1  5e85601ebcd52acb50fe1e15fb863868719ad9005752908431ba12cf433e5d0a \
-    rattler_shell                       0.26.1  6bbd794ff61cd08a8a0260e2288cc4c3b3194dda9689498933655951b16027fd \
-    rattler_solve                        4.2.5  e0aed2bd89330030bcd19216ddd92a2dbddfaec87697ad4d35533785bed206c7 \
-    rattler_virtual_packages            2.3.10  6bb5cadf2c3cff426ca0e9cb9ae0e9defe6da72244969edaf92f847f1d7e6504 \
+    rattler_repodata_gateway            0.27.5  927979192dd8e7644da0d6dcb0a1a98244f1412da7a69f0a9037e185caa01dd1 \
+    rattler_shell                       0.26.8  a39fdc6dab30c7eb958bd3d92c47b9b3e78f85cb0acdaebfa91ad3e3230a7e6b \
+    rattler_solve                        5.2.1  a71f5f4948fcd822f2612dd21c07de56a358c1404f6373e0ac0b34d97e9aa817 \
+    rattler_virtual_packages            2.3.17  8fddfeee1ea50f4f39d2b8750e9f6c5774678108666aa4ff2e0e4d73c733d347 \
     rayon                               1.11.0  368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
-    redox_syscall                        0.7.3  6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16 \
+    redox_syscall                        0.7.4  f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a \
     redox_users                          0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
     ref-cast                            1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                       1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
@@ -752,7 +763,7 @@ cargo.crates \
     rmcp-macros                          0.3.2  4aebc912b8fa7d54999adc4e45601d1d95fe458f97eb0a1277eddcd6382cf4b1 \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
-    roff                                 0.2.2  88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3 \
+    roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
     rops                                 0.1.7  b4beb52a5d008a707436d388c05e9fee9ae81039cce62813ee750918a13c0aaf \
     rowan                              0.15.18  62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208 \
     rsa                                 0.9.10  b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d \
@@ -773,7 +784,7 @@ cargo.crates \
     rustls-platform-verifier             0.6.2  1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
     rustls-webpki                      0.101.7  8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765 \
-    rustls-webpki                     0.103.10  df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef \
+    rustls-webpki                     0.103.11  20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4 \
     rustversion                         1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     rusty-fork                           0.3.1  cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2 \
     ryu                                 1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
@@ -823,8 +834,10 @@ cargo.crates \
     sevenz-rust                          0.6.1  26482cf1ecce4540dc782fc70019eba89ffc4d87b3717eb5ec524b5db6fdefef \
     sevenz-rust2                        0.20.2  29225600349ef74beda5a9fffb36ac660a24613c0bde9315d0c49be1d51e9c24 \
     sha1                                0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    sha1                                0.11.0  aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214 \
     sha1-checked                        0.10.0  89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423 \
     sha2                                0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
+    sha2                                0.11.0  446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4 \
     sharded-slab                         0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shared_child                         1.1.1  1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7 \
     shared_thread                        0.2.0  52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0 \
@@ -840,7 +853,7 @@ cargo.crates \
     sigstore                            0.13.0  52bba786054331bdc89e90f74373b68a6c3b63c9754cf20e3a4a629d0165fe38 \
     sigstore-protobuf-specs-derive       0.0.1  80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35 \
     sigstore-verification                0.2.2  62278e9ab9dcd8a08bffc8e85119ca5a40dcd1b24d4012fa07ddc6aeb1f0eff3 \
-    sigstore_protobuf_specs              0.5.0  b4827a7a6b539af686abf27c09cb3ddc76c786c0b8b999a1b13566747b22e77c \
+    sigstore_protobuf_specs              0.5.1  cd627b4d5240ac660de3357b5d0156d5c63b872be1deae5046c3c8eb65d488e2 \
     simd-adler32                         0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     simd-json                           0.17.0  4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3 \
     simd_cesu8                           1.1.1  94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33 \
@@ -858,7 +871,6 @@ cargo.crates \
     socket2                             0.5.10  e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678 \
     socket2                              0.6.3  3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
     spin                                 0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
-    spin                                0.10.0  d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591 \
     spki                                 0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     stable_deref_trait                   1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                    1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
@@ -907,7 +919,7 @@ cargo.crates \
     tinyvec_macros                       0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tls_codec                            0.4.2  0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b \
     tls_codec_derive                     0.4.2  2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd \
-    tokio                               1.51.0  2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd \
+    tokio                               1.51.1  f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c \
     tokio-macros                         2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-native-tls                     0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-retry                          0.3.0  7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f \
@@ -959,7 +971,7 @@ cargo.crates \
     untrusted                            0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                           2.18.2  1851c9ddbc3a428af152852227363e7f66b73ca2ce732c8db3c2d4ab37eb63d2 \
+    usage-lib                            3.2.0  211ee8a63c28a860c94d2a40ebc8e57eb98603fd8ddc808424230f9149a201f1 \
     utf8-decode                          1.0.1  ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498 \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -978,17 +990,17 @@ cargo.crates \
     wasi         0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                    1.0.2+wasi-0.2.9  9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5 \
     wasip3      0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                       0.2.117  0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0 \
-    wasm-bindgen-futures                0.4.67  03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e \
-    wasm-bindgen-macro                 0.2.117  7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be \
-    wasm-bindgen-macro-support         0.2.117  dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2 \
-    wasm-bindgen-shared                0.2.117  39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b \
+    wasm-bindgen                       0.2.118  0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89 \
+    wasm-bindgen-futures                0.4.68  f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8 \
+    wasm-bindgen-macro                 0.2.118  eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed \
+    wasm-bindgen-macro-support         0.2.118  9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904 \
+    wasm-bindgen-shared                0.2.118  5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129 \
     wasm-encoder                       0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                      0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasm-streams                         0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
     wasmparser                         0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
-    web-sys                             0.3.94  cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a \
+    web-sys                             0.3.95  4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webbrowser                           1.2.0  fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16 \
     webpki-root-certs                    1.0.6  804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca \
@@ -1016,6 +1028,7 @@ cargo.crates \
     windows-numerics                     0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
     windows-numerics                     0.3.1  6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26 \
     windows-registry                     0.5.3  5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e \
+    windows-registry                     0.6.1  02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720 \
     windows-result                       0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
     windows-result                       0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
     windows-strings                      0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
@@ -1080,7 +1093,7 @@ cargo.crates \
     x509-parser                         0.18.1  d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202 \
     xattr                                1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     xmlparser                           0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
-    xx                                   2.5.3  61cdbadb4cf2151c38b7c07c1383284bcf63b51baac062c83bd8286962b41dd9 \
+    xx                                   2.5.4  d61141ccbc979c1421bc450f1a800196abc073e0deccb0adcb100c96238b33e2 \
     xz2                                  0.1.7  388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2 \
     yansi                                1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                 0.8.2  abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca \
@@ -1097,8 +1110,7 @@ cargo.crates \
     zip                                  2.4.2  fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50 \
     zip                                  3.0.0  12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308 \
     zip                                  4.6.1  caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1 \
-    zip                                  6.0.0  eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b \
-    zip                                  8.5.0  2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464 \
+    zip                                  8.5.1  dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59 \
     zipsign-api                          0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
     zlib-rs                              0.6.3  3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513 \
     zmij                                1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \


### PR DESCRIPTION
#### Description

mise: Update to 2026.4.10


##### Tested on

macOS 26.3.1 25D771280a arm64
Xcode 26.4 17E192


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
