### PR TITLE
incus: new port at 6.23.0

### DIFF
--- a/net/incus/Portfile
+++ b/net/incus/Portfile
@@ -37,17 +37,31 @@ build.env-append    CGO_ENABLED=0
 
 # Build only the CLI. The daemon (cmd/incusd) and agent (cmd/incus-agent)
 # have Linux-only build constraints and will not compile on macOS.
-build.args          -o ${worksrcpath}/incus ./cmd/incus
+build.args          -o ${worksrcpath}/${name} ./cmd/incus
 
-destroot {
-    xinstall -m 0755 ${worksrcpath}/incus ${destroot}${prefix}/bin/incus
+post-build {
+    file mkdir ${worksrcpath}/completions
+
+    foreach _shell {bash fish zsh} {
+        system -W ${worksrcpath} \
+            "./${name} completion ${_shell} > ./completions/${name}.${_shell}"
+    }
 }
 
-notes "
-To add shell completions, run after install:
-  incus completion bash | sudo tee ${prefix}/share/bash-completion/completions/incus
-  incus completion zsh  | sudo tee ${prefix}/share/zsh/site-functions/_incus
-  incus completion fish | sudo tee ${prefix}/share/fish/vendor_completions.d/incus.fish
-"
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    set bash_comp_dir ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${bash_comp_dir}
+    copy ${worksrcpath}/completions/${name}.bash ${bash_comp_dir}/${name}
+
+    set fish_comp_dir ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${fish_comp_dir}
+    copy ${worksrcpath}/completions/${name}.fish ${fish_comp_dir}/
+
+    set zsh_comp_dir ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_dir}
+    copy ${worksrcpath}/completions/${name}.zsh ${zsh_comp_dir}/_${name}
+}
 
 github.livecheck.regex {([0-9]+\.[0-9]+\.[0-9]+)}

--- a/net/incus/Portfile
+++ b/net/incus/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/lxc/incus 6.23.0 v
+revision            0
+
+homepage            https://linuxcontainers.org/incus/
+
+description         CLI client for the Incus container and VM manager
+
+long_description    Incus is a community fork of Canonical LXD. This port \
+                    installs only the incus CLI, which connects to an Incus \
+                    server running on a Linux host. The server daemon \
+                    (incusd) is Linux-only and is not included.
+
+categories          net sysutils
+installs_libs       no
+license             Apache-2
+maintainers         {@vijay8i} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  bade197f021ea558084ace4967fb5e342de6ef6a \
+                        sha256  b44addaa328d9560071f34fd64eda77b4e5500e0450cc83efbe33f02ce363834 \
+                        size    5114374
+
+# FIXME: This port currently can't be built without allowing go mod to fetch
+# dependencies at build time. go2port does not support go.sum and the
+# dependency tree includes non-GitHub domains that go.vendors cannot handle.
+go.offline_build    no
+
+# CGO_ENABLED=0 prevents linking against Linux-only C libraries (liblxc,
+# libcowsql) that are pulled in by the daemon but not the client.
+build.env-append    CGO_ENABLED=0
+
+# Build only the CLI. The daemon (cmd/incusd) and agent (cmd/incus-agent)
+# have Linux-only build constraints and will not compile on macOS.
+build.args          -o ${worksrcpath}/incus ./cmd/incus
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/incus ${destroot}${prefix}/bin/incus
+}
+
+notes "
+To add shell completions, run after install:
+  incus completion bash | sudo tee ${prefix}/share/bash-completion/completions/incus
+  incus completion zsh  | sudo tee ${prefix}/share/zsh/site-functions/_incus
+  incus completion fish | sudo tee ${prefix}/share/fish/vendor_completions.d/incus.fish
+"
+
+github.livecheck.regex {([0-9]+\.[0-9]+\.[0-9]+)}


### PR DESCRIPTION
CLI client for Incus container and VM manager. The daemon is Linux-only; this port builds only the macOS-compatible client binary.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.5 24G624 x86_64
Xcode 16.4 16F6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
