### PR TITLE
claude-code: update to 2.1.109

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.108
+version             2.1.109
 revision            0
 
 categories          llm
@@ -26,13 +26,13 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  2e8aed117ca25f4222c8caabc3a508bed16401fa \
-                 sha256  9e19adaae3709ce5917d8bf2faa669f560459bf240a2054de4e5e89babd0546a \
-                 size    203207552
+    checksums    rmd160  ca3a0b4529325c5c141b05bed4c5dc2480021469 \
+                 sha256  533c0834474a123af9989576d733d4e1d51f67ebeca828d426f25d0eae28f317 \
+                 size    203224064
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  702941879d761f63a039e52e97f99571e84a03ee \
-                 sha256  8d66163313976b0045b829e37eb3fcccb10ce6fd7e04a6db85d2c3915ff8aaec \
+    checksums    rmd160  15ccc2f4d0a034e4fc1c720282d46621eb7def89 \
+                 sha256  cc7e26eb08521a5315094a522775c7f17bdeef2d6d8d9040205af6d2e6dee595 \
                  size    201725936
 } else {
     set arch_classifier unsupported_arch


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.109.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?