### PR TITLE
libfyaml: Use legacysupport for clock_gettime

### DIFF
--- a/devel/libfyaml/Portfile
+++ b/devel/libfyaml/Portfile
@@ -3,6 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       cmake 1.1
+PortGroup       legacysupport 1.1
 
 github.setup    pantoniou libfyaml 0.9.6 v
 maintainers     nomaintainer
@@ -24,6 +25,9 @@ configure.args-append \
 
 # __c11_atomic_load from Apple Clang 9.1.0 and earlier rejects const pointers
 compiler.c_standard 2017
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 # only allow numbers, to avoid pre-release versions
 github.livecheck.regex          {([0-9.]+)}


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/73857

Should fix: https://build.macports.org/builders/ports-10.11_x86_64-builder/builds/319251/steps/install-port/logs/stdio

```console
/opt/local/bin/clang-mp-16 -DFY_STATIC -D_GNU_SOURCE -I/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/include -I/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/src/valgrind -I/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/src/lib -I/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/src/util -I/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/src/xxhash -I/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/src/thread -I/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/src/allocator -I/opt/local/var/macports/build/libfyaml-12e0b87e/work/build -pipe -Os -DNDEBUG -I/opt/local/include -arch x86_64 -mmacosx-version-min=10.11 -MD -MT CMakeFiles/fy-thread.dir/src/internal/fy-thread.c.o -MF CMakeFiles/fy-thread.dir/src/internal/fy-thread.c.o.d -o CMakeFiles/fy-thread.dir/src/internal/fy-thread.c.o -c /opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/src/internal/fy-thread.c
/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/src/internal/fy-thread.c:196:2: error: call to undeclared function 'clock_gettime'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        clock_gettime(CLOCK_MONOTONIC, &s->execute);
        ^
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Command Line Tools 26.4.0.0.1774242506

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
