### PR TITLE
workflows/bootstrap.sh: Add diagnostics for Metal Toolchain

### DIFF
--- a/.github/workflows/bootstrap.sh
+++ b/.github/workflows/bootstrap.sh
@@ -32,6 +32,12 @@ esac
 
 MACPORTS_FILENAME=MacPorts-${MACPORTS_VERSION}-${OS_MAJOR}.tar.bz2
 
+
+begingroup "Metal Toolchain status:"
+xcrun metal -v
+endgroup
+
+
 begingroup "Fetching files"
 # Download resources in background ASAP but use later.
 # Use /usr/bin/curl so that we don't use Homebrew curl.

--- a/.github/workflows/bootstrap.sh
+++ b/.github/workflows/bootstrap.sh
@@ -52,7 +52,7 @@ esac
 MACPORTS_FILENAME=MacPorts-${MACPORTS_VERSION}-${macosvers}-${macosname}.pkg
 
 
-begingroup "Metal Toolchain status:"
+begingroup "Metal Toolchain status on bootstrap entry:"
 xcrun metal -v
 endgroup
 
@@ -170,3 +170,8 @@ git -C ports/ checkout -qf -
 (cd ports/ && portindex -e)
 endgroup
 fi
+
+
+begingroup "Metal Toolchain status on bootstrap exit:"
+xcrun metal -v
+endgroup


### PR DESCRIPTION
#### Description

Show Metal Toolchain status at start and end of CI bootstrap stage.
Needed because Metal Toolchain was removed from Xcode 26, and is now provided by Github runner for CI.

###### Type(s)

- [x] enhancement

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?\
- [x] tested basic functionality of ~all binary files~ CI process?