### PR TITLE
cmake: Update to 3.31.12

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -35,12 +35,12 @@ set base_long_description \
 homepage            https://cmake.org
 platforms           darwin freebsd
 
-github.setup        Kitware CMake 3.31.11 v
+github.setup        Kitware CMake 3.31.12 v
 github.tarball_from releases
 distname            ${my_name}-${version}
-checksums           rmd160  6a72426e7801f28cef72beff701c1db22f184d64 \
-                    sha256  c0a3b3f2912b2166f522d5010ffb6029d8454ee635f5ad7a3247e0be7f9a15c9 \
-                    size    11715545
+checksums           rmd160  b08518899f2fd701a28e4428ed73b37bd5b968b0 \
+                    sha256  5f3fd5a54dfa65602bdbed64f981a72673cc19f2d304cc2955cf0dfa0cfd8272 \
+                    size    11715065
 revision            0
 
 dist_subdir         ${my_name}

--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -23,7 +23,7 @@ set my_name         cmake
 categories          devel
 license             BSD
 installs_libs       no
-maintainers         {michaelld @michaelld} {mascguy @mascguy}
+maintainers         {mascguy @mascguy}
 
 description         Cross-platform make
 set base_long_description \


### PR DESCRIPTION
##### Description

* Update cmake 3.31.11 --> 3.31.12.
* Drop one maintainer on request.
* Ref: https://trac.macports.org/ticket/73660

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?