### PR TITLE
kubetail: update to 0.15.1-rc2

### DIFF
--- a/devel/kubetail/Portfile
+++ b/devel/kubetail/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubetail-org/kubetail 0.15.0 cli/v
+go.setup            github.com/kubetail-org/kubetail 0.15.1-rc2 cli/v
 github.tarball_from releases
 revision            0
 
@@ -23,9 +23,9 @@ long_description    Kubetail is a general-purpose logging tool for Kubernetes, o
                     terminal.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d7623a2b5acbc788d6723af0a2042c40ebd02be3 \
-                    sha256  63d4d9e0a8e86b4f128e695a935e2bb77e6c72fd9d6f9cd9a6d9139953704df4 \
-                    size    20905816
+                    rmd160  737217a443dc17c086463a9c80311f3cd9267548 \
+                    sha256  185242d7a417405b4d5b4dfeb75aa7ae61376878534885b7b24e54dcb03b823e \
+                    size    20945261
 
 build.env-append GO111MODULE=on \
                  GOWORK=off


### PR DESCRIPTION
#### Description

This PR upgrades `kubetail` to 0.15.1-rc2

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.3 25D125 arm64
Xcode 26.2 17C52

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
