### PR TITLE
openjdk17-zulu: update to 17.66.19

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.64.17
+version      ${feature}.66.19
 revision     0
 
-set openjdk_version ${feature}.0.18
+set openjdk_version ${feature}.0.19
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until September 2029)
@@ -34,21 +34,19 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  29f608071203416a1bd3f0aa62b6da6ed34162aa \
-                 sha256  9875615a2720eb1027f01693e2e08df770a14fc81849801f5fb87b91181dab22 \
-                 size    194587753
+    checksums    rmd160  1be949678876f00375320deb21246fe422830791 \
+                 sha256  6a7b8b23f2419ea1dde7eeace0d5a4cc5dbe7bbc83a8dda35dc64aa12269d041 \
+                 size    194731967
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  286c5c29bae20a0bb6a9b0a546a5c616999021a5 \
-                 sha256  122446b8ad36f1dc80677272dbdad71fd5ca8d76df774c01e7839c7bf4d267d6 \
-                 size    192516375
+    checksums    rmd160  2c1b8401bead2198f4cd18ea54b6dedfb0513611 \
+                 sha256  f2bd5afaaaa4c23eb4bf2c78913c7eb7d3d228e44209ffec652fb72388a2f25c \
+                 size    192646028
 } else {
     set arch_classifier unsupported_arch
 }
 
 distname     zulu${version}-ca-jdk${openjdk_version}-macosx_${arch_classifier}
-
-worksrcdir   ${distname}/zulu-${feature}.jdk
 
 homepage     https://www.azul.com/downloads/
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.66.19 (OpenJDK 17.0.19).

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?