### PR TITLE
py-curl-cffi: Fix extract failure; other improvements

### DIFF
--- a/python/py-curl-cffi/Portfile
+++ b/python/py-curl-cffi/Portfile
@@ -17,44 +17,37 @@ homepage            https://github.com/lexiforest/curl_cffi
 set curl_impersonate_version    1.5.2
 
 master_sites        https://github.com/lexiforest/curl_cffi/releases/download/v${version}/:curl-cffi \
-                    https://github.com/lexiforest/curl-impersonate/releases/download//v${curl_impersonate_version}/:libcurl-impersonate
+                    https://github.com/lexiforest/curl-impersonate/releases/download/v${curl_impersonate_version}/:libcurl-impersonate
 
-distfiles           ${python.rootname}-${version}${extract.suffix}:curl-cffi
+set cffi_distfile   ${python.rootname}-${version}${extract.suffix}
+set impersonate_distfile \
+                    libcurl-impersonate-v${curl_impersonate_version}.${configure.build_arch}-macos${extract.suffix}
 
-checksums           ${python.rootname}-${version}${extract.suffix} \
+checksums           ${cffi_distfile} \
                     rmd160  a0e0dd9cf2da647841e03345e713bfb3344f0fdd \
                     sha256  ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded \
                     size    196437
 
+extract.only        ${cffi_distfile}
+distfiles           ${cffi_distfile}:curl-cffi \
+                    ${impersonate_distfile}:libcurl-impersonate
+
+supported_archs     arm64 x86_64
+universal_variant   no
+
 python.versions     310 311 312 313 314
 
 # See: https://github.com/lexiforest/curl-impersonate
-if {${os.arch} eq "arm"} {
-    distfiles-append \
-        libcurl-impersonate-v${curl_impersonate_version}.arm64-macos${extract.suffix}:libcurl-impersonate
-
-    checksums-append    libcurl-impersonate-v${curl_impersonate_version}.arm64-macos${extract.suffix} \
+if {${configure.build_arch} eq "arm64"} {
+    checksums-append    ${impersonate_distfile} \
                         rmd160  7a7c734df788908ac568c297478208ae488359bc \
                         sha256  101b39b1e2e9e529b3eedbdca1da71c80ff84c781f3504c05cf45774d52068de \
                         size    10362657
-
-    post-extract {
-        copy ${distpath}/libcurl-impersonate-v${curl_impersonate_version}.arm64-macos${extract.suffix} \
-            ${worksrcpath}/libcurl-impersonate${extract.suffix}
-    }
 } else {
-    distfiles-append \
-        libcurl-impersonate-v${curl_impersonate_version}.x86_64-macos${extract.suffix}:libcurl-impersonate
-
-    checksums-append    libcurl-impersonate-v${curl_impersonate_version}.x86_64-macos${extract.suffix} \
+    checksums-append    ${impersonate_distfile} \
                         rmd160  2ff122b553b593b8567affd71af076de5268b4bf \
                         sha256  0b3cfa62fb4d682d745176e49b467c10bf403de280df8d11d5384c042839e9f2 \
                         size    10845158
-
-    post-extract {
-        copy ${distpath}/libcurl-impersonate-v${curl_impersonate_version}.x86_64-macos${extract.suffix} \
-            ${worksrcpath}/libcurl-impersonate${extract.suffix}
-    }
 }
 
 if {${name} ne ${subport}} {
@@ -63,4 +56,9 @@ if {${name} ne ${subport}} {
     depends_lib-append  \
                     port:py${python.version}-cffi \
                     port:py${python.version}-certifi
+
+    post-extract {
+        ln -s ${distpath}/${impersonate_distfile} \
+            ${worksrcpath}/libcurl-impersonate${extract.suffix}
+    }
 }


### PR DESCRIPTION
#### Description

Fix extract failure of py-curl-cffi subport by moving the post-extract block to the {${name} ne ${subport}} block.

Put the second (binary) distfile into worksrcpath using a symblic link; no need to spend time and disk space to copy it.

Tell MacPorts not to extract the second (binary) distfile; the build system does it itself.

Base the choice of second (binary) distfile on ${configure.build_arch} rather than ${os.arch}.

Mark the port as supporting only arm64 and x86_64, since those are the only architectures for which the second (binary) distfile is available.

Disable the universal variant since the port doesn't have any code to handle this.

Deduplicate and hopefully clarify code.

Remove duplicate slash in second (binary) distfile download URL.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix
