### PR TITLE
munge: Fix build on macOS < 10.11

### DIFF
--- a/net/munge/Portfile
+++ b/net/munge/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           openssl 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        dun munge 0.5.18 munge-
 revision            1
@@ -39,6 +40,9 @@ use_autoreconf      yes
 # Regenerating configure to patch implict functions
 # Fixed upstream, remove when newer version is available
 patchfiles          implicit.patch
+
+# getentropy, clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 configure.args      --disable-silent-rules
 

--- a/net/munge/Portfile
+++ b/net/munge/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           openssl 1.0
 
 github.setup        dun munge 0.5.18 munge-
-revision            0
+revision            1
 checksums           rmd160  bf539d8429c9b23e1bf2ac054cf1ec4869eec53e \
                     sha256  39c3ec6ef5604bfa206e8aa10fc05d5119040f6de4a554bc0fb98ca1aed838dc \
                     size    466672
@@ -36,7 +36,15 @@ depends_lib         port:bzip2 \
 
 use_autoreconf      yes
 
+# Regenerating configure to patch implict functions
+# Fixed upstream, remove when newer version is available
+patchfiles          implicit.patch
+
 configure.args      --disable-silent-rules
+
+# alignof is only available in C23, which is not needed
+# See: https://trac.macports.org/wiki/WimplicitFunctionDeclaration
+configure.checks.implicit_function_declaration.whitelist-append strchr alignof
 
 # We can either use OpenSSL or libgcrypt.  Let's default to OpenSSL.
 variant openssl conflicts libgcrypt description {Use openssl for cryptographic routines} {

--- a/net/munge/Portfile
+++ b/net/munge/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        dun munge 0.5.18 munge-
-revision            1
+revision            0
 checksums           rmd160  bf539d8429c9b23e1bf2ac054cf1ec4869eec53e \
                     sha256  39c3ec6ef5604bfa206e8aa10fc05d5119040f6de4a554bc0fb98ca1aed838dc \
                     size    466672

--- a/net/munge/files/implicit.patch
+++ b/net/munge/files/implicit.patch
@@ -1,0 +1,154 @@
+Fix implicit functions for EVP_CIPHER_CTX_cleanup and getgrent_r
+
+From: https://github.com/dun/munge/commit/ede8c9b613f5fce0bedea4f9e71924f4920b9edf
+From: https://github.com/dun/munge/commit/deb85536441ab28733e4d8f8a76e5a725afe8ecd
+From: https://github.com/dun/munge/commit/9317fe8a7efe692d8c5547c3b5c83dacb2c26872
+
+--- m4/x_ac_check_openssl.m4.orig	2026-02-10 03:07:53.000000000 -0500
++++ m4/x_ac_check_openssl.m4	2026-04-12 19:55:34.982749017 -0400
+@@ -124,28 +124,34 @@
+ #   and the <INCLUDES> are the prologue of the test source to be linked.
+ # The AC_LANG_PROGRAM #undef in the preamble is needed to thwart #define
+ #   macros used for backwards-compatibility of deprecated functions.
++# This check only runs if AC_CHECK_FUNCS has determined the function exists
++#   (i.e., ac_cv_func_<NAME> = yes), preventing implicit function declaration
++#   warnings when testing non-existent functions.
+ #
+ AC_DEFUN([_X_AC_CHECK_OPENSSL_FUNC_RETURNS_INT], [
+-  AC_CACHE_CHECK(
+-    [if $1 returns int],
+-    [ac_cv_func_$1_returns_int], [
+-    AS_VAR_SET([ac_cv_func_$1_returns_int], no)
+-    AC_LINK_IFELSE([
+-      AC_LANG_PROGRAM(
+-        [[
++  AS_IF(
++    [test "AS_VAR_GET([ac_cv_func_$1])" = yes], [
++    AC_CACHE_CHECK(
++      [if $1 returns int],
++      [ac_cv_func_$1_returns_int], [
++      AS_VAR_SET([ac_cv_func_$1_returns_int], no)
++      AC_LINK_IFELSE([
++        AC_LANG_PROGRAM(
++          [[
+ $3
+ #undef $1
+ ]],
+-        [[int rv = $1 ($2);]]
+-      )],
+-      AS_VAR_SET([ac_cv_func_$1_returns_int], yes),
+-      AS_VAR_SET([ac_cv_func_$1_returns_int], no)
+-    )]
+-  )
+-  AS_IF(
+-    [test AS_VAR_GET([ac_cv_func_$1_returns_int]) = yes],
+-    AC_DEFINE(AS_TR_CPP([HAVE_$1_RETURN_INT]), [1],
+-      [Define to 1 if the `$1' function returns int.]
++          [[int rv = $1 ($2);]]
++        )],
++        AS_VAR_SET([ac_cv_func_$1_returns_int], yes),
++        AS_VAR_SET([ac_cv_func_$1_returns_int], no)
++      )]
+     )
++    AS_IF(
++      [test AS_VAR_GET([ac_cv_func_$1_returns_int]) = yes],
++      AC_DEFINE(AS_TR_CPP([HAVE_$1_RETURN_INT]), [1],
++        [Define to 1 if the `$1' function returns int.]
++      )
++    )]
+   )]
+ )
+--- m4/x_ac_getgrent.m4.orig	2026-02-10 03:07:53.000000000 -0500
++++ m4/x_ac_getgrent.m4	2026-04-12 19:57:35.898190342 -0400
+@@ -18,17 +18,41 @@
+ 
+ AC_DEFUN([X_AC_GETGRENT], [
+   AC_CHECK_FUNCS(getgrent)
++  _X_AC_GETGRENT_CHECK_WNO_IMPLICIT
++  _x_ac_getgrent_cflags_save="${CFLAGS}"
++  _x_ac_getgrent_werror_save="${ac_c_werror_flag}"
++  CFLAGS="${CFLAGS} ${x_ac_getgrent_wno_implicit_flag}"
++  ac_c_werror_flag=yes
+   _X_AC_GETGRENT_R_AIX
+   _X_AC_GETGRENT_R_GNU
+   _X_AC_GETGRENT_R_SUN
++  CFLAGS="${_x_ac_getgrent_cflags_save}"
++  ac_c_werror_flag="${_x_ac_getgrent_werror_save}"
+ ])
+ 
++AC_DEFUN([_X_AC_GETGRENT_CHECK_WNO_IMPLICIT], [
++  AC_MSG_CHECKING([if ${CC} supports -Wno-implicit-function-declaration])
++  _x_ac_getgrent_check_cflags_save="${CFLAGS}"
++  CFLAGS="${CFLAGS} -Wno-implicit-function-declaration -Werror"
++  AC_COMPILE_IFELSE(
++    [AC_LANG_PROGRAM()],
++    [ x_ac_getgrent_have_wno_implicit=yes
++      x_ac_getgrent_wno_implicit_flag="-Wno-implicit-function-declaration" ],
++    [ x_ac_getgrent_have_wno_implicit=no
++      x_ac_getgrent_wno_implicit_flag="" ]
++  )
++  CFLAGS="${_x_ac_getgrent_check_cflags_save}"
++  AS_IF(
++    [test "x${x_ac_getgrent_have_wno_implicit}" = xyes],
++    [AC_MSG_RESULT([yes])],
++    [AC_MSG_RESULT([no])]
++  )]
++)
++
+ AC_DEFUN([_X_AC_GETGRENT_R_AIX], [
+   AC_CACHE_CHECK(
+     [for getgrent_r (AIX)],
+     [x_ac_cv_have_getgrent_r_aix], [
+-    _x_ac_getgrent_r_aix_c_werror_flag="$ac_c_werror_flag"
+-    ac_c_werror_flag=yes
+     AC_LINK_IFELSE([
+       AC_LANG_PROGRAM([[
+ #define _THREAD_SAFE 1
+@@ -44,8 +68,7 @@
+       )],
+       AS_VAR_SET(x_ac_cv_have_getgrent_r_aix, yes),
+       AS_VAR_SET(x_ac_cv_have_getgrent_r_aix, no)
+-    )
+-    ac_c_werror_flag="$_x_ac_getgrent_r_aix_c_werror_flag"]
++    )]
+   )
+   AS_IF([test AS_VAR_GET(x_ac_cv_have_getgrent_r_aix) = yes],
+     AC_DEFINE([HAVE_GETGRENT_R_AIX], [1],
+@@ -58,8 +81,6 @@
+   AC_CACHE_CHECK(
+     [for getgrent_r (GNU)],
+     [x_ac_cv_have_getgrent_r_gnu], [
+-    _x_ac_getgrent_r_gnu_c_werror_flag="$ac_c_werror_flag"
+-    ac_c_werror_flag=yes
+     AC_LINK_IFELSE([
+       AC_LANG_PROGRAM([[
+ #define _GNU_SOURCE 1
+@@ -73,8 +94,7 @@
+       )],
+       AS_VAR_SET(x_ac_cv_have_getgrent_r_gnu, yes),
+       AS_VAR_SET(x_ac_cv_have_getgrent_r_gnu, no)
+-    )
+-    ac_c_werror_flag="$_x_ac_getgrent_r_gnu_c_werror_flag"]
++    )]
+   )
+   AS_IF([test AS_VAR_GET(x_ac_cv_have_getgrent_r_gnu) = yes],
+     AC_DEFINE([HAVE_GETGRENT_R_GNU], [1],
+@@ -87,8 +107,6 @@
+   AC_CACHE_CHECK(
+     [for getgrent_r (SunOS)],
+     [x_ac_cv_have_getgrent_r_sun], [
+-    _x_ac_getgrent_r_sun_c_werror_flag="$ac_c_werror_flag"
+-    ac_c_werror_flag=yes
+     AC_LINK_IFELSE([
+       AC_LANG_PROGRAM([[
+ #include <grp.h>
+@@ -100,8 +118,7 @@
+       )],
+       AS_VAR_SET(x_ac_cv_have_getgrent_r_sun, yes),
+       AS_VAR_SET(x_ac_cv_have_getgrent_r_sun, no)
+-    )
+-    ac_c_werror_flag="$_x_ac_getgrent_r_sun_c_werror_flag"]
++    )]
+   )
+   AS_IF([test AS_VAR_GET(x_ac_cv_have_getgrent_r_sun) = yes],
+     AC_DEFINE([HAVE_GETGRENT_R_SUN], [1],


### PR DESCRIPTION
#### Description

Fix munge building on macOS < 10.11 with legacysupport PG, while patching implicit function declarations (which are already on upstream)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files??

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
