### PR TITLE
openjdk26-corretto: update to 26.0.1.8.1

### DIFF
--- a/java/openjdk26-corretto/Portfile
+++ b/java/openjdk26-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-24/releases
-version      ${feature}.0.0.35.2
+version      ${feature}.0.1.8.1
 revision     0
 
 # Support calendar: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set corretto_arch x64
-    checksums    rmd160  ea8d0a22d2da771e3ed0e51c5ed9a4cbdba1083c \
-                 sha256  9c474db14280ae9c0776ff40d3288dc60e2a5df689ec70cf5fef29d05de8f7a3 \
-                 size    226215371
+    checksums    rmd160  82371b94edf8a9cf525a579e97e199b8619d4f96 \
+                 sha256  7da780f1176119fb81d84839f7d0faa825c5aead799e116f37b278899ff55fe3 \
+                 size    226160588
 } elseif {${configure.build_arch} eq "arm64"} {
     set corretto_arch aarch64
-    checksums    rmd160  e7e52857deb961a45f93d03c3e84cf17d9b56502 \
-                 sha256  c8d5ce938779612ebb429261b12a443c3e4580a37c4d08a1dc82380bf6c57cbb \
-                 size    223740341
+    checksums    rmd160  9bdfd9fb749a21d05e811878e826198ac61100a4 \
+                 sha256  b385a8d73b53f0b2ee25fe8b0836adae9554f9284aa43fc3bc516ff527097338 \
+                 size    223380962
 } else {
     set corretto_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 26.0.1.8.1.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?