### PR TITLE
claude-code: update to 2.1.118

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.117
+version             2.1.118
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  6fc5025353e0ec58c24a1356c42b7a2d37bfd31b \
-                 sha256  c6614176252bc789000ad7b8a19b22957a4e9d40878773e98dafde6bbda63e86 \
-                 size    208077984
+    checksums    rmd160  83d955ccf58f8fb5ec82efa57fe7c16e80f2d8f2 \
+                 sha256  2cd554070f0588de05e9efd88c1f073770cb620ed3e5f45ba7df833fc3414c1b \
+                 size    209238608
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  24153cc4eec6a34f28cc1f77c88d8e4a798f4ae9 \
-                 sha256  12cf77a447d129d3fb691023ee3ced3e43efbde72ab910c6162db2c7be5ca374 \
-                 size    206534320
+    checksums    rmd160  37f94e7062113ca3eee994de7463d6f4075286e4 \
+                 sha256  54e5d3f65109b89c6046f47440944d52906c662d1e51748f620a430d26ad3665 \
+                 size    207690848
 } else {
     set arch_classifier unsupported_arch
     distfiles
@@ -73,7 +73,7 @@ destroot {
     # Create launch script
     set launch_script [open ${destroot}${prefix}/bin/claude w 0755]
     puts $launch_script "#!/bin/sh"
-    puts $launch_script "DISABLE_AUTOUPDATER=1 DISABLE_TELEMETRY=1 ${binary} $@"
+    puts $launch_script "DISABLE_UPDATES=1 DISABLE_TELEMETRY=1 ${binary} $@"
     close $launch_script
 }
 


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.118.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?