### PR TITLE
claude-code: update to 2.1.120

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.119
+version             2.1.120
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  b79f920a2b69bffdaefa4838fec3e39e5a39259e \
-                 sha256  52b3b75cfe80c626982b2ffb3a6ce1c797824f257dc275cf0a3c32c202b6a3df \
-                 size    214951760
+    checksums    rmd160  b88a89a6bd75587046d37a0b25c5a1ad19298fbe \
+                 sha256  ad68f225e96db8b7d12d0c31f0343bc3227ea2886ecefae2f483cb32310b0004 \
+                 size    215529168
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  e4ff2d85b29d3097890ae77d5459f1a889738cb2 \
-                 sha256  31db3444309d5d0f8b85e8782e2dcd86f31f7e48c1a1e83d69b09268c7b4f9a2 \
-                 size    213404000
+    checksums    rmd160  782ffeeb873ae307065d5ab7e3edf025da7f3a4b \
+                 sha256  fad8faf49c7b1b454c38d785b75e17edbdadc7ffaf450b31349aafc6560b8ef6 \
+                 size    213981440
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.120.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?