### PR TITLE
algol68g: Update to 3.11.1

### DIFF
--- a/lang/algol68g/Portfile
+++ b/lang/algol68g/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                algol68g
-version             3.10.10
+version             3.11.1
 revision            0
 categories          lang algol devel
 license             GPL-3
@@ -15,9 +15,9 @@ long_description    Algol68G is an implementation of Algol 68 as defined by the 
 homepage            https://jmvdveer.home.xs4all.nl/algol.html
 master_sites        https://jmvdveer.home.xs4all.nl
 
-checksums           rmd160  df2ce4685c5c45a965c0767db39c6a2a270d415d \
-                    sha256  22356f526fa38f8de65f0697c9cf32f668d0cc68cd6c5529a3c1f93be8c39803 \
-                    size    673261
+checksums           rmd160  79e44bd3dae0d34ef44857a9fba44ece0d56dac2 \
+                    sha256  53004c643832b0b67d83aadf7392310a06f8a3ecdd98f413ece437b7970befa8 \
+                    size    680752
 
 extract.rename      yes
 


### PR DESCRIPTION
#### Description

Update algol68g 3.10.10 --> 3.11.1.

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?