### PR TITLE
py-cozempic: new port, version 1.7.1

### DIFF
--- a/python/py-cozempic/Portfile
+++ b/python/py-cozempic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cozempic
-version             1.8.2
+version             1.8.3
 revision            0
 
 license             MIT
@@ -20,9 +20,9 @@ long_description    Cozempic prunes bloated Claude Code session JSONL files, \
 
 homepage            https://github.com/Ruya-AI/cozempic
 
-checksums           rmd160  440cea56ef4073cf31bb079efed575f246dcc994 \
-                    sha256  eff75930e9a877a8091d7245c2d3ec51fe09b3249396aeac317d01724a16151d \
-                    size    149514
+checksums           rmd160  b37626a3afaa99ce5e924866c5046eea9142b0e1 \
+                    sha256  90e9e42828271099ea1983c228cf0cd56b21839b450e35c7c3aecaaeb43fc952 \
+                    size    149590
 
 python.versions     310 311 312 313
 python.default_version 312

--- a/python/py-cozempic/Portfile
+++ b/python/py-cozempic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cozempic
-version             1.7.1
+version             1.8.0
 revision            0
 
 license             MIT
@@ -20,9 +20,9 @@ long_description    Cozempic prunes bloated Claude Code session JSONL files, \
 
 homepage            https://github.com/Ruya-AI/cozempic
 
-checksums           rmd160  0efb02049ed579451dc068e3d13e8827e6f4b8c1 \
-                    sha256  9878ca1e0ddde69b478d66f0ce0b4d5abb49ecc105f493e51fffa0a738436a88 \
-                    size    130983
+checksums           rmd160  78c96233e31073085d3bc6bb3023066a4235141b \
+                    sha256  1040674778ac5cb4d37957a2864fd4123e012066b8942318511d0b756b9edd0a \
+                    size    148479
 
 python.versions     310 311 312 313
 python.default_version 312

--- a/python/py-cozempic/Portfile
+++ b/python/py-cozempic/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cozempic
+version             1.7.1
+revision            0
+
+license             MIT
+supported_archs     noarch
+platforms           {darwin any}
+maintainers         {@junaidtitan junaidq.com:j} openmaintainer
+
+description         Context cleaning CLI for Claude Code
+long_description    Cozempic prunes bloated Claude Code session JSONL files, \
+                    protects agent teams from compaction, and monitors token \
+                    usage via MCP tools. Zero runtime dependencies — Python \
+                    stdlib only.
+
+homepage            https://github.com/Ruya-AI/cozempic
+
+checksums           rmd160  0efb02049ed579451dc068e3d13e8827e6f4b8c1 \
+                    sha256  9878ca1e0ddde69b478d66f0ce0b4d5abb49ecc105f493e51fffa0a738436a88 \
+                    size    130983
+
+python.versions     310 311 312 313
+python.default_version 312
+
+python.pep517_backend setuptools
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    # Zero runtime dependencies — Python stdlib only.
+}

--- a/python/py-cozempic/Portfile
+++ b/python/py-cozempic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cozempic
-version             1.8.0
+version             1.8.2
 revision            0
 
 license             MIT
@@ -20,9 +20,9 @@ long_description    Cozempic prunes bloated Claude Code session JSONL files, \
 
 homepage            https://github.com/Ruya-AI/cozempic
 
-checksums           rmd160  78c96233e31073085d3bc6bb3023066a4235141b \
-                    sha256  1040674778ac5cb4d37957a2864fd4123e012066b8942318511d0b756b9edd0a \
-                    size    148479
+checksums           rmd160  440cea56ef4073cf31bb079efed575f246dcc994 \
+                    sha256  eff75930e9a877a8091d7245c2d3ec51fe09b3249396aeac317d01724a16151d \
+                    size    149514
 
 python.versions     310 311 312 313
 python.default_version 312
@@ -32,6 +32,4 @@ python.pep517_backend setuptools
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
-
-    # Zero runtime dependencies — Python stdlib only.
 }


### PR DESCRIPTION
New Python port for [cozempic](https://github.com/Ruya-AI/cozempic) — a CLI that prunes bloated Claude Code session JSONL files, protects multi-agent teams from context compaction, and monitors token usage via MCP tools.

## Details

- Version: 1.7.1
- License: MIT
- Runtime deps: **none** (Python stdlib only)
- Build deps: setuptools
- Homepage: https://github.com/Ruya-AI/cozempic
- PyPI: https://pypi.org/project/cozempic/
- Python versions supported: 3.10, 3.11, 3.12, 3.13 (default 3.12)
- Widely used: ~35k+ installs across PyPI + npm

## Testing

I do not have MacPorts installed on my dev machine, so I have not run \`port lint\` or \`port install\` locally. The same sdist (\`cozempic-1.7.1.tar.gz\`, sha256 \`9878ca1e...\`) is verified working via PyPI + Homebrew tap + npm. Happy to iterate on any lint or install issues you spot.

Checksums are computed directly from the PyPI sdist:
- \`rmd160 0efb02049ed579451dc068e3d13e8827e6f4b8c1\`
- \`sha256 9878ca1e0ddde69b478d66f0ce0b4d5abb49ecc105f493e51fffa0a738436a88\`
- \`size   130983\`