### PR TITLE
buku: update to 5.1

### DIFF
--- a/python/buku/Portfile
+++ b/python/buku/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                buku
-version             5.0
+version             5.1
 revision            0
-checksums           rmd160  8881149f3fca57e7eab7fbb4296e1e60f577edc0 \
-                    sha256  895a86b099adfe420c1925f333ce6cb00b851a6f11bcc7e42fb125fa81cae8b2 \
-                    size    287044
+checksums           rmd160  989c4f8a246734a7d0f179a9d0998b857540c758 \
+                    sha256  c7028bdd211bf5b88377938fa19d1819e057c198197383a4298ef4aeea8689bf \
+                    size    292496
 
 description         A command-line bookmark manager
 long_description    buku is a powerful bookmark manager written in \
@@ -33,7 +33,7 @@ supported_archs     noarch
 maintainers         {acm.org:cardi @cardi} openmaintainer
 license             GPL-3
 
-python.default_version  313
+python.default_version  314
 
 depends_build-append \
                     port:py${python.version}-setuptools
@@ -46,8 +46,8 @@ depends_lib-append  port:py${python.version}-beautifulsoup4 \
 
 post-extract {
     # build only buku by default
-    reinplace "s|exclude=\\\['tests'\\\]|include=\\\['buku'\\\]|" ${worksrcpath}/setup.py
-    reinplace "s|, 'bukuserver=bukuserver.server:cli'||" ${worksrcpath}/setup.py
+    reinplace "/^bukuserver/d" ${worksrcpath}/pyproject.toml
+    reinplace "s|\"bukuserver\", \"bukuserver\.\*\"||" ${worksrcpath}/pyproject.toml
 }
 
 pre-destroot {}


### PR DESCRIPTION
#### Description
buku: update to 5.1
* Update Python default version to 3.14
* Update post-extract reinplace regexes to work with pyproject.toml

###### Tested on
macOS 15.7.3 24G419 arm64
Xcode 26.2 17C52

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

