### PR TITLE
esptool: update to 5.2.0

### DIFF
--- a/cross/esptool/Portfile
+++ b/cross/esptool/Portfile
@@ -13,13 +13,13 @@ description         A serial utility to communicate & flash code to Espressif ES
 long_description    {*}${description}
 homepage            https://github.com/espressif/esptool
 
-version             5.1.0
-checksums           rmd160  97074ffef0c64086097a7d1101c089208031deaa \
-                    sha256  2ea9bcd7eb263d380a4fe0170856a10e4c65e3f38c757ebdc73584c8dd8322da \
-                    size    383926
+version             5.2.0
+checksums           rmd160  1ffccb2778b4a881424d9b776502fa464add4d55 \
+                    sha256  9c355b7d6331cc92979cc710ae5c41f59830d1ea29ec24c467c6005a092c06d6 \
+                    size    463000
 revision            0
 
-python.versions     310 311 312
+python.versions     310 311 312 313 314
 
 depends_lib-append \
     port:py${python.version}-serial \

--- a/python/py-intelhex/Portfile
+++ b/python/py-intelhex/Portfile
@@ -20,4 +20,4 @@ checksums           rmd160  f6aa96053d8b6cd85df8c433acb02a0e368c04cd \
                     sha256  892b7361a719f4945237da8ccf754e9513db32f5628852785aea108dcd250093 \
                     size    44513
 
-python.versions     310 311 312
+python.versions     310 311 312 313 314

--- a/python/py-reedsolo/Portfile
+++ b/python/py-reedsolo/Portfile
@@ -18,5 +18,5 @@ checksums           rmd160  4ab17569762ebcb69dfb12b2bdafe00232a53f69 \
                     sha256  c1359f02742751afe0f1c0de9f0772cc113835aa2855d2db420ea24393c87732 \
                     size    59723
 
-python.versions     310 311 312
+python.versions     310 311 312 313 314
 


### PR DESCRIPTION
Add py313 and py314 subports to py-intelhex and py-reedsolo.

Closes: https://trac.macports.org/ticket/73825

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D771280a x86_64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
