### PR TITLE
opencode: update to 1.14.20

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.4.7
+version             1.14.20
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  22fd5fa5daca7a77d93344ab4e6d222a20770520 \
-                    sha256  bdfcb7ae20d0597657fd736a7391320ce56bfb216695ae54cb4ee6680e87b465 \
-                    size    3372
+checksums           rmd160  4766db15f1298368828aff433cd3d0911551da41 \
+                    sha256  843679b137cb587c9b98d7388bca867957d06e01237d9d70a247a99af4fc0716 \
+                    size    3360


### PR DESCRIPTION
#### Description

Update to OpenCode 1.14.20.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?