### PR TITLE
Adding a patchfile for mkvtoolnix and mkvtoolnix-dev to display icons

### DIFF
--- a/multimedia/mkvtoolnix-devel/Portfile
+++ b/multimedia/mkvtoolnix-devel/Portfile
@@ -15,7 +15,7 @@ name                mkvtoolnix-devel
 conflicts           mkvtoolnix mkvtoolnix-legacy
 set my_name         mkvtoolnix
 
-version             98.0
+version             98.0.1
 revision            0
 categories          multimedia
 maintainers         {ryandesign @ryandesign} {mascguy @mascguy} {i0ntempest @i0ntempest} openmaintainer

--- a/multimedia/mkvtoolnix-devel/Portfile
+++ b/multimedia/mkvtoolnix-devel/Portfile
@@ -15,7 +15,7 @@ name                mkvtoolnix-devel
 conflicts           mkvtoolnix mkvtoolnix-legacy
 set my_name         mkvtoolnix
 
-version             98.0
+version             98.0.1
 revision            0
 categories          multimedia
 maintainers         {ryandesign @ryandesign} {mascguy @mascguy} {i0ntempest @i0ntempest} openmaintainer
@@ -33,6 +33,8 @@ use_xz              yes
 checksums           rmd160  9ff63087e2ff5f9946f2d37b551d4b012407ccd8 \
                     sha256  1600f4a768ede6356e70785393f02f34dd54fbb5f661ffe6e7e8bc0f40229b79 \
                     size    11774440
+
+patchfiles-append   patch-icons-in-menus.diff
 
 distname            ${my_name}-${version}
 dist_subdir         ${my_name}

--- a/multimedia/mkvtoolnix-devel/Portfile
+++ b/multimedia/mkvtoolnix-devel/Portfile
@@ -34,6 +34,8 @@ checksums           rmd160  9ff63087e2ff5f9946f2d37b551d4b012407ccd8 \
                     sha256  1600f4a768ede6356e70785393f02f34dd54fbb5f661ffe6e7e8bc0f40229b79 \
                     size    11774440
 
+patchfiles-append   patch-icons-in-menus.diff
+
 distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 

--- a/multimedia/mkvtoolnix-devel/files/patch-icons-in-menus.diff
+++ b/multimedia/mkvtoolnix-devel/files/patch-icons-in-menus.diff
@@ -1,0 +1,12 @@
+--- src/mkvtoolnix-gui/mkvtoolnix_gui.cpp
++++ src/mkvtoolnix-gui/mkvtoolnix_gui.cpp
+@@ -43,6 +43,11 @@ initiateSettings() {
+   QCoreApplication::setOrganizationName("bunkus.org");
+   QCoreApplication::setOrganizationDomain("bunkus.org");
+   QCoreApplication::setApplicationName("mkvtoolnix-gui");
++
++#if defined(SYS_APPLE)
++  // Qt 6.7.3+ defaults AA_DontShowIconsInMenus to true on macOS; restore prior behavior.
++  QApplication::setAttribute(Qt::AA_DontShowIconsInMenus, false);
++#endif
+ }

--- a/multimedia/mkvtoolnix/Portfile
+++ b/multimedia/mkvtoolnix/Portfile
@@ -15,7 +15,7 @@ name                mkvtoolnix
 conflicts           mkvtoolnix-devel mkvtoolnix-legacy
 set my_name         mkvtoolnix
 
-version             98.0
+version             98.0.1
 revision            0
 categories          multimedia
 maintainers         {ryandesign @ryandesign} {i0ntempest @i0ntempest} openmaintainer

--- a/multimedia/mkvtoolnix/Portfile
+++ b/multimedia/mkvtoolnix/Portfile
@@ -34,6 +34,8 @@ checksums           rmd160  9ff63087e2ff5f9946f2d37b551d4b012407ccd8 \
                     sha256  1600f4a768ede6356e70785393f02f34dd54fbb5f661ffe6e7e8bc0f40229b79 \
                     size    11774440
 
+patchfiles-append   patch-icons-in-menus.diff
+
 distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 

--- a/multimedia/mkvtoolnix/Portfile
+++ b/multimedia/mkvtoolnix/Portfile
@@ -15,7 +15,7 @@ name                mkvtoolnix
 conflicts           mkvtoolnix-devel mkvtoolnix-legacy
 set my_name         mkvtoolnix
 
-version             98.0
+version             98.0.1
 revision            0
 categories          multimedia
 maintainers         {ryandesign @ryandesign} {i0ntempest @i0ntempest} openmaintainer
@@ -33,6 +33,8 @@ use_xz              yes
 checksums           rmd160  9ff63087e2ff5f9946f2d37b551d4b012407ccd8 \
                     sha256  1600f4a768ede6356e70785393f02f34dd54fbb5f661ffe6e7e8bc0f40229b79 \
                     size    11774440
+
+patchfiles-append   patch-icons-in-menus.diff
 
 distname            ${my_name}-${version}
 dist_subdir         ${my_name}

--- a/multimedia/mkvtoolnix/files/patch-icons-in-menus.diff
+++ b/multimedia/mkvtoolnix/files/patch-icons-in-menus.diff
@@ -1,0 +1,12 @@
+--- src/mkvtoolnix-gui/mkvtoolnix_gui.cpp
++++ src/mkvtoolnix-gui/mkvtoolnix_gui.cpp
+@@ -43,6 +43,11 @@ initiateSettings() {
+   QCoreApplication::setOrganizationName("bunkus.org");
+   QCoreApplication::setOrganizationDomain("bunkus.org");
+   QCoreApplication::setApplicationName("mkvtoolnix-gui");
++
++#if defined(SYS_APPLE)
++  // Qt 6.7.3+ defaults AA_DontShowIconsInMenus to true on macOS; restore prior behavior.
++  QApplication::setAttribute(Qt::AA_DontShowIconsInMenus, false);
++#endif
+ }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Adding a patchfile to fix icons not displaying in menus/buttons

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Command Line Tools 26.4.1.0.1775747724

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
