### PR TITLE
google-cloud-sdk: update to 565.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             564.0.0
+version             565.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  03d4413036f1f5482e75e3bfe99ebebbda7ca26a \
-                    sha256  2becac66d5a780d3ea0e2d2f41ea294e6bba005274887cc314bab919ae07b3f4 \
-                    size    57837946
+    checksums       rmd160  77041304ff885c23b53620718471f32e4c993ce3 \
+                    sha256  f63cccd550f6fb3000dcccb3d0d8ee92b1a34894094912e141fdee8fda8f5159 \
+                    size    58605544
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  36a157c2f7c567b5c0dc8f876c49fbf432669cd5 \
-                    sha256  0c6840e9635b7cb3f3f2e03d37b63c0d65e76968f02e7d5fa551c03621721d1d \
-                    size    59489080
+    checksums       rmd160  47d9667180e86efba028554a103f4a48e9214fb9 \
+                    sha256  10b446c52ad9dfb70f0a8134bf37932610eb790e340960a1351fab35a7c9d9c3 \
+                    size    60262777
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  bd77b630d369c21db97879df2b10df62cfc2bd9e \
-                    sha256  d76c1a5766d50815c9d35218bd74b3c2030b6d3cd5344ee642b3f85d1fc2905e \
-                    size    59393631
+    checksums       rmd160  49e115474f242d19cfeb9be685ff2d86178a4a71 \
+                    sha256  8d1980d5d43041850b10c75409a755538d23459cb6815d2c9dd3a172ff03f0ac \
+                    size    60166391
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 565.0.0.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?