### PR TITLE
OpenJPH: update to 0.27.0

### DIFF
--- a/graphics/OpenJPH/Portfile
+++ b/graphics/OpenJPH/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       cmake 1.0
 PortGroup       github 1.0
 
-github.setup    aous72 OpenJPH 0.26.3
+github.setup    aous72 OpenJPH 0.27.0
 categories      graphics
 license         BSD
 maintainers     nomaintainer
@@ -18,8 +18,9 @@ long_description \
     irreversible 9/7 are supported).
 
 github.tarball_from archive
-checksums       rmd160 1d72a70228281038ef3309222431c4d2bf038add \
-                sha256 29de006da7f1e8cf0cd7c3ec424cf29103e465052c00b5a5f0ccb7e1f917bb3f
+checksums       rmd160  b6f551f991fe0af1c9ecc45ff6a942e1732d8edb \
+                sha256  f6768e927d8e4e4884a2efcf500a88d1b6714a48d69516332a9256803a3c8343 \
+                size    483754
 
 cmake.out_of_source yes
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Command Line Tools 26.4.0.0.1774242506

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
-  [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? (tested building openexr 3.4.9)
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? (tested `+debug`)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
