### PR TITLE
openjdk11: update to 11.0.31

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -7,8 +7,8 @@ set feature 11
 name                openjdk${feature}
 
 # See https://github.com/openjdk/jdk11u/tags for the version and build number that matches the latest tag that ends with '-ga'
-set openjdk_version ${feature}.0.30
-set build 7
+set openjdk_version ${feature}.0.31
+set build 11
 revision            0
 
 github.setup        openjdk jdk${feature}u ${openjdk_version}+${build} jdk-
@@ -25,9 +25,9 @@ long_description    {*}${description} \
     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/${feature}/
 
-checksums           rmd160  45e9f657d3d7760c234f1a0fb64b3cd628f273a6 \
-                    sha256  cb3997de994369b7f6e323901c69c51131042c565c70e51eff154f316a651ec2 \
-                    size    116661372
+checksums           rmd160  47c8d67e7445a9f6ceae2f6a764f98a2ae610924 \
+                    sha256  d409a47d58b5ab9deb344b185d48395b4cce8ab84ec4229aa4589b4f65ff59b4 \
+                    size    116728518
 
 depends_lib         port:freetype \
                     port:libiconv


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.31.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?