### PR TITLE
openspec: update to 1.3.0

### DIFF
--- a/llm/openspec/Portfile
+++ b/llm/openspec/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                openspec
-version             1.2.0
+version             1.3.0
 revision            0
 
 categories          llm
@@ -23,6 +23,6 @@ homepage            https://openspec.dev
 npm.rootname        @fission-ai/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  7074ff93cac6da8b3dbc52b6e064489620a6031d \
-                    sha256  2aceda94693f1db0b0d2ea3c750a2a418737eab30d026d1d066629945cde98ba \
-                    size    204816
+checksums           rmd160  ae329279864ec3fa4b6e35ff1fec786b46e86bed \
+                    sha256  7e0245e638db3b494aa5e4c49c359688fe6a0cabe7dbe2d6c28fd730582e8e6e \
+                    size    207735


### PR DESCRIPTION
#### Description

Update to OpenSpec 1.3.0.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?