### PR TITLE
new port: ble.sh, recommended dependency of atuin

### DIFF
--- a/sysutils/ble.sh/Portfile
+++ b/sysutils/ble.sh/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        akinomyoga ble.sh 0.4.0-devel3 v
+fetch.type          git
+
+description         Bash Line Editor (${name}) is a command line editor written in pure Bash which replaces the default GNU Readline.
+long_description    ${description}
+license             BSD
+
+platforms           any
+maintainers         {cal @neverpanic} openmaintainer
+categories          sysutils shells
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init --recursive"
+}
+
+depends_build-append \
+                    port:gawk
+
+use_configure       no
+
+build.type          gnu
+use_parallel_build  no
+
+post-destroot {
+    xinstall -m 644 \
+        ${filespath}/_package.bash.in \
+        ${destroot}${prefix}/share/blesh/lib/_package.bash
+    reinplace \
+        "s|@sudo@|[expr {${sudo_user} != "" ? "sudo" : ""}]|g; s|@prefix@|$prefix|g" \
+        ${destroot}${prefix}/share/blesh/lib/_package.bash
+}
+
+destroot.args-append \
+                    PREFIX=${prefix}
+
+notes "\
+To enable ${name} in interactive sessions of bash, add the following line at the top of your ~/.bashrc:\n\
+    \t\[\[ $- == *i* ]] && source -- ${prefix}/share/blesh/ble.sh --attach=none\n\
+and the following line at the end of your ~/.bashrc:\n\
+    \t\[\[ ! \${BLE_VERSION-} ]] || ble-attach"

--- a/sysutils/ble.sh/files/_package.bash.in
+++ b/sysutils/ble.sh/files/_package.bash.in
@@ -1,0 +1,5 @@
+_ble_base_package_type=macports
+
+function ble/base/package:macports/update {
+	@sudo@ @prefix@/bin/port upgrade ble.sh && return 6
+}


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
