### PR TITLE
rust-src: fix symlink to rust source

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -34,7 +34,7 @@ if {${os.platform} eq "darwin" && ${os.major} > 16} {
     revision                1
 }
 
-subport rust-src            {revision  0}
+subport rust-src            {revision  1}
 
 categories                  lang devel
 license                     {MIT Apache-2} BSD zlib NCSA Permissive
@@ -292,7 +292,8 @@ subport rust-src {
             }
         }
         xinstall -d -m 0755 "${destroot}${prefix}/lib/rustlib"
-        ln -s "../../libexec/rust/src/rustc-${version}-src" "${destroot}${prefix}/lib/rustlib/rust"
+        file mkdir "${destroot}${prefix}/lib/rustlib/src/"
+        ln -s "../../../libexec/rust/src/rustc-${version}-src" "${destroot}${prefix}/lib/rustlib/src/rust"
     }
 
     proc rust::rust_pg_callback {} {}


### PR DESCRIPTION
#### Description

When I'm using zed editor which runs rust-analyzer (default config) I'm still getting errors like in https://trac.macports.org/ticket/68987:
```
Workspace has sysroot errors: can't load standard library from sysroot
/opt/local
(discovered via `rustc --print sysroot`)
try installing `rust-src` the same way you installed `rustc`
```

Moreover I cannot browse source code of standard library.

The symlink workaround suggested in https://trac.macports.org/ticket/68987 fixes both problems.

There was a PR #30606 which enabled proc-macro server (part of original problem) but put the symlink in different path than suggested in trac ticket:
```
tree -L 2 /opt/local/lib/rustlib
/opt/local/lib/rustlib
├── aarch64-apple-darwin
│   ├── bin
│   └── lib
├── components
├── etc
│   ├── gdb_load_rust_pretty_printers.py
│   ├── gdb_lookup.py
│   ├── gdb_providers.py
│   ├── lldb_commands
│   ├── lldb_lookup.py
│   ├── lldb_providers.py
│   └── rust_types.py
├── manifest-clippy-preview
├── manifest-llvm-tools-preview
├── manifest-rust-std-aarch64-apple-darwin
├── manifest-rustc
├── manifest-rustfmt-preview
├── rust -> ../../libexec/rust/src/rustc-1.94.1-src         <-- PR #30606
├── rust-installer-version
└── src
    └── rust -> ../../../libexec/rust/src/rustc-1.94.1-src  <-- suggested in trac ticket #68987
   
```

This PR puts symlink in the path suggested in that trac ticket. 

After reinstalling rust-src port from changed Portfile the rust-analyzer works out of the box in zed editor (installed from dmg).

Correct me if I'm missing something.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.4 24G517 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
