### PR TITLE
openjdk21-zulu: update to 21.50.19

### DIFF
--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk#zulu
-version      ${feature}.48.17
+version      ${feature}.50.19
 revision     0
 
-set openjdk_version ${feature}.0.10
+set openjdk_version ${feature}.0.11
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until December 2030)
@@ -34,21 +34,19 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  7777698ae0f73d12507f2641cbd16234c56ee94a \
-                 sha256  0dc3de9c4de5fe732a09bafe2103687c365c904ab9542043e89c829dd49e9e28 \
-                 size    208997037
+    checksums    rmd160  9f3cd0cfc6a0606a67e01ec97665384e72fa22c3 \
+                 sha256  906990cbe599731e3c8ec85f7a6f2e72d4a0f9ec1cc18b6b52a16e1e2fc5934d \
+                 size    209136241
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  b3923ae18b5377f99841b042ac2505a94e130e03 \
-                 sha256  7c29d3232a163c366af3fda303bd54ffda22f41c16ba4c87f19b6adb91b1d232 \
-                 size    206768158
+    checksums    rmd160  c3a1028d112215f4e131337eb11a64cfd7611898 \
+                 sha256  59cf896951a1f3cd132abfc1f74ba4db1f916ecc81b3c0022c5c16a21ae940ad \
+                 size    206898411
 } else {
     set arch_classifier unsupported_arch
 }
 
 distname     zulu${version}-ca-jdk${openjdk_version}-macosx_${arch_classifier}
-
-worksrcdir   ${distname}/zulu-${feature}.jdk
 
 homepage     https://www.azul.com/downloads/
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 21.50.19 (OpenJDK 21.0.11).

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?