### PR TITLE
openjdk21: update to 21.0.11

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -8,8 +8,8 @@ set feature 21
 name                openjdk${feature}
 
 # See https://github.com/openjdk/jdk21u/tags for the latest '*-ga' tag and its corresponding build number
-set openjdk_version ${feature}.0.10
-set build 7
+set openjdk_version ${feature}.0.11
+set build 10
 github.setup        openjdk jdk${feature}u jdk-${openjdk_version}+${build}
 github.tarball_from archive
 version             ${openjdk_version}
@@ -29,9 +29,9 @@ long_description    JDK ${feature} builds of OpenJDK, the Open-Source implementa
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  5b83d8468d56fa62a8c92a1ce0ed7663222abd45 \
-                    sha256  6500906cb7cc49268ce4ca368db3ddf3541b40afd25eecb378e13d5a72f43214 \
-                    size    113960811
+checksums           rmd160  9ce2dc7b847efd823831229dbafa141baf7b1242 \
+                    sha256  18edf62aa95c99325725475c0ad5621d8de61f4c84fdb8d2b7efd015a6de8e42 \
+                    size    114063214
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.11.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?