### PR TITLE
new port: py-mitogen, a plugin to speed up ansible

### DIFF
--- a/python/py-mitogen/Portfile
+++ b/python/py-mitogen/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-mitogen
+version             0.3.45
+revision            0
+checksums           rmd160  55caba439d020119f84137d316b0b29c300c3d85 \
+                    sha256  ee41b1595778903948b94c34ecee853f4ec67c6c5ac3239caa3bc6b4c34e61e8 \
+                    size    241033
+
+categories-append   sysutils
+supported_archs     noarch
+platforms           {darwin any}
+maintainers         {cal @neverpanic} openmaintainer
+
+license             BSD
+homepage            https://mitogen.networkgenomics.com/ansible_detailed.html
+description         \
+    Mitogen for Ansible is a completely redesigned UNIX connection layer and \
+    module runtime for Ansible.
+long_description    \
+    ${description} \
+    Requiring minimal configuration changes, it updates Ansible’s slow and \
+    wasteful shell-centric implementation with pure-Python equivalents, invoked \
+    via highly efficient remote procedure calls to persistent interpreters \
+    tunnelled over SSH. No changes are required to target hosts.
+
+python.versions     312 313 314
+
+if {${name} ne ${subport}} {
+    depends_lib-append  port:py${python.version}-ansible
+}


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
