### PR TITLE
ruby-build: Update to 20260422

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20260412 v
+github.setup        rbenv ruby-build 20260422 v
 revision            0
 github.tarball_from archive
 categories          ruby
@@ -17,9 +17,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  2df5ea017d9488a6a4621290a70fc22374df6707 \
-                    sha256  7215fbadd7e57d9fa1b6939f478e50bb6929e9044226a50f405962c7aeb0c969 \
-                    size    99922
+checksums           rmd160  907e587c3bab282647efecbe45922e6cb5705074 \
+                    sha256  4563507bb25b37bfb9eaf97d525d3c4b635c1e16ba262bf80fda83852830b16b \
+                    size    100357
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20260422


##### Tested on

macOS 26.3.1 25D771280a arm64
Xcode 26.4.1 17E202


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
