### PR TITLE
libfido2: update to 1.17.0

### DIFF
--- a/security/libfido2/Portfile
+++ b/security/libfido2/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           openssl 1.0
 PortGroup           legacysupport 1.1
@@ -9,10 +8,13 @@ PortGroup           legacysupport 1.1
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-# next release download from https://developers.yubico.com/libfido2/Releases/
-github.setup        Yubico libfido2 1.16.0
-github.tarball_from tarball
-revision            2
+name                libfido2
+version             1.17.0
+revision            0
+
+homepage            https://developers.yubico.com/libfido2/
+master_sites        ${homepage}Releases/
+distname            ${name}-${version}
 
 categories          security crypto
 maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
@@ -21,9 +23,9 @@ license             bsd
 description         library to communicate with a FIDO device over USB
 long_description    provides library functionality and command-line tools to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.
 
-checksums           rmd160  4adb73f4f695393b92ab32d541f0a9980b2c2586 \
-                    sha256  c9795fff9183eaf111114e8619ff79a4aea9aeac2ddc5935616b1e32dd60e3b2 \
-                    size    682408
+checksums           rmd160  cdb493d47e411f1e5d77bd9f056ee896b3836180 \
+                    sha256  c1012c8871d71b65872fd5ff1a9d6b0838a55683a03e85ba97479ce57129c736 \
+                    size    714675
 
 depends_build-append \
                     port:mandoc \
@@ -33,6 +35,30 @@ depends_lib-append  port:libcbor
 
 platform darwin {
     if {${os.major} < 16} {
+        # kIOHIDManagerOptionNone undefined before macOS 10.12
+        patchfiles-append \
+                    patch-compat-pre1012.diff
+    }
+    if {${os.major} < 14} {
+        # 10.9 and below: old Apple Clang mishandles __attribute__((fallthrough))
+        patchfiles-append \
+                    patch-fallthrough.diff
+    }
+    if {${os.major} < 13} {
+        # 10.8 and below: bzero hidden by _POSIX_C_SOURCE, needs explicit declaration
+        patchfiles-append \
+                    patch-bzero.diff
+    }
+    if {${os.major} < 11} {
+        # 10.5 and 10.6: F_SETNOSIGPIPE unavailable
+        patchfiles-append \
+                    patch-nosigpipe.diff
+        # 10.5 and 10.6: Apple Clang does not recognize FALLTHROUGH comment form
+        patchfiles-append \
+                    patch-cmake-no-fallthrough.diff
+    }
+    if {${os.major} < 10} {
+        # 10.5 only: IOHIDDeviceGetService/IORegistryEntryGetRegistryEntryID unavailable
         patchfiles-append \
                     patch-hid_osx.diff
     }

--- a/security/libfido2/files/patch-apple-gcc.diff
+++ b/security/libfido2/files/patch-apple-gcc.diff
@@ -2,11 +2,11 @@
 # Apparently -exported_symbols_list works with Apple ld:
 # https://developer.apple.com/library/archive/documentation/Performance/Conceptual/CodeFootprint/Articles/ReducingExports.html
 
---- CMakeLists.txt.orig	2021-10-27 19:02:28.000000000 +0700
-+++ CMakeLists.txt	2022-09-05 22:14:55.000000000 +0700
-@@ -297,9 +297,8 @@
- add_definitions(-DTLS=${TLS})
- 
+--- CMakeLists.txt.orig	2026-04-18 10:42:30
++++ CMakeLists.txt	2026-04-18 10:42:51
+@@ -358,9 +358,8 @@
+ endif()
+
  # export list
 -if(APPLE AND (CMAKE_C_COMPILER_ID STREQUAL "Clang" OR
 -   CMAKE_C_COMPILER_ID STREQUAL "AppleClang"))

--- a/security/libfido2/files/patch-bzero.diff
+++ b/security/libfido2/files/patch-bzero.diff
@@ -1,0 +1,11 @@
+--- openbsd-compat/explicit_bzero.c.orig
++++ openbsd-compat/explicit_bzero.c
+@@ -10,6 +10,8 @@
+ #if !defined(HAVE_EXPLICIT_BZERO) && !defined(_WIN32)
+
+ #include <string.h>
++/* declare bzero explicitly: hidden by _POSIX_C_SOURCE on older SDKs */
++extern void bzero(void *, size_t);
+
+ /*
+  * explicit_bzero - don't let the compiler optimize away bzero

--- a/security/libfido2/files/patch-cmake-no-fallthrough.diff
+++ b/security/libfido2/files/patch-cmake-no-fallthrough.diff
@@ -1,0 +1,10 @@
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -306,7 +306,6 @@
+ 	add_compile_options(-Wwrite-strings)
+ 	add_compile_options(-Wmissing-prototypes)
+ 	add_compile_options(-Wbad-function-cast)
+-	add_compile_options(-Wimplicit-fallthrough)
+ 	add_compile_options(-pedantic)
+ 	add_compile_options(-pedantic-errors)
+ 

--- a/security/libfido2/files/patch-compat-pre1012.diff
+++ b/security/libfido2/files/patch-compat-pre1012.diff
@@ -1,0 +1,9 @@
+--- src/hid_osx.c.orig
++++ src/hid_osx.c
+@@ -22,6 +22,7 @@
+ #if __MAC_OS_X_VERSION_MIN_REQUIRED < 120000
+ #define kIOMainPortDefault kIOMasterPortDefault
++#define kIOHIDManagerOptionNone 0x0
+ #endif
+
+ #define IOREG "ioreg://"

--- a/security/libfido2/files/patch-fallthrough.diff
+++ b/security/libfido2/files/patch-fallthrough.diff
@@ -1,0 +1,18 @@
+--- src/fallthrough.h.orig
++++ src/fallthrough.h
+@@ -8,14 +8,6 @@
+ #ifndef _FALLTHROUGH_H
+ #define _FALLTHROUGH_H
+
+-#if defined(__GNUC__)
+-#if __has_attribute(fallthrough)
+-#define FALLTHROUGH	__attribute__((fallthrough));
+-#endif
+-#endif /* __GNUC__ */
+-
+-#ifndef FALLTHROUGH
+ #define FALLTHROUGH	/* FALLTHROUGH */
+-#endif
+
+-#endif /* !_FALLTHROUGH_H */
++#endif /* _FALLTHROUGH_H */

--- a/security/libfido2/files/patch-hid_osx.diff
+++ b/security/libfido2/files/patch-hid_osx.diff
@@ -9,17 +9,6 @@
  #include <CoreFoundation/CoreFoundation.h>
  #include <IOKit/IOKitLib.h>
  #include <IOKit/hid/IOHIDKeys.h>
-@@ -20,8 +20,9 @@
- 
- #include "fido.h"
- 
--#if __MAC_OS_X_VERSION_MIN_REQUIRED < 120000
-+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
- #define kIOMainPortDefault kIOMasterPortDefault
-+#define kIOHIDManagerOptionNone 0x0
- #endif
- 
- #define IOREG "ioreg://"
 @@ -169,25 +170,27 @@
  static char *
  get_path(IOHIDDeviceRef dev)
@@ -54,40 +43,3 @@
  
  	return (path);
  }
-@@ -362,6 +365,7 @@
- 	return (0);
- }
- 
-+#if MAC_OS_X_VERSION_MIN_REQUIRED > 1060
- static int
- disable_sigpipe(int fd)
- {
-@@ -391,6 +395,7 @@
- 	return (IOServiceGetMatchingService(kIOMainPortDefault,
- 	    IORegistryEntryIDMatching(id)));
- }
-+#endif
- 
- void *
- fido_hid_open(const char *path)
-@@ -414,6 +419,7 @@
- 		goto fail;
- 	}
- 
-+#if MAC_OS_X_VERSION_MIN_REQUIRED > 1060
- 	if (set_nonblock(ctx->report_pipe[0]) < 0 ||
- 	    set_nonblock(ctx->report_pipe[1]) < 0) {
- 		fido_log_debug("%s: set_nonblock", __func__);
-@@ -429,6 +435,12 @@
- 		fido_log_debug("%s: get_ioreg_entry: %s", __func__, path);
- 		goto fail;
- 	}
-+#else
-+	if ((entry = IORegistryEntryFromPath(kIOMainPortDefault,path)) == MACH_PORT_NULL) {
-+		fido_log_debug("%s: IORegistryEntryFromPath: %s", __func__, path);
-+		goto fail;
-+	}
-+#endif
- 
- 	if ((ctx->ref = IOHIDDeviceCreate(kCFAllocatorDefault,
- 	    entry)) == NULL) {

--- a/security/libfido2/files/patch-nosigpipe.diff
+++ b/security/libfido2/files/patch-nosigpipe.diff
@@ -1,0 +1,39 @@
+--- src/hid_osx.c.orig
++++ src/hid_osx.c
+@@ -347,6 +347,7 @@
+ 	CFRunLoopStop(CFRunLoopGetCurrent());
+ }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1060
+ static int
+ set_nonblock(int fd)
+ {
+@@ -394,6 +395,7 @@
+ 	return (IOServiceGetMatchingService(kIOMainPortDefault,
+ 	    IORegistryEntryIDMatching(id)));
+ }
++#endif
+ 
+ void *
+ fido_hid_open(const char *path)
+@@ -417,6 +419,7 @@
+ 		goto fail;
+ 	}
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1060
+ 	if (set_nonblock(ctx->report_pipe[0]) < 0 ||
+ 	    set_nonblock(ctx->report_pipe[1]) < 0) {
+ 		fido_log_debug("%s: set_nonblock", __func__);
+@@ -432,6 +435,12 @@
+ 		fido_log_debug("%s: get_ioreg_entry: %s", __func__, path);
+ 		goto fail;
+ 	}
++#else
++	if ((entry = IORegistryEntryFromPath(kIOMainPortDefault,path)) == MACH_PORT_NULL) {
++		fido_log_debug("%s: IORegistryEntryFromPath: %s", __func__, path);
++		goto fail;
++	}
++#endif
+ 
+ 	if ((ctx->ref = IOHIDDeviceCreate(kCFAllocatorDefault,
+ 	    entry)) == NULL) {


### PR DESCRIPTION
#### Description

Update libfido2 from 1.16.0 to 1.17.0.

The upstream project switched from GitHub tarball to official Yubico
release tarball, so the fetch configuration was updated accordingly.
Several legacy macOS compatibility patches were added to support builds
on Mac OS X 10.5–10.9, and the existing `patch-hid_osx.diff` was
simplified by extracting unrelated concerns into separate patch files.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

Also verified on: macOS 15, 10.11, 10.10, 10.9, 10.8, 10.7, 10.6

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?