### PR TITLE
py-requests: update to 2.33.1

### DIFF
--- a/python/py-requests/Portfile
+++ b/python/py-requests/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-requests
-version             2.32.5
+version             2.33.1
 revision            0
 categories-append   devel
 license             Apache-2
@@ -27,15 +27,15 @@ long_description    Most existing Python modules for dealing HTTP \
 
 homepage            https://requests.readthedocs.io/
 
-checksums           rmd160  dda387149b51cf62dc5f33c9cd96ebe310b03d72 \
-                    sha256  dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf \
-                    size    134517
+checksums           rmd160  2051438db5a98dc7067cb2eb694e57515b483968 \
+                    sha256  18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517 \
+                    size    134120
 
 if {${name} ne ${subport}} {
 
     depends_lib-append  port:py${python.version}-charset-normalizer \
                         port:py${python.version}-idna \
-                        port:py${python.version}-urllib3 \
+                        path:${python.pkgd}/urllib3/__init__.py:py${python.version}-urllib3 \
                         port:py${python.version}-certifi
 
     if {${python.version} < 37} {


### PR DESCRIPTION
switch urllib3 to path dependency, allowing the use of urllib3-future

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
