### PR TITLE
qca-qt5: update to 2.3.10; qca-qt6: new port version 2.3.10

### DIFF
--- a/devel/qca/Portfile
+++ b/devel/qca/Portfile
@@ -7,9 +7,19 @@ name                    qca
 # Qt version handling logic
 global Qt_Major
 subport ${name}-qt5     {}
+subport ${name}-qt6     {}
 
-if {[string match "${name}-qt5*" ${subport}]} {
+if {[string match "${name}-qt6*" ${subport}]} {
+    PortGroup           qt6 1.0
+
+    set Qt_Major        qt6
+    version             2.3.10
+    checksums           rmd160  bf26dcacbb5629a60ceffbeb168f1560b4cb1e5e \
+                        sha256  1c5b722da93d559365719226bb121c726ec3c0dc4c67dea34f1e50e4e0d14a02 \
+                        size    764844
+} elseif {[string match "${name}-qt5*" ${subport}]} {
     PortGroup           qt5 1.0
+
     set Qt_Major        qt5
     version             2.3.10
     checksums           rmd160  bf26dcacbb5629a60ceffbeb168f1560b4cb1e5e \
@@ -17,6 +27,7 @@ if {[string match "${name}-qt5*" ${subport}]} {
                         size    764844
 } else {
     PortGroup           qt4 1.0
+
     set Qt_Major        qt4
     # last release with Qt4 support:
     version             2.2.1
@@ -36,8 +47,6 @@ description             Qt Cryptographic Architecture
 long_description        Qt Cryptographic Architecture provides an easy API for the following \
                         features: SSL/TLS, X509, SASL, RSA, Hashing (SHA1, MD5), Ciphers \
                         (BlowFish, 3DES, AES).  Functionality is supplied via plugins.
-
-platforms               darwin
 
 homepage                https://userbase.kde.org/QCA
 master_sites            kde:stable/qca/${version}
@@ -71,6 +80,23 @@ switch ${Qt_Major} {
                         -DQCA_SUFFIX:STRING="qt5"
         build.post_args-append -wk
     }
+    qt6 {
+        maintainers           nomaintainer
+        
+        set qt_dir            ${qt6.dir}
+        set qt_plugins_dir    ${qt6.dir}/plugins
+        set qt_libs_dir       ${qt6.dir}/lib
+        set qt_bins_dir       ${qt6.dir}/bin
+        set qt_mkspecs_dir    ${qt6.dir}/mkspecs
+        set qt_includes_dir   ${qt6.dir}/include
+        set qt_docs_dir       ${qt6.dir}/doc
+        set qt_pkg_config_dir ${qt_libs_dir}/pkgconfig
+        
+        depends_build-append  path:bin/pkg-config:pkgconfig
+        qt6.depends_lib       qt5compat
+        configure.args-append \
+                              -DBUILD_WITH_QT6=ON
+    }
     default {
         ui_error "unsupported Qt version \"${Qt_Major}\""
         return -code error "Unsupported Qt version"
@@ -93,10 +119,14 @@ configure.args-append   -DCMAKE_INSTALL_PREFIX:PATH=${qt_dir} \
                         -DPKGCONFIG_INSTALL_PREFIX:PATH=${qt_pkg_config_dir} \
                         -DOSX_FRAMEWORK:BOOL=OFF
 
-# botan requires C++11
-compiler.cxx_standard   2011
-configure.cxxflags-append \
-                        -std=c++11
+if {${Qt_Major} eq "qt6"} {
+    compiler.cxx_standard   2017
+} else {
+    # botan requires C++11
+    compiler.cxx_standard   2011
+    configure.cxxflags-append \
+                            -std=c++11
+}
 
 post-destroot {
     if {${subport} eq ${name} || ${subport} eq "${subport}-qt5"} {
@@ -122,7 +152,7 @@ post-destroot {
 variant examples description {Include examples in install} {
     post-destroot {
         xinstall -d -m 755 ${destroot}${prefix}/share/${subport}/examples/
-        eval file copy [glob ${worksrcpath}/examples/*] \
+        file copy {*}[glob ${worksrcpath}/examples/*] \
             ${destroot}${prefix}/share/${subport}/examples/
     }
 }
@@ -133,7 +163,7 @@ variant examples description {Include examples in install} {
 ### plugins are built together with the main ports.
 ###
 # Qt4 receives no suffix:
-set qt.versions     {"" "-qt5"}
+set qt.versions     {"" "-qt5" "-qt6"}
 foreach qv ${qt.versions} {
     # the main ports
     if {${subport} eq "${name}${qv}"} {
@@ -148,6 +178,7 @@ foreach qv ${qt.versions} {
     # plugins depend on the corresponding main port and the libraries of which they expose the Functionality
     subport ${name}${qv}-ossl {
         PortGroup               openssl 1.0
+
         license                 LGPL-2.1+
         depends_lib             port:${name}${qv}
         if {${Qt_Major} eq "qt4"} {
@@ -162,14 +193,9 @@ foreach qv ${qt.versions} {
         configure.args-append   -DBUILD_PLUGINS:STRING="cyrus-sasl"
         build.dir               ${workpath}/build/plugins/qca-cyrus-sasl
     }
-    # gnupg subports obsolete, may be removed in April 2027
-    subport ${name}${qv}-gnupg {
-        PortGroup               obsolete 1.0
-
-        replaced_by             ${name}${qv}
-    }
     subport ${name}${qv}-pkcs11 {
         PortGroup               openssl 1.0
+
         license                 LGPL-2.1+
         depends_lib             port:${name}${qv} port:nss port:pkcs11-helper
         if {${Qt_Major} eq "qt4"} {
@@ -179,6 +205,16 @@ foreach qv ${qt.versions} {
         }
         configure.args-append   -DBUILD_PLUGINS:STRING="pkcs11"
         build.dir               ${workpath}/build/plugins/qca-pkcs11
+    }
+}
+
+set qt.versions     {"" "-qt5"}
+foreach qv ${qt.versions} {
+    # gnupg subports obsolete, may be removed in April 2027
+    subport ${name}${qv}-gnupg {
+        PortGroup               obsolete 1.0
+
+        replaced_by             ${name}${qv}
     }
 }
 

--- a/devel/qca/Portfile
+++ b/devel/qca/Portfile
@@ -129,8 +129,8 @@ variant examples description {Include examples in install} {
 
 ### Plugin subports:
 ### The ossl, cyrus-sasl and gnupg plugins used to be standalone ports
-### are now implemented as subports. The other plugins are built together with
-### the main ports.
+### the former two are now implemented as subports. The gnupg and the other
+### plugins are built together with the main ports.
 ###
 # Qt4 receives no suffix:
 set qt.versions     {"" "-qt5"}
@@ -142,7 +142,7 @@ foreach qv ${qt.versions} {
         depends_lib-append      port:botan \
                                 port:libgcrypt \
                                 port:nss
-        configure.args-append   -DBUILD_PLUGINS:STRING="botan\;gcrypt\;logger\;nss\;softstore"
+        configure.args-append   -DBUILD_PLUGINS:STRING="botan\;gcrypt\;gnupg\;logger\;nss\;softstore"
     }
 
     # plugins depend on the corresponding main port and the libraries of which they expose the Functionality
@@ -162,11 +162,11 @@ foreach qv ${qt.versions} {
         configure.args-append   -DBUILD_PLUGINS:STRING="cyrus-sasl"
         build.dir               ${workpath}/build/plugins/qca-cyrus-sasl
     }
+    # gnupg subports obsolete, may be removed in April 2027
     subport ${name}${qv}-gnupg {
-        license                 LGPL-2.1+
-        depends_lib             port:${name}${qv}
-        configure.args-append   -DBUILD_PLUGINS:STRING="gnupg"
-        build.dir               ${workpath}/build/plugins/qca-gnupg
+        PortGroup               obsolete 1.0
+
+        replaced_by             ${name}${qv}
     }
     subport ${name}${qv}-pkcs11 {
         PortGroup               openssl 1.0

--- a/devel/qca/Portfile
+++ b/devel/qca/Portfile
@@ -11,10 +11,10 @@ subport ${name}-qt5     {}
 if {[string match "${name}-qt5*" ${subport}]} {
     PortGroup           qt5 1.0
     set Qt_Major        qt5
-    version             2.3.4
-    checksums           rmd160  88589c5b4f2a87cb048b5a90ff39256ec996fdb1 \
-                        sha256  6b695881a7e3fd95f73aaee6eaeab96f6ad17e515e9c2b3d4b3272d7862ff5c4 \
-                        size    737072
+    version             2.3.10
+    checksums           rmd160  bf26dcacbb5629a60ceffbeb168f1560b4cb1e5e \
+                        sha256  1c5b722da93d559365719226bb121c726ec3c0dc4c67dea34f1e50e4e0d14a02 \
+                        size    764844
 } else {
     PortGroup           qt4 1.0
     set Qt_Major        qt4
@@ -65,8 +65,6 @@ switch ${Qt_Major} {
             known_fail yes
         }
         patchfiles-append \
-                        patch-qca-ossl.diff \
-                        patch-missing-headers.diff \
                         qt5/patch-qca210-qt550.diff \
                         qt5/patch-support-older-qt5.diff
         configure.args-append \
@@ -140,7 +138,7 @@ foreach qv ${qt.versions} {
     # the main ports
     if {${subport} eq "${name}${qv}"} {
         # revbump for botan2
-        revision                2
+        revision                0
         depends_lib-append      port:botan \
                                 port:libgcrypt \
                                 port:nss

--- a/devel/qca/files/qt5/patch-support-older-qt5.diff
+++ b/devel/qca/files/qt5/patch-support-older-qt5.diff
@@ -63,9 +63,9 @@ index f4ecffa013e51d505938b9393a8196edff252583..8ee4fc3fb987b3dea78f910ef995c164
 --- a/plugins/qca-gnupg/utils.cpp
 +++ b/plugins/qca-gnupg/utils.cpp
 @@ -130,7 +130,12 @@ QString find_bin()
-     const QString pathSep = QStringLiteral(":");
  #endif
  
+     // Look up at PATH environment
 -    QStringList paths = QString::fromLocal8Bit(qgetenv("PATH")).split(pathSep, Qt::SkipEmptyParts);
 +#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
 +    const auto splitPars = Qt::SkipEmptyParts;


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

`qca-qt5`: update to 2.3.10

`qca-qt6`: new port version 2.3.10

Closes https://trac.macports.org/ticket/70937.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
