### PR TITLE
g-ls: Update to 0.31.2

### DIFF
--- a/sysutils/g-ls/Portfile
+++ b/sysutils/g-ls/Portfile
@@ -3,23 +3,23 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/Equationzhao/g 0.31.0 v
+go.setup                github.com/Equationzhao/g 0.31.2 v
 name                    g-ls
 revision                0
 categories              sysutils
 license                 MIT
-platforms               {darwin >= 18}
+platforms               {darwin >= 21}
 installs_libs           no
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
 description             Powerful and cross-platform ls
 long_description        {*}${description}. Built for the modern terminal.
 
-homepage                https://g.equationzhao.space
+homepage                https://equationzhao.github.io/g/
 
-checksums               rmd160  a0bb5bc53aa4fe03775dd5c5960dbaefb3aaf250 \
-                        sha256  122ca7ebf32ab2aada05cd513d44b55082d9bcfa9b890ee0ff60fdebfea06d0c \
-                        size    414031
+checksums               rmd160  792fec563d2abb19a4c0e77c5692c612fe5fc580 \
+                        sha256  a1ef8a6872fa80625287c19167152081b833abc4db88910ab145b35b3bbc6da3 \
+                        size    1614267
 
 # Vendored libraries cause failure, fetch them at build time
 go.offline_build        no


### PR DESCRIPTION
#### Description

Update `g-ls` to its latest released version, 0.31.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
