### PR TITLE
ImageMagick, perlmagick: Update to 6.9.13-46

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -82,6 +82,8 @@ depends_lib-append          path:bin/pkg-config:pkgconfig
 
 depends_run                 port:urw-fonts
 
+compiler.c_standard         2011
+
 configure.ccache            no
 
 configure.args              --enable-shared \

--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -13,12 +13,12 @@ legacysupport.newest_darwin_requires_legacy 10
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.13-43
+version                     6.9.13-46
 revision                    0
 
-checksums                   rmd160  dab775ff5a70bc9cc0bbe9d58fc5654606203c25 \
-                            sha256  6fcd60539e788a9d51c5a5e59be51e6090cdbcf443b968560d632b4e2c42075c \
-                            size    9641712
+checksums                   rmd160  1361bb5a5d5b115a1963ba7bad5e771e648dfcad \
+                            sha256  012216e6e20985185922ced98e8e971cc91319e15df154255a49a716b06742d2 \
+                            size    9634252
 
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}


### PR DESCRIPTION
#### Description

ImageMagick, perlmagick: Update 6.9.13-43 --> 6.9.13-46.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?