### PR TITLE
kubetail: update to 0.14.1

### DIFF
--- a/devel/kubetail/Portfile
+++ b/devel/kubetail/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubetail-org/kubetail 0.14.0 cli/v
+go.setup            github.com/kubetail-org/kubetail 0.14.1 cli/v
 github.tarball_from releases
 revision            0
 
@@ -23,9 +23,9 @@ long_description    Kubetail is a general-purpose logging tool for Kubernetes, o
                     terminal.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  cf485d4bb827cf8c7a4c6f1457ea859e0dce7ab8 \
-                    sha256  1309f0b53dc3917adc4f05a42a9ea66b4c961443f01a7d15953bad5f6c239d8f \
-                    size    20818707
+                    rmd160  0c32e9c4950acc5540bcc9061daf52454b930f11 \
+                    sha256  308b9d49de6183c207756ff035d9bcce4ea41643ddf9ee80a7abb39c617b3131 \
+                    size    20817225
 
 build.env-append GO111MODULE=on \
                  GOWORK=off


### PR DESCRIPTION
#### Description

This PR upgrades `kubetail` to 0.14.1

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.3 25D125 arm64
Xcode 26.2 17C52

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
