### PR TITLE
mise: Update to 2026.4.16

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.4.10 v
+github.setup        jdx mise 2026.4.16 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  54ae44d56b673a7f2ec0d45b46d397ead5e6c8c3 \
-                    sha256  7b99d5eb931b348aa4c6fc5b457066ffd19d6979c1a6b9b62e4e5f66479b8615 \
-                    size    6750969
+                    rmd160  3656df8e45c119019e87cd8c9e0f8519e1c31dbe \
+                    sha256  2337fd999874a2fa5cfa1c51eb54966d2a5cfa550824026089cff6b6987395be \
+                    size    6779482
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -128,8 +128,8 @@ cargo.crates \
     aws-config                          1.8.13  c456581cb3c77fafcc8c67204a70680d40b61112d6da78c77bd31d945b65f1b5 \
     aws-credential-types                1.2.11  3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3 \
     aws-lc-fips-sys                    0.13.14  d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568 \
-    aws-lc-rs                           1.16.2  a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc \
-    aws-lc-sys                          0.39.1  83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399 \
+    aws-lc-rs                           1.16.3  0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f \
+    aws-lc-sys                          0.40.0  f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7 \
     aws-runtime                          1.6.0  c635c2dc792cb4a11ce1a4f392a925340d1bdf499289b5ec1ec6810954eb43f5 \
     aws-sdk-s3                         1.119.0  1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c \
     aws-sdk-sts                         1.97.0  e6443ccadc777095d5ed13e21f5c364878c9f5bad4e35187a6cdbd863b0afcad \
@@ -168,7 +168,7 @@ cargo.crates \
     bit-set                              0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                              0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
     bit-vec                              0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
-    bitflags                            2.11.0  843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af \
+    bitflags                            2.11.1  c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3 \
     bitvec                               1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
     blake2                              0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
     blake3                               1.8.4  4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e \
@@ -205,10 +205,10 @@ cargo.crates \
     ci_info                            0.14.15  7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23 \
     cipher                               0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     clang-sys                            1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
-    clap                                 4.6.0  b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351 \
+    clap                                 4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap-sort                            1.0.3  3c9f374a541bd277ba6f4ccd08d955024ba09fda8dfc69ca1a750799ebed97a9 \
     clap_builder                         4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
-    clap_derive                          4.6.0  1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a \
+    clap_derive                          4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                             1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
     clru                                 0.6.3  197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5 \
     clx                                  1.3.0  5fd84e27faf914a0353eab8ac31ca3c8d719a493f46ff884f4b4eb5a5d7f34d0 \
@@ -259,7 +259,7 @@ cargo.crates \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
     crypto_secretbox                     0.1.1  b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1 \
-    ctor                                 0.9.1  c1c888a2a4f677017373fb6c01e13e318dd9e78758445ed5eb985e355d3f8281 \
+    ctor                                0.10.0  95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775 \
     ctor-proc-macro                     0.0.12  a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
@@ -301,7 +301,7 @@ cargo.crates \
     displaydoc                           0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     document-features                   0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dotenvy                             0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
-    dtor                                 0.6.0  30e4690622ab6700ced40fc370a3f07b7d111f0154bb6fb08f73b4c8834f75b6 \
+    dtor                                 0.7.0  17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293 \
     dtor-proc-macro                     0.0.12  8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131 \
     duct                                0.13.7  e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c \
     duct                                 1.1.1  7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684 \
@@ -337,7 +337,7 @@ cargo.crates \
     fastrand                             2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     ff                                  0.13.1  c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393 \
     fiat-crypto                          0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
-    file_url                             0.2.7  81d37aab514a05a249a5b15408dc74d716f5745a2c5daf22e40a245ffd38fa84 \
+    file_url                             0.2.8  77b3f3f3326607002e13f1b44a624279f5ca21afce4259730aa619c420cca73b \
     filetime                            0.2.27  f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db \
     filetime_creation                    0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
     find-crate                           0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
@@ -475,7 +475,7 @@ cargo.crates \
     hyper                              0.14.32  41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7 \
     hyper                                1.9.0  6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca \
     hyper-rustls                        0.24.2  ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590 \
-    hyper-rustls                        0.27.7  e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58 \
+    hyper-rustls                        0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-tls                            0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
     hyper-util                          0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
     i18n-config                          0.4.8  3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef \
@@ -554,12 +554,12 @@ cargo.crates \
     lexical-write-float                  1.0.6  50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361 \
     lexical-write-integer                1.0.6  409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df \
     libbz2-rs-sys                        0.2.2  2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7 \
-    libc                               0.2.184  48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af \
+    libc                               0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
     libredox                            0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
-    link-section                        0.0.12  f52437d47b0358721ec869cc7374b2a21f7b2237af9b439c0391341a1fbfbf1b \
+    link-section                         0.2.0  468808413fa8bdf0edbe61c2bbc182dfc59885b94f496cf3fb42c9c96b1e0149 \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                              0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
@@ -604,6 +604,7 @@ cargo.crates \
     netrc-rs                             0.1.2  ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836 \
     nix                                 0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
     nix                                 0.31.2  5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3 \
+    nodejs-semver                        4.2.0  2a29bc3430baa1e00e10d9aa5f4ed19ce4433eecb40e3926ade5ff2954cc2f3a \
     nom                                  7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     nom                                  8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
     nom-language                         0.1.0  2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29 \
@@ -634,10 +635,10 @@ cargo.crates \
     once_cell_polyfill                  1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     opaque-debug                         0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
     openidconnect                        4.0.1  0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2 \
-    openssl                            0.10.76  951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf \
+    openssl                            0.10.77  bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f \
     openssl-macros                       0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                        0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
-    openssl-sys                        0.9.112  57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb \
+    openssl-sys                        0.9.113  ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644 \
     option-ext                           0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                       2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     os-release                           0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
@@ -676,7 +677,7 @@ cargo.crates \
     pkcs1                                0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
     pkcs5                                0.7.1  e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6 \
     pkcs8                               0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
-    pkg-config                          0.3.32  7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c \
+    pkg-config                          0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
     plain                                0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
     platforms                           3.10.0  f6001d2ac55b4eb1ca634c65fc06555068b8dd89c9f20fd92064e5341a436e63 \
     plist                                1.8.0  740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07 \
@@ -717,29 +718,29 @@ cargo.crates \
     r-efi                                6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radium                               0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
     rand                                 0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
-    rand                                 0.9.3  7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166 \
+    rand                                 0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
     rand                                0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
     rand_chacha                          0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                          0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                            0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                            0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
-    rand_core                           0.10.0  0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba \
+    rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.40.5  d5e004d0371d9671efc0c41c9d5311a21479db551fd68236a3299b7d7b8447f0 \
-    rattler_cache                       0.6.20  1b829f276e98d7d670be90df8aebaac4ce92606d766e315c230ee4c1782ec9e4 \
-    rattler_conda_types                 0.44.5  251545c07ce023c159c6673e9e5da7f49ae9a5cc791d1f5dbb6067a00612550a \
+    rattler                             0.40.6  4d0e63e5cba12a01904b7002c40d31aa93d62554526f1abcf733bcfaa0464102 \
+    rattler_cache                       0.6.21  e41ab6700748842122199ae89c110bf152b0c95d0fcf0bdf9c6fd49255f05533 \
+    rattler_conda_types                 0.44.6  809c0147f00c67143f90a1e01870a8856b68d3072dbe91cdf78c4dbab44a944e \
     rattler_digest                       1.2.3  fa6239d5be357419ba579b1cda7fe0e140a22134ebc999adb62b818989fbc7c7 \
     rattler_macros                      1.0.12  18d0d45ce3ae00333421569d2fafa4b877708a901c3cb217f8d4acfab4328df0 \
-    rattler_menuinst                    0.2.55  be28b61681374a243151224f09d8691ef59db158001f075b64ef60f26622cc1a \
-    rattler_networking                  0.26.8  6c737c889ed175f55fb86986694a916a58f97bb22cf466169abd9c1dd363712e \
-    rattler_package_streaming           0.24.8  b9cf2ab39920b58ac3cd41a23ef4ec40ab9fdc4a3645c045f5de6b2677b1398f \
+    rattler_menuinst                    0.2.56  303d912b90c44cc3539ac47bf28633e0ef84085c3ef36007f51bdfec580a0c94 \
+    rattler_networking                  0.26.9  a7f21a2e0a5b3ef35ff1a9d7d9dd62001b2953060299140dfc52ddb22907d41f \
+    rattler_package_streaming           0.24.9  62e2d688fd457ecd88ec9fcd610a638152814191d53a5d84798c5b3cac2897b4 \
     rattler_pty                          0.2.9  ec435d69bcc064b5cb0f6a49d8cfc1dbed93f0ec233d4499156ae7c3bc7f90d7 \
     rattler_redaction                   0.1.13  961121cad9792daafc176a7f4caafc0fc889fb17507c23a4c86e1777a8b5e179 \
-    rattler_repodata_gateway            0.27.5  927979192dd8e7644da0d6dcb0a1a98244f1412da7a69f0a9037e185caa01dd1 \
-    rattler_shell                       0.26.8  a39fdc6dab30c7eb958bd3d92c47b9b3e78f85cb0acdaebfa91ad3e3230a7e6b \
-    rattler_solve                        5.2.1  a71f5f4948fcd822f2612dd21c07de56a358c1404f6373e0ac0b34d97e9aa817 \
-    rattler_virtual_packages            2.3.17  8fddfeee1ea50f4f39d2b8750e9f6c5774678108666aa4ff2e0e4d73c733d347 \
-    rayon                               1.11.0  368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f \
+    rattler_repodata_gateway            0.27.6  b49ec1a9f8de181bb4e5e62060f48d3c0a66d69dd2b93119c7fb77b0e242ffcc \
+    rattler_shell                       0.26.9  8beacee0b6fac56c621bb9c61799d476c32b107061a207586d1a259b54376cec \
+    rattler_solve                        5.2.2  69719a26caf0689659097a85e7d3fc5174200ef0c64d65e5f9f89f14afd700e0 \
+    rattler_virtual_packages            2.3.18  8c3d2a564b41942dd87e441e4c68a31e4be517915daf5d20fe4b36cd3f4a7c5e \
+    rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     redox_syscall                        0.7.4  f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a \
@@ -761,6 +762,7 @@ cargo.crates \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rmcp                                 0.3.2  1f0d0d5493be0d181a62db489eab7838669b81885972ca00ceca893cf6ac2883 \
     rmcp-macros                          0.3.2  4aebc912b8fa7d54999adc4e45601d1d95fe458f97eb0a1277eddcd6382cf4b1 \
+    rmcp-macros                         0.17.0  abad6f5f46e220e3bda2fc90fd1ad64c1c2a2bd716d52c845eb5c9c64cda7542 \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
     roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
@@ -778,13 +780,13 @@ cargo.crates \
     rustix                             0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                               1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustls                             0.21.12  3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e \
-    rustls                             0.23.37  758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4 \
+    rustls                             0.23.38  69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21 \
     rustls-native-certs                  0.8.3  612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63 \
     rustls-pki-types                    1.14.0  be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd \
     rustls-platform-verifier             0.6.2  1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
     rustls-webpki                      0.101.7  8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765 \
-    rustls-webpki                     0.103.11  20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4 \
+    rustls-webpki                     0.103.12  8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06 \
     rustversion                         1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     rusty-fork                           0.3.1  cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2 \
     ryu                                 1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
@@ -852,7 +854,7 @@ cargo.crates \
     signature                            2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
     sigstore                            0.13.0  52bba786054331bdc89e90f74373b68a6c3b63c9754cf20e3a4a629d0165fe38 \
     sigstore-protobuf-specs-derive       0.0.1  80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35 \
-    sigstore-verification                0.2.2  62278e9ab9dcd8a08bffc8e85119ca5a40dcd1b24d4012fa07ddc6aeb1f0eff3 \
+    sigstore-verification                0.2.5  234e57d0dbeea51543961991b61785d44ec7a6eb37d344a7f9ac47f1d7c9f8f0 \
     sigstore_protobuf_specs              0.5.1  cd627b4d5240ac660de3357b5d0156d5c63b872be1deae5046c3c8eb65d488e2 \
     simd-adler32                         0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     simd-json                           0.17.0  4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3 \
@@ -919,10 +921,10 @@ cargo.crates \
     tinyvec_macros                       0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tls_codec                            0.4.2  0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b \
     tls_codec_derive                     0.4.2  2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd \
-    tokio                               1.51.1  f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c \
+    tokio                               1.52.1  b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6 \
     tokio-macros                         2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-native-tls                     0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
-    tokio-retry                          0.3.0  7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f \
+    tokio-retry                          0.3.1  40f644c762e9d396831ae2f8935c954b0d758c4532e924bead0f666d0c1c8640 \
     tokio-rustls                        0.24.1  c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081 \
     tokio-rustls                        0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                        0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
@@ -930,7 +932,8 @@ cargo.crates \
     toml                                0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
     toml                     0.9.12+spec-1.1.0  cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863 \
     toml_datetime             0.7.5+spec-1.1.0  92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347 \
-    toml_edit                0.24.1+spec-1.1.0  01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e \
+    toml_datetime             1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
+    toml_edit               0.25.11+spec-1.1.0  0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b \
     toml_parser               1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
     toml_writer               1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
     tough                               0.21.0  e88d0ee9525696569cc2af5d46f8a739028c0268895071e0386957195b0c9161 \
@@ -1028,7 +1031,6 @@ cargo.crates \
     windows-numerics                     0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
     windows-numerics                     0.3.1  6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26 \
     windows-registry                     0.5.3  5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e \
-    windows-registry                     0.6.1  02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720 \
     windows-result                       0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
     windows-result                       0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
     windows-strings                      0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
@@ -1112,6 +1114,7 @@ cargo.crates \
     zip                                  4.6.1  caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1 \
     zip                                  8.5.1  dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59 \
     zipsign-api                          0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
+    zipsign-api                          0.2.1  32a55ebb27e67d9a9d116dd3a19637ee8cc0570c8ef816fb504c453f15448c99 \
     zlib-rs                              0.6.3  3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513 \
     zmij                                1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
     zopfli                               0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249 \


### PR DESCRIPTION
#### Description

mise: Update to 2026.4.16


##### Tested on

macOS 26.3.1 25D771280a arm64
Xcode 26.4 17E192


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
