### PR TITLE
x11/xkeyboard-config: fix configuration error

### DIFF
--- a/x11/xkeyboard-config/files/patch-autogen.sh.diff
+++ b/x11/xkeyboard-config/files/patch-autogen.sh.diff
@@ -7,6 +7,7 @@
 -intltoolize
 +# use --force to overwrite existing files
 +intltoolize --force
- 
- autoreconf -v --install || exit 1
+
+-autoreconf -v --install || exit 1
++autoreconf -v --install --force || exit 1
  cd $ORIGDIR || exit $?


### PR DESCRIPTION
Encountered the following error in the configuration phase.  Fixed via passing `--force` to autoreconf step.

     Executing:  cd "/opt/local/var/macports/build/xkeyboard-config-3ae3adfa/work/xkeyboard-config-2.5.1" && ./autogen.sh --prefix=/opt/local
     You should update your 'aclocal.m4' by running aclocal.
     autoreconf: export WARNINGS=
     autoreconf: warning: autoconf input should be named 'configure.ac', not 'configure.in'
     autoreconf: Entering directory '.'
     autoreconf: running: /opt/local/bin/autopoint
     autopoint: File ABOUT-NLS has been locally modified.
     autopoint: File config.rpath has been locally modified.
     autopoint: File po/Makefile.in.in has been locally modified.
     autopoint: *** Some files have been locally modified. Not overwriting them because --force has not been specified. For your convenience, you find the local modifications in the file '/opt/local/var/macports/build/xkeyboard-config-3ae3adfa/work/.tmp/arGWSU2t/gtGv4AQV/autopoint.diff'.
     autopoint: *** Stop.

c.f. <https://trac.macports.org/ticket/73856>