### PR TITLE
gpsd: revbump for dbus-glib update

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    gpsd
 version                 3.27.5
-revision                0
+revision                1
 categories              net
 license                 BSD
 maintainers             {michaelld @michaelld} \
@@ -80,6 +80,11 @@ pre-fetch {
     return -code error "Invalid Python variant selection"
     }
 }
+
+# Avoid building webpages that we won't install, anyway.
+# Aside from saving time, this avoids a mysterious new problem
+# with the 'dia' program and compressed input.
+patchfiles-append       patch-no-www.diff
 
 set pyver_dotted [dotted_ver ${pyver_no_dot}]
 

--- a/net/gpsd/files/patch-no-www.diff
+++ b/net/gpsd/files/patch-no-www.diff
@@ -1,0 +1,32 @@
+--- SConscript.orig	2025-12-30 14:16:31.000000000 -0800
++++ SConscript	2026-04-25 15:56:19.000000000 -0700
+@@ -2215,7 +2215,6 @@ python_misc = [
+     "tests/test_clienthelpers.py",
+     "tests/test_misc.py",
+     "tests/test_xgps_deps.py",
+-    "www/gpscap.py",
+     "valgrind-audit.py"
+ ]
+ 
+@@ -2409,13 +2408,6 @@ templated = {
+     "systemd/gpsdctl@.service": "systemd/gpsdctl@.service.in",
+     "systemd/gpsd.service": "systemd/gpsd.service.in",
+     "systemd/gpsd.socket": "systemd/gpsd.socket.in",
+-    "www/faq.html": "www/faq.html.in",
+-    "www/gps_report.cgi": "www/gps_report.cgi.in",
+-    "www/gpscap.py": "www/gpscap.py.in",
+-    "www/hacking.html": "www/hacking.html.in",
+-    "www/hardware-head.html": "www/hardware-head.html.in",
+-    "www/index.html": "www/index.html.in",
+-    "www/troubleshooting.html": "www/troubleshooting.html.in",
+     }
+ 
+ for (tgt, src) in templated.items():
+@@ -2625,7 +2617,6 @@ build_src = [
+     mib_files,
+     packing,
+     sbin_binaries,
+-    webpages,
+     ]
+ 
+ if env['python']:


### PR DESCRIPTION
This only actually matters with +dbus.

Also disables building the www pages that we don't install, as well as some related tests.  Aside from saving time, this avoids a problem with the 'dia' program and compressed input, which mysteriously didn't affect previous builds.

TESTED:
Tested on 10.5-10.6 i386, 10.5-12.x x86_64, and 11.x-26.x arm64. Only tested -dbus on 10.5 ppc, due to broken indirect dependency on python314.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.5.8 9L31a, ppc, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.11 20G1443, x86_64, Xcode 13.2.1 13C100
macOS 11.7.11 20G1443, arm64, Xcode 13.2.1 13C100
macOS 12.7.6 21H1320, x86_64, Xcode 14.2 14C18
macOS 12.7.6 21H1320, arm64, Xcode 14.2 14C18
macOS 13.7.8 22H730, arm64, Xcode 15.2 15C500b
macOS 14.8.5 23J423, arm64, Xcode 16.2 16C5032a
macOS 15.7.5 24G624, arm64, Xcode 26.3 17C529
macOS 26.4.1 25E253, arm64, Xcode 26.4.1 17E202
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [NO] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? `*`

`*` - Due to the minimal changes, only tested default variants and +dbus.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
