### PR TITLE
scamper: update to 20260420

### DIFF
--- a/net/scamper/Portfile
+++ b/net/scamper/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           openssl 1.0
 
 name                scamper
-version             20260331
+version             20260420
 revision            0
 categories          net
 license             GPL-2
@@ -21,9 +21,9 @@ long_description    ${name} is a program that is able to conduct Internet \
 homepage            https://www.caida.org/catalog/software/scamper
 master_sites        ${homepage}/code/
 
-checksums           rmd160  210d4af5b0812f0a87befd0c7a1bd654bd69ca33 \
-                    sha256  1bd3a025dc8ded231df2fd72c92c5b85fc1e389af6e9cb020c02067b811a9917 \
-                    size    3396971
+checksums           rmd160  696704458ed8b25370c5e1e070d2b5f740eb6568 \
+                    sha256  7d6f6b94e0b80439e45218318a92d30645a7bdbb23c711f68536c8f243fd3317 \
+                    size    3417544
 
 distname            ${name}-cvs-${version}
 
@@ -33,6 +33,7 @@ if {${subport} eq ${name}} {
     configure.args-append \
                     --enable-sc_hoiho \
                     --enable-sc_minrtt \
+                    --enable-sc_rxifd \
                     --enable-sc_uptime \
                     --with-pcre2
 


### PR DESCRIPTION
#### Description

Update scamper to 20260420.  pass a new configure parameter to build sc_rxifd.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
