### PR TITLE
llmfit: update to 0.9.13

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.2 v
+github.setup            AlexsJones llmfit 0.9.13 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  ea9f278d189e4115bcdff847abeb07252dcde499 \
-                        sha256  2537624809c0b92114f0e3aab3e60a9d28f4a6f5f157e346a0ee4698c9f08364 \
-                        size    6180044
+                        rmd160  17a82d70e34593ecb82e3185f5e9d2e568f5f28d \
+                        sha256  1382aa7734cefffd0e357fc40aca3a6c3558dc80476a19061e2b484ed430c0d0 \
+                        size    6934083
 
 categories              llm
 platforms               macosx
@@ -39,7 +39,7 @@ cargo.crates \
     allocator-api2                  0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anstream                         1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
-    anstyle                         1.0.13  5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78 \
+    anstyle                         1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
     anstyle-parse                    1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                    1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
     anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
@@ -50,16 +50,17 @@ cargo.crates \
     atomic                           0.6.1  a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
-    axum                             0.8.8  8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8 \
+    axum                             0.8.9  31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90 \
     axum-core                        0.5.6  08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1 \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                          0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     bit-set                          0.5.3  0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1 \
+    bit-set                          0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
+    bit-vec                          0.8.0  5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    bitflags                        2.11.0  843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af \
+    bitflags                        2.11.1  c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3 \
     block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
-    block2                           0.5.1  2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f \
     block2                           0.6.2  cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5 \
     brotli                           8.0.2  4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560 \
     brotli-decompressor              5.0.0  874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03 \
@@ -76,19 +77,19 @@ cargo.crates \
     cargo_metadata                  0.19.2  dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba \
     cargo_toml                      0.22.3  374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77 \
     castaway                         0.2.4  dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a \
-    cc                              1.2.56  aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2 \
+    cc                              1.2.60  43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20 \
     cesu8                            1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cfb                              0.7.3  d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f \
     cfg-expr                        0.15.8  d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02 \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    chrono                          0.4.43  fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118 \
-    clap                             4.6.0  b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351 \
+    chrono                          0.4.44  c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0 \
+    clap                             4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap_builder                     4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
-    clap_derive                      4.6.0  1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a \
-    clap_lex                         1.0.0  3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831 \
+    clap_derive                      4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
+    clap_lex                         1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
     clipboard-win                    5.4.1  bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4 \
-    colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
+    colorchoice                      1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
     colored                          3.1.1  faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
     combine                          4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
     compact_str                      0.9.0  3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a \
@@ -98,7 +99,7 @@ cargo.crates \
     cookie_store                    0.22.1  15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206 \
     core-foundation                 0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
-    core-graphics                   0.24.0  fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1 \
+    core-graphics                   0.25.0  064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97 \
     core-graphics-types              0.2.0  3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb \
     cpufeatures                     0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
     crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
@@ -110,42 +111,43 @@ cargo.crates \
     crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     csscolorparser                   0.6.2  eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf \
     cssparser                       0.29.6  f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa \
+    cssparser                       0.36.0  dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2 \
     cssparser-macros                 0.6.1  13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331 \
+    csv                              1.4.0  52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938 \
+    csv-core                        0.1.13  704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782 \
     ctor                             0.2.9  32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501 \
-    darling                         0.21.3  9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0 \
     darling                         0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
-    darling_core                    0.21.3  1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4 \
     darling_core                    0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
-    darling_macro                   0.21.3  d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81 \
     darling_macro                   0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
     deltae                           0.3.2  5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4 \
-    deranged                         0.5.7  2163a0e204a148662b6b6816d4b5d5668a5f2f8df498ccbd5cd0e864e78fecba \
+    deranged                         0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
     derive_more                    0.99.20  6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f \
     derive_more                      2.1.1  d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
     derive_more-impl                 2.1.1  799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     dirs                             6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
-    dispatch                         0.2.0  bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b \
-    dispatch2                        0.3.0  89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec \
+    dispatch2                        0.3.1  1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38 \
     displaydoc                       0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     dlopen2                          0.8.2  5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4 \
     dlopen2_derive                   0.4.3  0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f \
     document-features               0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
+    dom_query                       0.27.0  521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89 \
     dpi                              0.1.2  d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76 \
     dtoa                            1.0.11  4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590 \
     dtoa-short                       0.3.5  cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87 \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
     either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
-    embed-resource                   3.0.6  55a075fc573c64510038d7ee9abc7990635863992f83ebc52c8b433b8411a02e \
+    embed-resource                   3.0.8  63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45 \
     embed_plist                      1.2.2  4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
-    erased-serde                     0.4.9  89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3 \
+    erased-serde                    0.4.10  d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec \
     errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
     error-code                       3.3.2  dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59 \
-    euclid                         0.22.13  df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63 \
+    euclid                         0.22.14  f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06 \
     fancy-regex                     0.11.0  b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2 \
+    fastrand                         2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     fax                              0.2.6  f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab \
     fax_derive                       0.2.0  a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d \
     fdeflate                         0.3.7  1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c \
@@ -184,7 +186,7 @@ cargo.crates \
     getrandom                       0.1.16  8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
     getrandom                       0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
-    getrandom                        0.4.1  139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec \
+    getrandom                        0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
     gio                             0.18.4  d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73 \
     gio-sys                         0.18.1  37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2 \
     glib                            0.18.5  233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5 \
@@ -199,50 +201,54 @@ cargo.crates \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
+    hashbrown                       0.17.0  4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     html5ever                       0.29.1  3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c \
+    html5ever                       0.38.0  1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2 \
     http                             1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    hyper                            1.8.1  2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11 \
+    hyper                            1.9.0  6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca \
     hyper-util                      0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
     iana-time-zone                  0.1.65  e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     ico                              0.5.0  3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371 \
-    icu_collections                  2.1.1  4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43 \
-    icu_locale_core                  2.1.1  edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6 \
-    icu_normalizer                   2.1.1  5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599 \
-    icu_normalizer_data              2.1.1  7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a \
-    icu_properties                   2.1.2  020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec \
-    icu_properties_data              2.1.2  616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af \
-    icu_provider                     2.1.1  85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614 \
+    icu_collections                  2.2.0  2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c \
+    icu_locale_core                  2.2.0  92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29 \
+    icu_normalizer                   2.2.0  c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4 \
+    icu_normalizer_data              2.2.0  da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38 \
+    icu_properties                   2.2.0  bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de \
+    icu_properties_data              2.2.0  8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
+    icu_provider                     2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
     id-arena                         2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     ident_case                       1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
     image                          0.25.10  85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104 \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
-    indexmap                        2.13.0  7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017 \
+    indexmap                        2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     indoc                            2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     infer                           0.19.0  a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7 \
-    instability                     0.3.11  357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d \
-    ipnet                           2.11.0  469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130 \
-    iri-string                      0.7.10  c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a \
+    instability                     0.3.12  5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971 \
+    ipnet                           2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
+    iri-string                      0.7.12  25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20 \
     is_terminal_polyfill            1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
-    itoa                            1.0.17  92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2 \
+    itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     javascriptcore-rs                1.1.2  ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc \
     javascriptcore-rs-sys            1.1.1  af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124 \
     jni                             0.21.1  1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97 \
-    jni-sys                          0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
-    js-sys                          0.3.87  93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21 \
+    jni-sys                          0.3.1  41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258 \
+    jni-sys                          0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
+    jni-sys-macros                   0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
+    js-sys                          0.3.95  2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca \
     json-patch                       3.0.1  863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08 \
     jsonptr                          0.6.3  5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70 \
-    kasuari                         0.4.11  8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b \
+    kasuari                         0.4.12  bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899 \
     keyboard-types                   0.7.0  b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a \
     kuchikiki            0.8.8-speedreader  02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2 \
     lab                             0.11.0  bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f \
@@ -250,19 +256,20 @@ cargo.crates \
     leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
     libappindicator                  0.9.0  03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a \
     libappindicator-sys              0.9.0  6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf \
-    libc                           0.2.182  6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112 \
+    libc                           0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
     libloading                       0.7.4  b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f \
-    libredox                        0.1.12  3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616 \
-    line-clipping                    0.3.5  5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a \
+    libredox                        0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
+    line-clipping                    0.3.7  3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8 \
     linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
-    litemap                          0.8.1  6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77 \
+    litemap                          0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
     litrs                            1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
     log                             0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
-    lru                             0.16.3  a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593 \
+    lru                             0.16.4  7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39 \
     mac                              0.1.1  c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4 \
     mac_address                      1.1.8  c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303 \
     markup5ever                     0.14.1  c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18 \
+    markup5ever                     0.38.0  8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862 \
     match_token                      0.1.0  88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b \
     matches                         0.1.10  2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5 \
     matchit                          0.8.4  47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3 \
@@ -272,9 +279,9 @@ cargo.crates \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                              1.1.1  a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc \
+    mio                              1.2.0  50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1 \
     moxcms                           0.8.1  bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b \
-    muda                            0.17.1  01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a \
+    muda                            0.17.2  7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177 \
     ndk                              0.9.0  c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4 \
     ndk-context                      0.1.1  27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b \
     ndk-sys                 0.6.0+11769913  ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873 \
@@ -283,29 +290,25 @@ cargo.crates \
     nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     ntapi                            0.4.3  c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae \
-    num-conv                         0.2.0  cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050 \
+    num-conv                         0.2.1  c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967 \
     num-derive                       0.4.2  ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202 \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
-    num_enum                         0.7.5  b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c \
-    num_enum_derive                  0.7.5  ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7 \
+    num_enum                         0.7.6  5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26 \
+    num_enum_derive                  0.7.6  680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8 \
     num_threads                      0.1.7  5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
-    objc-sys                         0.3.5  cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310 \
-    objc2                            0.5.2  46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804 \
-    objc2                            0.6.3  b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05 \
-    objc2-app-kit                    0.3.1  e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc \
+    objc2                            0.6.4  3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f \
+    objc2-app-kit                    0.3.2  d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c \
     objc2-core-foundation            0.3.2  2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536 \
-    objc2-core-graphics              0.3.1  989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4 \
+    objc2-core-graphics              0.3.2  e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807 \
     objc2-encode                     4.1.0  ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
     objc2-exception-helper           0.1.1  c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a \
-    objc2-foundation                 0.2.2  0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8 \
-    objc2-foundation                 0.3.1  900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c \
+    objc2-foundation                 0.3.2  e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272 \
     objc2-io-kit                     0.3.2  33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15 \
-    objc2-io-surface                 0.3.1  7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c \
-    objc2-metal                      0.2.2  dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6 \
-    objc2-quartz-core                0.2.2  e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a \
-    objc2-ui-kit                     0.3.1  25b1312ad7bc8a0e92adae17aa10f90aae1fb618832f9b993b022b591027daed \
-    objc2-web-kit                    0.3.1  91672909de8b1ce1c2252e95bbee8c1649c9ad9d14b9248b3d7b4c47903c47ad \
-    once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
+    objc2-io-surface                 0.3.2  180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d \
+    objc2-quartz-core                0.3.2  96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f \
+    objc2-ui-kit                     0.3.2  d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22 \
+    objc2-web-kit                    0.3.2  b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f \
+    once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                    4.6.0  7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951 \
@@ -322,44 +325,49 @@ cargo.crates \
     phf                              0.8.0  3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12 \
     phf                             0.10.1  fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259 \
     phf                             0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
+    phf                             0.13.1  c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf \
     phf_codegen                      0.8.0  cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815 \
     phf_codegen                     0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
+    phf_codegen                     0.13.1  49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1 \
     phf_generator                    0.8.0  17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526 \
     phf_generator                   0.10.0  5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6 \
     phf_generator                   0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
+    phf_generator                   0.13.1  135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737 \
     phf_macros                      0.10.0  58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0 \
     phf_macros                      0.11.3  f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216 \
+    phf_macros                      0.13.1  812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef \
     phf_shared                       0.8.0  c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7 \
     phf_shared                      0.10.0  b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096 \
     phf_shared                      0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
-    pin-project-lite                0.2.16  3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b \
-    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    pkg-config                      0.3.32  7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c \
+    phf_shared                      0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
+    pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
+    pkg-config                      0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
     plist                            1.8.0  740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07 \
     png                            0.17.16  82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526 \
     png                             0.18.1  60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61 \
     portable-atomic                 1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
-    potential_utf                    0.1.4  b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77 \
+    potential_utf                    0.1.5  0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     precomputed-hash                 0.1.1  925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
     prettyplease                    0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
     proc-macro-crate                 1.3.1  7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919 \
     proc-macro-crate                 2.0.2  b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24 \
-    proc-macro-crate                 3.4.0  219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983 \
+    proc-macro-crate                 3.5.0  e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f \
     proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro-hack      0.5.20+deprecated  dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068 \
     proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
-    pxfm                            0.1.28  b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d \
+    pxfm                            0.1.29  e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f \
     quick-error                      2.0.1  a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3 \
     quick-xml                       0.38.4  b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c \
     quote                           1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
     r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
+    r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
-    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand                             0.8.6  5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a \
     rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
@@ -379,14 +387,15 @@ cargo.crates \
     ref-cast-impl                   1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
     regex                           1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
     regex-automata                  0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
-    regex-syntax                     0.8.9  a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c \
+    regex-syntax                    0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
     reqwest                         0.13.2  ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801 \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
+    rustc-hash                       2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
     rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustls                         0.23.36  c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b \
+    rustls                         0.23.38  69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21 \
     rustls-pki-types                1.14.0  be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd \
-    rustls-webpki                  0.103.9  d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53 \
+    rustls-webpki                 0.103.12  8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06 \
     rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     ryu                             1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
@@ -396,7 +405,8 @@ cargo.crates \
     schemars_derive                 0.8.22  32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     selectors                       0.24.0  0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416 \
-    semver                          1.0.27  d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2 \
+    selectors                       0.36.1  c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c \
+    semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
     serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
     serde-untagged                   0.1.9  f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058 \
     serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
@@ -406,31 +416,34 @@ cargo.crates \
     serde_path_to_error             0.1.20  10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457 \
     serde_repr                      0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
     serde_spanned                    0.6.9  bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3 \
-    serde_spanned                    1.0.4  f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776 \
+    serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_with                      3.16.1  4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7 \
-    serde_with_macros               3.16.1  52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c \
+    serde_with                      3.18.0  dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f \
+    serde_with_macros               3.18.0  d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65 \
     serialize-to-javascript          0.1.2  04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5 \
     serialize-to-javascript-impl     0.1.2  772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d \
     servo_arc                        0.2.0  d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741 \
+    servo_arc                        0.4.3  170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930 \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook                     0.3.18  d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2 \
     signal-hook-mio                  0.2.5  b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc \
     signal-hook-registry             1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
-    simd-adler32                     0.3.8  e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2 \
+    simd-adler32                     0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
     siphasher                        1.0.2  b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e \
     slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
-    socket2                          0.6.2  86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0 \
-    softbuffer                       0.4.6  18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08 \
+    socket2                          0.6.3  3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
+    softbuffer                       0.4.8  aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3 \
     soup3                            0.5.0  471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f \
     soup3-sys                        0.5.0  7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27 \
     stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     string_cache                     0.8.9  bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f \
+    string_cache                     0.9.0  a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901 \
     string_cache_codegen             0.5.4  c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0 \
+    string_cache_codegen             0.6.1  585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
     strum_macros                    0.27.2  7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7 \
@@ -444,7 +457,7 @@ cargo.crates \
     system-deps                      6.2.2  a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349 \
     tabled                          0.20.0  e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d \
     tabled_derive                   0.11.0  0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846 \
-    tao                             0.34.5  f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7 \
+    tao                             0.34.8  9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20 \
     tao-macros                       0.1.3  f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd \
     target-lexicon                 0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
     tauri                           2.10.3  da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d \
@@ -456,6 +469,7 @@ cargo.crates \
     tauri-utils                      2.8.3  219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d \
     tauri-winres                     0.3.5  1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0 \
     tendril                          0.4.3  d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0 \
+    tendril                          0.5.0  c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24 \
     terminfo                         0.9.0  d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662 \
     termios                          0.3.3  411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b \
     termwiz                         0.23.3  4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7 \
@@ -468,19 +482,20 @@ cargo.crates \
     time                            0.3.47  743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c \
     time-core                        0.1.8  7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca \
     time-macros                     0.2.27  2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215 \
-    tinystr                          0.8.2  42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869 \
-    tokio                           1.50.0  27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d \
-    tokio-macros                     2.6.1  5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c \
+    tinystr                          0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
+    tokio                           1.52.1  b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6 \
+    tokio-macros                     2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-util                      0.7.18  9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
     toml                             0.8.2  185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d \
     toml                 0.9.12+spec-1.1.0  cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863 \
     toml_datetime                    0.6.3  7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b \
     toml_datetime         0.7.5+spec-1.1.0  92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347 \
+    toml_datetime         1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
     toml_edit                      0.19.15  1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421 \
     toml_edit                       0.20.2  396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338 \
-    toml_edit           0.23.10+spec-1.0.0  84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269 \
-    toml_parser           1.0.9+spec-1.1.0  702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4 \
-    toml_writer           1.0.6+spec-1.1.0  ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607 \
+    toml_edit           0.25.11+spec-1.1.0  0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b \
+    toml_parser           1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
+    toml_writer           1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
     tower                            0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                       0.6.8  d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
@@ -498,19 +513,20 @@ cargo.crates \
     unic-ucd-ident                   0.9.0  e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987 \
     unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
     unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
-    unicode-segmentation            1.12.0  f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493 \
+    unicode-segmentation            1.13.2  9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c \
     unicode-truncate                 2.0.1  16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5 \
-    unicode-width                    0.2.0  1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd \
+    unicode-width                    0.2.2  b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
     unicode-xid                      0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    ureq                             3.2.0  fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc \
-    ureq-proto                       0.5.3  d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f \
+    ureq                             3.3.0  dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0 \
+    ureq-proto                       0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                              2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlpattern                       0.3.0  70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
+    utf8-zero                        0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.21.0  b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb \
+    uuid                            1.23.1  ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76 \
     version-compare                  0.2.1  03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     vswhom                           0.1.0  be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b \
@@ -522,19 +538,20 @@ cargo.crates \
     wasi     0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                1.0.2+wasi-0.2.9  9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5 \
     wasip3  0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                   0.2.110  1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866 \
-    wasm-bindgen-futures            0.4.60  a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da \
-    wasm-bindgen-macro             0.2.110  e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52 \
-    wasm-bindgen-macro-support     0.2.110  0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309 \
-    wasm-bindgen-shared            0.2.110  e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53 \
+    wasm-bindgen                   0.2.118  0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89 \
+    wasm-bindgen-futures            0.4.68  f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8 \
+    wasm-bindgen-macro             0.2.118  eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed \
+    wasm-bindgen-macro-support     0.2.118  9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904 \
+    wasm-bindgen-shared            0.2.118  5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129 \
     wasm-encoder                   0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                  0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasm-streams                     0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
     wasmparser                     0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
-    web-sys                         0.3.87  f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff \
+    web-sys                         0.3.95  4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d \
+    web_atoms                        0.2.3  57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576 \
     webkit2gtk                       2.0.2  a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793 \
     webkit2gtk-sys                   2.0.2  916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5 \
-    webpki-roots                     1.0.6  22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed \
+    webpki-roots                     1.0.7  52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \
     webview2-com                    0.38.2  7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a \
     webview2-com-macros              0.8.1  67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54 \
     webview2-com-sys                0.38.2  381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c \
@@ -604,7 +621,8 @@ cargo.crates \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
     winnow                          0.5.40  f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876 \
-    winnow                          0.7.14  5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829 \
+    winnow                          0.7.15  df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945 \
+    winnow                           1.0.1  09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5 \
     winreg                          0.55.0  cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97 \
     wit-bindgen                     0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
     wit-bindgen-core                0.51.0  ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
@@ -612,22 +630,22 @@ cargo.crates \
     wit-bindgen-rust-macro          0.51.0  0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a \
     wit-component                  0.244.0  9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
     wit-parser                     0.244.0  ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
-    writeable                        0.6.2  9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9 \
-    wry                             0.54.2  bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a \
+    writeable                        0.6.3  1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
+    wry                             0.54.4  e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc \
     x11                             2.21.0  502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e \
     x11-dl                          2.21.0  38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f \
     x11rb                           0.13.2  9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414 \
     x11rb-protocol                  0.13.2  ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd \
-    yoke                             0.8.1  72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954 \
-    yoke-derive                      0.8.1  b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d \
-    zerocopy                        0.8.39  db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a \
-    zerocopy-derive                 0.8.39  4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517 \
-    zerofrom                         0.1.6  50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5 \
-    zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
+    yoke                             0.8.2  abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca \
+    yoke-derive                      0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
+    zerocopy                        0.8.48  eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9 \
+    zerocopy-derive                 0.8.48  70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4 \
+    zerofrom                         0.1.7  69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df \
+    zerofrom-derive                  0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                          1.8.2  b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \
-    zerotrie                         0.2.3  2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851 \
-    zerovec                         0.11.5  6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002 \
-    zerovec-derive                  0.11.2  eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3 \
+    zerotrie                         0.2.4  0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
+    zerovec                         0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
+    zerovec-derive                  0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
     zmij                            1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
     zune-core                        0.5.1  cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9 \
-    zune-jpeg                       0.5.14  0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6
+    zune-jpeg                       0.5.15  27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296


### PR DESCRIPTION
#### Description

Upstream fixed Cargo.lock (AlexsJones/llmfit#476) so it now builds fine with macports cargo group defaults

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.4 24G517 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
