### PR TITLE
claude-code: update to 2.1.121

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.120
+version             2.1.121
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  b88a89a6bd75587046d37a0b25c5a1ad19298fbe \
-                 sha256  ad68f225e96db8b7d12d0c31f0343bc3227ea2886ecefae2f483cb32310b0004 \
-                 size    215529168
+    checksums    rmd160  8fa9d1bb3deaf3e5597341d726e7325b134a1f2c \
+                 sha256  59d817dde54eeef0d752e7bd3869586e6eb5fa2b1d785c06fb9cda8804166037 \
+                 size    216982224
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  782ffeeb873ae307065d5ab7e3edf025da7f3a4b \
-                 sha256  fad8faf49c7b1b454c38d785b75e17edbdadc7ffaf450b31349aafc6560b8ef6 \
-                 size    213981440
+    checksums    rmd160  d6db243aa42596b9e2e2c6fc485658b16c61900c \
+                 sha256  3810e55d47ed4d413de6dc037e34d58948f779a4c6bdeeacf1748d850c5daad6 \
+                 size    215417984
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.121.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?