### PR TITLE
termscp: update to 1.0.0

### DIFF
--- a/sysutils/termscp/Portfile
+++ b/sysutils/termscp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        veeso termscp 0.19.1 v
+github.setup        veeso termscp 1.0.0 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {@sikmir disroot.org:sikmir} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  e1d568b306d2b52129a5b8c579401da348f37930 \
-                    sha256  04248fc89e71a050463ad1824eccab4c04d34bff3126a8f9e26a77c75fe55b0f \
-                    size    11942307
+                    rmd160  3bdf2b5c0a4b879d4eaeccde07b62b8b8c9fe798 \
+                    sha256  c07e2b82cb1cc327d977548e24d27fbbda8ee0cc4f2c3df9fb1b90c6e971e568 \
+                    size    11968546
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig
@@ -36,170 +36,209 @@ destroot {
 
 cargo.crates \
     adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
+    aead                             0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
     aes                              0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
+    aes-gcm                         0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
+    ahash                           0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                     1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
     allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anyhow                         1.0.100  a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61 \
+    anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     arbitrary                        1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
-    argh                            0.1.13  34ff18325c8a36b82f992e533ece1ec9f9a9db446bd1c14d4f936bac88fcd240 \
-    argh_derive                     0.1.13  adb7b2b83a50d329d5d8ccc620f5c7064028828538bdf5646acd60dc1f767803 \
-    argh_shared                     0.1.13  a464143cc82dedcdc3928737445362466b7674b5db4e2eb8e869846d6d84f4f6 \
+    argh                            0.1.19  211818e820cda9ca6f167a64a5c808837366a6dfd807157c64c1304c486cd033 \
+    argh_derive                     0.1.19  c442a9d18cef5dde467405d27d461d080d68972d6d0dfd0408265b6749ec427d \
+    argh_shared                     0.1.19  e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1 \
+    argon2                           0.5.3  3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072 \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
+    async-trait                     0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
-    aws-config                      1.8.12  96571e6996817bf3d58f6b569e4b9fd2e9d2fcf9f7424eed07b2ce9bb87535e5 \
+    aws-config                      1.8.13  c456581cb3c77fafcc8c67204a70680d40b61112d6da78c77bd31d945b65f1b5 \
     aws-credential-types            1.2.11  3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3 \
-    aws-lc-rs                       1.15.2  6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288 \
-    aws-lc-sys                      0.35.0  b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1 \
-    aws-runtime                     1.5.17  d81b5b2898f6798ad58f484856768bca817e3cd9de0974c24ae0f1113fe88f1b \
-    aws-sdk-s3                     1.118.0  d3e6b7079f85d9ea9a70643c9f89f50db70f5ada868fa9cfe08c1ffdf51abc13 \
-    aws-sdk-sso                     1.91.0  8ee6402a36f27b52fe67661c6732d684b2635152b676aa2babbfb5204f99115d \
-    aws-sdk-ssooidc                 1.93.0  a45a7f750bbd170ee3677671ad782d90b894548f4e4ae168302c57ec9de5cb3e \
-    aws-sdk-sts                     1.95.0  55542378e419558e6b1f398ca70adb0b2088077e79ad9f14eb09441f2f7b2164 \
-    aws-sigv4                        1.3.7  69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c \
-    aws-smithy-async                 1.2.7  9ee19095c7c4dda59f1697d028ce704c24b2d33c6718790c7f1d5a3015b4107c \
-    aws-smithy-checksums           0.63.12  87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae \
-    aws-smithy-eventstream         0.60.14  dc12f8b310e38cad85cf3bef45ad236f470717393c613266ce0a89512286b650 \
-    aws-smithy-http                 0.62.6  826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b \
-    aws-smithy-http-client           1.1.5  59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a \
-    aws-smithy-json                 0.61.9  49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551 \
-    aws-smithy-observability         0.1.5  17f616c3f2260612fe44cede278bafa18e73e6479c4e393e2c4518cf2a9a228a \
-    aws-smithy-query                0.60.9  ae5d689cf437eae90460e944a58b5668530d433b4ff85789e69d2f2a556e057d \
-    aws-smithy-runtime               1.9.6  65fda37911905ea4d3141a01364bc5509a0f32ae3f3b22d6e330c0abfb62d247 \
-    aws-smithy-runtime-api           1.9.3  ab0d43d899f9e508300e587bf582ba54c27a452dd0a9ea294690669138ae14a2 \
-    aws-smithy-types                 1.3.5  905cb13a9895626d49cf2ced759b062d913834c7482c38e49557eac4e6193f01 \
+    aws-lc-rs                       1.16.2  a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc \
+    aws-lc-sys                      0.39.0  1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a \
+    aws-runtime                      1.6.0  c635c2dc792cb4a11ce1a4f392a925340d1bdf499289b5ec1ec6810954eb43f5 \
+    aws-sdk-s3                     1.122.0  94c2ca0cba97e8e279eb6c0b2d0aa10db5959000e602ab2b7c02de6b85d4c19b \
+    aws-sdk-sso                     1.93.0  9dcb38bb33fc0a11f1ffc3e3e85669e0a11a37690b86f77e75306d8f369146a0 \
+    aws-sdk-ssooidc                 1.95.0  2ada8ffbea7bd1be1f53df1dadb0f8fdb04badb13185b3321b929d1ee3caad09 \
+    aws-sdk-sts                     1.97.0  e6443ccadc777095d5ed13e21f5c364878c9f5bad4e35187a6cdbd863b0afcad \
+    aws-sigv4                        1.3.8  efa49f3c607b92daae0c078d48a4571f599f966dce3caee5f1ea55c4d9073f99 \
+    aws-smithy-async                1.2.11  52eec3db979d18cb807fc1070961cc51d87d069abe9ab57917769687368a8c6c \
+    aws-smithy-checksums            0.64.3  ddcf418858f9f3edd228acb8759d77394fed7531cce78d02bdda499025368439 \
+    aws-smithy-eventstream         0.60.18  35b9c7354a3b13c66f60fe4616d6d1969c9fd36b1b5333a5dfb3ee716b33c588 \
+    aws-smithy-http                 0.63.3  630e67f2a31094ffa51b210ae030855cb8f3b7ee1329bdd8d085aaf61e8b97fc \
+    aws-smithy-http-client           1.1.9  12fb0abf49ff0cab20fd31ac1215ed7ce0ea92286ba09e2854b42ba5cabe7525 \
+    aws-smithy-json                 0.62.3  3cb96aa208d62ee94104645f7b2ecaf77bf27edf161590b6224bfbac2832f979 \
+    aws-smithy-observability         0.2.4  c0a46543fbc94621080b3cf553eb4cbbdc41dd9780a30c4756400f0139440a1d \
+    aws-smithy-query               0.60.13  0cebbddb6f3a5bd81553643e9c7daf3cc3dc5b0b5f398ac668630e8a84e6fff0 \
+    aws-smithy-runtime              1.10.0  f3df87c14f0127a0d77eb261c3bc45d5b4833e2a1f63583ebfb728e4852134ee \
+    aws-smithy-runtime-api          1.11.3  49952c52f7eebb72ce2a754d3866cc0f87b97d2a46146b79f80f3a93fb2b3716 \
+    aws-smithy-types                 1.4.3  3b3a26048eeab0ddeba4b4f9d51654c79af8c3b32357dc5f336cee85ab331c33 \
     aws-smithy-xml                 0.60.13  11b2f670422ff42bf7065031e72b45bc52a3508bd089f743ea90731ca2b6ea57 \
     aws-types                       1.3.11  1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164 \
     base16ct                         0.1.1  349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce \
+    base16ct                         0.2.0  4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf \
+    base16ct                         1.0.0  fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6 \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     base64-simd                      0.8.0  339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195 \
-    base64ct                         1.8.1  0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a \
+    base64ct                         1.8.3  2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06 \
+    bcrypt-pbkdf                    0.10.0  6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                        2.10.0  812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3 \
+    bitflags                        2.11.0  843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af \
+    blake2                          0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    block-buffer                    0.12.0  cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be \
     block-padding                    0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
     block2                           0.6.2  cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5 \
-    bumpalo                         3.19.1  5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510 \
+    blowfish                         0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
+    bumpalo                         3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
-    bytes                           1.11.0  b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3 \
+    bytes                           1.11.1  1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
     bytes-utils                      0.1.4  7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35 \
     bytesize                         2.3.1  6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3 \
     bytestring                       1.5.0  113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289 \
     camino                           1.2.2  e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48 \
-    cargo-platform                   0.1.9  e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea \
-    cargo_metadata                  0.19.2  dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba \
-    cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
+    cargo-platform                   0.3.2  87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082 \
+    cargo_metadata                  0.23.1  ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9 \
     castaway                         0.2.4  dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a \
     cbc                              0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                              1.2.50  9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c \
+    cc                              1.2.57  7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423 \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    chrono                          0.4.42  145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2 \
+    chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
+    chrono                          0.4.44  c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0 \
     cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
     cmake                           0.1.57  75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d \
-    compact_str                      0.8.1  3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32 \
+    cmov                          0.5.0-pre.0  5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96 \
+    compact_str                      0.9.0  3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a \
     console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
+    const-oid                       0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
+    const-random                    0.1.18  87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359 \
+    const-random-macro              0.1.16  f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e \
     content_inspector                0.2.4  b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38 \
     convert_case                    0.10.0  633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9 \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
     core-foundation                 0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
+    core-models                      0.0.4  0940496e5c83c54f3b753d5317daec82e8edac71c33aaa1f666d76f518de2444 \
     cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
-    crc                              3.4.0  5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d \
-    crc-any                          2.5.0  a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73 \
+    crc                              3.3.0  9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675 \
     crc-catalog                      2.4.0  19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5 \
-    crc-fast                         1.6.0  6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3 \
+    crc-fast                         1.9.0  2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d \
     crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
     crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
-    crossterm                       0.28.1  829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6 \
     crossterm                       0.29.0  d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b \
     crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
+    crunchy                          0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
     crypto-bigint                    0.4.9  ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef \
     crypto-bigint                    0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
+    crypto-bigint                 0.7.0-rc.18  37387ceb32048ff590f2cbd24d8b05fffe63c3f69a5cfa089d4f722ca4385a19 \
     crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
+    crypto-common                    0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
+    crypto-primes                 0.7.0-pre.6  e79c98a281f9441200b24e3151407a629bfbe720399186e50516da939195e482 \
+    ctr                              0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
+    ctutils                          0.3.2  758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4 \
     curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
     darling                        0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
+    darling                         0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
     darling_core                   0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
+    darling_core                    0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
     darling_macro                  0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
-    data-encoding                    2.9.0  2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476 \
+    darling_macro                   0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
+    data-encoding                   2.10.0  d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea \
     dbus                            0.9.10  21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4 \
     dbus-secret-service              4.1.0  708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6 \
-    debug-helper                    0.3.13  f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e \
+    delegate                        0.13.5  780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370 \
     der                              0.6.1  f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de \
     der                             0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
-    deranged                         0.5.5  ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587 \
+    der                              0.8.0  71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b \
+    deranged                         0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
     derive_arbitrary                 1.4.2  1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a \
     derive_builder                  0.20.2  507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947 \
     derive_builder_core             0.20.2  2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8 \
     derive_builder_macro            0.20.2  ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c \
-    derive_more                      2.1.0  10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618 \
-    derive_more-impl                 2.1.0  6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b \
-    des                              0.8.1  ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e \
+    derive_more                      2.1.1  d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
+    derive_more-impl                 2.1.1  799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    digest                          0.11.2  4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c \
     dirs                             6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
-    dispatch2                        0.3.0  89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec \
+    dispatch2                        0.3.1  1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38 \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     document-features               0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
     ecdsa                           0.14.8  413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c \
+    ecdsa                           0.16.9  ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca \
     ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                    2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
     edit                             0.1.5  f364860e764787163c8c8f58231003839be31276e821e2ad2092ddf496b1aa09 \
     either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     elliptic-curve                  0.12.3  e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3 \
+    elliptic-curve                  0.13.8  b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47 \
     encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
+    enum_dispatch                   0.3.13  aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
     fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     ff                              0.12.1  d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160 \
+    ff                              0.13.1  c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393 \
     fiat-crypto                      0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
-    filetime                        0.2.26  bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed \
-    find-msvc-tools                  0.1.5  3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844 \
-    flate2                           1.1.5  bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb \
+    filetime                        0.2.27  f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db \
+    find-msvc-tools                  0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+    flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    flurry                           0.5.2  cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     foldhash                         0.1.5  d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2 \
+    foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
     foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
     foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
     form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
     fs_extra                         1.3.0  42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
     fsevent-sys                      4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
-    futures                         0.3.31  65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876 \
-    futures-channel                 0.3.31  2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10 \
-    futures-core                    0.3.31  05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e \
-    futures-executor                0.3.31  1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f \
-    futures-io                      0.3.31  9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6 \
+    futures                         0.3.32  8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d \
+    futures-channel                 0.3.32  07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d \
+    futures-core                    0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
+    futures-executor                0.3.32  baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d \
+    futures-io                      0.3.32  cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718 \
     futures-lite                     2.6.1  f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad \
-    futures-macro                   0.3.31  162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650 \
-    futures-sink                    0.3.31  e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7 \
-    futures-task                    0.3.31  f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988 \
-    futures-util                    0.3.31  9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81 \
+    futures-macro                   0.3.32  e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b \
+    futures-sink                    0.3.32  c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
+    futures-task                    0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
+    futures-util                    0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
-    getrandom                       0.2.16  335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592 \
+    generic-array                    1.3.5  eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542 \
+    getrandom                       0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
-    git2                            0.20.3  3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c \
+    getrandom                        0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
+    ghash                            0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
+    git2                            0.20.4  7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b \
     glob                             0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     group                           0.12.1  5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7 \
+    group                           0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
     h2                              0.3.27  0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d \
-    h2                              0.4.12  f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386 \
+    h2                              0.4.13  2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54 \
     hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
+    hax-lib                          0.3.5  74d9ba66d1739c68e0219b2b2238b5c4145f491ebf181b9c6ab561a19352ae86 \
+    hax-lib-macros                   0.3.5  24ba777a231a58d1bce1d68313fa6b6afcc7966adef23d60f45b8a2b9b688bf1 \
+    hax-lib-macros-types             0.3.5  867e19177d7425140b417cd27c2e05320e727ee682e98368f88b7194e80ad515 \
     headers                          0.4.1  b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb \
     headers-core                     0.3.0  54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
+    hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
+    hex-literal                      0.4.1  6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46 \
+    hkdf                            0.12.4  7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7 \
     hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
     home                            0.5.12  cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d \
-    hostname                         0.4.2  617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd \
     http                            0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
     http                             1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
     http-body                        0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
@@ -207,6 +246,7 @@ cargo.crates \
     http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
+    hybrid-array                     0.4.8  8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1 \
     hyper                          0.14.32  41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7 \
     hyper                            1.8.1  2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11 \
     hyper-http-proxy                 1.1.0  7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08 \
@@ -214,8 +254,8 @@ cargo.crates \
     hyper-rustls                    0.27.7  e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58 \
     hyper-timeout                    0.5.2  2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0 \
     hyper-tls                        0.5.0  d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905 \
-    hyper-util                      0.1.19  727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f \
-    iana-time-zone                  0.1.64  33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb \
+    hyper-util                      0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
+    iana-time-zone                  0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     icu_collections                  2.1.1  4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43 \
     icu_locale_core                  2.1.1  edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6 \
@@ -224,178 +264,235 @@ cargo.crates \
     icu_properties                   2.1.2  020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec \
     icu_properties_data              2.1.2  616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af \
     icu_provider                     2.1.1  85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614 \
+    id-arena                         2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
-    indexmap                        2.12.1  0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2 \
+    indexmap                        2.13.0  7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017 \
     indicatif                      0.17.11  183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235 \
     indoc                            2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
-    inotify                         0.11.0  f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3 \
+    inotify                         0.11.1  bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199 \
     inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
     inout                            0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
-    instability                     0.3.10  6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c \
-    ipnet                           2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
-    iri-string                       0.7.9  4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397 \
+    instability                     0.3.12  5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971 \
+    internal-russh-forked-ssh-key  0.6.16+upstream-0.6.7  fe44f2bbd99fcb302e246e2d6bcf51aeda346d02a365f80296a07a8c711b6da6 \
+    ipnet                           2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
+    iri-string                      0.7.10  c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-wsl                           0.4.0  173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5 \
-    itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
-    itoa                            1.0.15  4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
+    itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
+    itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     jobserver                       0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                          0.3.83  464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8 \
+    js-sys                          0.3.91  b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c \
     jsonpath-rust                    0.5.1  19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200 \
     k8s-openapi                     0.22.0  19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755 \
+    kasuari                         0.4.12  bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899 \
     keyring                          3.6.3  eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c \
     kqueue                           1.1.1  eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a \
     kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
     kube                            0.92.1  231c5a5392d9e2a9b0d923199760d3f1dd73b95288f2871d16c7c90ba4954506 \
     kube-client                     0.92.1  8f4bf54135062ff60e2a0dfb3e7a9c8e931fc4a535b4d6bd561e0a1371321c61 \
     kube-core                       0.92.1  40fb9bd8141cbc0fe6b0d9112d371679b4cb607b45c31dd68d92e40864a12975 \
-    lazy-regex                       3.4.2  191898e17ddee19e60bccb3945aa02339e81edd4a8c50e21fd4d48cdecda7b29 \
-    lazy-regex-proc_macros           3.4.2  c35dc8b0da83d1a9507e12122c80dea71a9c7c613014347392483a83ea593e04 \
+    lazy-regex                       3.6.0  6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
+    lazy-regex-proc_macros           3.6.0  4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.178  37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091 \
+    leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
+    libc                           0.2.183  b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d \
+    libcrux-intrinsics               0.0.4  bc9ee7ef66569dd7516454fe26de4e401c0c62073929803486b96744594b9632 \
+    libcrux-ml-kem                   0.0.4  4bb6a88086bf11bd2ec90926c749c4a427f2e59841437dbdede8cde8a96334ab \
+    libcrux-platform                 0.0.2  db82d058aa76ea315a3b2092f69dfbd67ddb0e462038a206e1dcd73f058c0778 \
+    libcrux-secrets                  0.0.4  6e4dbbf6bc9f2bc0f20dc3bea3e5c99adff3bdccf6d2a40488963da69e2ec307 \
+    libcrux-sha3                     0.0.4  2400bec764d1c75b8a496d5747cffe32f1fb864a12577f0aca2f55a92021c962 \
+    libcrux-traits                   0.0.4  9adfd58e79d860f6b9e40e35127bfae9e5bd3ade33201d1347459011a2add034 \
     libdbus-sys                      0.2.7  328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043 \
     libgit2-sys                   0.18.3+1.9.2  c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487 \
-    libredox                        0.1.11  df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50 \
-    libssh-rs                        0.3.6  3066e110d6bb95a5addbd9c2ee595efdaeecaddd4793f3803dfee2968a74c685 \
-    libssh-rs-sys                    0.2.6  01d528ea9ac190fa364ff12193da82222dfc645e7ab28666ae91493bd288a1a0 \
+    libm                            0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
+    libredox                        0.1.14  1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a \
     libssh2-sys                      0.3.1  220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9 \
-    libz-sys                        1.1.23  15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7 \
+    libz-sys                        1.1.25  d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1 \
+    line-clipping                    0.3.7  3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8 \
     linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
-    linux-raw-sys                   0.11.0  df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039 \
+    linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                          0.8.1  6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77 \
     litrs                            1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
     log                             0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
-    lru                             0.12.5  234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38 \
+    lru                             0.16.3  a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593 \
     lru-slab                         0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
-    mac-notification-sys             0.6.9  65fd3f75411f4725061682ed91f131946e912859d0044d39c4ec0aac818d7621 \
-    magic-crypt                      4.0.1  844b6169eeaae32ae8a61855964331a67f12d2afba9170303fbd3e3c2a861a52 \
+    mac-notification-sys            0.6.12  29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3 \
     md-5                            0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
-    memchr                           2.7.6  f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273 \
+    md5                              0.7.0  490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771 \
+    memchr                           2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                              1.1.1  a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc \
-    native-tls                      0.2.14  87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e \
+    native-tls                      0.2.18  465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2 \
+    nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nonempty                         0.9.0  995defdca0a589acfdd1bd2e8e3b896b4d4f7675a31fd14c32611440c7f608e6 \
     notify                           8.2.0  4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3 \
-    notify-rust                     4.11.7  6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400 \
-    notify-types                     2.0.0  5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d \
-    ntapi                            0.4.2  c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081 \
+    notify-rust                     4.12.0  21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2 \
+    notify-types                     2.1.0  42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a \
+    ntapi                            0.4.3  c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae \
     nucleo                           0.5.0  5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4 \
     nucleo-matcher                   0.3.1  bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85 \
-    num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
+    num-bigint                       0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
+    num-bigint-dig                   0.8.6  e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7 \
+    num-conv                         0.2.0  cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050 \
     num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
+    num-iter                        0.1.45  1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
+    num_cpus                        1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
     num_threads                      0.1.7  5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
-    objc2                            0.6.3  b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05 \
+    objc2                            0.6.4  3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f \
     objc2-core-foundation            0.3.2  2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536 \
     objc2-encode                     4.1.0  ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
     objc2-foundation                 0.3.2  e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272 \
-    once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
+    objc2-io-kit                     0.3.2  33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15 \
+    objc2-system-configuration       0.3.2  7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396 \
+    once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
+    opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
     open                             5.3.3  43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc \
-    openssl                        0.10.75  08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328 \
+    openssl                        0.10.76  951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf \
     openssl-macros                   0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                    0.1.6  d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e \
-    openssl-src                   300.5.4+3.5.4  a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72 \
-    openssl-sys                    0.9.111  82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321 \
+    openssl-probe                    0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
+    openssl-src                   300.5.5+3.5.5  3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709 \
+    openssl-sys                    0.9.112  57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                   2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     outref                           0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
     p256                            0.11.1  51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594 \
+    p256                            0.13.2  c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b \
+    p384                            0.13.1  fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6 \
+    p521                            0.13.3  0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2 \
+    pageant                          0.0.1  032d6201d2fb765158455ae0d5a510c016bb6da7232e5040e39e9c8db12b0afc \
+    pageant                          0.2.0  1b537f975f6d8dcf48db368d7ec209d583b015713b5df0f5d92d2631e4ff5595 \
     parking                          2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                     0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
-    paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
+    password-hash                    0.5.0  346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166 \
+    pastey                           0.1.1  35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec \
     path-slash                       0.2.1  1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42 \
     pathdiff                         0.2.3  df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3 \
     pavao                           0.2.16  cca8302d5f1b5dc7a8dfb04e5ea7185b43571db5811e084746bf0aeb0d7b18f1 \
     pavao-src                     4.22.0-4  30b8c63418f1e7dfbb786268ae0927537b87d90b1211216c1ba50ce25d8d9495 \
     pavao-sys                       0.2.16  07b390d8c7372e94c7e0f7d92e36c98404634c554a52b1cb9ae030b4e7888cde \
+    pbkdf2                          0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
     pem                              3.0.6  1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
+    pem-rfc7468                      0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
+    pem-rfc7468                      1.0.0  a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9 \
     percent-encoding                 2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
-    pest                             2.8.4  cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22 \
-    pest_derive                      2.8.4  51f72981ade67b1ca6adc26ec221be9f463f2b5839c7508998daa17c23d94d7f \
-    pest_generator                   2.8.4  dee9efd8cdb50d719a80088b76f81aec7c41ed6d522ee750178f83883d271625 \
-    pest_meta                        2.8.4  bf1d70880e76bdc13ba52eafa6239ce793d85c8e43896507e43dd8984ff05b82 \
-    pin-project                     1.1.10  677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a \
-    pin-project-internal            1.1.10  6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861 \
-    pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
+    pest                             2.8.6  e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662 \
+    pest_derive                      2.8.6  11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77 \
+    pest_generator                   2.8.6  8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f \
+    pest_meta                        2.8.6  89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220 \
+    pin-project                     1.1.11  f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517 \
+    pin-project-internal            1.1.11  d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6 \
+    pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    pkcs1                            0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
+    pkcs1                         0.8.0-rc.4  986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e \
+    pkcs5                            0.7.1  e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6 \
     pkcs8                            0.9.0  9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba \
     pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
+    pkcs8                         0.11.0-rc.11  12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577 \
     pkg-config                      0.3.32  7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c \
-    portable-atomic                 1.12.0  f59e70c4aef1e55797c2e8fd94a4f2a973fc972cfde0e0b05f683667b0cd39dd \
+    plain                            0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
+    poly1305                         0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
+    polyval                          0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
+    portable-atomic                 1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
     potential_utf                    0.1.4  b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     pretty_assertions                1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
-    proc-macro2                    1.0.103  5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8 \
+    prettyplease                    0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
+    primeorder                      0.13.6  353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6 \
+    proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
+    proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
+    proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
     quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
     quick-xml                       0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
     quinn                           0.11.9  b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
-    quinn-proto                    0.11.13  f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31 \
+    quinn-proto                    0.11.14  434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098 \
     quinn-udp                       0.5.14  addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
-    quote                           1.0.42  a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f \
+    quote                           1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
     r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
+    r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand                             0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
-    rand_core                        0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
-    ratatui                         0.29.0  eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b \
+    rand_core                        0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
+    rand_core                     0.10.0-rc-3  f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05 \
+    ratatui                         0.30.0  d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc \
+    ratatui-core                     0.1.0  5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293 \
+    ratatui-crossterm                0.1.0  577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3 \
+    ratatui-widgets                  0.3.0  d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db \
     rayon                           1.11.0  368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f \
     rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                   0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
-    redox_syscall                    0.6.0  ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5 \
+    redox_syscall                    0.7.3  6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16 \
     redox_users                      0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
-    regex                           1.12.2  843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4 \
-    regex-automata                  0.4.13  5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c \
-    regex-lite                       0.1.8  8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da \
-    regex-syntax                     0.8.8  7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58 \
+    regex                           1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
+    regex-automata                  0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
+    regex-lite                       0.1.9  cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
+    regex-syntax                    0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
     remotefs                         0.3.1  b229ef0bf00ce8ae4cbe349bd8d71f3473e26de30efa637cfc53e08eaf6867f0 \
     remotefs-aws-s3                  0.4.3  26a12e6cbd233e9443127029a373bca1daff5372def8fa96b28ea0a2e69b8057 \
-    remotefs-ftp                     0.3.0  b1c84ed1367170d6f589f09998b648e7d9bc09d93091130293be8ff09b7a8329 \
+    remotefs-ftp                     0.4.0  107c234184fd822d1270c482eb8a42354887479cb9fe7834c29655f31e80a4bb \
     remotefs-kube                    0.4.0  a7ca6df262715fd3c88b58bcc9d219ed46ace67bf73e4216b9fa9b73eafd8426 \
     remotefs-smb                     0.3.1  c077c88aecf906b0267def951277dc4f6fd1f368edb73d333771a24c0b47970a \
-    remotefs-ssh                     0.7.1  5ca8b65fbd60801ac03973a41196b030fb04d1ce1af33d3c58c5bad94d46eb27 \
+    remotefs-ssh                     0.8.3  ba2f1a9c39acd963f2bec3a7f5f0f42204d5d020c1db593de95d704dd1dda1e4 \
     remotefs-webdav                  0.2.0  5d2b34f3ac2069b106c65b2d0c91b9b4b24a0b5fe9585b49f50fff4135f2cff8 \
     reqwest                        0.11.27  dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62 \
-    reqwest                        0.12.26  3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f \
+    reqwest                        0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
     rfc6979                          0.3.1  7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb \
+    rfc6979                          0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rpassword                        7.4.0  66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39 \
+    rsa                             0.9.10  b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d \
+    rsa                           0.10.0-rc.12  c9a2b1eacbc34fbaf77f6f1db1385518446008d49b9f9f59dc9d1340fce4ca9e \
     rtoolbox                         0.0.3  a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f \
-    rust-fuzzy-search                0.1.1  a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2 \
+    russh                           0.58.0  30f6ce4f5d5105b934cfb4b8b3028aab4d5dcdff863cb8dda9edd06d39b8c4e8 \
+    russh-cryptovec                 0.48.0  4d8e7e854e1a87e4be00fa287c98cad23faa064d0464434beaa9f014ec3baa98 \
+    russh-cryptovec                 0.58.0  cc109749696a6853cf2c3fba3537635264f3519a78a9f43c6b08c91edc024384 \
+    russh-keys                      0.49.2  788a2439ce385856585346beb37c48e7c9eb5de5f4f00736720a19ffdb3f5bb5 \
+    russh-sftp                       2.1.1  3bb94393cafad0530145b8f626d8687f1ee1dedb93d7ba7740d6ae81868b13b5 \
+    russh-util                      0.48.0  92c7dd577958c0cefbc8f8a2c05c48c88c42e2fdb760dbe9b96ae31d4de97a1f \
+    russh-util                      0.52.0  668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6 \
     rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                         0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
-    rustix                           1.1.2  cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e \
+    rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustls                         0.21.12  3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e \
-    rustls                         0.23.35  533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f \
+    rustls                         0.23.37  758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4 \
     rustls-native-certs              0.7.3  e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5 \
-    rustls-native-certs              0.8.2  9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923 \
+    rustls-native-certs              0.8.3  612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63 \
     rustls-pemfile                   1.0.4  1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c \
     rustls-pemfile                   2.2.0  dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50 \
-    rustls-pki-types                1.13.2  21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282 \
+    rustls-pki-types                1.14.0  be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd \
     rustls-webpki                  0.101.7  8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765 \
-    rustls-webpki                  0.103.8  2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52 \
+    rustls-webpki                 0.103.10  df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef \
     rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     rustydav                         0.1.3  bc4c86c47126ac8bfc573084610e93f4ca8726f3ae7bf6c64bd60476731b6e42 \
-    ryu                             1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
+    ryu                             1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
+    salsa20                         0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scc                              2.4.0  46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc \
-    schannel                        0.1.28  891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1 \
+    schannel                        0.1.29  91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    scrypt                          0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
     sct                              0.7.1  da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414 \
     sdd                             3.0.10  490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca \
     sec1                             0.3.0  3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928 \
+    sec1                             0.7.3  d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc \
     secrecy                          0.8.0  9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e \
     security-framework              2.11.1  897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02 \
-    security-framework               3.5.1  b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef \
-    security-framework-sys          2.15.0  cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0 \
+    security-framework               3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
+    security-framework-sys          2.17.0  6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
+    seize                            0.3.3  689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
     self_update                     0.42.0  d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c \
     semver                          1.0.27  d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2 \
@@ -403,75 +500,87 @@ cargo.crates \
     serde-value                      0.7.0  f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c \
     serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
     serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                     1.0.145  402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c \
+    serde_json                     1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
     serde_spanned                    1.0.4  f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     serde_yaml                    0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
-    serial_test                      3.2.0  1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9 \
-    serial_test_derive               3.2.0  5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef \
+    serdect                          0.4.2  9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06 \
+    serial_test                      3.4.0  911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f \
+    serial_test_derive               3.4.0  0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9 \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    sha1                          0.11.0-rc.5  3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
-    shellexpand                      3.1.1  8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb \
+    sha2                          0.11.0-rc.5  7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024 \
+    shellexpand                      3.1.2  32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                     0.3.18  d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
     signal-hook-mio                  0.2.5  b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc \
-    signal-hook-registry             1.4.7  7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad \
+    signal-hook-registry             1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
     signature                        1.6.4  74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c \
     signature                        2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
+    signature                     3.0.0-rc.6  597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d \
     simd-adler32                     0.3.8  e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2 \
     simplelog                       0.12.2  16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0 \
-    slab                            0.4.11  7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589 \
+    slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     smawk                            0.3.2  b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c \
     socket2                         0.5.10  e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678 \
-    socket2                          0.6.1  17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881 \
+    socket2                          0.6.3  3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
+    spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
+    spin                            0.10.0  d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591 \
     spki                             0.6.0  67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
-    ssh2                             0.9.5  2f84d13b3b8a0d4e91a2629911e951db1bb8671512f5c09d7d4ba34500ba68c8 \
-    ssh2-config                      0.6.2  bc7aae258493fa8ea06796b133b9076f3002c46cd1a4085ddd6df7236fee7034 \
+    spki                          0.8.0-rc.4  8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80 \
+    ssh-cipher                       0.2.0  caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f \
+    ssh-encoding                     0.2.0  eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15 \
+    ssh-key                          0.6.7  3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3 \
+    ssh2-config                      0.7.0  52b8139953690127e92a058701bc65c0ea292c08084c6136fa052021373d739c \
     stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
-    strum                           0.26.3  8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06 \
-    strum_macros                    0.26.4  4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be \
+    strum                           0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
+    strum_macros                    0.27.2  7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7 \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
-    suppaftp                         7.0.7  ba8928c89e226be233f0eb1594e9bd023f72a948dc06581c0d908387f57de1de \
-    syn                            2.0.111  390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87 \
+    suppaftp                         8.0.2  7d3da253d7e9993de86df41eb89e8cb1b6f567abe215798645651fca4148d0aa \
+    syn                            2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
     sync_wrapper                     0.1.2  2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
-    sysinfo                         0.34.2  a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2 \
+    sysinfo                         0.37.2  16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f \
     system-configuration             0.5.1  ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7 \
     system-configuration-sys         0.5.0  a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9 \
-    tar                             0.4.44  1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a \
+    tar                             0.4.45  22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973 \
     tauri-winrt-notification         0.7.2  0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9 \
-    tempfile                        3.23.0  2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16 \
+    tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     textwrap                        0.16.2  c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
-    thiserror                       2.0.17  f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8 \
+    thiserror                       2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
-    thiserror-impl                  2.0.17  3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913 \
-    tiger                            0.2.1  579abbce4ad73b04386dbeb34369c9873a8f9b749c7b99cbf479a2949ff715ed \
-    time                            0.3.44  91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d \
-    time-core                        0.1.6  40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b \
-    time-macros                     0.2.24  30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3 \
+    thiserror-impl                  2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
+    time                            0.3.47  743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c \
+    time-core                        0.1.8  7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca \
+    time-macros                     0.2.27  2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215 \
+    tiny-keccak                      2.0.2  2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237 \
     tinystr                          0.8.2  42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869 \
-    tinyvec                         1.10.0  bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa \
+    tinyvec                         1.11.0  3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.48.0  ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408 \
-    tokio-macros                     2.6.0  af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5 \
+    tls_codec                        0.4.2  0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b \
+    tls_codec_derive                 0.4.2  2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd \
+    tokio                           1.50.0  27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d \
+    tokio-macros                     2.6.1  5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c \
     tokio-native-tls                 0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                    0.24.1  c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081 \
     tokio-rustls                    0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
+    tokio-stream                    0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
     tokio-tungstenite               0.23.1  c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd \
-    tokio-util                      0.7.17  2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594 \
-    toml                          0.9.10+spec-1.1.0  0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48 \
-    toml_datetime                 0.7.5+spec-1.1.0  92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347 \
-    toml_parser                   1.0.6+spec-1.1.0  a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44 \
-    toml_writer                   1.0.6+spec-1.1.0  ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607 \
+    tokio-util                      0.7.18  9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
+    toml                          1.0.7+spec-1.1.0  dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96 \
+    toml_datetime                 1.0.1+spec-1.1.0  9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9 \
+    toml_parser                   1.0.10+spec-1.1.0  7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420 \
+    toml_writer                   1.0.7+spec-1.1.0  f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d \
     tower                           0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
-    tower                            0.5.2  d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9 \
+    tower                            0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                       0.5.2  1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5 \
     tower-http                       0.6.8  d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
@@ -480,33 +589,35 @@ cargo.crates \
     tracing-attributes              0.1.31  7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da \
     tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
-    tui-realm-stdlib                 3.1.0  333d8b8da2b3479a68fdf4bd2621f888fa869501d6c5c72bac940d0eeb19b083 \
-    tui-term                         0.2.0  72af159125ce32b02ceaced6cffae6394b0e6b6dfd4dc164a6c59a2db9b3c0b0 \
-    tuirealm                         3.3.0  c3a96abaf33552e9e2487bf56f537e49fad1d1fbc55a3fd542449d4e30e7c8f3 \
-    tuirealm_derive                  2.0.1  bad3c151090da5a036321776209b3d026df637d7f52c0984ff8d45927326ab4f \
+    tui-realm-stdlib                 4.0.0  16a0e19fc8b6ea3a7a88d51ae8df4d657fb4f9a1cdf79f354217e5136838d5dd \
+    tui-term                         0.3.0  f740cf128bd2ecffea958989646e79a546c45772dac6e42c0b86451185ec6933 \
+    tuirealm                         4.0.0  257b2348be6fc22fad4b6ba6288207016d88417c071fc96268b5865e24662305 \
+    tuirealm_derive                  4.0.0  19eb242ebcb03507baa4a13392bdfc019c54dbb74492fe5e8b75d1b69ea78ecf \
     tungstenite                     0.23.0  6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8 \
     typenum                         1.19.0  562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
-    unicode-ident                   1.0.22  9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5 \
+    unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
     unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
-    unicode-truncate                 1.1.0  b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf \
+    unicode-truncate                 2.0.1  16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5 \
     unicode-width                   0.1.14  7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af \
     unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
+    unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
+    universal-hash                   0.5.1  fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea \
     unsafe-libyaml                  0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
+    untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    url                              2.5.7  08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b \
+    url                              2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.19.0  e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a \
+    uuid                            1.22.0  a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37 \
     uzers                           0.12.2  0b8275fb1afee25b4111d2dc8b5c505dbbc4afd0b990cb96deb2d88bff8be18d \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
-    vergen                           9.0.6  6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777 \
-    vergen-git2                      1.0.7  4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1 \
-    vergen-lib                       0.1.6  9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166 \
-    version-compare                  0.2.1  03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e \
+    vergen                           9.1.0  b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75 \
+    vergen-git2                      9.1.0  d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57 \
+    vergen-lib                       9.1.0  b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     vsimd                            0.8.0  5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64 \
     vt100                           0.15.2  84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de \
@@ -515,40 +626,50 @@ cargo.crates \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi                          0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
-    wasip2                        1.0.1+wasi-0.2.4  0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7 \
-    wasite                           0.1.0  b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b \
-    wasm-bindgen                   0.2.106  0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd \
-    wasm-bindgen-futures            0.4.56  836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c \
-    wasm-bindgen-macro             0.2.106  48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3 \
-    wasm-bindgen-macro-support     0.2.106  cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40 \
-    wasm-bindgen-shared            0.2.106  cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4 \
-    web-sys                         0.3.83  9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac \
+    wasi                          0.14.7+wasi-0.2.4  883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c \
+    wasip2                        1.0.2+wasi-0.2.9  9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5 \
+    wasip3                        0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
+    wasite                           1.0.2  66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42 \
+    wasm-bindgen                   0.2.114  6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e \
+    wasm-bindgen-futures            0.4.64  e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8 \
+    wasm-bindgen-macro             0.2.114  18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6 \
+    wasm-bindgen-macro-support     0.2.114  03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3 \
+    wasm-bindgen-shared            0.2.114  75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16 \
+    wasm-encoder                   0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
+    wasm-metadata                  0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
+    wasmparser                     0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
+    web-sys                         0.3.91  854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9 \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-roots                     1.0.4  b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e \
+    webpki-roots                     1.0.6  22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed \
     which                            4.4.2  87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7 \
-    whoami                           1.6.1  5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d \
+    whoami                           2.1.1  d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d \
     wildmatch                        2.6.1  29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                     0.1.11  c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows                         0.57.0  12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143 \
+    windows                         0.58.0  dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6 \
     windows                         0.61.3  9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893 \
+    windows                         0.62.2  527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580 \
     windows-collections              0.2.0  3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8 \
-    windows-core                    0.57.0  d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d \
+    windows-collections              0.3.2  23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610 \
+    windows-core                    0.58.0  6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99 \
     windows-core                    0.61.2  c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3 \
     windows-core                    0.62.2  b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb \
     windows-future                   0.2.1  fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e \
-    windows-implement               0.57.0  9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7 \
+    windows-future                   0.3.2  e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb \
+    windows-implement               0.58.0  2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b \
     windows-implement               0.60.2  053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf \
-    windows-interface               0.57.0  29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7 \
+    windows-interface               0.58.0  053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515 \
     windows-interface               0.59.3  3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358 \
     windows-link                     0.1.3  5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a \
     windows-link                     0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
     windows-numerics                 0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
-    windows-result                   0.1.2  5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8 \
+    windows-numerics                 0.3.1  6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26 \
+    windows-result                   0.2.0  1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e \
     windows-result                   0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
     windows-result                   0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
+    windows-strings                  0.1.0  4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10 \
     windows-strings                  0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
     windows-strings                  0.5.1  7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
@@ -560,6 +681,7 @@ cargo.crates \
     windows-targets                 0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
     windows-targets                 0.53.5  4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3 \
     windows-threading                0.1.0  b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6 \
+    windows-threading                0.2.1  3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37 \
     windows-version                  0.1.7  e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631 \
     windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
     windows_aarch64_gnullvm         0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
@@ -584,24 +706,30 @@ cargo.crates \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
-    winnow                          0.7.14  5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829 \
+    winnow                           1.0.0  a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8 \
     winreg                          0.50.0  524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1 \
-    wit-bindgen                     0.46.0  f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59 \
+    wit-bindgen                     0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
+    wit-bindgen-core                0.51.0  ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
+    wit-bindgen-rust                0.51.0  b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21 \
+    wit-bindgen-rust-macro          0.51.0  0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a \
+    wit-component                  0.244.0  9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
+    wit-parser                     0.244.0  ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
     writeable                        0.6.2  9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9 \
     xattr                            1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     xmlparser                       0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                             0.8.1  72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954 \
     yoke-derive                      0.8.1  b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d \
-    zerocopy                        0.8.31  fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3 \
-    zerocopy-derive                 0.8.31  d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a \
+    zerocopy                        0.8.47  efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87 \
+    zerocopy-derive                 0.8.47  0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89 \
     zerofrom                         0.1.6  50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5 \
     zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
     zeroize                          1.8.2  b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \
-    zeroize_derive                   1.4.2  ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69 \
+    zeroize_derive                   1.4.3  85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e \
     zerotrie                         0.2.3  2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851 \
     zerovec                         0.11.5  6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002 \
     zerovec-derive                  0.11.2  eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3 \
     zip                              2.4.2  fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50 \
     zipsign-api                      0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
+    zmij                            1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
     zopfli                           0.8.3  f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249


### PR DESCRIPTION
#### Description
https://github.com/veeso/termscp/releases/tag/v1.0.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
