### PR TITLE
openjdk11-zulu: update to 11.88.17

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      ${feature}.86.21
+version      ${feature}.88.17
 revision     0
 
-set openjdk_version ${feature}.0.30
+set openjdk_version ${feature}.0.31
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until January 2032)
@@ -34,21 +34,19 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  0781639633988e5c406e6ce46b30c18fd0cae79b \
-                 sha256  7cc4010eb89cc8f0af3bd5c073b6772e7f8251f3a3eb8f1db00cc2ebfe271acf \
-                 size    194668403
+    checksums    rmd160  56f8a209ca024b7f8005f9d6284d9195899de017 \
+                 sha256  fb7382de640ea36b9c246d0e00293b209b53bd3c0f9f958f6dc1b9713f430007 \
+                 size    194720094
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  1ef9932fa83852d45e2b83def3f851f1a106c89d \
-                 sha256  a6feb4c541c9f4f1d3b4bdcca2a25ca39b8d2d73d3529ed96cc910b69ae251a2 \
-                 size    192680094
+    checksums    rmd160  4a791593f10a068312ccbc1956b3273a802a8d99 \
+                 sha256  fe756215bc360cab0703c9c851f7e46d4762591dff33011420a710d4950e79b1 \
+                 size    192716379
 } else {
     set arch_classifier unsupported_arch
 }
 
 distname     zulu${version}-ca-jdk${openjdk_version}-macosx_${arch_classifier}
-
-worksrcdir   ${distname}/zulu-${feature}.jdk
 
 homepage     https://www.azul.com/downloads/
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.88.17 (OpenJDK 11.0.31).

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?