### PR TITLE
prek: update to 0.3.11

### DIFF
--- a/devel/prek/Portfile
+++ b/devel/prek/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        j178 prek 0.3.5 v
+github.setup        j178 prek 0.3.11 v
 github.tarball_from archive
 revision            0
 
-description         Better `pre-commit`, re-engineered in Rust
+description         A fast Git hook manager written in Rust, drop-in alternative to pre-commit.
 long_description    {*}${description}
 
 categories          devel
@@ -18,9 +18,9 @@ maintainers         {@j178 j178.dev:hi} openmaintainer
 homepage            https://prek.j178.dev
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  953c5729f50d8e57a4011fca43978abcc2308849 \
-                    sha256  3d0bf93af3591762b2fce97965fb88f8dc4b750164451162f57f866e26e4bb67 \
-                    size    524673
+                    rmd160  286d91969d00139c7886f2a5a4b4789494e638af \
+                    sha256  7480500dea21e8d457e5fa189ed9061fbb1219a897c28c66dc97e50afeef13f6 \
+                    size    681943
 
 post-build {
     # Generate shell completions for supported shells
@@ -55,25 +55,25 @@ cargo.crates \
     ahash                           0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                     1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
     aligned-vec                      0.6.4  dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b \
-    annotate-snippets              0.12.12  c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980 \
-    anstream                        0.6.21  43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a \
-    anstyle                         1.0.13  5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78 \
-    anstyle-parse                    0.2.7  4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2 \
+    annotate-snippets              0.12.15  92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7 \
+    anstream                         1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
+    anstyle                         1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
+    anstyle-parse                    1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
     anstyle-query                    1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
     anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
     anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     ar_archive_writer                0.5.1  7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b \
     arraydeque                       0.5.1  7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236 \
     arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
-    assert_cmd                       2.1.2  9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514 \
+    assert_cmd                       2.2.1  39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd \
     assert_fs                        1.1.3  a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9 \
-    astral-tokio-tar                 0.5.6  ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5 \
+    astral-tokio-tar                 0.6.0  3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9 \
     astral_async_zip                0.0.17  ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba \
     async-compression               0.4.41  d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
-    aws-lc-rs                       1.16.1  94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf \
-    aws-lc-sys                      0.38.0  4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e \
+    aws-lc-rs                       1.16.2  a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc \
+    aws-lc-sys                      0.39.1  83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399 \
     axoasset                         2.0.1  1be1b9c2739b635e04c7bbcde9e89dd5e874b9e86e28f1b41c44eb830635d83e \
     axoprocess                       0.2.1  8a4b4798a6c02e91378537c63cd6e91726900b595450daa5d487bc3c11e95e1b \
     axotag                           0.3.0  dc923121fbc4cc72e9008436b5650b98e56f94b5799df59a1b4f572b5c6a7e6b \
@@ -93,23 +93,22 @@ cargo.crates \
     camino                           1.2.2  e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48 \
     cargo-platform                   0.3.2  87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082 \
     cargo_metadata                  0.23.1  ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9 \
-    cc                              1.2.56  aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2 \
+    cc                              1.2.59  b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283 \
     cesu8                            1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                      0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
     chacha20                        0.10.0  6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601 \
-    clap                            4.5.60  2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a \
-    clap_builder                    4.5.60  24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876 \
-    clap_complete                   4.5.66  c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031 \
-    clap_derive                     4.5.55  a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5 \
-    clap_lex                         1.0.0  3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831 \
-    cmake                           0.1.57  75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d \
-    colorchoice                      1.0.4  b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75 \
+    clap                             4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
+    clap_builder                     4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
+    clap_complete                    4.6.2  3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb \
+    clap_derive                      4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
+    clap_lex                         1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
+    cmake                           0.1.58  c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
+    colorchoice                      1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
     combine                          4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
     compression-codecs              0.4.37  eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7 \
     compression-core                0.4.31  75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d \
-    console                        0.15.11  054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8 \
-    console                         0.16.2  03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4 \
+    console                         0.16.3  d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
     core-foundation                 0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys              0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
@@ -132,14 +131,13 @@ cargo.crates \
     encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                     0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
     encoding_rs_io                   0.1.7  1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83 \
-    env_home                         0.1.0  c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe \
     equator                          0.4.2  4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc \
     equator-macro                    0.4.2  44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3 \
     equivalent                       1.0.2  877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f \
     errno                           0.3.14  39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb \
     etcetera                        0.11.0  de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96 \
     fancy-regex                     0.17.0  72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8 \
-    fastrand                         2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
+    fastrand                         2.4.0  a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f \
     filetime                        0.2.27  f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db \
     find-msvc-tools                  0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
     findshlibs                      0.10.2  40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64 \
@@ -178,50 +176,52 @@ cargo.crates \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                   0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
     httparse                        1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
-    hyper                            1.8.1  2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11 \
+    hyper                            1.9.0  6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca \
     hyper-rustls                    0.27.7  e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58 \
     hyper-util                      0.1.20  96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0 \
-    icu_collections                  2.1.1  4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43 \
-    icu_locale_core                  2.1.1  edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6 \
-    icu_normalizer                   2.1.1  5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599 \
-    icu_normalizer_data              2.1.1  7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a \
-    icu_properties                   2.1.2  020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec \
-    icu_properties_data              2.1.2  616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af \
-    icu_provider                     2.1.1  85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614 \
+    icu_collections                  2.2.0  2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c \
+    icu_locale_core                  2.2.0  92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29 \
+    icu_normalizer                   2.2.0  c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4 \
+    icu_normalizer_data              2.2.0  da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38 \
+    icu_properties                   2.2.0  bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de \
+    icu_properties_data              2.2.0  8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14 \
+    icu_provider                     2.2.0  139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421 \
     id-arena                         2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     idna                             1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                     1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
     ignore                          0.4.25  d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a \
-    image                           0.25.9  e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a \
-    indexmap                        2.13.0  7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017 \
+    image                          0.25.10  85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104 \
+    indexmap                        2.13.1  45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff \
     indicatif                       0.18.4  25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
     indoc                            2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     inferno                        0.11.21  232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88 \
-    insta                           1.46.3  e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4 \
+    insta                           1.47.2  7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e \
     insta-cmd                        0.6.0  ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6 \
     ipnet                           2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
-    iri-string                      0.7.10  c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a \
+    iri-string                      0.7.12  25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20 \
     is-terminal                     0.4.17  3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46 \
     is_executable                    1.0.5  baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4 \
     is_terminal_polyfill            1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
-    itoa                            1.0.17  92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2 \
+    itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
     jni                             0.21.1  1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97 \
-    jni-sys                          0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
+    jni-sys                          0.3.1  41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258 \
+    jni-sys                          0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
+    jni-sys-macros                   0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                       0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                          0.3.91  b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c \
+    js-sys                          0.3.94  2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9 \
     json5                            1.3.1  733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c \
     lazy-regex                       3.6.0  6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
     lazy-regex-proc_macros           3.6.0  4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
     levenshtein                      1.0.5  db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760 \
-    libc                           0.2.182  6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112 \
+    libc                           0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
     liblzma                          0.4.6  b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899 \
-    liblzma-sys                      0.4.5  9f2db66f3268487b5033077f266da6777d057949b8f93c8ad82e441df25e6186 \
-    libredox                        0.1.14  1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a \
+    liblzma-sys                      0.4.6  1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6 \
+    libredox                        0.1.15  7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08 \
     linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
-    litemap                          0.8.1  6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77 \
+    litemap                          0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
     lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
     log                             0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
     lru-slab                         0.1.2  112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154 \
@@ -234,8 +234,8 @@ cargo.crates \
     miette-derive                    7.6.0  db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                              1.1.1  a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc \
-    moxcms                          0.7.11  ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97 \
+    mio                              1.2.0  50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1 \
+    moxcms                           0.8.1  bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b \
     nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
     nix                             0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
     nix                             0.31.2  5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3 \
@@ -247,7 +247,7 @@ cargo.crates \
     objc2                            0.6.4  3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f \
     objc2-encode                     4.1.0  ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
     object                          0.37.3  ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe \
-    once_cell                       1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
+    once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     openssl-probe                    0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
     owo-colors                       4.3.0  d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d \
@@ -261,11 +261,10 @@ cargo.crates \
     pin-project                     1.1.11  f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517 \
     pin-project-internal            1.1.11  d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6 \
     pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
-    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkg-config                      0.3.32  7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c \
     plain                            0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
     portable-atomic                 1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
-    potential_utf                    0.1.4  b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77 \
+    potential_utf                    0.1.5  0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564 \
     pprof                           0.15.0  38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187 \
     ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     predicates                       3.1.4  ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe \
@@ -279,17 +278,17 @@ cargo.crates \
     quick-xml                       0.26.0  7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd \
     quick-xml                       0.39.2  958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d \
     quinn                           0.11.9  b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
-    quinn-proto                    0.11.13  f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31 \
+    quinn-proto                    0.11.14  434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098 \
     quinn-udp                       0.5.14  addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
     quote                           1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
     r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     rand                             0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
-    rand                            0.10.0  bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8 \
+    rand                            0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_core                       0.10.0  0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba \
-    rayon                           1.11.0  368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f \
+    rayon                           1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                    0.7.3  6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16 \
     ref-cast                        1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
@@ -301,43 +300,45 @@ cargo.crates \
     rgb                             0.8.53  47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4 \
     ring                           0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rustc-demangle                  0.1.27  b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d \
-    rustc-hash                       2.1.1  357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d \
+    rustc-hash                       2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
     rustix                           1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustls                         0.23.37  758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4 \
     rustls-native-certs              0.8.3  612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63 \
     rustls-pki-types                1.14.0  be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd \
     rustls-platform-verifier         0.6.2  1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
-    rustls-webpki                  0.103.9  d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53 \
+    rustls-webpki                 0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
     rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    saphyr-parser-bw               0.0.608  d55ae5ea09894b6d5382621db78f586df37ef18ab581bf32c754e75076b124b1 \
-    schannel                        0.1.28  891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1 \
+    saphyr-parser-bw               0.0.611  67dec0c833db75dc98957956b303fe447ffc5eb13f2325ef4c2350f7f3aa69e3 \
+    schannel                        0.1.29  91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939 \
     schemars                         1.2.1  a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc \
     schemars_derive                  1.2.1  7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
     security-framework               3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
     security-framework-sys          2.17.0  6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
     self-replace                     1.5.0  03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7 \
-    semver                          1.0.27  d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2 \
+    semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
     serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
-    serde-saphyr                    0.0.20  bfcaa44cda9e21eaf5fefc86175d544a359d4de9bcd1f3a90be7bbf77dfc3492 \
+    serde-saphyr                    0.0.23  09fbdfe7a27a1b1633dfc0c4c8e65940b8d819c5ddb9cca48ebc3223b00c8b14 \
     serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
     serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
     serde_json                     1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
-    serde_spanned                    1.0.4  f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776 \
+    serde_spanned                    1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_stacker                   0.1.14  d4936375d50c4be7eff22293a9344f8e46f323ed2b3c243e52f89138d9bb0f4a \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
     signal-hook-registry             1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
-    simd-adler32                     0.3.8  e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2 \
+    simd-adler32                     0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     similar                          2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
+    similar                          3.1.0  04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f \
     siphasher                        1.0.2  b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e \
     slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     smawk                            0.3.2  b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c \
-    socket2                          0.6.2  86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0 \
+    socket2                          0.6.3  3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
     spin                            0.10.0  d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591 \
     stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     stacker                         0.1.23  08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013 \
@@ -346,16 +347,16 @@ cargo.crates \
     strum                           0.28.0  9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd \
     strum_macros                    0.28.0  ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664 \
     subtle                           2.6.1  13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292 \
-    symbolic-common                12.17.2  751a2823d606b5d0a7616499e4130a516ebd01a44f39811be2b9600936509c23 \
-    symbolic-demangle              12.17.2  79b237cfbe320601dd24b4ac817a5b68bb28f5508e33f08d42be0682cadc8ac9 \
+    symbolic-common                12.17.3  52ca086c1eb5c7ee74b151ba83c6487d5d33f8c08ad991b86f3f58f6629e68d5 \
+    symbolic-demangle              12.17.3  baa911a28a62823aaf2cc2e074212492a3ee69d0d926cc8f5b12b4a108ff5c0c \
     syn                            2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
     sync_wrapper                     1.0.2  0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263 \
     synstructure                    0.13.2  728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2 \
     system-configuration             0.7.0  a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b \
     system-configuration-sys         0.6.0  8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4 \
     target-lexicon                  0.13.5  adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca \
-    tempfile                        3.26.0  82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0 \
-    terminal_size                    0.4.3  60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0 \
+    tempfile                        3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
+    terminal_size                    0.4.4  230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874 \
     termtree                         0.5.1  8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683 \
     textwrap                        0.16.2  c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057 \
     thiserror                       1.0.69  b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52 \
@@ -363,19 +364,19 @@ cargo.crates \
     thiserror-impl                  1.0.69  4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1 \
     thiserror-impl                  2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
     thread_local                     1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
-    tinystr                          0.8.2  42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869 \
-    tinyvec                         1.10.0  bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa \
+    tinystr                          0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
+    tinyvec                         1.11.0  3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.50.0  27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d \
-    tokio-macros                     2.6.1  5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c \
+    tokio                           1.52.1  b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6 \
+    tokio-macros                     2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-rustls                    0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                    0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
     tokio-util                      0.7.18  9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098 \
-    toml                          1.0.3+spec-1.1.0  c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c \
-    toml_datetime                 1.0.0+spec-1.1.0  32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e \
-    toml_edit                     0.25.3+spec-1.1.0  a0a07913e63758bc95142d9863a5a45173b71515e68b690cad70cf99c3255ce1 \
-    toml_parser                   1.0.9+spec-1.1.0  702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4 \
-    toml_writer                   1.0.6+spec-1.1.0  ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607 \
+    toml                          1.1.2+spec-1.1.0  81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee \
+    toml_datetime                 1.1.1+spec-1.1.0  3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7 \
+    toml_edit                     0.25.11+spec-1.1.0  0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b \
+    toml_parser                   1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
+    toml_writer                   1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
     tower                            0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                       0.6.8  d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8 \
     tower-layer                      0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
@@ -384,7 +385,7 @@ cargo.crates \
     tracing-attributes              0.1.31  7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da \
     tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
-    tracing-subscriber              0.3.22  2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e \
+    tracing-subscriber              0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     ucd-trie                         0.1.7  2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971 \
     unicode-id                       0.3.6  70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580 \
@@ -398,7 +399,7 @@ cargo.crates \
     url                              2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     utf8_iter                        1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                            1.21.0  b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb \
+    uuid                            1.23.0  5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9 \
     valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
     version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     wait-timeout                     0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
@@ -407,19 +408,19 @@ cargo.crates \
     wasi                          0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                        1.0.2+wasi-0.2.9  9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5 \
     wasip3                        0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                   0.2.114  6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e \
-    wasm-bindgen-futures            0.4.64  e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8 \
-    wasm-bindgen-macro             0.2.114  18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6 \
-    wasm-bindgen-macro-support     0.2.114  03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3 \
-    wasm-bindgen-shared            0.2.114  75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16 \
+    wasm-bindgen                   0.2.117  0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0 \
+    wasm-bindgen-futures            0.4.67  03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e \
+    wasm-bindgen-macro             0.2.117  7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be \
+    wasm-bindgen-macro-support     0.2.117  dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2 \
+    wasm-bindgen-shared            0.2.117  39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b \
     wasm-encoder                   0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                  0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasm-streams                     0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
     wasmparser                     0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
-    web-sys                         0.3.91  854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9 \
+    web-sys                         0.3.94  cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a \
     web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webpki-root-certs                1.0.6  804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca \
-    which                            8.0.0  d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d \
+    webpki-root-certs                1.0.7  f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c \
+    which                            8.0.2  81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459 \
     widestring                       1.2.1  72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
@@ -471,25 +472,24 @@ cargo.crates \
     windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
     windows_x86_64_msvc             0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc             0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
-    winnow                          0.7.14  5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829 \
-    winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
+    winnow                           1.0.1  09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5 \
     wit-bindgen                     0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
     wit-bindgen-core                0.51.0  ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc \
     wit-bindgen-rust                0.51.0  b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21 \
     wit-bindgen-rust-macro          0.51.0  0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a \
     wit-component                  0.244.0  9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
     wit-parser                     0.244.0  ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
-    writeable                        0.6.2  9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9 \
+    writeable                        0.6.3  1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
     xattr                            1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     yansi                            1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
-    yoke                             0.8.1  72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954 \
-    yoke-derive                      0.8.1  b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d \
-    zerocopy                        0.8.40  a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5 \
-    zerocopy-derive                 0.8.40  f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953 \
-    zerofrom                         0.1.6  50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5 \
-    zerofrom-derive                  0.1.6  d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502 \
+    yoke                             0.8.2  abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca \
+    yoke-derive                      0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
+    zerocopy                        0.8.48  eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9 \
+    zerocopy-derive                 0.8.48  70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4 \
+    zerofrom                         0.1.7  69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df \
+    zerofrom-derive                  0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                          1.8.2  b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \
-    zerotrie                         0.2.3  2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851 \
-    zerovec                         0.11.5  6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002 \
-    zerovec-derive                  0.11.2  eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3 \
+    zerotrie                         0.2.4  0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf \
+    zerovec                         0.11.6  90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239 \
+    zerovec-derive                  0.11.3  625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555 \
     zmij                            1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa


### PR DESCRIPTION
#### Description

Update prek to 0.3.11

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

