### PR TITLE
fastfetch: update to 2.62.1

### DIFF
--- a/sysutils/fastfetch/Portfile
+++ b/sysutils/fastfetch/Portfile
@@ -5,7 +5,7 @@ PortGroup           github  1.0
 PortGroup           cmake   1.1
 PortGroup           legacysupport 1.1
 
-github.setup        fastfetch-cli fastfetch 2.61.0
+github.setup        fastfetch-cli fastfetch 2.62.1
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  957dbd4ce743b8f093cea688839a05d9fdb37095 \
-                    sha256  b05b95bcc0915431cf732382813261497fa4412c3967904c1a9f207d5c946c65 \
-                    size    1452448
+checksums           rmd160  22233bfdd6b6c8c9ef8e68301c8343bd88c7dbe2 \
+                    sha256  8c4833e55b8b445a32c7cb7570007b5e10a9ee4cee74a494004ba61e88b12b26 \
+                    size    1463802
 
 set py_branch       3.14
 set py_version      [string map {. ""} ${py_branch}]


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.4 24G517 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
