### PR TITLE
cvemap: obsolete; vulnx: update to 2.0.1

### DIFF
--- a/security/cvemap/Portfile
+++ b/security/cvemap/Portfile
@@ -1,32 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           golang 1.0
+PortGroup           obsolete 1.0
 
-go.setup            github.com/projectdiscovery/cvemap 1.0.0 v
-go.offline_build    no
-revision            0
-
-description         Navigate the CVE jungle with ease
-
-long_description    \
-    Navigate the Common Vulnerabilities and Exposures \(CVE\) jungle with \
-    ease using CVEMAP, a command-line interface \(CLI\) tool designed to \
-    provide a structured and easily navigable interface to various \
-    vulnerability databases.
-
+name                cvemap
+version             1.0.0
+revision            1
+replaced_by         vulnx
 categories          security
-installs_libs       no
-license             MIT
-maintainers         {gmail.com:herby.gillot @herbygillot} \
-                    openmaintainer
-
-checksums           rmd160  b36cc7efef026587d1a3aca1d333476dd7d1c283 \
-                    sha256  76146c23e94493106c9d9bc6f039b33e182415d0a35e5adf43b83f1712cf8d35 \
-                    size    35836938
-
-build.args          ./cmd/${name}
-
-destroot {
-    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
-}

--- a/security/vulnx/Portfile
+++ b/security/vulnx/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/projectdiscovery/vulnx 2.0.1 v
+go.offline_build    no
+revision            0
+
+description         Modern CLI for exploring vulnerability data
+
+long_description    \
+    Modern CLI for exploring vulnerability data with powerful search, \
+    filtering, and analysis capabilities
+
+categories          security
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  dd9dca1f06d73e5d2c589de549e5bb20e9df33da \
+                    sha256  101dcbc93c412b1acfb4b8149660488f42d5c5e4d1b3ff1fd8be3f41c787a4dc \
+                    size    18621376
+
+build.pre_args-append \
+    -ldflags \" -s -w -X ${go.package}/v2/cmd/${name}/clis.Version=${version} \"
+
+build.args          ./cmd/${name}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Poartfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
