### PR TITLE
valgrind: update to 3.27.0

### DIFF
--- a/devel/valgrind/Portfile
+++ b/devel/valgrind/Portfile
@@ -5,8 +5,6 @@ PortGroup           mpi 1.0
 
 name                valgrind
 categories          devel
-platforms           darwin
-supported_archs     i386 x86_64
 license             GPL-2
 maintainers         nomaintainer
 
@@ -16,7 +14,7 @@ long_description \
     attached to a program, it intercepts calls to malloc/new/free/delete and \
     all memory operations are checked for invalid read or write.
 
-homepage            http://valgrind.org
+homepage            https://valgrind.org
 master_sites        https://sourceware.org/pub/valgrind/
 
 # older clangs identify as applellvm-4.2 and are rejected
@@ -29,7 +27,14 @@ compiler.blacklist-append \
                     llvm-gcc-4.2
 
 compilers.choose    cc cxx
-mpi.setup           -gcc44 -gcc45 -gcc46
+
+if {${os.platform} eq "darwin" && ${os.arch} eq "arm"} {
+    # error: this compiler does not support 'arm64e'
+    compiler.blacklist-append *gcc*
+    mpi.setup       -gcc
+} else {
+    mpi.setup       -gcc44 -gcc45 -gcc46
+}
 
 depends_build       bin:perl:perl5
 # Ignore trace reports about boost, Qt and OpenMP
@@ -64,7 +69,12 @@ variant universal {
 
 pre-patch {
     if {[gcc_variant_isset]} {
-        patchfiles-append patch-gcc.diff
+        # if compiling with gcc, fix clang-isms (applying patch with -l
+        # because valgrind-macos-devel has different trailing whitespace), and
+        # ensure that configure is regenerated after patching configure.ac
+        patchfiles-append   patch-gcc.diff
+        patch.args          -l
+        use_autoreconf      yes
     }
 }
 
@@ -76,22 +86,30 @@ pre-configure {
 }
 
 if {$subport eq $name} {
-    version             3.16.1
-    revision            0
-    conflicts           valgrind-devel valgrind-macos-devel
+    platforms       {darwin >= 9 < 23}
+    supported_archs i386 x86_64
 
-    checksums           rmd160  f06068b1f2aa9f6c2377816a0af809459da2c5a8 \
-                        sha256  c91f3a2f7b02db0f3bc99479861656154d241d2fdb265614ba918cc6720a33ca \
-                        size    16262776
+    if {${os.platform} eq "darwin" && ${os.major} < 12} {
+        version     3.16.1
+        checksums   rmd160  f06068b1f2aa9f6c2377816a0af809459da2c5a8 \
+                    sha256  c91f3a2f7b02db0f3bc99479861656154d241d2fdb265614ba918cc6720a33ca \
+                    size    16262776
+    } else {
+        version     3.27.0
+        checksums   rmd160  9a80964de2145941d24a6aa68587f865cd84441f \
+                    sha256  5b5937de8257ee8f51698ea71b9711adce98061aa07daa4a685efc3af9215bef \
+                    size    17294027
+    }
 
-    use_bzip2           yes
+    conflicts       valgrind-devel valgrind-macos-devel
+    use_bzip2       yes
 
     # Avoid conflict of faq.html and FAQ.html, #30541
     extract.post_args-append --exclude=${distname}/docs/html/FAQ.html
 
     pre-fetch {
-        if {${os.platform} eq "darwin" && (${os.major} < 9 || ${os.major} > 17)} {
-            ui_error "${subport} @${version} is only compatible with macOS versions from 10.5 up to 10.13."
+        if {${os.platform} eq "darwin" && (${os.major} >= 23 || ${os.arch} eq "arm")} {
+            ui_error "${subport} @${version} is only compatible with Intel Macs running macOS 13 or earlier."
             ui_error "Consider installing valgrind-macos-devel on newer macOS systems."
             return -code error "incompatible macOS version"
         }
@@ -103,45 +121,64 @@ if {$subport eq $name} {
 }
 
 subport valgrind-devel {
-    epoch           1
-    set date        2020-12-17
-    version         3.16.1-r${date}
-    conflicts       valgrind valgrind-macos-devel
+    platforms       {darwin >= 12 < 23}
+    supported_archs i386 x86_64
 
+    epoch           1
+    set date        2026-04-22
+    version         3.27.0-r${date}
+    git.branch      b62544e78b037b9a786814d047f41faf5f523e8d
+
+    conflicts       valgrind valgrind-macos-devel
     fetch.type      git
-    git.url         http://repo.or.cz/valgrind.git
-    git.branch      04cdc29b007594a0e58ffef0c9dd87df3ea595ea
+    git.url         https://sourceware.org/git/valgrind.git
+    use_autoreconf  yes
+    livecheck.type  none
 
     pre-fetch {
-        if {${os.platform} eq "darwin" && ${os.major} < 9 } {
-            ui_error "${subport} @${version} is only compatible with macOS versions from 10.5 up."
-            return -code error "incompatible macOS version"
-        }
-
-        if {${os.platform} eq "darwin" && ${os.major} > 17 } {
-            ui_error "${subport} @${version} is not presently compatible with macOS Mojave or newer"
+        if {${os.platform} eq "darwin" && (${os.major} >= 23 || ${os.arch} eq "arm")} {
+            ui_error "${subport} @${version} is only compatible with Intel Macs running macOS 13 or earlier."
             ui_error "Consider installing valgrind-macos-devel on newer macOS systems."
             return -code error "incompatible macOS version"
         }
     }
-
-    use_autoreconf      yes
-
-    livecheck.type none
 }
 
 subport valgrind-macos-devel {
-    set date        2023-10-29
-    version         3.22.0-r${date}
-    conflicts       valgrind valgrind-devel
+    # support for macOS 15 on arm64 is broken
+    # https://github.com/LouisBrunner/valgrind-macos/issues/123
+    if {${os.arch} eq "arm"} {
+        platforms   {darwin >= 9 != 24.*}
+    } else {
+        platforms   {darwin >= 9}
+    }
+    supported_archs i386 x86_64 arm64
 
+    set date        2025-12-16
+    version         3.27.0-r${date}
+    git.branch      176d0873890e61f10e47cff445c822c4949cf93d
+
+    description     A powerful memory debugger with latest macOS support (experimental)
+
+    # work around linker assertion failure with Xcode 15+ on macOS 14
+    # ld: Assertion failed: (((Header*)(fileOutputBuffer))->hasMachOMagic()),
+    #   function writeFixupsLinkEditContent, file Layout.cpp, line 809.
+    # https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking
+    if {${os.platform} eq "darwin" && ${os.major} == 23} {
+        patchfiles-append ldclassic-macos14.diff
+    }
+
+    conflicts       valgrind valgrind-devel
     fetch.type      git
     git.url         https://github.com/LouisBrunner/valgrind-macos.git
-    git.branch      d14be1d4f76466560ed6515d0f314f0925522456
-
-    description     A powerful memory debugger with latest macOS support
-
     use_autoreconf  yes
-
     livecheck.type  none
 }
+
+# detection of optional C23 support; intentional error if not C23
+configure.checks.implicit_function_declaration.whitelist-append alignof
+configure.checks.implicit_int no
+# detection of optional nested function support
+configure.checks.implicit_function_declaration.whitelist-append foo
+# detection of optional function aio_readv in aio.h; not available on macOS
+configure.checks.implicit_function_declaration.whitelist-append aio_readv

--- a/devel/valgrind/files/ldclassic-macos14.diff
+++ b/devel/valgrind/files/ldclassic-macos14.diff
@@ -1,0 +1,12 @@
+diff -rupN ../valgrind-orig/coregrind/link_tool_exe_darwin.in ./coregrind/link_tool_exe_darwin.in
+--- ../valgrind-orig/coregrind/link_tool_exe_darwin.in
++++ ./coregrind/link_tool_exe_darwin.in
+@@ -163,7 +163,7 @@ if ($archstr eq "arm64") {
+ 
+ # Xcode 16 is completely borked and crashes when you use -segaddr so we rollback to
+ # the old linker in the meantime
+-if (@DARWIN_VERS@ >= 150000) {
++if (@DARWIN_VERS@ >= 140000) {
+     $cmd = "$cmd -ld_classic";
+ 
+ # If we're building with clang (viz, the C compiler as specified

--- a/devel/valgrind/files/patch-gcc.diff
+++ b/devel/valgrind/files/patch-gcc.diff
@@ -1,7 +1,25 @@
+diff -rupN ../valgrind-orig/configure.ac ./configure.ac
+--- ../valgrind-orig/configure.ac
++++ ./configure.ac
+@@ -589,9 +589,12 @@ case "${host_os}" in
+             DARWIN_MIN_SDK="10.8"
+           fi
+ 
+-          # they changed the names around 11.0
++          # Apple removed the 'x' from the option name in macOS 11.0 to match
++          # the OS name change, but gcc only supports the older option
+           ld_os_min_vers_arg="-macos_version_min ${DARWIN_MIN_SDK}"
+-          clang_os_min_vers_arg="-mmacos-version-min=${DARWIN_MIN_SDK}"
++          if test $is_clang = applellvm -o $is_clang = clang; then
++            clang_os_min_vers_arg="-mmacos-version-min=${DARWIN_MIN_SDK}"
++          fi
+         fi
+         ;;
+       iphoneos)
 diff -rupN ../valgrind-orig/coregrind/m_syscall.c ./coregrind/m_syscall.c
---- ../valgrind-orig/coregrind/m_syscall.c	2014-04-09 15:07:48.000000000 -0500
-+++ ./coregrind/m_syscall.c	2014-04-09 15:09:06.000000000 -0500
-@@ -505,7 +505,7 @@ asm(
+--- ../valgrind-orig/coregrind/m_syscall.c
++++ ./coregrind/m_syscall.c
+@@ -863,7 +863,7 @@ asm(
     nb here, sizeof(UWord) == sizeof(UInt)
  */
  
@@ -10,7 +28,7 @@ diff -rupN ../valgrind-orig/coregrind/m_syscall.c ./coregrind/m_syscall.c
  do_syscall_unix_WRK ( UWord a1, UWord a2, UWord a3, /* 4(esp)..12(esp) */
                        UWord a4, UWord a5, UWord a6, /* 16(esp)..24(esp) */
                        UWord a7, UWord a8, /* 28(esp)..32(esp) */
-@@ -525,7 +525,7 @@ asm(".private_extern _do_syscall_unix_WR
+@@ -883,7 +883,7 @@ asm(".private_extern _do_syscall_unix_WR
      "    1:  ret                      \n"
      );
  
@@ -19,7 +37,7 @@ diff -rupN ../valgrind-orig/coregrind/m_syscall.c ./coregrind/m_syscall.c
  do_syscall_mach_WRK ( UWord a1, UWord a2, UWord a3, /* 4(esp)..12(esp) */
                        UWord a4, UWord a5, UWord a6, /* 16(esp)..24(esp) */
                        UWord a7, UWord a8, /* 28(esp)..32(esp) */
-@@ -538,7 +538,7 @@ asm(".private_extern _do_syscall_mach_WR
+@@ -896,7 +896,7 @@ asm(".private_extern _do_syscall_mach_WR
      "        ret                      \n"
      );
  
@@ -28,7 +46,7 @@ diff -rupN ../valgrind-orig/coregrind/m_syscall.c ./coregrind/m_syscall.c
  do_syscall_mdep_WRK ( UWord a1, UWord a2, UWord a3, /* 4(esp)..12(esp) */
                        UWord a4, UWord a5, UWord a6, /* 16(esp)..24(esp) */
                        UWord a7, UWord a8, /* 28(esp)..32(esp) */
-@@ -571,7 +571,7 @@ asm(
+@@ -929,7 +929,7 @@ asm(
     nb here, sizeof(UWord) == sizeof(ULong)
  */
  
@@ -37,7 +55,7 @@ diff -rupN ../valgrind-orig/coregrind/m_syscall.c ./coregrind/m_syscall.c
  do_syscall_unix_WRK ( UWord a1, UWord a2, UWord a3, /* rdi, rsi, rdx */
                        UWord a4, UWord a5, UWord a6, /* rcx, r8,  r9 */
                        UWord a7, UWord a8,           /* 8(rsp), 16(rsp) */
-@@ -595,7 +595,7 @@ asm(".private_extern _do_syscall_unix_WR
+@@ -953,7 +953,7 @@ asm(".private_extern _do_syscall_unix_WR
      "        retq                     \n"  /* return 1st result word */
      );
  
@@ -47,9 +65,9 @@ diff -rupN ../valgrind-orig/coregrind/m_syscall.c ./coregrind/m_syscall.c
                        UWord a4, UWord a5, UWord a6, /* rcx, r8,  r9 */
                        UWord a7, UWord a8,           /* 8(rsp), 16(rsp) */
 diff -rupN ../valgrind-orig/coregrind/m_syswrap/syswrap-darwin.c ./coregrind/m_syswrap/syswrap-darwin.c
---- ../valgrind-orig/coregrind/m_syswrap/syswrap-darwin.c	2014-04-09 15:07:48.000000000 -0500
-+++ ./coregrind/m_syswrap/syswrap-darwin.c	2014-04-09 15:09:28.000000000 -0500
-@@ -423,7 +423,7 @@ static OpenPort *info_for_port(mach_port
+--- ../valgrind-orig/coregrind/m_syswrap/syswrap-darwin.c
++++ ./coregrind/m_syswrap/syswrap-darwin.c
+@@ -516,7 +516,7 @@ static OpenPort *info_for_port(mach_port
  
  // Give a port a name, without changing its refcount
  // GrP fixme don't override name if it already has a specific one
@@ -59,9 +77,9 @@ diff -rupN ../valgrind-orig/coregrind/m_syswrap/syswrap-darwin.c ./coregrind/m_s
     OpenPort *i;
     if (!port) return;
 diff -rupN ../valgrind-orig/coregrind/vg_preloaded.c ./coregrind/vg_preloaded.c
---- ../valgrind-orig/coregrind/vg_preloaded.c	2014-04-09 15:07:48.000000000 -0500
-+++ ./coregrind/vg_preloaded.c	2014-04-09 15:08:49.000000000 -0500
-@@ -101,7 +101,7 @@ void * VG_NOTIFY_ON_LOAD(ifunc_wrapper) 
+--- ../valgrind-orig/coregrind/vg_preloaded.c
++++ ./coregrind/vg_preloaded.c
+@@ -159,7 +159,7 @@ void * VG_NOTIFY_ON_LOAD(ifunc_wrapper) 
  
  /* This string will be inserted into crash logs, so crashes while 
     running under Valgrind can be distinguished from other crashes. */


### PR DESCRIPTION
The valgrind-devel and valgrind-macos-devel subports are also updated.

Previously Valgrind supported only Mac OS X 10.5 through macOS 10.12, with preliminary support for macOS 10.13 (Intel only).  Valgrind 3.27.0 supports OS X 10.8 through macOS 12, with preliminary support for macOS 13 (Intel only).  The valgrind-macos-devel fork includes experimental support for up to macOS 26 on both Intel and Apple Silicon, although support for macOS 15 on Apple Silicon is known to be broken.

Because Valgrind 3.27.0 no longer builds on Mac OS X 10.5 through 10.7, those versions of Mac OS X are kept at Valgrind 3.16.1.  (A later version may work but I have no way to test it.)

In addition, the homepage is updated to https and valgrind-devel's git.url is updated to the current official repository (documented at https://valgrind.org/downloads/repository.html).

Fixes: https://trac.macports.org/ticket/69261

###### Tested on
macOS 12.7.6 21H1320 x86_64
Xcode 14.2 14C18
and others

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
