### PR TITLE
openjdk25-corretto: update to 25.0.3.9.1

### DIFF
--- a/java/openjdk25-corretto/Portfile
+++ b/java/openjdk25-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-24/releases
-version      ${feature}.0.2.10.1
+version      ${feature}.0.3.9.1
 revision     0
 
 # Support calendar: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set corretto_arch x64
-    checksums    rmd160  eab24aa6b886a4870d76f246d0703b29936a7683 \
-                 sha256  1fe28a4a95bbbc6d4c0b0c85457b922d77ae012fa7c39b3390d97504fc0917f0 \
-                 size    221423595
+    checksums    rmd160  784a388d2da4c98fe5ae2992677b19b59c3dfd96 \
+                 sha256  0cfef7feb0f4d7d352881b08d527c22840b8fb5eaaa7552b25619edb449d6d94 \
+                 size    221430346
 } elseif {${configure.build_arch} eq "arm64"} {
     set corretto_arch aarch64
-    checksums    rmd160  00d5c0e97241f8b70477b962635ff9ec2613ea38 \
-                 sha256  9932010ff70950d30073a00ce8dd7f6b10b5d9c100d55d3d6dac751d66c1aa74 \
-                 size    219175373
+    checksums    rmd160  ccc95113a6a23374afff143d1be8d0a882f8a8c4 \
+                 sha256  614107ed76e9fb86d62d8cf2686a9cc4b3a11c019502ca3ba605fc5d51f4d7bb \
+                 size    218752889
 } else {
     set corretto_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 25.0.3.9.1.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?