### PR TITLE
claude-code: update to 2.1.108

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.104
+version             2.1.108
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  5e3dc89079f06abcfbcbba0ec1e01052a7b83a6a \
-                 sha256  f1ad0ee6ff3401aceb922cf85ccaf6672a8b894ced23d63ca149d918c01a471d \
-                 size    202959872
+    checksums    rmd160  2e8aed117ca25f4222c8caabc3a508bed16401fa \
+                 sha256  9e19adaae3709ce5917d8bf2faa669f560459bf240a2054de4e5e89babd0546a \
+                 size    203207552
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  7a630db13f5ab5eaef439faa30eb2f7e0507c842 \
-                 sha256  185aabd6d16dacb01a6dd41fc8d8ae5ea78ac8a6a3683caa05b759c47b24de60 \
-                 size    201461744
+    checksums    rmd160  702941879d761f63a039e52e97f99571e84a03ee \
+                 sha256  8d66163313976b0045b829e37eb3fcccb10ce6fd7e04a6db85d2c3915ff8aaec \
+                 size    201725936
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.108.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?