### PR TITLE
claude-code: update to 2.1.117

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.114
+version             2.1.117
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  7407764b7b1d1a2a64c5fcc3c3a1bb67307d09af \
-                 sha256  1a30360b6240056a58ba9187c8f9d2e88e949e0f970d5cf81f8d69bc65568f6a \
-                 size    206004048
+    checksums    rmd160  6fc5025353e0ec58c24a1356c42b7a2d37bfd31b \
+                 sha256  c6614176252bc789000ad7b8a19b22957a4e9d40878773e98dafde6bbda63e86 \
+                 size    208077984
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  6e462fa634ff73bd9c14bf67b373883f697dca8e \
-                 sha256  bf1b4da368da7970f0d1d4a1675acea99b6f2ad94f24e9f8ccfcc7940ac67894 \
-                 size    204534752
+    checksums    rmd160  24153cc4eec6a34f28cc1f77c88d8e4a798f4ae9 \
+                 sha256  12cf77a447d129d3fb691023ee3ced3e43efbde72ab910c6162db2c7be5ca374 \
+                 size    206534320
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.117.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?