### PR TITLE
vim: Add variant sodium

### DIFF
--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -234,6 +234,12 @@ variant cscope description {Enable source code browsing with cscope} {
     configure.args-append   --enable-cscope
 }
 
+variant sodium description {Enable libsodium encryption} {
+    depends_lib-append      port:libsodium
+    depends_build-append    path:bin/pkg-config:pkgconfig
+    configure.args-replace  --disable-libsodium --enable-libsodium
+}
+
 # Disable Cocoa on PureDarwin, as well as on < 10.6
 # or when building for powerpc, since it fails to build there:
 # os_macosx.m:74: error: ‘NSPasteboardTypeString’ undeclared (first use in this function)


### PR DESCRIPTION
Add variant sodium for vim to enable libsodium encryption