### PR TITLE
plotutils: Fix build with a C23 compiler

### DIFF
--- a/graphics/plotutils/Portfile
+++ b/graphics/plotutils/Portfile
@@ -8,7 +8,6 @@ version          2.6
 revision         5
 conflicts        bsd-plotutils
 categories       graphics
-platforms        darwin
 maintainers      {snc @nerdling} openmaintainer
 license          GPL-3+
 
@@ -30,7 +29,8 @@ checksums        rmd160  2a32244eb20e00b82a0742dde7b690f688e82774 \
                  size    3657562
 
 patchfiles       patch-configure.ac.diff \
-                 patch-libpng-1.5.diff
+                 patch-libpng-1.5.diff \
+                 patch-sys-defines.h-c23-compat.diff
 
 use_autoreconf   yes
 

--- a/graphics/plotutils/files/patch-sys-defines.h-c23-compat.diff
+++ b/graphics/plotutils/files/patch-sys-defines.h-c23-compat.diff
@@ -1,0 +1,27 @@
+Do not redefine bool constants in C23
+
+C23 now includes predefined constants for the boolean values true and
+false, and attempting to redefine them ends with a compiler error. Avoid
+doing that by adjusting the preprocessor guard around that.
+
+Upstream-Status: Submitted [email]
+--- include/sys-defines.h.orig	2026-04-13 22:50:46
++++ include/sys-defines.h	2026-04-13 22:53:57
+@@ -253,7 +253,7 @@
+ /* Support the `bool' datatype, which is used widely in this package.     */
+ /**************************************************************************/
+ 
+-#ifndef __cplusplus
++#if !defined(__cplusplus) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L)
+ #ifdef __STDC__
+ typedef enum { false = 0, true = 1 } bool;
+ #else  /* not __STDC__, do things the old-fashioned way */
+@@ -261,7 +261,7 @@
+ #define false 0
+ #define true 1
+ #endif /* not __STDC__ */
+-#endif /* not __cplusplus */
++#endif /* not __cplusplus and (not __STDC_VERSION__ or __STDC_VERSION__ < 202311L) */
+ 
+ /**************************************************************************/
+ /* Define numerical constants (unofficial, so may not be in math.h).      */


### PR DESCRIPTION
#### Description

The configure script auto-enables `-std=gnu23` when it's available, but the header that defines the boolean constants doesn't support C23, breaking compilation.

No revbump, because this either builds correctly, or not at all.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
