### PR TITLE
anyrow: new port 1.0.0

### DIFF
--- a/sysutils/anyrow/Portfile
+++ b/sysutils/anyrow/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/anyrow/cli 1.0.0 v
+go.offline_build    no
+name                anyrow
+revision            0
+
+categories          sysutils
+license             MIT
+maintainers         {@lovrozagar gmail.com:lovro.zagar5} \
+                    openmaintainer
+description         AI-native document extraction CLI
+long_description    Command-line client for Anyrow. Extract structured data from PDFs, \
+                    images, emails, calls, and websites. Manages tables, rows, batches, \
+                    and live extraction streams. Config via ~/.config/anyrow/config.toml \
+                    or ANYROW_API_KEY.
+homepage            https://anyrow.ai
+
+checksums           rmd160  1764691f74a3915e158a12ddb91c30ee5d8072bc \
+                    sha256  52c2ca674af64e56f3db6be54e1d24932888b5e9b97fc852c077360ce2bb1a38 \
+                    size    149233
+
+build.args          -trimpath -o anyrow .
+build.env-append    CGO_ENABLED=0
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/anyrow ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
Adds `sysutils/anyrow` — AI-native document extraction CLI.

## Addresses prior review feedback (#32332)

- `PortGroup golang 1.0` with `go.setup github.com/anyrow/cli 1.0.0 v` — build-from-source via upstream archive tarball, not prebuilt binary
- `go.offline_build no` + committed `go.sum` — Go can fetch + verify modules during build
- Real rmd160 + sha256 + size checksums for the v1.0.0 source tarball
- Modeline first line per MacPorts guide
- Maintainer: `{@lovrozagar gmail.com:lovro.zagar5}` + `openmaintainer`
- `long_description` uses backslash continuation (no curly brackets)
- Single commit `anyrow: new port 1.0.0`

## Local verification

Tarball extracts cleanly; `go build -trimpath -o anyrow .` in the extracted root produces a working 13 MB binary. Smoke-tested with `anyrow --help`.

Thanks to @reneeotten and @herbygillot for the earlier review pass — prior PR was closed to restart with everything in place.