### PR TITLE
i2pd: fix build on macOS <12

### DIFF
--- a/security/i2pd/Portfile
+++ b/security/i2pd/Portfile
@@ -8,10 +8,11 @@ PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
 
 # on <10.15 built-in libc++ has no support for std::filesystem
+# uses number 19 due to a bug in macOS Catalina SDK
 legacysupport.use_mp_libcxx \
                         yes
 legacysupport.newest_darwin_requires_legacy \
-                        18
+                        19
 
 github.setup            PurpleI2P i2pd 2.60.0
 revision                0
@@ -32,6 +33,14 @@ boost.version           1.81
 depends_lib-append      port:zlib
 
 patchfiles-append       0001-i2pd.conf-adjust-for-MacPorts.patch
+
+# util.cpp:319:30: error: no viable conversion from
+# 'std::string_view' (aka 'basic_string_view<char>')
+# to 'const key_type' (aka 'const std::basic_string<char>')
+# Clang <18 on macOS <12 supports C++20, but gets stuck at this section of code
+if {${os.platform} eq "darwin" && ${os.major} < 21} {
+    patchfiles-append   0002-patch-util-cpp.patch
+}
 
 set i2pddir             ${prefix}/var/db/${name}
 

--- a/security/i2pd/files/0002-patch-util-cpp.patch
+++ b/security/i2pd/files/0002-patch-util-cpp.patch
@@ -1,0 +1,11 @@
+--- libi2pd/util.cpp
++++ libi2pd/util.cpp
+@@ -315,7 +315,7 @@ namespace util
+ 
+ 	bool Mapping::Contains (std::string_view param) const
+ 	{
+-#if __cplusplus >= 202002L // C++20
++#if !defined(__clang__) && (__cplusplus >= 202002L) // C++20
+ 		return m_Options.contains (param);
+ #else
+ 		auto it = m_Options.find (param);


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?