### PR TITLE
openjdk17-corretto: update to 17.0.19.10.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.18.9.1
+version      ${feature}.0.19.10.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  c91ed4c9c3a3c9b946e466c077b2174b7dd00603 \
-                 sha256  147b813655775b5a1ccd0cab7c9f79179ad18072bcd4493e41dce1ad0645e805 \
-                 size    188592842
+    checksums    rmd160  6dcec2f5020d0811c0a7b1a6f4a1f8b6d4e5799e \
+                 sha256  6d3b3e367e1a77b9867bc1b5aa925b1f05d76a0ec62b075e375fa91fdcea0e93 \
+                 size    188646524
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  72a475fccb9f8b1d01cc1e60b77d5098ac8febf3 \
-                 sha256  00feafc025457a04e486042dd7db3c97294f033e438b69b46b5e03669abdf233 \
-                 size    186977347
+    checksums    rmd160  2377a82a08b2d9d680df4078885c83f4db5be2ec \
+                 sha256  3ba2ab957f60e33c6164d7330b1f6c9f48b5ffd60e4cc9bbcc67def319c29a29 \
+                 size    186597310
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.19.10.1.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?