### PR TITLE
llvm-2*: fix incompatibility with ocaml-findlib

### DIFF
--- a/lang/llvm-20/Portfile
+++ b/lang/llvm-20/Portfile
@@ -46,8 +46,6 @@ worksrcdir              ${worksrcdir}/llvm
 
 # https://github.com/macports/macports-ports/commit/a83a493bc21cbe7e14b1f5884379649ec8f31bae#commitcomment-132530885
 conflicts_build-append  libunwind libunwind-headers
-# https://trac.macports.org/ticket/72695
-conflicts_build-append  ocaml-findlib
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*
@@ -82,7 +80,8 @@ configure.args-append \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_ENABLE_FFI=ON \
     -DFFI_INCLUDE_DIR=${prefix}/include \
-    -DFFI_LIBRARY_DIR=${prefix}/lib
+    -DFFI_LIBRARY_DIR=${prefix}/lib \
+    -DLLVM_ENABLE_BINDINGS=OFF
 
 # Remove for now. See https://trac.macports.org/ticket/70333
 # Probably need to detect when Xcode is available

--- a/lang/llvm-21/Portfile
+++ b/lang/llvm-21/Portfile
@@ -46,8 +46,6 @@ worksrcdir              ${worksrcdir}/llvm
 
 # https://github.com/macports/macports-ports/commit/a83a493bc21cbe7e14b1f5884379649ec8f31bae#commitcomment-132530885
 conflicts_build-append  libunwind libunwind-headers
-# https://trac.macports.org/ticket/72695
-conflicts_build-append  ocaml-findlib
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*
@@ -82,7 +80,8 @@ configure.args-append \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_ENABLE_FFI=ON \
     -DFFI_INCLUDE_DIR=${prefix}/include \
-    -DFFI_LIBRARY_DIR=${prefix}/lib
+    -DFFI_LIBRARY_DIR=${prefix}/lib \
+    -DLLVM_ENABLE_BINDINGS=OFF
 
 # Remove for now. See https://trac.macports.org/ticket/70333
 # Probably need to detect when Xcode is available

--- a/lang/llvm-22/Portfile
+++ b/lang/llvm-22/Portfile
@@ -49,8 +49,6 @@ worksrcdir              ${worksrcdir}/llvm
 
 # https://github.com/macports/macports-ports/commit/a83a493bc21cbe7e14b1f5884379649ec8f31bae#commitcomment-132530885
 conflicts_build-append  libunwind libunwind-headers
-# https://trac.macports.org/ticket/72695
-conflicts_build-append  ocaml-findlib
 
 # hand-tweaked, approximately c++ standard 2017
 compiler.blacklist      *gcc* {clang < 1001} macports-clang-3.*
@@ -83,7 +81,8 @@ configure.args-append \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_ENABLE_FFI=ON \
     -DFFI_INCLUDE_DIR=${prefix}/include \
-    -DFFI_LIBRARY_DIR=${prefix}/lib
+    -DFFI_LIBRARY_DIR=${prefix}/lib \
+    -DLLVM_ENABLE_BINDINGS=OFF
 
 # Remove for now. See https://trac.macports.org/ticket/70333
 # Probably need to detect when Xcode is available


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

CMake option LLVM_ENABLE_BINDINGS is specifically used to enable OCaml bindings (in spite of the name). Use it to disable this broken binding and therefore remove the conflict with ocaml-findlib.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D771280a x86_64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
