### PR TITLE
mat2: update to 0.14.0

### DIFF
--- a/multimedia/mat2/Portfile
+++ b/multimedia/mat2/Portfile
@@ -2,9 +2,12 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           github 1.0 
+
+github.setup        jvoisin mat2 0.14.0                    
+github.tarball_from archive
 
 name                mat2
-version             0.13.5
 revision            0
 categories-prepend  multimedia
 license             LGPL-3
@@ -16,13 +19,13 @@ maintainers         {@akierig fastmail.de:akierig} \
 description         metadata removal tool
 long_description    mat2 is a metadata removal tool, supporting a wide range \
                     of commonly used file formats, written in python3.
-homepage            https://0xacab.org/jvoisin/mat2
+homepage            https://github.com/jvoisin/mat2
 
-checksums           rmd160  f46d1fb8933eb07ee66cff173560cceabc692678 \
-                    sha256  d7e7c4f0f0cfcf8bd656f97919281d0c6207886d84bdfdbb192c152ebf91fe19 \
-                    size    52277
+checksums           rmd160  1093685b62e90489fb1113f1cfe89fee620a8423 \
+                    sha256  bf15251cb249a6028fd8532d31388b296dffc28c90782fcc0e7ba6f56354f4c5 \
+                    size    11544055
 
-python.default_version 313
+python.default_version 314
 
 depends_lib-append  port:py${python.version}-cairo \
                     port:py${python.version}-mutagen \
@@ -31,7 +34,7 @@ depends_lib-append  port:py${python.version}-cairo \
                     path:lib/pkgconfig/librsvg-2.0.pc:librsvg
 
 depends_run-append  port:exiftool \
-                    path:lib/libavcodec.dylib:ffmpeg
+                    path:lib/libavcodec.dylib:ffmpeg8
 
 post-destroot {
     ln -s ${python.prefix}/man/man1/mat2.1 ${destroot}${prefix}/share/man/man1/mat2.1


### PR DESCRIPTION
#### Description

mat2: update to 0.14.0, updates to use github. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
