### PR TITLE
ecCodes: update to 2.47.0

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 16
 legacysupport.use_mp_libcxx yes
 
 name                ecCodes
-version             2.46.0
+version             2.47.0
 revision            0
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
@@ -24,9 +24,9 @@ homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
 
-checksums           rmd160  09dbce16c5172d8f2e26df1884a2a125d61c865f \
-                    sha256  7d959253d5e34aeb16caa14d4889ac06486d19821216743142733a32ee7b4935 \
-                    size    12673280
+checksums           rmd160  1586c655fad79f6fa60f491cde5d8903d08c53a0 \
+                    sha256  82da819aa9b51831dc14b3bf2918bfee50b1cd53a05088d0c3f4493758aae094 \
+                    size    12664464
 
 patchfiles          patch-pkg-config.diff
 


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.47.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.5 24G624 x86_64
Command Line Tools 26.3.0.0.1.1771626560


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
