### PR TITLE
gallery-dl: update to 1.32.0

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,18 +4,16 @@ PortSystem          1.0
 PortGroup           codeberg 1.0
 PortGroup           python 1.0
 
-codeberg.setup      mikf gallery-dl 1.31.10 v
+codeberg.setup      mikf gallery-dl 1.32.0 v
 
 categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
-# remove at next update
-dist_subdir         ${name}/${version}_1
 
 
-checksums           rmd160  6e1167f3ed27ffd7db0ac431a17b84691d112579 \
-                    sha256  969499d6dcea82591b1ef715e8bdccabfdc51c72ac3a940da1e19fa3358e59e9 \
-                    size    1110832
+checksums           rmd160  5f5d2f2adddd476e84981ada6e80aee00689ee7d \
+                    sha256  caa5bd59d32eb91547f151336f230bd6d070edd1ea56dd461969ae08f0b6e9e8 \
+                    size    1188314
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites


### PR DESCRIPTION
#### Description

gallery-dl: update to 1.32.0

I should've known this would happen the day after I update for the switch to codeberg.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
