### PR TITLE
openjdk26-zulu: update to 26.30.11

### DIFF
--- a/java/openjdk26-zulu/Portfile
+++ b/java/openjdk26-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-25&package=jdk#zulu
-version      ${feature}.28.59
+version      ${feature}.30.11
 revision     0
 
-set openjdk_version ${feature}.0.0
+set openjdk_version ${feature}.0.1
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Short Term Support until September 2026)
@@ -34,21 +34,19 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  9663f453633246112b22f843a9ab4fc22af25882 \
-                 sha256  3a8d520c63eead9da76517291b5e58debc923b5ad7a48a654805a15a6f0807f9 \
-                 size    231480112
+    checksums    rmd160  285682556e6fe710355933cd8bc2b9e824912e18 \
+                 sha256  192610410dcdfb6edca2429b0d5d2b1cdf322f532218ac00327e1bcf8dfe29b3 \
+                 size    231453738
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  ed40916aa90bff682fcd3bf5332f5ea868dc2f96 \
-                 sha256  f7d151adcc91b6a2513983066b0ca1db409df99d7a3a87ac31b21e60c978a5c7 \
-                 size    228873898
+    checksums    rmd160  661db8886c95062fa6ebb7e8e3940f472020a9fb \
+                 sha256  7f1b123232537a30a6ed4aa87d6a84d426b75abf350ebe2356784a261e9d6076 \
+                 size    228824305
 } else {
     set arch_classifier unsupported_arch
 }
 
 distname     zulu${version}-ca-jdk${openjdk_version}-macosx_${arch_classifier}
-
-worksrcdir   ${distname}/zulu-${feature}.jdk
 
 homepage     https://www.azul.com/downloads/
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 26.30.11 (OpenJDK 26.0.1).

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?