### PR TITLE
pangomm-1.4: update Python dependency to 3.14, fix variant typo

### DIFF
--- a/x11/pangomm-1.4/Portfile
+++ b/x11/pangomm-1.4/Portfile
@@ -33,7 +33,7 @@ checksums           rmd160  bb3ad778efe08053f29b522fc327184f4e083459 \
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload
 
-set py_ver          3.12
+set py_ver          3.14
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build-append \
@@ -81,7 +81,7 @@ if {[variant_isset x11]} {
 
 if {[variant_isset quartz]} {
     require_active_variants path:lib/pkgconfig/cairomm-1.0.pc:cairomm quartz
-    require_active_variants ath:lib/pkgconfig/pango.pc:pango quartz
+    require_active_variants path:lib/pkgconfig/pango.pc:pango quartz
 }
 
 livecheck.type      gnome


### PR DESCRIPTION
## Summary
- Update `py_ver` from 3.12 to 3.14 in `x11/pangomm-1.4/Portfile`
- Fix typo `ath:lib/pkgconfig/pango.pc:pango` -> `path:lib/pkgconfig/pango.pc:pango` in the `+quartz` variant's `require_active_variants` check (was silently a no-op)
- Python is already a build-only dependency; meson requires Python >= 3.5, which 3.14 satisfies
- No revision bump: build-only dep, installed files do not reference Python (verified via `port contents pangomm-1.4 | xargs grep -l python`)

Mirrors the maintainer-approved approach from #32172 (gtkmm3).

## Test plan
- [ ] `port lint --nitpick pangomm-1.4` is clean
- [ ] `sudo port -v -s clean pangomm-1.4 && sudo port -v -s install pangomm-1.4 +quartz` builds successfully against `python314`
- [ ] `port contents pangomm-1.4 | xargs grep -l python` returns no matches
- [ ] Downstream consumer (e.g. `gtkmm3 +quartz`) still builds against the rebuilt `pangomm-1.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)