### PR TITLE
openjdk25-zulu: update to 25.34.17

### DIFF
--- a/java/openjdk25-zulu/Portfile
+++ b/java/openjdk25-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25&package=jdk#zulu
-version      ${feature}.32.21
+version      ${feature}.34.17
 revision     0
 
-set openjdk_version ${feature}.0.2
+set openjdk_version ${feature}.0.3
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until September 2033)
@@ -34,21 +34,19 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  af04047176d56622d500d73038118908ea24d5bb \
-                 sha256  3d3e9e544ea0d1b042ba52344533e9205ef82723ff05780262ccb171ac980d55 \
-                 size    227659500
+    checksums    rmd160  b3874d9a4cd8a70ad06265ac63eeae384b625157 \
+                 sha256  ecc005bf7b129c035379e0de9bebfd667be93098f5f1e329cd498c46769167ae \
+                 size    227804338
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  4ca22ac5bd1bf75adc3db9fd9e2efdfef92deb85 \
-                 sha256  5992fede1295fddf6e19cd073c24e61135b42f79ffbfda5bcec544206246a079 \
-                 size    225129123
+    checksums    rmd160  99b856b643c37804805e9a4ff3b21ed7a03f3ba9 \
+                 sha256  74847e7ac930ad143950607421dd6c0a7ccb3d1cbbd8b1665f24ab62b8b7de42 \
+                 size    225264022
 } else {
     set arch_classifier unsupported_arch
 }
 
 distname     zulu${version}-ca-jdk${openjdk_version}-macosx_${arch_classifier}
-
-worksrcdir   ${distname}/zulu-${feature}.jdk
 
 homepage     https://www.azul.com/downloads/
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 25.34.17 (OpenJDK 25.0.3).

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?