### PR TITLE
openjdk25: update to 25.0.3

### DIFF
--- a/java/openjdk25/Portfile
+++ b/java/openjdk25/Portfile
@@ -11,8 +11,8 @@ name                openjdk${feature}
 set boot_feature 24
 
 # See https://github.com/openjdk/jdk25u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set openjdk_version ${feature}.0.2
-set build 10
+set openjdk_version ${feature}.0.3
+set build 9
 revision            0
 
 github.setup        openjdk jdk${feature}u jdk-${openjdk_version}+${build}
@@ -29,9 +29,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  feaad165b9e59d8ee74b3270a7a2790cb491fc23 \
-                    sha256  9b3164cedf78d7a76a59499d7a6833145c7e0269ec7b664bfe5ee03ced2f449e \
-                    size    119407935
+checksums           rmd160  4ac991bfdd9b43e78e559b89481b56cf9a5137de \
+                    sha256  33991482d2e08eaa865212239db7815ad627f2449a836e4a4362301fc1893e12 \
+                    size    119520713
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 25.0.3.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
