### PR TITLE
riscv64-none-elf-gcc: new port at version 15.2.0

### DIFF
--- a/_resources/port1.0/group/crossgcc-1.0.tcl
+++ b/_resources/port1.0/group/crossgcc-1.0.tcl
@@ -174,6 +174,11 @@ array set newlib.versions_info {
         sha256  83a62a99af59e38eb9b0c58ed092ee24d700fff43a22c03e433955113ef35150 \
         size    8832922
     }}
+    4.6.0.20260123 {gz {
+        rmd160  97d1a15f06e550301d2cc68a9cc41bbc3c7b8bd2 \
+        sha256  6ff27e3bf022666f43f7802255be680eeff722ac181b1725d21e2e8318604ee3 \
+        size    9208322
+    }}
 }
 
 proc crossgcc.setup {target version} {

--- a/cross/riscv64-none-elf-binutils/Portfile
+++ b/cross/riscv64-none-elf-binutils/Portfile
@@ -1,0 +1,10 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           crossbinutils 1.0
+
+crossbinutils.setup riscv64-none-elf 2.46.0
+revision            0
+maintainers         {gmail.com:dblarkqwq @dblark} openmaintainer
+
+configure.args-append --disable-werror

--- a/cross/riscv64-none-elf-gcc/Portfile
+++ b/cross/riscv64-none-elf-gcc/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           crossgcc 1.0
+
+set gccversion      15.2.0
+set newlibversion   4.6.0.20260123
+crossgcc.setup      riscv64-none-elf ${gccversion}
+crossgcc.setup_libc newlib ${newlibversion}
+revision            0
+
+maintainers         {gmail.com:dblarkqwq @dblark} openmaintainer
+
+depends_build-append \
+                    bin:makeinfo:texinfo
+
+configure.args-append \
+                    --disable-newlib-supplied-syscalls \
+                    --with-arch=rv64gc \
+                    --with-abi=lp64d \
+                    "--with-multilib-generator=rv64gc-lp64d--\\;rv64imac-lp64--\\;rv64ima-lp64--"


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
