### PR TITLE
openjdk21-corretto: update to 21.0.11.10.1

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      ${feature}.0.10.7.1
+version      ${feature}.0.11.10.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  0fba66f79e13aa4fb5e056ffff2e4b79e06eb9e1 \
-                 sha256  0ea7660acf9eb5d4e3a0896c3d1c7329843ebc40747880d47f59ff06e7f8c8f8 \
-                 size    202891884
+    checksums    rmd160  af061a9b3abb56cbbb0f54d3cc6afe693ad45f02 \
+                 sha256  fb08b09af67ca930d6868405263259d5e43faab89216f6886780e544fd700f00 \
+                 size    202893526
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  0c0646d93aeacaade5d726d0dcfaa42a5f477ec9 \
-                 sha256  85541edd1793bce224aab4ac6d1fa80e84bf31bf9b64b5c5384e48b6ef07c76c \
-                 size    200964450
+    checksums    rmd160  9172ab6c68af275a5ef3d5190bf33acd7ed9a207 \
+                 sha256  c6c9ba09ef0ae741aa04cfbd5ef8a6b75dd2d26034a1de0808ee7976a04446ea \
+                 size    200535571
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 21.0.11.10.1.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?