### PR TITLE
vtk: Use external viskores

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -28,7 +28,7 @@ compiler.blacklist-append {clang < 1100}
 
 github.setup        Kitware vtk 9.6.1 v
 github.tarball_from archive
-revision            0
+revision            1
 categories          graphics devel
 license             BSD
 
@@ -54,14 +54,16 @@ depends_lib-append  path:share/pkgconfig/eigen3.pc:eigen3 \
                     port:hdf5 \
                     port:libxml2 \
                     port:${proj_version} \
-                    port:tiff
+                    port:tiff \
+                    port:viskores
 
 configure.args-append \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_eigen:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_hdf5:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_libproj:BOOL=ON \
                     -DVTK_MODULE_USE_EXTERNAL_VTK_libxml2:BOOL=ON \
-                    -DVTK_MODULE_USE_EXTERNAL_VTK_tiff:BOOL=ON
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_tiff:BOOL=ON \
+                    -DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores:BOOL=ON
 
 mpi.enforce_variant hdf5
 


### PR DESCRIPTION
#### Description

vtk: Switch from bundled viskores, to external MacPorts viskores.

###### Type(s)

- [x] enhancement

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?