### PR TITLE
claude-code: update to 2.1.114

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.113
+version             2.1.114
 revision            0
 
 categories          llm
@@ -26,13 +26,13 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  6c679cff0f8a3c26918b2f4d25e9a8c1e3d4cc85 \
-                 sha256  5b9d04c3bf924d41962754c4c9371c9439a42ddeb838faeb01b63b074673e14e \
+    checksums    rmd160  7407764b7b1d1a2a64c5fcc3c3a1bb67307d09af \
+                 sha256  1a30360b6240056a58ba9187c8f9d2e88e949e0f970d5cf81f8d69bc65568f6a \
                  size    206004048
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  e456a20dbdfc4a665034a299593214959f296b58 \
-                 sha256  189b1c94ace3f3e90cd4836562cbb7f1eba69148b1353ba92a38ff966cb6cb00 \
+    checksums    rmd160  6e462fa634ff73bd9c14bf67b373883f697dca8e \
+                 sha256  bf1b4da368da7970f0d1d4a1675acea99b6f2ad94f24e9f8ccfcc7940ac67894 \
                  size    204534752
 } else {
     set arch_classifier unsupported_arch


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.114.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?