### PR TITLE
claude-code: update to 2.1.104

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.101
+version             2.1.104
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  94bb81dee7695614369f1b33acb8aefca414384b \
-                 sha256  53f987ed6f107c73bb891401e576bd7e86223ca8e20ec1f123b113ef880950b8 \
-                 size    202943360
+    checksums    rmd160  5e3dc89079f06abcfbcbba0ec1e01052a7b83a6a \
+                 sha256  f1ad0ee6ff3401aceb922cf85ccaf6672a8b894ced23d63ca149d918c01a471d \
+                 size    202959872
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  d19074fa61ce2e155b70bd7d5dc90df068b4110f \
-                 sha256  a6ddd3a7ddd9a51b8ad3b0585875d383024a37cf2dde4c8cabde775b74512d74 \
-                 size    201445232
+    checksums    rmd160  7a630db13f5ab5eaef439faa30eb2f7e0507c842 \
+                 sha256  185aabd6d16dacb01a6dd41fc8d8ae5ea78ac8a6a3683caa05b759c47b24de60 \
+                 size    201461744
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.104.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?