### PR TITLE
cdo: Another legacy build fix

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -32,6 +32,9 @@ fetch.ignore_sslcert        yes
 # https://code.mpimet.mpg.de/news/536
 compiler.cxx_standard       2020
 
+# fatal error: 'ranges' file not found
+compiler.blacklist-append {clang < 900}
+
 compiler.thread_local_storage yes
 compilers.choose            cc cxx
 mpi.setup


### PR DESCRIPTION
#### Description

Tentative fix for 10.14 builds, maybe others.
"fatal error: 'ranges' file not found"
Blacklist clang < 900.
Build fix only.  No rev bump.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.
Waiting for merge to test on builders <= 10.14.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?