### PR TITLE
viskores: Fix builds for 10.11, 10.12

### DIFF
--- a/graphics/viskores/Portfile
+++ b/graphics/viskores/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  e56a5f9ed785ad6a001d3511e62146031d783098 \
                     sha256  24eb77decff0370789594a8064060d64b51ba0b9ae9d78c882daada4d8f19a20 \
                     size    17158572
 
-compiler.cxx_standard   2014
+compiler.cxx_standard   2017
 compiler.thread_local_storage yes
 
 variant native description {Enable CPU-specific optimizations} {


### PR DESCRIPTION
#### Description

viskores:  Specify C++ standard = 2017, fix some legacy builds.
2017 is specified upstream:
https://github.com/Viskores/viskores?tab=readme-ov-file#dependencies

###### Type(s)

- [x] bugfix

###### Tested on

CI only.
Waiting for merge to check legacy builds.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?