### PR TITLE
llmfit: update to 0.9.14

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.13 v
+github.setup            AlexsJones llmfit 0.9.14 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  17a82d70e34593ecb82e3185f5e9d2e568f5f28d \
-                        sha256  1382aa7734cefffd0e357fc40aca3a6c3558dc80476a19061e2b484ed430c0d0 \
-                        size    6934083
+                        rmd160  6e5cb2ae6dbfb109fd85a37a72fc630936d6be1a \
+                        sha256  8b411b158a62794297b72205ef0bcca5158218cf2d89cbda46ec45e9a5215832 \
+                        size    6942812
 
 categories              llm
 platforms               macosx


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.4 24G517 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
