### PR TITLE
sfeed: update to 2.4

### DIFF
--- a/net/sfeed/Portfile
+++ b/net/sfeed/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 name                sfeed
-version             2.3
+version             2.4
 revision            0
 license             ISC
 
@@ -18,9 +18,9 @@ homepage            https://git.codemadness.org/${name}/
 
 master_sites        https://codemadness.org/releases/${name}/
 
-checksums           rmd160  34c2cc7f3626b620d92e866c37254ffa5fb11e6d \
-                    sha256  a1daa0ecbe0b77e7540de8d9781d9645e0c068135e1767a54fdc6c380c0c48b7 \
-                    size    70031
+checksums           rmd160  56f8d783412d357f9f76fc66e165f979e43a2819 \
+                    sha256  f9503fe9205a8136f76a9b753c6007abad33e2a516807e416a986723db06e879 \
+                    size    70093
 
 depends_lib-append  port:ncurses
 


### PR DESCRIPTION
#### Description
https://git.codemadness.org/sfeed/log.html

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
