### PR TITLE
claude-code: update to 2.1.119

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.118
+version             2.1.119
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  83d955ccf58f8fb5ec82efa57fe7c16e80f2d8f2 \
-                 sha256  2cd554070f0588de05e9efd88c1f073770cb620ed3e5f45ba7df833fc3414c1b \
-                 size    209238608
+    checksums    rmd160  b79f920a2b69bffdaefa4838fec3e39e5a39259e \
+                 sha256  52b3b75cfe80c626982b2ffb3a6ce1c797824f257dc275cf0a3c32c202b6a3df \
+                 size    214951760
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  37f94e7062113ca3eee994de7463d6f4075286e4 \
-                 sha256  54e5d3f65109b89c6046f47440944d52906c662d1e51748f620a430d26ad3665 \
-                 size    207690848
+    checksums    rmd160  e4ff2d85b29d3097890ae77d5459f1a889738cb2 \
+                 sha256  31db3444309d5d0f8b85e8782e2dcd86f31f7e48c1a1e83d69b09268c7b4f9a2 \
+                 size    213404000
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.119.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?