### PR TITLE
lagrange: update to 1.20.4

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           gitea 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.20.3 v
+gitea.setup         gemini lagrange 1.20.4 v
 revision            0
 categories          net gemini
 license             BSD
@@ -14,9 +14,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  c1b4d44499637af3ac0ec744c9c625fc0b8769dd \
-                    sha256  a6eddc3188e1908fb6b3d03fb8f9057579a967fc18469b996987e7d24117a48b \
-                    size    9828332
+checksums           rmd160  4a8d3a9edd8da31c662ccfb6d4f5098452e7e853 \
+                    sha256  57fa800c7db4dfd14627bf88b4caa22449fd0429c3f29d72bfd2002f138a5baa \
+                    size    9830667
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
https://github.com/skyjake/lagrange/releases/tag/v1.20.4

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
