### PR TITLE
micronaut: update to 4.10.12

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.10.11 v
+github.setup    micronaut-projects micronaut-starter 4.10.12 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  b036934800e9ada187d2110edaadd947635dd6ab \
-                 sha256  fb7b2bbfd868216058a578283d6ed5b01e51c357c5afb97862090934a90729d2 \
-                 size    30547188
+    checksums    rmd160  e92da4fe7a1e3dc8d5dd077cd79a210732666b94 \
+                 sha256  c60f75b47f58e0e1033adab9e6d551e2b36eb35b33b2ba8f89f641754f5ad90b \
+                 size    30543278
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  851b7394dfac5fe2f5f8111d2a97361f3db6d29d \
-                 sha256  8449629fa5a0b64ae2f7fdd74fab152c8645dbbb4b9b3e4cacd82712b43b241a \
-                 size    30552495
+    checksums    rmd160  4807de6b682885ab33e878dc15c21c937816eaa0 \
+                 sha256  5d7496c219e7704884b4b3b22d7414a0a3d25c3207761f631fd55e26e2886bf6 \
+                 size    30540223
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut 4.10.12.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?