### PR TITLE
openjdk26: update to 26.0.1

### DIFF
--- a/java/openjdk26/Portfile
+++ b/java/openjdk26/Portfile
@@ -11,9 +11,9 @@ name                openjdk${feature}
 set boot_feature 25
 
 # See https://github.com/openjdk/jdk26u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set build 35
-github.setup        openjdk jdk${feature}u ${feature} jdk- +${build}
-revision            1
+set build 8
+github.setup        openjdk jdk${feature}u ${feature}.0.1 jdk- +${build}
+revision            0
 github.tarball_from archive
 
 categories          java devel
@@ -26,9 +26,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  3a2f1f1ae6809901b04b64f54f76b2e38e75a1fd \
-                    sha256  958ce142d3aaa26e170dfbf087321219e8bfac60bc41a6a91d7c68455a765d73 \
-                    size    121608107
+checksums           rmd160  72c45f7bebdf84a13cc5edde9207d55038fe2d5a \
+                    sha256  f5d5496a2f9a81605681209d93fc99726313e5d9a9a2af059f1adaa3914b862d \
+                    size    121612462
 
 set bootjdk_port    openjdk${boot_feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 26.0.1.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?