### PR TITLE
openjdk8-zulu: update to 8.94.0.17

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -20,10 +20,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      ${feature}.92.0.21
+version      ${feature}.94.0.17
 revision     0
 
-set openjdk_version ${feature}.0.482
+set openjdk_version ${feature}.0.492
 
 # Support roadmap: https://www.azul.com/products/azul-support-roadmap/
 description Azul Zulu Community OpenJDK ${feature} (Long Term Support until December 2030)
@@ -34,21 +34,19 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  1b510d0abf9ee8fd946c379a3bc994c9ba4c401f \
-                 sha256  ba78b3ffa88836594e6a4afb31fd7ffc769ce4a84fc2bd9091e7253e1bfced0d \
-                 size    106714375
+    checksums    rmd160  1907d6923b042624d160ddd32ca19e1ce02d1f27 \
+                 sha256  5114b269b88e3d89b0d6b2c28af0c96b5489f340fbaded8fa17613b2adca180c \
+                 size    106725768
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  7c8866ad315f9acb26896896d2f544d1947c60f6 \
-                 sha256  1f5cff8fca7bdc82169f81fe1de5c267a8bc0c026daab7e4c3bf612b6afa7cf0 \
-                 size    104273241
+    checksums    rmd160  9ba4941a1b275c52166bf72168514c7e01965c56 \
+                 sha256  73b84abff0ca4a1b648b6cd12381194496bcf31ee01f2bdd1ed0914c9ee5a159 \
+                 size    104292873
 } else {
     set arch_classifier unsupported_arch
 }
 
 distname     zulu${version}-ca-jdk${openjdk_version}-macosx_${arch_classifier}
-
-worksrcdir   ${distname}/zulu-${feature}.jdk
 
 configure.cxx_stdlib libstdc++
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.94.0.17.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?