### PR TITLE
openjdk21-temurin: update to 21.0.11

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -17,11 +17,11 @@ license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
 universal_variant no
 
-# https://adoptium.net/temurin/releases/
+# https://adoptium.net/temurin/releases/?version=21&os=mac
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.10
-set build    7
+version      ${feature}.0.11
+set build    10
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least December 2029)
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  ad85bc48703cdbd5c96690816210e9d8ddb930eb \
-                 sha256  7484d5d4cdb02fc17a842ab86ddac2524a0365066659c46b2e258c64152379cd \
-                 size    194134523
+    checksums    rmd160  5cf073ec8efca8df7c837bac1cd15b82307aaefd \
+                 sha256  34180eb03e6d207c388cce3da668f6cc7cd7508c185c24782fadac2c9c0e66f9 \
+                 size    194283642
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  f8d256250a45e030d2987fb44b7f12e9af584ebc \
-                 sha256  01ca390455216ca27bdddf8cfad51aaedb4f90e1e23aad9bfd9e90caaa2c5f1b \
-                 size    199896082
+    checksums    rmd160  9f6fafcdf98cd1fbea497b597a5da2e7049b1e73 \
+                 sha256  6ebcf221c9b41507b14c098e93c6ead6440b8d9bd154f8ec666c4c73abbdb201 \
+                 size    200030394
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 21.0.11.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?