### PR TITLE
GPXSee: update to 16.3

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 16.1
+github.setup        tumic0 GPXSee 16.3
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  fb94b8f036f812e435598cdb033745ec430bb6c1 \
-                    sha256  39924a5ed1dd45cce3b286b569cbf071166a3e92cab0a9cdcb246bfd89d94181 \
-                    size    6575257
+checksums           rmd160  525159e2ed4eceddd6b4b446d8c3f11531caa5b5 \
+                    sha256  7625907c1eaf108e02b235f406b2b124274f9b80c9716b92cc8ffd1f287a1437 \
+                    size    6575831
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
