### PR TITLE
llmfit: update to 0.9.15

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.14 v
+github.setup            AlexsJones llmfit 0.9.15 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  6e5cb2ae6dbfb109fd85a37a72fc630936d6be1a \
-                        sha256  8b411b158a62794297b72205ef0bcca5158218cf2d89cbda46ec45e9a5215832 \
-                        size    6942812
+                        rmd160  bb1633f13d3c4ba3b8bb0d88e074989655287869 \
+                        sha256  b42e018599be79f4230bf5939169fafd9ebd34b1dd92f5d17354d914ac66da7b \
+                        size    2691195
 
 categories              llm
 platforms               macosx
@@ -45,6 +45,7 @@ cargo.crates \
     anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
     anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     arboard                          3.6.1  0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf \
+    assert_cmd                       2.2.0  9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9 \
     atk                             0.18.2  241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b \
     atk-sys                         0.18.2  c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086 \
     atomic                           0.6.1  a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340 \
@@ -64,6 +65,7 @@ cargo.crates \
     block2                           0.6.2  cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5 \
     brotli                           8.0.2  4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560 \
     brotli-decompressor              5.0.0  874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03 \
+    bstr                            1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
     bumpalo                         3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
     bytecount                        0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
     bytemuck                        1.25.0  c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec \
@@ -124,6 +126,7 @@ cargo.crates \
     derive_more                    0.99.20  6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f \
     derive_more                      2.1.1  d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
     derive_more-impl                 2.1.1  799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
+    difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     dirs                             6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                         0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
@@ -350,6 +353,9 @@ cargo.crates \
     powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     precomputed-hash                 0.1.1  925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c \
+    predicates                       3.1.4  ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe \
+    predicates-core                 1.0.10  cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144 \
+    predicates-tree                 1.0.13  d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2 \
     prettyplease                    0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
     proc-macro-crate                 1.3.1  7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919 \
     proc-macro-crate                 2.0.2  b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24 \
@@ -472,6 +478,7 @@ cargo.crates \
     tendril                          0.5.0  c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24 \
     terminfo                         0.9.0  d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662 \
     termios                          0.3.3  411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b \
+    termtree                         0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     termwiz                         0.23.3  4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7 \
     testing_table                    0.3.0  0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
@@ -532,6 +539,7 @@ cargo.crates \
     vswhom                           0.1.0  be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b \
     vswhom-sys                       0.1.3  fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150 \
     vtparse                          0.6.2  6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0 \
+    wait-timeout                     0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
     wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.4 24G517 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

