### PR TITLE
google-cloud-sdk: update to 566.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -86,6 +86,7 @@ variant minikube description {Add Minikube} { dict set variant_to_component mini
 variant nomos description {Add Nomos CLI} { dict set variant_to_component nomos nomos }
 variant package_go_module description {Add Artifact Registry Go Module Package Helper} { dict set variant_to_component package_go_module package-go-module }
 variant pkg description {Add pkg} { dict set variant_to_component pkg pkg }
+variant preview description {Add gcloud CLI Preview Commands} { dict set variant_to_component preview preview }
 variant pubsub_emulator description {Add Cloud Pub/Sub Emulator} { dict set variant_to_component pubsub_emulator pubsub-emulator }
 variant spanner_cli description {Add Spanner CLI} { dict set variant_to_component spanner_cli spanner-cli }
 variant spanner_migration_tool description {Add Spanner migration tool} { dict set variant_to_component spanner_migration_tool spanner-migration-tool }

--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             565.0.0
+version             566.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  77041304ff885c23b53620718471f32e4c993ce3 \
-                    sha256  f63cccd550f6fb3000dcccb3d0d8ee92b1a34894094912e141fdee8fda8f5159 \
-                    size    58605544
+    checksums       rmd160  cccb53e4ce78ad73bdf205b929e51f3ba623a52c \
+                    sha256  870216a870cc31b706076606a633e435cba1625e354217f60db4da7cdc9d6dd8 \
+                    size    58632575
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  47d9667180e86efba028554a103f4a48e9214fb9 \
-                    sha256  10b446c52ad9dfb70f0a8134bf37932610eb790e340960a1351fab35a7c9d9c3 \
-                    size    60262777
+    checksums       rmd160  705a44046c9fcb66ee75f8069ef660fc3d94c749 \
+                    sha256  5544218052d6620deb0a70414fbea53f7fd820da16b94b585f462f4fde1fd7b6 \
+                    size    60292398
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  49e115474f242d19cfeb9be685ff2d86178a4a71 \
-                    sha256  8d1980d5d43041850b10c75409a755538d23459cb6815d2c9dd3a172ff03f0ac \
-                    size    60166391
+    checksums       rmd160  08feacb054fa4ed2bed913cfe951cf7044c520df \
+                    sha256  ffd8dfb56b91eca749dd50c69171308f9754e8423103b6310cdac5536df8c35f \
+                    size    60195038
 } else {
     set arch_classifier invalid
 }
@@ -48,7 +48,7 @@ worksrcdir          ${name}
 # Most recent Python version that is compatible with both
 # glcoud (https://docs.cloud.google.com/sdk/docs/install-sdk#mac) and
 # gsutil (https://docs.cloud.google.com/storage/docs/gsutil_install#specifications)
-python.default_version 313
+python.default_version 314
 
 # MacPorts variants are not allowed to contain '-' and gcloud component names use both '-' and '_',
 # so each variant adds an explicit mapping from variant name to gcloud component name.


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 566.0.0.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?