### PR TITLE
[volk-]gnss-sdr: update to 0.0.21

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -24,13 +24,12 @@ if {${subport} eq "gnss-sdr"} {
     long_description    {*}${description}: \
         This port is kept up with the GNSS-SDR release, which is typically updated every few months.
 
-    github.setup    gnss-sdr gnss-sdr 0.0.19 v
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    github.tarball_from tarball
-    revision        1
-    checksums       rmd160  11daaaa2e4acbbcc837d8bd4f42546a6440675bc \
-                    sha256  e1f555da5ed8d0e0002441b771993409af29ed897784a0ebc7ee8d6c74b0cb98 \
-                    size    4086145
+    github.setup    gnss-sdr gnss-sdr 0.0.21 v
+    github.tarball_from archive
+    revision        0
+    checksums       rmd160  ac607f6c42e5a54eaa1637785a58e5ad16db68e5 \
+                    sha256  3b3265f5636d3ac27f030146e7028aa07e7d3b7bedb543ea707fb549f0c0da7a \
+                    size    4203004
 
     conflicts       gnss-sdr-devel
 
@@ -41,14 +40,12 @@ if {${subport} eq "gnss-sdr"} {
 subport gnss-sdr-devel {
     long_description    {*}${description}: \
         This port is kept up with the GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
-    github.setup    gnss-sdr gnss-sdr ec180d852574e10c621f9bf498d3ef70d26342ce
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    github.tarball_from tarball
-    version         20240126-[string range ${github.version} 0 7]
-    checksums       rmd160  6171d3966487f1cdf78fcc18e9a3f33f7a6f87a4 \
-                    sha256  6fbf9bfa1813a00daefdaa5a11b3f15f396af4c957b1792378e4f2a92952723a \
-                    size    4086092
-    revision        1
+    github.setup    gnss-sdr gnss-sdr 08df7e0635c97f96fa40e84fae200f7151eecfe0
+    github.tarball_from archive
+    version         20260414-[string range ${github.version} 0 7]
+    checksums       rmd160  0075d60f67ac235650d0d7abeef04d49c0f84030 \
+                    sha256  7dd41d80a2ada03f0489970fb4d71a5928780c3320cd1d10145055c29858562e \
+                    size    4206060
 
     conflicts       gnss-sdr
 
@@ -75,7 +72,7 @@ depends_build-append \
 
 depends_lib-append  \
     port:armadillo \
-    port:google-glog \
+    port:abseil \
     port:matio \
     port:protobuf3-cpp \
     port:pugixml \
@@ -117,10 +114,6 @@ if {[catch {set installed [lindex [registry_active gnuradio-next] 1]}]} {
 test.run yes
 test.target run_tests
 
-# require specific variants
-
-require_active_variants port:google-glog gflags
-
 # do VPATH (out of source tree) build
 
 cmake.out_of_source yes
@@ -132,7 +125,6 @@ configure.ldflags-delete -L${prefix}/lib
 
 configure.args-append \
     -DENABLE_PACKAGING=OFF \
-    -DENABLE_OWN_GLOG=OFF \
     -DENABLE_GENERIC_ARCH=OFF \
     -DENABLE_UNIT_TESTING_MINIMAL=ON
 
@@ -141,8 +133,6 @@ configure.args-append \
 configure.args-append \
     -DARMADILLO_INCLUDE_DIR=${prefix}/include \
     -DARMADILLO_LIBRARY=${prefix}/lib/libarmadillo.dylib \
-    -DGLOG_INCLUDE_DIR=${prefix}/include/glog \
-    -DGLOG_LIBRARY=${prefix}/lib/libglog.dylib \
     -DGNUTLS_INCLUDE_DIR=${prefix}/include \
     -DGNUTLS_LIBRARY=${prefix}/lib/libgnutls.dylib \
     -DGNUTLS_OPENSSL_LIBRARY=${prefix}/lib/libgnutls-openssl.dylib \

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -22,13 +22,12 @@ if {${subport} eq "volk-gnss-sdr"} {
     long_description    {*}${description}: \
         This port is kept up with the VOLK-GNSS-SDR release, which is typically updated every few months.
 
-    github.setup    gnss-sdr gnss-sdr 0.0.19 v
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    github.tarball_from tarball
+    github.setup    gnss-sdr gnss-sdr 0.0.21 v
+    github.tarball_from archive
     revision        0
-    checksums       rmd160  11daaaa2e4acbbcc837d8bd4f42546a6440675bc \
-                    sha256  e1f555da5ed8d0e0002441b771993409af29ed897784a0ebc7ee8d6c74b0cb98 \
-                    size    4086145
+    checksums       rmd160  ac607f6c42e5a54eaa1637785a58e5ad16db68e5 \
+                    sha256  3b3265f5636d3ac27f030146e7028aa07e7d3b7bedb543ea707fb549f0c0da7a \
+                    size    4203004
 
     conflicts       volk-gnss-sdr-devel
 
@@ -38,13 +37,12 @@ subport volk-gnss-sdr-devel {
     long_description    {*}${description}: \
         This port is kept up with the VOLK-GNSS-SDR GIT next branch, which is typically updated daily to weekly. This version of VOLK-GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release.
 
-    github.setup    gnss-sdr gnss-sdr ec180d852574e10c621f9bf498d3ef70d26342ce
-    # Change github.tarball_from to 'releases' or 'archive' next update
-    github.tarball_from tarball
-    version         20240126-[string range ${github.version} 0 7]
-    checksums       rmd160  6171d3966487f1cdf78fcc18e9a3f33f7a6f87a4 \
-                    sha256  6fbf9bfa1813a00daefdaa5a11b3f15f396af4c957b1792378e4f2a92952723a \
-                    size    4086092
+    github.setup    gnss-sdr gnss-sdr 08df7e0635c97f96fa40e84fae200f7151eecfe0
+    github.tarball_from archive
+    version         20260414-[string range ${github.version} 0 7]
+    checksums       rmd160  0075d60f67ac235650d0d7abeef04d49c0f84030 \
+                    sha256  7dd41d80a2ada03f0489970fb4d71a5928780c3320cd1d10145055c29858562e \
+                    size    4206060
     revision        0
 
     conflicts       volk-gnss-sdr
@@ -77,7 +75,7 @@ depends_lib-append \
 # specify the Python dependencies; these are checked for at configure,
 # then used for building, but not at runtime.
 
-set pythons_suffixes {310 311 312}
+set pythons_suffixes {310 311 312 313 314}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {
@@ -115,7 +113,7 @@ foreach s ${pythons_suffixes} {
 }
 
 if {![variant_isset debug]} {
-    set selected_python python39
+    set selected_python python314
     foreach s ${pythons_suffixes} {
         if {[variant_isset python${s}]} {
             set selected_python python${s}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update volk-gnss-sdr and gnss-sdr to 0.0.21.

github.tarball_from set to `archive`.
Dependency `google-glog +gflags` replaced by abseil

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
