### PR TITLE
openjdk21-sap: update to 21.0.11

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -20,7 +20,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/21
-version      ${feature}.0.10
+version      ${feature}.0.11
 revision     0
 
 description  SAP Machine ${feature}
@@ -30,14 +30,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  4e1fcb6280a544352d374b0c7324a94f28b7a124 \
-                 sha256  edf2b2496f83fbad6022300cfda0955b78ab1e023d7e72edee8b966359d5fe8e \
-                 size    203880645
+    checksums    rmd160  543088f706335b158aab9c8115c90958cab49928 \
+                 sha256  dbbffaa9ccacee3589315deee46e0a9db0be0ee204e1830414fa3ba2fa9073ee \
+                 size    204031098
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  14b734d6138f5ec3caa05e60cfb5400425c04564 \
-                 sha256  132139dfe2ff09160b9a2a0154d68fb5d6d2a6fc7e626de02175cd57b66fc086 \
-                 size    201589336
+    checksums    rmd160  3ea65af22bd6cf04b4cc0352a58f30deb5ef865f \
+                 sha256  a2e8c57e87dd09b75efe5e7573b16f894f84f20319b67f1f1bb80562c84926c2 \
+                 size    201725449
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to SapMachine 21.0.11.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?