### PR TITLE
openjdk17-temurin: update to 17.0.19

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.18
-set build    8
+version      ${feature}.0.19
+set build    10
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least October 2027)
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  91be33d221df8fdbc35f8ad58c0f21dd5c8fdce8 \
-                 sha256  47c2a8a62d6ba44bf46f2e468f9b3f26ad4b0bf6a51544e29c4520c18e709744 \
-                 size    180379640
+    checksums    rmd160  5279fdb6f131129d12765ddbb7fad33364761754 \
+                 sha256  03632d1fbf139ab3719a9f4b47dc206251449b87557143c822336dbf8c06560f \
+                 size    180540440
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  88985c06f56c531b33c79497b3e3cdbb6b764a59 \
-                 sha256  d81de06d938384fe76c4aa3c13395933aa11e2d19b0428743f810db06b05e312 \
-                 size    185658966
+    checksums    rmd160  20ce85d17efbc286daf51cf8692f47cf09b00f2b \
+                 sha256  8fa1eff40bb637a33613b2ccb8b12c70dc3661cc22cf8e784943715769a05336 \
+                 size    185818964
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.19.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?