### PR TITLE
osxphotos: update to 0.75.9

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.75.8
+version                 0.75.9
 revision                0
 
 categories              graphics python
@@ -25,9 +25,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  028f4105e0bc4c1d4b3ab8142e2f6d5627382736 \
-                        sha256  9b1d5f6162848a7d6338f68ada15423945091aca395f34bea6b2841ae1d8b69a \
-                        size    2400910
+checksums               rmd160  b68600e51055337712521bcaf10965a0890fc4b4 \
+                        sha256  e96dbb64a28504a78e100f86356e38f0524a0358e78a89a5f45de8af42d1970f \
+                        size    2401099
 
 # Latest Python version supported by osxphotos
 python.default_version  314


### PR DESCRIPTION
#### Description

Update to osxphotos 0.75.9.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?