### PR TITLE
folly: fix libc++ compressed_pair removal on darwin 25

### DIFF
--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -20,7 +20,7 @@ if {[string match *clang* ${configure.compiler}]} {
 # upgrade without also upgrading its dependents, as listed by:
 # port list rdepends:folly
 github.setup        facebook folly 2024.09.23.00 v
-revision            1
+revision            2
 checksums           rmd160  ccb164ce200b2fd10c4b3d931914696d281b1b9e \
                     sha256  25f2affdc97728ecd42d599b2b66090cddf48c306f4fa806444d1e5c57b02cee \
                     size    4185562
@@ -71,6 +71,11 @@ cmake.generator     Ninja
 # https://github.com/facebook/folly/pull/2124
 # https://github.com/facebook/folly/pull/1907
 patchfiles-append   patch-legacy-systems.diff
+
+# Mirror upstream fix for libc++ removal of std::__compressed_pair<>
+# (Xcode 26 / CLT 16 / macOS 26 / darwin 25); folly's installed
+# UninitializedMemoryHacks.h header otherwise breaks downstream consumers.
+patchfiles-append   patch-libcpp-compressed-pair.diff
 
 # https://github.com/facebook/folly/issues/2266
 platform darwin {

--- a/devel/folly/files/patch-libcpp-compressed-pair.diff
+++ b/devel/folly/files/patch-libcpp-compressed-pair.diff
@@ -1,0 +1,18 @@
+--- folly/memory/UninitializedMemoryHacks.h.orig
++++ folly/memory/UninitializedMemoryHacks.h
+@@ -307,7 +307,14 @@
+   using allocator_type = Alloc;
+   using pointer = typename std::allocator_traits<allocator_type>::pointer;
+
+   pointer __begin_;
+   pointer __end_;
+-  std::__compressed_pair<pointer, allocator_type> __end_cap_;
++#ifdef _LIBCPP_COMPRESSED_PAIR
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wgnu-anonymous-struct"
++  _LIBCPP_COMPRESSED_PAIR(pointer, __cap_ = nullptr, allocator_type, __alloc_);
++#pragma GCC diagnostic pop
++#else
++  std::__compressed_pair<pointer, allocator_type> __end_cap_;
++#endif
+ };


### PR DESCRIPTION
## Symptom

On darwin 25 (macOS 26 / Xcode 26 / CLT 16), `folly @2024.09.23.00_1` builds and installs cleanly, but downstream consumers (`fizz`, `fbthrift`, `watchman`, etc.) fail to compile against the installed `folly/memory/UninitializedMemoryHacks.h` header. The new libc++ shipping with Xcode 26 has removed the private symbol `std::__compressed_pair<>`, which folly's header references directly to mirror libc++ vector internals.

## Fix

Mirror the upstream fix on [`facebook/folly@main`](https://raw.githubusercontent.com/facebook/folly/main/folly/memory/UninitializedMemoryHacks.h): gate the `__end_cap_` member declaration behind `_LIBCPP_COMPRESSED_PAIR` and use the new `_LIBCPP_COMPRESSED_PAIR(...)` macro form when libc++ defines it. The pre-existing `std::__compressed_pair<...>` form remains the fallback for older libc++ revisions.

This is a header-only patch; the change does not alter folly's own ABI and only adjusts how folly's hack-layout struct mirrors libc++'s vector internals.

## Changes

- New patch: `devel/folly/files/patch-libcpp-compressed-pair.diff` (the exact ifdef block taken from upstream `folly@main`).
- `devel/folly/Portfile`: bump `revision` 1 -> 2 and append the patch unconditionally (the underlying libc++ change is darwin-25-specific, but the macro guard `_LIBCPP_COMPRESSED_PAIR` makes the patch a no-op on libc++ versions that still define `std::__compressed_pair`, so no platform gate is needed).

## Verification

- Patch applies cleanly to the `2024.09.23.00` source tarball.
- `folly @2024.09.23.00_2` rebuilds successfully on darwin 25 + Xcode 26.4 + arm64.
- After rebuild, `fizz` compiles against the patched folly (previously failed in the same environment).

No other testing claimed.