### PR TITLE
clang compilers: pick up non-darwin selections

### DIFF
--- a/_resources/port1.0/compilers/clang_compilers.tcl
+++ b/_resources/port1.0/compilers/clang_compilers.tcl
@@ -12,33 +12,40 @@ if {${os.platform} eq "darwin" && [option configure.build_arch] in [list ppc ppc
     return
 }
 
+if {${os.platform} ne "darwin"} {
+    lappend compilers macports-clang-22 macports-clang-21 macports-clang-20 \
+                      macports-clang-19 macports-clang-18 macports-clang-17 macports-clang-16 \
+                      macports-clang-15 macports-clang-14 macports-clang-13 macports-clang-12
+    return
+}
+
 # Clang 17+ only available on newer Darwin versions
-if {${os.major} >= 17 || ${os.platform} ne "darwin"} {
+if { ${os.major} >= 17 } {
     # For now limit exposure of clang-18+ to macOS13+ due to issues like
     # https://github.com/macports/macports-ports/pull/21051
     # https://trac.macports.org/ticket/68640
-    if {${os.major} >= 22 || ${os.platform} ne "darwin"} {
+    if { ${os.major} >= 22 } {
         # Expose clang-21 to ports needing the newest standards
-        if { ${os.platform} ne "darwin" || ${compiler.cxx_standard} >= 2020 } {
+        if { ${compiler.cxx_standard} >= 2020 } {
             lappend compilers macports-clang-22 macports-clang-21
         }
-        if { ${os.platform} ne "darwin" || ${compiler.cxx_standard} >= 2014 } {
+        if { ${compiler.cxx_standard} >= 2014 } {
             lappend compilers macports-clang-20 macports-clang-19
         }
         # Always allow clang-18 on macOS15+, otherwise if c++11 or newer is required
-        if { ${os.platform} ne "darwin" || ${os.major} >= 24 || ${compiler.cxx_standard} >= 2011 } {
+        if { ${os.major} >= 24 || ${compiler.cxx_standard} >= 2011 } {
             lappend compilers macports-clang-18
         }
     }
     lappend compilers macports-clang-17
 }
 
-if { ${os.major} >= 10 || ${os.platform} ne "darwin"} {
+if { ${os.major} >= 10 } {
     # On Darwin10 only use selection here if c++20+ required
-    if { ${os.platform} ne "darwin" || ${os.major} >= 11 || ${compiler.cxx_standard} >= 2020 } {
-        if {${os.major} < 25 || ${os.platform} ne "darwin"} {
+    if { ${os.major} >= 11 || ${compiler.cxx_standard} >= 2020 } {
+        if { ${os.major} < 25 } {
             lappend compilers macports-clang-16 macports-clang-15 macports-clang-14 macports-clang-13
-            if {${os.major} < 23 || ${os.platform} ne "darwin"} {
+            if { ${os.major} < 23 } {
                 # https://trac.macports.org/ticket/68257
                 # Versions of clang older than clang-13 probably have build issues on
                 # macOS14+. Until resolved do not append to fallback list.


### PR DESCRIPTION
#### Description

`${os.platform} ne "darwin"` is first introduced in a24826e by @jmroot , and it has been duplicated many times. 
Simplify it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
