### PR TITLE
wireshark4: Update to 4.6.4

### DIFF
--- a/net/wireshark4/Portfile
+++ b/net/wireshark4/Portfile
@@ -29,12 +29,13 @@ if { ${os.platform} eq "darwin" && ${os.major} < 16 } {
     }
 }
 
-version         4.6.0
-revision        1
+version         4.6.4
+revision        0
 
-checksums       sha256  ab016463062bb635285b9678dd45ddd84c65938911fd40b3cca9a903a08ad8d9 \
-                sha1    9440b807951ecc9b46f261a64b33e3cd4d0b17fa \
-                size    50726944
+checksums       sha256  fbeab3d85c6c8a5763c8d9b7fe20b5c69ca9f9e7f2b824bedc73135bdca332e2 \
+                sha1    694a28aedceef0061736d13c7fdff0ebddc46e77 \
+                rmd160  650922619eb2a91855ca5152f50cf356d5636f6a \
+                size    50566640
 
 livecheck.type  regex
 livecheck.url   ${homepage}download/src/


### PR DESCRIPTION
#### Description

This release fixes a number of security issues.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
