### PR TITLE
openjdk11-corretto: update to 11.0.31.11.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      ${feature}.0.30.7.1
+version      ${feature}.0.31.11.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  4b61db4fd11ac935c985c78ffcde672b9a783b83 \
-                 sha256  15bd8eb73ad93340690e2d03d7e7ed6cff10605dd9685ce6fd7a74a584f99550 \
-                 size    187735988
+    checksums    rmd160  b02c2ba6b343f0fc033365e5607ef0f92df5de2a \
+                 sha256  ce278c17516502934179faff7e6d64aac0bab0e48633c792b59b70893b56a0e6 \
+                 size    187827837
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  257c54ea8b44db89e1cc349ca8b85105cae6b53f \
-                 sha256  66c9597fceca3eda2bf2c763b4d9235bfa9b137e8d945483ad00f6fea51da715 \
-                 size    185427698
+    checksums    rmd160  f8668f2cde8a1386ecd8db31d587acd07fed0fdf \
+                 sha256  e31cc1fd9b42bf40ec0682a027c024599ac1d84bf2447ab1f32b4caa94c08faa \
+                 size    185315671
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.31.11.1.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4 17E192

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?