### PR TITLE
openjdk17: update to 17.0.19

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -7,8 +7,8 @@ set feature 17
 name                openjdk${feature}
 
 # See https://github.com/openjdk/jdk17u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set openjdk_version ${feature}.0.18
-set build 8
+set openjdk_version ${feature}.0.19
+set build 10
 revision            0
 
 github.setup        openjdk jdk${feature}u jdk-${openjdk_version}+${build}
@@ -26,9 +26,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  4d3e9d5e076bafb7e98ca0aa548928108066a9e1 \
-                    sha256  7ebfcc2aafd514c23df3fe5280e1a34630b9b1d429c65a80dd5a4b6e7f177bc3 \
-                    size    108122935
+checksums           rmd160  a7dd196e2432a5921f7a285957f8f078f4fca333 \
+                    sha256  87dfd1c72a3c9edec212176fd051dec2249bc42202b539b1cb308f0cc7565b74 \
+                    size    108206305
 
 set port_jdk_build  openjdk${feature}-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.19.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?