### PR TITLE
gimp2: Use C99

### DIFF
--- a/graphics/gimp2-devel/Portfile
+++ b/graphics/gimp2-devel/Portfile
@@ -95,6 +95,11 @@ depends_run-append \
 compiler.cxx_standard 2014
 compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 700}
 
+# cannot compile under C23 because it uses "bool" as a variable name
+# https://gitlab.gnome.org/GNOME/gimp/-/issues/12843
+compiler.c_standard 1999
+configure.cflags-append -std=gnu99
+
 configure.cflags-append \
                     -Wno-deprecated-declarations
 

--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -95,6 +95,11 @@ depends_run-append \
 compiler.cxx_standard 2014
 compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 700}
 
+# cannot compile under C23 because it uses "bool" as a variable name
+# https://gitlab.gnome.org/GNOME/gimp/-/issues/12843
+compiler.c_standard 1999
+configure.cflags-append -std=gnu99
+
 configure.cflags-append \
                     -Wno-deprecated-declarations
 


### PR DESCRIPTION
#### Description

Fixes build by not trying to compile under C23, avoiding the following errors:

```
:info:build gimpconfig-serialize.c:370:16: error: cannot combine with previous 'type-name' declaration specifier
:info:build   370 |       gboolean bool;
:info:build       |                ^
:info:build gimpconfig-serialize.c:370:7: warning: declaration does not declare anything [-Wmissing-declarations]
:info:build   370 |       gboolean bool;
:info:build       |       ^~~~~~~~~~~~~
:info:build gimpconfig-serialize.c:372:12: error: expected identifier or '('
:info:build   372 |       bool = g_value_get_boolean (value);
:info:build       |            ^
:info:build gimpconfig-serialize.c:373:29: error: expected expression
:info:build   373 |       g_string_append (str, bool ? "yes" : "no");
:info:build       |                             ^
:info:build gimpconfig-serialize.c:373:34: error: expected ')'
:info:build   373 |       g_string_append (str, bool ? "yes" : "no");
:info:build       |                                  ^
:info:build gimpconfig-serialize.c:373:7: note: to match this '('
:info:build   373 |       g_string_append (str, bool ? "yes" : "no");
:info:build       |       ^
:info:build /opt/local/include/glib-2.0/glib/gstring.h:267:34: note: expanded from macro 'g_string_append'
:info:build   267 |       const char * const __val = (val);             \
:info:build       |                                  ^
:info:build gimpconfig-serialize.c:373:7: error: expected expression
:info:build   373 |       g_string_append (str, bool ? "yes" : "no");
:info:build       |       ^
:info:build /opt/local/include/glib-2.0/glib/gstring.h:267:39: note: expanded from macro 'g_string_append'
:info:build   267 |       const char * const __val = (val);             \
:info:build       |                                       ^
:info:build gimpconfig-serialize.c:373:29: error: expected expression
:info:build   373 |       g_string_append (str, bool ? "yes" : "no");
:info:build       |                             ^
:info:build 1 warning and 6 errors generated.
```

This change was made in imitation of 5ecabcf4bd01a296cef08138c4fbe58cfa668288 and tested locally.

###### Type(s)
- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.4 24G517 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?

  Using `-t` causes the `tar` command to fail. This seems unrelated.

- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
