### PR TITLE
py-torchvision: fix C++17 flag applied to C files

### DIFF
--- a/python/py-torchvision/Portfile
+++ b/python/py-torchvision/Portfile
@@ -30,7 +30,8 @@ platforms           {darwin >= 19}
 
 # Remove torch from build-system requires to avoid transitive
 # dependency version checks (same approach as py-pytorch)
-patchfiles-append   patch-pyproject_toml.diff
+patchfiles-append   patch-pyproject_toml.diff \
+                    patch-setup_py-c-flags.diff
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-torchvision/files/patch-setup_py-c-flags.diff
+++ b/python/py-torchvision/files/patch-setup_py-c-flags.diff
@@ -1,0 +1,10 @@
+--- setup.py.orig	2024-01-01 00:00:00.000000000 +0000
++++ setup.py	2024-01-01 00:00:00.000000000 +0000
+@@ -120,7 +120,7 @@
+ def get_macros_and_flags():
+     define_macros = []
+-    extra_compile_args = {"cxx": []}
++    extra_compile_args = {"cxx": [], "c": []}
+     if BUILD_CUDA_SOURCES:
+         if IS_ROCM:
+             define_macros += [("WITH_HIP", None)]


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D771280a x86_64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
