### PR TITLE
libfyaml: Disable ASM building on 32-bit

### DIFF
--- a/devel/libfyaml/Portfile
+++ b/devel/libfyaml/Portfile
@@ -20,8 +20,14 @@ checksums       rmd160  eb916191b89856a26286d5395ced0649fc3e716e \
                 sha256  a59cc3331e2eb903ec36933ad52a45888041cac31e44f553a00511131242c483 \
                 size    1146628
 
+patchfiles      fy_skip_size32.patch
+
 configure.args-append \
                 -DBUILD_TESTING=OFF
+
+if { ${configure.build_arch} eq "i386" } {
+    configure.args-append -DENABLE_PORTABLE_TARGET=ON
+}
 
 # __c11_atomic_load from Apple Clang 9.1.0 and earlier rejects const pointers
 compiler.c_standard 2017

--- a/devel/libfyaml/files/fy_skip_size32.patch
+++ b/devel/libfyaml/files/fy_skip_size32.patch
@@ -1,0 +1,23 @@
+From 0982fcefc6a16d4c8cb5b06747d3fc8e630de3ae Mon Sep 17 00:00:00 2001
+From: Fredrik Fornwall <fredrik@fornwall.net>
+Date: Sun, 15 Mar 2026 21:47:27 +0100
+Subject: [PATCH] Fix 32-bit build by removing stray parameter to
+ fy_skip_size32()
+
+---
+ include/libfyaml/libfyaml-vlsize.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/libfyaml/libfyaml-vlsize.h b/include/libfyaml/libfyaml-vlsize.h
+index 6ccb7ab1..1b950c4c 100644
+--- include/libfyaml/libfyaml-vlsize.h
++++ include/libfyaml/libfyaml-vlsize.h
+@@ -816,7 +816,7 @@ fy_decode_size_nocheck(const uint8_t *start, size_t *sizep)
+ static inline const uint8_t *
+ fy_skip_size(const uint8_t *start, size_t bufsz)
+ {
+-	return fy_skip_size32(start, bufsz, &sz);
++	return fy_skip_size32(start, bufsz);
+ }
+ 
+ static inline const uint8_t *


### PR DESCRIPTION
#### Description

Should fix:

```console
/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/include/libfyaml/libfyaml-vlsize.h:819:39: error: use of undeclared identifier 'sz'
        return fy_skip_size32(start, bufsz, &sz);
                                             ^
```

and

```console
/opt/local/var/macports/build/libfyaml-12e0b87e/work/libfyaml-0.9.6/src/blake3/blake3_sse41_x86-64_unix.S:31:14: error: register %r15 is only available in 64-bit mode
        push r15
             ^~~
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Command Line Tools 26.4.0.0.1774242506

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
