### PR TITLE
editorconfig-core-c: Update to 0.12.11

### DIFF
--- a/devel/editorconfig-core-c/Portfile
+++ b/devel/editorconfig-core-c/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cmake  1.1
 PortGroup               github 1.0
 
-github.setup            editorconfig editorconfig-core-c 0.12.10 v
+github.setup            editorconfig editorconfig-core-c 0.12.11 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -16,14 +16,12 @@ long_description        This code produces a program that accepts a filename as 
                         look for .editorconfig files with sections applicable to the given file, \
                         outputting any properties found.
 
-checksums               rmd160  925a0fb2f66d4887c085bf32360dc8c3c006e3f1 \
-                        sha256  ab9f897a90fb36cfc34e5b67221e55ab0e3119b3512de8e31029d376c6bab870 \
-                        size    77716
+checksums               rmd160  18823c23536cbaacb2234c81306fe370a8d4a377 \
+                        sha256  9d8b420b56a969ea3cf784861c72d26fa0e158fa1494d732df2c8a1480d36a5c \
+                        size    77800
 
 depends_build-append    path:bin/doxygen:doxygen
 depends_lib-append      port:pcre2
-
-use_parallel_build      no
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update editorconfig-core-c to 0.12.11

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
