### PR TITLE
openjdk8-corretto: update to 8.492.09.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.482.08.1
+version      ${feature}.492.09.1
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  09caa685a1a6bcbe1fd0b00aee93cb4ccb17c346 \
-                 sha256  402d3ad8e98154f89ae24fd5253321380d319a0d2b50db8a552319324163f0a9 \
-                 size    118426590
+    checksums    rmd160  bd7bd132ececd391597ec84105519a4978c951cb \
+                 sha256  ad2f6d4349af461c44e98d5b0528ad1bbe1e798a87347dde4205f64f667eeb5e \
+                 size    118424918
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  cb6ce36180ddb7d8979a8a7d82de0c9408906e6d \
-                 sha256  6ecdf0cc410196ec8efa3bdc3932effb6dff5735d19d1d1f20655ce0703fef79 \
-                 size    103021776
+    checksums    rmd160  cc939bb66a70e6f74e5d0522182f98f7dcd0ff5e \
+                 sha256  aa265e63071ab2a50bb9c1ef6df3d452b5e2d4c6aa81eae859917c7540459c70 \
+                 size    102888492
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.492.09.1.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?