### PR TITLE
skaffold: update to 2.19.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.18.3 v
+github.setup        GoogleContainerTools skaffold 2.19.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  5f33122ef067a875d891248eacf82c85186bc4f1 \
-                    sha256  837f26b35d30f900f9b72b8da7499fe679900576d6a27a8cecbc7d4e600d7318 \
-                    size    63847618
+checksums           rmd160  b7a34591e2b9c643887147f143ffa7d6572f5680 \
+                    sha256  c8dc955a77f9696d16e3c1fd6970784bc5c37f1375907a83a1b67aa937bc7c29 \
+                    size    63900602
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.19.0.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?