### PR TITLE
klog: new port (v7.1)

### DIFF
--- a/office/klog/Portfile
+++ b/office/klog/Portfile
@@ -1,0 +1,99 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+revision            0
+
+go.setup            github.com/jotaen/klog 7.1 v
+categories          office
+license             MIT
+maintainers         {@mcookly fclr.net:mcookly} openmaintainer
+
+homepage            https://klog.jotaen.net
+description         A command-line tool for time tracking
+long_description    ${name} is a command-line tool for time tracking in a \
+                    human-readable, plain-text file format. It allows you to \
+                    display and search records in files, pretty print and \
+                    evaluate them, and apply some basic manipulations.
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  583e1cc1db229ed83e232bbdecfefbcf9ec136ee \
+                        sha256  3cd6eee1adc16c2105713718e23b67d9607ac9872a0dbc31689c6051d0176ea6 \
+                        size    150413
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
+                    github.com/stretchr/testify \
+                        lock    v1.11.1 \
+                        rmd160  d6dec631a506398b8b731a0476b9e44c206243ac \
+                        sha256  759279b90772bfc79db1620874f45eb008aceab35b14f007cb4ab8316a2398db \
+                        size    116867 \
+                    github.com/riywo/loginshell \
+                        lock    7d26008be1ab \
+                        rmd160  28f5a7f32af3da08b7a365d249fdd0c46122ec00 \
+                        sha256  8b92269dfd168dfc3c24d3cf5e481175eec1fc95c7e08c4f3bd0c715bcbb51d9 \
+                        size    2072 \
+                    github.com/posener/complete \
+                        lock    v1.2.3 \
+                        rmd160  6144bcf9c89075d599423bfc1ed78af017176ec3 \
+                        sha256  10d434d0dd64f516a11e795fe35de984c76ad410f8988e6f4fab2012d1213d59 \
+                        size    22736 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/kballard/go-shellquote \
+                        lock    95032a82bc51 \
+                        rmd160  40415cd59ece9fb38b22170feec07f1f48d518a2 \
+                        sha256  41aa42696f96fb2783c5135d71ff1ec5938dfe178b51eb703e509c8ac0e7db4e \
+                        size    4335 \
+                    github.com/jotaen/kong-completion \
+                        lock    v0.0.12 \
+                        rmd160  b403c95b9aefd0535bcbb8d9bf6cf5bfff7e4336 \
+                        sha256  35ec74cceac6bbdf1cc600f192de6122733eede00544b85e754c1214ea39d295 \
+                        size    13041 \
+                    github.com/jotaen/genie \
+                        lock    v0.0.3 \
+                        rmd160  16c804ee2e73b0a23d6b3732777dc876aa3e6232 \
+                        sha256  f78bb324b84ef69fa1aeb39dabcdbc2fed38715da1dba8061076201cc49adddc \
+                        size    5219 \
+                    github.com/hashicorp/go-multierror \
+                        lock    v1.1.1 \
+                        rmd160  94493cc3074dc39be0de76f04fa2a44a405d0a42 \
+                        sha256  52e986cca6d6335bfcd23b4867f884311cfb5ca060325496b6692029797d64e2 \
+                        size    13805 \
+                    github.com/hashicorp/errwrap \
+                        lock    v1.1.0 \
+                        rmd160  25e655fc958685dd949900eea8c3d97f33d85eab \
+                        sha256  f3e47c96ca16c7360f7d3fd3a57d8861be5835a5d5a9d9d1dc2ec10ae4a1208d \
+                        size    8586 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/alecthomas/kong \
+                        lock    v1.14.0 \
+                        rmd160  931a15b5f00506349f8db235ac9c3ebf928c7489 \
+                        sha256  e817133b9479aeb71c47886ac05f966a32b4d7c5a47b42efa496e0c83725104c \
+                        size    325797 \
+                    cloud.google.com/go \
+                        repo    github.com/googleapis/google-cloud-go \
+                        lock    v0.123.0 \
+                        rmd160  866913b30fdec764d744d4d96bfd4dee579c64eb \
+                        sha256  b06366f599c951134ab7647b1176d22942cbe1cffd425b44a10281bdaa9dc7c6 \
+                        size    38707581
+
+# Imitating `run::build()` from run.sh...
+build.args          -ldflags '-s -w -X main.BinaryVersion=v${version} -X main.BinaryBuildHash=macport' \
+                        -o ./out/klog \
+                        klog.go
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/out/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

This is a new port. I know Kubernetes also has a tool called `klog`, so maybe it's better to disambiguate by calling this port `klog-time-tracker` or something like that.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.6 24G711 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
