### PR TITLE
openjdk25-temurin: update to 25.0.3

### DIFF
--- a/java/openjdk25-temurin/Portfile
+++ b/java/openjdk25-temurin/Portfile
@@ -17,11 +17,11 @@ license          GPL-2+
 # They are not universal binaries
 universal_variant no
 
-# https://adoptium.net/temurin/releases/?version=25&os=mac&arch=any&mode=filter
+# https://adoptium.net/temurin/releases/?version=25&os=mac
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.2
-set build    10
+version      ${feature}.0.3
+set build    9
 revision     0
 
 # End of availability: https://adoptium.net/support
@@ -33,14 +33,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  d127792b1f63f22a625a3a57b2b110c6a0a1caf2 \
-                 sha256  7caddeb2d1d06a21487fdf55198349f122ba7b24bfc613b8923a42a133a92dc5 \
-                 size    120443487
+    checksums    rmd160  fa2d496babb96dea3e152a0a93214f6881e7d114 \
+                 sha256  4c539a18b4d656960ff6766727e9ca546fc17f7a29714dba9e7b47bdcb37c447 \
+                 size    120533867
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  f0c97f46c132e4f53ee0c0f8c20e66490ce16687 \
-                 sha256  74ff6e892924a49767c35eb61251b1969c03213819d51065d9b8f9e0238c4f97 \
-                 size    136512710
+    checksums    rmd160  1ebb3ee20f09b6ac49d3db141e2a4baf1b778fa8 \
+                 sha256  7baab4d69a15554e119b86ff78d40e3fdc28819b5b322955c913cebfe3f6a37c \
+                 size    136601548
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 25.0.3.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?