### PR TITLE
glab: update to 1.92.1

### DIFF
--- a/devel/glab/Portfile
+++ b/devel/glab/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/cli 1.86.0 v
+go.setup            gitlab.com/gitlab-org/cli 1.92.1 v
 name                glab
 revision            0
 categories          devel
@@ -16,9 +16,9 @@ long_description    ${name} is an open source GitLab CLI tool \
                     you are already working with git and your code.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  dac022faae6ec1c47a51cf3da209e8c1a91eb2a4 \
-                        sha256  b530590b7ebc3a64e8f0f85038ded62e0019c99142fdc96951f184de7c92d0e1 \
-                        size    17098791
+                    rmd160  05bc51a6d19074fa11bb9a7849230f7a7d6df094 \
+                    sha256  b85999ac0ee7c76044b44d1a7e6294533ca0607bc3828f8dda1e52a9e453561b \
+                    size    17120184
 
 # If not set, it states that it's a developer build
 # Suppress build date for reproducible builds


### PR DESCRIPTION
#### Description

Update to new upstream release

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
