### PR TITLE
luanti: update to 5.15.2 and drop minetest-game packaging

### DIFF
--- a/games/luanti/Portfile
+++ b/games/luanti/Portfile
@@ -5,9 +5,9 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           openssl 1.0
 
-github.setup        luanti-org luanti 5.15.1
+github.setup        luanti-org luanti 5.15.2
 github.tarball_from archive
-revision            1
+revision            0
 
 set game_version    5.8.0
 
@@ -22,9 +22,9 @@ master_sites        ${github.master_sites}:main \
                     ${game_mastersite}:game
 
 checksums           ${main_distfile} \
-                    rmd160  c5c1bbb0243f53ae84973c13c9242457697ce83d \
-                    sha256  fe0b10df866f57c0047d84a4c6f6cd848650f52d9b0cab563fbbedc81632d616 \
-                    size    12329736 \
+                    rmd160  7fa900016e3bac0b27dd1d4b59240e8de50c86bd \
+                    sha256  1fdfa8b973968f8fcf5a264ce3fb3a170c3882105f953498a64d6415eff83471 \
+                    size    12332073 \
                     ${game_distfile} \
                     rmd160  9300fde834d5f7e37286225ba0e851e891db2ef1 \
                     sha256  33a3bb43b08497a0bdb2f49f140a2829e582d5c16c0ad52be1595c803f706912 \

--- a/games/luanti/Portfile
+++ b/games/luanti/Portfile
@@ -9,26 +9,9 @@ github.setup        luanti-org luanti 5.15.2
 github.tarball_from archive
 revision            0
 
-set game_version    5.8.0
-
-set main_distfile   ${distfiles}
-set game_distfile   ${game_version}${extract.suffix}
-set game_mastersite https://github.com/luanti-org/minetest_game/archive/refs/tags
-
-distfiles           ${main_distfile}:main \
-                    ${game_distfile}:game
-
-master_sites        ${github.master_sites}:main \
-                    ${game_mastersite}:game
-
-checksums           ${main_distfile} \
-                    rmd160  7fa900016e3bac0b27dd1d4b59240e8de50c86bd \
+checksums           rmd160  7fa900016e3bac0b27dd1d4b59240e8de50c86bd \
                     sha256  1fdfa8b973968f8fcf5a264ce3fb3a170c3882105f953498a64d6415eff83471 \
-                    size    12332073 \
-                    ${game_distfile} \
-                    rmd160  9300fde834d5f7e37286225ba0e851e891db2ef1 \
-                    sha256  33a3bb43b08497a0bdb2f49f140a2829e582d5c16c0ad52be1595c803f706912 \
-                    size    2608281
+                    size    12332073
 
 compiler.cxx_standard 2017
 compiler.thread_local_storage yes
@@ -105,7 +88,3 @@ configure.args-append \
                     -DENABLE_LUAJIT=ON \
                     -DINSTALL_DEVTEST=ON \
                     -DVERSION_EXTRA=MacPorts-rev${revision}
-
-post-destroot {
-    move ${workpath}/minetest_game-${game_version} ${destroot}${applications_dir}/${name}.app/Contents/Resources/games/minetest_game
-}


### PR DESCRIPTION
#### Description

- Bump luanti to new upstream bugfix release 5.15.2
- Drop packaging default game `minetest-game`
  - Upstream discourages the packaging of any game as 'default', see e.g. [here](https://blog.luanti.org/2024/10/13/Introducing-Our-New-Name/). Instead upstream expects any user to manually install the game of their choosing via the in-game browser.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
