### PR TITLE
py-audiocraft: new port (1.3.0)

### DIFF
--- a/python/py-audiocraft/Portfile
+++ b/python/py-audiocraft/Portfile
@@ -1,0 +1,77 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-audiocraft
+version             1.3.0
+revision            0
+
+categories-append   audio science
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+maintainers         {pguyot @pguyot} openmaintainer
+
+description         Audio generation framework from Meta AI Research
+
+long_description    AudioCraft is a library for audio generation from \
+                    Meta AI Research, providing the code and models for \
+                    MusicGen (music generation), AudioGen (audio \
+                    generation), EnCodec (audio compression), and \
+                    Multi Band Diffusion (enhancement).
+
+homepage            https://github.com/facebookresearch/audiocraft
+
+checksums           rmd160  906c8fcc99c2836fb003f5edf2a6b72bc4b20f54 \
+                    sha256  d82ade3eb4f934ee1adb438ae687a2bf59d33ca4a20039beab072548c038ac80 \
+                    size    635718
+
+python.versions     313 314
+
+# Upstream pins exact versions of torch, torchvision, torchtext, av, and xformers.
+# Remove these pins to work with MacPorts versions.
+# Also remove torchtext (deprecated upstream).
+patchfiles-append   patch-remove-version-pins.diff
+
+if {${name} ne ${subport}} {
+    # spaCy uses pydantic v1 compat layer which is broken on Python 3.14.
+    # Remove spaCy import and stub out WhiteSpaceTokenizer on 3.14.
+    if {${python.version} >= 314} {
+        patchfiles-append \
+                    patch-conditioners-no-spacy.diff
+    }
+
+    depends_lib-append \
+                    port:py${python.version}-av \
+                    port:py${python.version}-demucs \
+                    port:py${python.version}-einops \
+                    port:py${python.version}-encodec \
+                    port:py${python.version}-flashy \
+                    port:py${python.version}-gradio \
+                    port:py${python.version}-huggingface_hub \
+                    port:py${python.version}-hydra-colorlog \
+                    port:py${python.version}-hydra-core \
+                    port:py${python.version}-julius \
+                    port:py${python.version}-librosa \
+                    port:py${python.version}-num2words \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-pesq \
+                    port:py${python.version}-protobuf3 \
+                    port:py${python.version}-pystoi \
+                    port:py${python.version}-pytorch \
+                    port:py${python.version}-sentencepiece \
+                    port:py${python.version}-soundfile \
+                    port:py${python.version}-torchaudio \
+                    port:py${python.version}-torchdiffeq \
+                    port:py${python.version}-torchmetrics \
+                    port:py${python.version}-torchvision \
+                    port:py${python.version}-transformers \
+                    port:py${python.version}-xformers \
+                    port:py${python.version}-tqdm
+
+    if {${python.version} < 314} {
+        depends_lib-append \
+                    port:py${python.version}-spaCy
+    }
+}

--- a/python/py-audiocraft/files/patch-conditioners-no-spacy.diff
+++ b/python/py-audiocraft/files/patch-conditioners-no-spacy.diff
@@ -1,0 +1,33 @@
+--- audiocraft/modules/conditioners.py.orig	2024-01-01 00:00:00.000000000 +0000
++++ audiocraft/modules/conditioners.py	2024-01-01 00:00:00.000000000 +0000
+@@ -18,7 +18,6 @@
+
+ import einops
+ from num2words import num2words
+-import spacy
+ from transformers import RobertaTokenizer, T5EncoderModel, T5Tokenizer  # type: ignore
+ import torch
+ from torch import nn
+@@ -194,17 +193,11 @@
+     """
+     PUNCTUATION = "?:!.,;"
+
+-    def __init__(self, n_bins: int, pad_idx: int = 0, language: str = "en_core_web_sm",
+-                 lemma: bool = True, stopwords: bool = True) -> None:
+-        self.n_bins = n_bins
+-        self.pad_idx = pad_idx
+-        self.lemma = lemma
+-        self.stopwords = stopwords
+-        try:
+-            self.nlp = spacy.load(language)
+-        except IOError:
+-            spacy.cli.download(language)  # type: ignore
+-            self.nlp = spacy.load(language)
++    def __init__(self, *args, **kwargs) -> None:
++        raise NotImplementedError(
++            "WhiteSpaceTokenizer requires spaCy which is not available "
++            "on this Python version. Use the 'noop' tokenizer instead."
++        )
+
+     @tp.no_type_check
+     def __call__(self, texts: tp.List[tp.Optional[str]],

--- a/python/py-audiocraft/files/patch-remove-version-pins.diff
+++ b/python/py-audiocraft/files/patch-remove-version-pins.diff
@@ -1,0 +1,33 @@
+--- requirements.txt.orig	2024-01-01 00:00:00.000000000 +0000
++++ requirements.txt	2024-01-01 00:00:00.000000000 +0000
+@@ -1,5 +1,5 @@
+-# please make sure you have already a pytorch install that is cuda enabled!
+-av==11.0.0
++# please make sure you have already a pytorch install
++av
+ einops
+ flashy>=0.0.1
+ hydra-core>=1.1
+@@ -9,17 +9,16 @@
+ numpy
+ sentencepiece
+ spacy>=3.6.1
+-torch==2.1.0
+-torchaudio>=2.0.0,<2.1.2
++torch
++torchaudio
+ huggingface_hub
+ tqdm
+-transformers>=4.31.0  # need Encodec there.
+-xformers<0.0.23
++transformers>=4.31.0
++xformers
+ demucs
+ librosa
+ gradio
+ torchmetrics
+ encodec
+ protobuf
+-torchvision==0.16.0
+-torchtext==0.16.0
++torchvision


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D771280a x86_64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
