### PR TITLE
mod_tile: implement script change to handle deprecated behavior

### DIFF
--- a/gis/mod_tile/Portfile
+++ b/gis/mod_tile/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 
 github.setup        openstreetmap mod_tile 0.8.1 v
 github.tarball_from archive
-revision            3
+revision            4
 
 categories-append   gis
 maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
@@ -32,6 +32,7 @@ checksums           rmd160  6b6df6cc45757624039cf3fa9f5a16b09093ffd5 \
 boost.version       1.87
 
 depends_build       port:apache2 \
+                    port:autoconf-archive \
                     port:carto \
                     port:iniparser \
                     port:pkgconfig
@@ -77,8 +78,13 @@ patchfiles          configure-ac.diff \
                     osmosis-db_replag.diff
 
 use_autoreconf      yes
+autoreconf.args     --install --force --replace-handwritten
 
 configure.args      --with-apxs=${apxs}
+
+configure.cxxflags-append -Wno-deprecated-declarations
+
+configure.cflags-append -Wno-deprecated-declarations
 
 use_parallel_build  no
 

--- a/gis/mod_tile/files/configure-ac.diff
+++ b/gis/mod_tile/files/configure-ac.diff
@@ -1,7 +1,11 @@
---- configure.ac~	2024-06-21 02:56:34
-+++ configure.ac	2024-12-26 16:58:22
-@@ -21,11 +21,11 @@
+--- configure.ac~	2026-04-13 17:22:31
++++ configure.ac	2026-04-13 17:55:20
+@@ -19,14 +19,15 @@
+ AC_PROG_CC
  AC_PROG_CC_C99
+ AC_PROG_CXX
++AX_CXX_COMPILE_STDCXX([17], [ext])
+ AC_PROG_RANLIB
  
  dnl Find C++ compiler
 -AC_CHECK_PROG(HAVE_CXX, $CXX, yes, no)

--- a/gis/mod_tile/files/openstreetmap-tiles-update-expire.diff
+++ b/gis/mod_tile/files/openstreetmap-tiles-update-expire.diff
@@ -1,17 +1,20 @@
---- utils/openstreetmap-tiles-update-expire~	2025-11-19 14:40:49
-+++ utils/openstreetmap-tiles-update-expire	2025-11-19 14:39:31
-@@ -19,13 +19,34 @@
+--- utils/openstreetmap-tiles-update-expire~	2026-04-08 17:41:22
++++ utils/openstreetmap-tiles-update-expire	2026-04-08 17:41:02
+@@ -19,13 +19,38 @@
  
  #*************************************************************************
  #*************************************************************************
 -OSMOSIS_BIN=osmosis
 -OSM2PGSQL_BIN=osm2pgsql
 -OSM2PGSQL_OPTIONS=
+-#OSM2PGSQL_OPTIONS="--flat-nodes /path/to/flatnodes --hstore"
 +PREFIX="${PREFIX:-/usr/local}"
 +if [ -r ${PREFIX}/etc/mod_tile/osm-tiles-update.conf ]; then
 +    source ${PREFIX}/etc/mod_tile/osm-tiles-update.conf
 +fi
-+
+ 
+-BASE_DIR=/var/cache/renderd/tiles
+-LOG_DIR=/var/log/tiles/
 +# **Note:** Changes merged in from git commit
 +# `dd3c843697cfef8100c05312237d1d63ee44ffde` on the `switch2osm`
 +# branch, of <https://github.com/SomeoneElseOSM/mod_tile.git>.
@@ -27,20 +30,22 @@
 +OSM2PGSQL_RAM="${OSM2PGSQL_RAM:-4096}"
 +OSM2PGSQL_CPUS="${OSM2PGSQL_CPUS:-4}"
 +DBNAME="${GIS_DB:-gis}"
-+OSM2PGSQL_OPTIONS="-d $DBNAME -G --hstore --tag-transform-script ${PREFIX}/share/openstreetmap-carto/openstreetmap-carto.lua --number-processes $OSM2PGSQL_CPUS -S ${PREFIX}/share/openstreetmap-carto/openstreetmap-carto.style -C $OSM2PGSQL_RAM"
- #OSM2PGSQL_OPTIONS="--flat-nodes /path/to/flatnodes --hstore"
++if [ -f "$PREFIX/share/openstreetmap-carto/openstreetmap-carto-flex.lua" ];then
++    OSM2PGSQL_OPTIONS="--database $DBNAME --output flex --number-processes $OSM2PGSQL_CPUS --style=${PREFIX}/share/openstreetmap-carto/openstreetmap-carto-flex.lua --cache=$OSM2PGSQL_RAM"
++else
++    OSM2PGSQL_OPTIONS="--database $DBNAME --multi-geometry --hstore --tag-transform-script ${PREFIX}/share/openstreetmap-carto/openstreetmap-carto.lua --number-processes $OSM2PGSQL_CPUS --style ${PREFIX}/share/openstreetmap-carto/openstreetmap-carto.style --cache=$OSM2PGSQL_RAM"
++    #OSM2PGSQL_OPTIONS="--flat-nodes /path/to/flatnodes --hstore"
++fi
 +TRIM_BIN=${PREFIX}/share/trim_osc/trim_osc.py
 +TRIM_OPTIONS="-d $DBNAME --user $ACCOUNT"
 +TRIM_REGION_OPTIONS="${TRIM_REGION_OPTIONS:--p region.poly}"
- 
--BASE_DIR=/var/cache/renderd/tiles
--LOG_DIR=/var/log/tiles/
++
 +BASE_DIR=${PREFIX}/var/lib/mod_tile
 +LOG_DIR=${PREFIX}/var/log/renderd
  WORKOSM_DIR=$BASE_DIR/.osmosis
  
  LOCK_FILE=/tmp/openstreetmap-update-expire-lock.txt
-@@ -36,14 +57,26 @@
+@@ -36,14 +61,26 @@
  OSMOSISLOG=$LOG_DIR/osmosis.log
  PGSQLLOG=$LOG_DIR/osm2pgsql.log
  EXPIRYLOG=$LOG_DIR/expiry.log
@@ -70,7 +75,7 @@
  m_info() {
    echo "[$(date +"%Y-%m-%d %H:%M:%S")] $$ $1" >>"$RUNLOG"
  }
-@@ -85,6 +118,8 @@
+@@ -85,6 +122,8 @@
    mkdir $WORKOSM_DIR
    $OSMOSIS_BIN --read-replication-interval-init workingDirectory=$WORKOSM_DIR 1>&2 2>"$OSMOSISLOG"
    wget "https://replicate-sequences.osm.mazdermind.de/?"$1"T00:00:00Z" -O $WORKOSM_DIR/state.txt
@@ -79,7 +84,7 @@
  else
    # make sure the lockfile is removed when we exit and then claim it
  
-@@ -98,9 +133,13 @@
+@@ -98,9 +137,13 @@
      exit 2
    fi
  
@@ -94,7 +99,7 @@
  
    /bin/cp $WORKOSM_DIR/state.txt $WORKOSM_DIR/last.state.txt
    m_ok "downloading diff"
-@@ -109,21 +148,54 @@
+@@ -109,21 +152,54 @@
      m_error "Osmosis error"
    fi
  

--- a/gis/mod_tile/files/osm_setup_db.sh
+++ b/gis/mod_tile/files/osm_setup_db.sh
@@ -180,14 +180,23 @@ createDatabase()
     sudo -u "$GIS_USER" test -r "$PBF_FILE"
     if [ $? -eq 0 ]; then
 	>&2 echo "Importing from $PBF_FILE... (This can take a very long time, depending on import size and other factors)"
-	sudo -u nobody "$OSM2PGSQL_BIN" -d "$GIS_DB" \
-	     --create --slim  -G --hstore \
-	     --tag-transform-script \
-	     "$PREFIX/share/openstreetmap-carto/openstreetmap-carto.lua" \
-	     -C "$OSM2PGSQL_RAM" --number-processes "$OSM2PGSQL_CPUS" \
-	     -S "$PREFIX/share/openstreetmap-carto/openstreetmap-carto.style" \
-	     --input-reader='pbf' \
-	     "$PBF_FILE"
+	if [ -f "$PREFIX/share/openstreetmap-carto/openstreetmap-carto-flex.lua" ];then
+	    sudo -u nobody "$OSM2PGSQL_BIN" --database="$GIS_DB" \
+		 --create --slim \
+		 --output flex --style="$PREFIX/share/openstreetmap-carto/openstreetmap-carto-flex.lua" \
+		 --cache="$OSM2PGSQL_RAM" --number-processes "$OSM2PGSQL_CPUS" \
+		 --input-reader='pbf' \
+		 "$PBF_FILE"
+	else
+	    sudo -u nobody "$OSM2PGSQL_BIN" -d "$GIS_DB" \
+		 --create --slim  -G --hstore \
+		 --tag-transform-script \
+		 "$PREFIX/share/openstreetmap-carto/openstreetmap-carto.lua" \
+		 -C "$OSM2PGSQL_RAM" --number-processes "$OSM2PGSQL_CPUS" \
+		 -S "$PREFIX/share/openstreetmap-carto/openstreetmap-carto.style" \
+		 --input-reader='pbf' \
+		 "$PBF_FILE"
+	fi
 	if [ $? -ne 0 ]; then
 	    >&2 echo "Error importing $PBF_FILE"
 	    exit 1
@@ -205,6 +214,16 @@ createDatabase()
 		 -f "$PREFIX/share/openstreetmap-carto/functions.sql" >/dev/null
 	    if [ $? -ne 0 ]; then
 		>&2 echo "Error creating functions in PostgreSQL"
+		exit 1
+	    fi
+	fi
+	# White listed key-value tags introduced in openstreetmap-carto version 6.0.0
+	if [ -f "$PREFIX/share/openstreetmap-carto/common-values.sql" ]; then
+	    >&2 echo "Creating table for white listed key-value tags..."
+	    sudo -u "$GIS_USER" "$PGSQLBINPATH/psql" -d "$GIS_DB" -U "$GIS_DB_USER" \
+		 -f "$PREFIX/share/openstreetmap-carto/common-values.sql" >/dev/null
+	    if [ $? -ne 0 ]; then
+		>&2 echo "Error creating table for white listed key-value tags in PostgreSQL"
 		exit 1
 	    fi
 	fi


### PR DESCRIPTION
#### Description

`osm2pgsql` has deprecated using the `pgsql` style output.  These changes support both the deprecated `pgsql` and new `flex` style output types, testing for the presence of the new configuration file in the `openstreetmap-carto` port.

This update is also necessary to support `openstreetmap-carto` version 6.0.0

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
