### PR TITLE
OCRmyPDF: add missing dependencies for versions >= 17

### DIFF
--- a/python/py-fpdf2/Portfile
+++ b/python/py-fpdf2/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-fpdf2
+version             2.8.7
+revision            0
+categories          python graphics
+license             LGPL-3
+maintainers         {@akierig fastmail.de:akierig} openmaintainer
+description         fpdf2 is a library for simple & fast PDF document generation in Python.
+long_description    {*}${description} It is a fork and the successor of PyFPDF.
+homepage            https://py-pdf.github.io/fpdf2/
+
+supported_archs     noarch
+platforms           {darwin any}
+
+checksums           rmd160  524e83ed1b02fd99162832a30f80937d36e20290 \
+                    sha256  7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9 \
+                    size    362351
+
+python.versions     310 311 312 313 314
+
+if {${name} ne ${subport}} {
+    depends_lib-append  port:py${python.version}-defusedxml \
+                        port:py${python.version}-fonttools \
+                        port:py${python.version}-Pillow
+    depends_build-append port:py${python.version}-wheel
+}

--- a/python/py-uharfbuzz/Portfile
+++ b/python/py-uharfbuzz/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-uharfbuzz
+version             0.53.7
+revision            0
+categories          python graphics
+license             Apache-2
+maintainers         {@akierig fastmail.de:akierig} openmaintainer
+description         Streamlined Cython bindings for the HarfBuzz shaping engine.
+long_description    {*}${description}
+homepage            https://github.com/trufont/uharfbuzz
+
+checksums           rmd160  50b76ec7270d4540637bb2090f1dd0a4b61a18dc \
+                    sha256  c13cfe32accd4dc5b7e5d1c3c7bd5f04ba77be186ffd249ab1ba82a0b25b70bc \
+                    size    1869099
+
+python.versions     310 311 312 313 314
+
+if {${name} ne ${subport}} {
+    depends_lib-append  port:harfbuzz
+    depends_build-append port:py${python.version}-cython \
+                     port:py${python.version}-pkgconfig \
+                     port:py${python.version}-setuptools_scm \
+                     port:py${python.version}-wheel \
+                     path:bin/pkg-config:pkgconfig
+}

--- a/textproc/ocrmypdf/Portfile
+++ b/textproc/ocrmypdf/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                ocrmypdf
 version             17.4.2
-revision            0
+revision            1
 categories          textproc
 
 homepage            https://github.com/ocrmypdf/OCRmyPDF
@@ -37,8 +37,8 @@ foreach pyver $pyvers {
     }
 }
 if {![info exists any_py_variant_set]} {
-    default_variants +python313
-    python.default_version 313
+    default_variants +python314
+    python.default_version 314
 }
 
 python.pep517_backend   hatch
@@ -50,15 +50,19 @@ depends_lib-append  port:img2pdf \
                     port:libpng \
                     port:qpdf \
                     port:py${python.version}-deprecation \
+                    port:py${python.version}-fpdf2 \
                     port:py${python.version}-freetype \
+                    port:py${python.version}-img2pdf \
                     port:py${python.version}-packaging \
+                    port:py${python.version}-pluggy \
+                    port:py${python.version}-pikepdf \
+                    port:py${python.version}-pybind11 \
                     port:py${python.version}-pdfminer \
                     port:py${python.version}-Pillow \
-                    port:py${python.version}-pikepdf \
-                    port:py${python.version}-pluggy \
-                    port:py${python.version}-pybind11 \
+                    port:py${python.version}-pydantic \
                     port:py${python.version}-pyheif \
-                    port:py${python.version}-rich
+                    port:py${python.version}-rich \
+                    port:py${python.version}-uharfbuzz
 
 depends_run-append  port:ghostscript \
                     port:jbig2enc \


### PR DESCRIPTION
#### Description

A recent update to OCRmyPDF (https://github.com/macports/macports-ports/commit/7b51bab7e643b2fde6baa64d08e195ca921660d4) by a different contributor did not include the changed dependencies, including new ports that needed to be added to Macports. I was only made aware of the update because I noticed it when updating my own port tree, it was not made through the normal PR process, I did not receive a notification. The resulting OCRmyPDF port was broken. It built and installed but did not actually function correctly.

This PR adds two ports (`fpdf2` and `uharfbuzz`) to MacPorts, fixes their omission in the OCRmyPDF portfile, and changes the default OCRmyPDF Python to 3.14.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
