### PR TITLE
neovim, -devel: update to 0.12.2 and 20260423

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -71,9 +71,9 @@ subport neovim-devel {}
 if {${subport} eq ${name}} {
     # stable
 
-    github.setup        neovim neovim 0.12.1 v
+    github.setup        neovim neovim 0.12.2 v
     github.tarball_from archive
-    revision            1
+    revision            0
     conflicts           neovim-devel
 
     # cat cmake.deps/deps.txt \
@@ -89,9 +89,9 @@ if {${subport} eq ${name}} {
     }
 
     checksums           ${name}-${version}.tar.gz \
-                        rmd160  e73209feab2bdcb918a925c73d83b46bf47f1c4b \
-                        sha256  41898a5073631bc8fd9ac43476b811c05fb3b88ffb043d4fbb9e75e478457336 \
-                        size    13652732 \
+                        rmd160  5b2572e9ef1ae4a2d0cded4f156d79799fcf68e5 \
+                        sha256  ef9f58da7d687ed4d1dad9715542bf0dabdeedbfe8089e2ce17fff21b920a268 \
+                        size    13689620 \
                         tree-sitter-c-0.24.1.tar.gz \
                         rmd160  12c732f8ccc097fd1ef4f171c19a89d06cfb85cd \
                         sha256  25dd4bb3dec770769a407e0fc803f424ce02c494a56ce95fedc525316dcf9b48 \
@@ -119,10 +119,10 @@ if {${subport} eq ${name}} {
 } else {
     # devel
 
-    github.setup        neovim neovim 6b0367481c6542bebb47f6e9a6b4eb419708ddaf
+    github.setup        neovim neovim a4ad469fb1f935aed6f84cfa9e663ab4f7ca1e02
     github.tarball_from archive
-    version             20260407-[string range ${github.version} 0 6]
-    revision            1
+    version             20260423-[string range ${github.version} 0 6]
+    revision            0
     conflicts           neovim
     github.livecheck.branch \
                         nightly
@@ -138,9 +138,9 @@ if {${subport} eq ${name}} {
     }
 
     checksums           ${name}-${github.version}.tar.gz \
-                        rmd160  107d4d40356a3a55418f6005ba6880cd6e906544 \
-                        sha256  159992dbf60a021cc7e6a00de92a03ffd1dc82da70ff12080aaff6894f725967 \
-                        size    13669913 \
+                        rmd160  3f5c4e8bce5dbdf14ccb4398791a23d08d0dc77b \
+                        sha256  2d17905d15531a3712a6ffaea39ad41258321f97ce2f1845471e797d0a3cb997 \
+                        size    13737562 \
                         tree-sitter-c-0.24.1.tar.gz \
                         rmd160  12c732f8ccc097fd1ef4f171c19a89d06cfb85cd \
                         sha256  25dd4bb3dec770769a407e0fc803f424ce02c494a56ce95fedc525316dcf9b48 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- update neovim to 0.12.2
- update neovim-devel to 20260423

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3 25D125 arm64
Command Line Tools 26.2.0.0.1.1764812424


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->