### PR TITLE
ImageMagick, p5-perlmagick: Update to 6.9.13-44

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -13,12 +13,12 @@ legacysupport.newest_darwin_requires_legacy 10
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.13-43
+version                     6.9.13-44
 revision                    0
 
-checksums                   rmd160  dab775ff5a70bc9cc0bbe9d58fc5654606203c25 \
-                            sha256  6fcd60539e788a9d51c5a5e59be51e6090cdbcf443b968560d632b4e2c42075c \
-                            size    9641712
+checksums                   rmd160  0fa4399cea431ab2c8918aa04ce6d92705b504cb \
+                            sha256  c0bd44e4377bd33245634a0cf6c30eb6c02f9960d09c3256833ad29f35e170dd \
+                            size    9630728
 
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -7,12 +7,12 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         PerlMagick 6.9.13-43
+perl5.setup         PerlMagick 6.9.13-44
 revision            0
 
-checksums           rmd160  dab775ff5a70bc9cc0bbe9d58fc5654606203c25 \
-                    sha256  6fcd60539e788a9d51c5a5e59be51e6090cdbcf443b968560d632b4e2c42075c \
-                    size    9641712
+checksums           rmd160  0fa4399cea431ab2c8918aa04ce6d92705b504cb \
+                    sha256  c0bd44e4377bd33245634a0cf6c30eb6c02f9960d09c3256833ad29f35e170dd \
+                    size    9630728
 
 set my_name         ImageMagick
 maintainers         {ryandesign @ryandesign}


### PR DESCRIPTION
#### Description

ImageMagick, p5-perlmagick: Update 6.9.13-43 --> 6.9.13-44

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?