### PR TITLE
hydrogen: update to version 1.2.6

### DIFF
--- a/audio/hydrogen/Portfile
+++ b/audio/hydrogen/Portfile
@@ -3,14 +3,14 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           qt5 1.0
+PortGroup           qt6 1.0
 
 epoch               1
-github.setup        hydrogen-music hydrogen 1.2.3
+github.setup        hydrogen-music hydrogen 1.2.6
 revision            0
-checksums           rmd160  93c296cc5a719ab29b113666cfe7d42aa969f11f \
-                    sha256  47b374ca162538b4fd6bc042721f9c6ac60b8c0fec5e8b1a2ac885d8bb56b753 \
-                    size    13692726
+checksums           rmd160  fe55aab0bc91d1736aeb7f6e81d6875581f8ac3b \
+                    sha256  efba32610498acde76fa2e147017c91b20c13ec945e05e348cd4183fd1613be1 \
+                    size    14412178
 
 categories          audio
 platforms           macosx
@@ -32,17 +32,20 @@ patchfiles          patch-CMakeLists.txt.diff
 
 depends_build-append \
                     port:cppunit
+
 depends_lib-append  port:libarchive \
                     port:libsndfile \
                     port:libtar \
                     port:pulseaudio \
                     port:zlib
 
-qt5.depends_component \
-                    qttools \
-                    qtxmlpatterns
+cmake.module_path-append \
+                    ${qt6.dir}/lib/cmake
+
+qt6.depends_lib     qttools
 
 configure.args-append \
+                    -DWANT_QT6=ON \
                     -DWANT_JACK:BOOL=OFF \
                     -DWANT_LRDF:BOOL=OFF \
                     -DWANT_SHARED:BOOL=ON

--- a/audio/hydrogen/Portfile
+++ b/audio/hydrogen/Portfile
@@ -16,7 +16,8 @@ categories          audio
 platforms           macosx
 # https://github.com/hydrogen-music/hydrogen/issues/1239#issuecomment-854661271
 license             GPL-2+
-maintainers         nomaintainer
+maintainers         {mailo.eu:timo.juhala @juhalati} \
+                    openmaintainer
 
 description         Hydrogen is an advanced drum machine.
 long_description    ${description} \

--- a/audio/hydrogen/files/patch-CMakeLists.txt.diff
+++ b/audio/hydrogen/files/patch-CMakeLists.txt.diff
@@ -1,8 +1,8 @@
 Don't add include and link paths; MacPorts will set these.
 Don't override the install prefix; MacPorts will set this.
---- CMakeLists.txt.orig	2024-01-12 08:08:23.000000000 -0600
-+++ CMakeLists.txt	2024-01-24 09:31:06.000000000 -0600
-@@ -217,11 +217,6 @@
+--- CMakeLists.txt.orig    2026-04-18 09:28:15
++++ CMakeLists.txt    2026-04-18 11:36:07
+@@ -231,11 +231,6 @@
  set(CMAKE_AUTOUIC ON)
  
  if(APPLE)


### PR DESCRIPTION
#### Description
* update to version 1.2.6
* add maintainer

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.3 25D125 arm64
Xcode 26.4 17E192

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
  - ~~though unsuccessfully; this is an Apple Silicon Mac~~ scratch that, even `-vst install` works with latest `macports-base`
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
