### PR TITLE
algol68g: Update to 3.12.0

### DIFF
--- a/lang/algol68g/Portfile
+++ b/lang/algol68g/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                algol68g
-version             3.11.1
+version             3.12.0
 revision            0
 categories          lang algol devel
 license             GPL-3
@@ -12,12 +12,12 @@ description         Algol 68 implementation as defined by the Revised Report
 long_description    Algol68G is an implementation of Algol 68 as defined by the Revised Report. \
                     It ranks among the most complete implementations of the language.
 
-homepage            https://jmvdveer.home.xs4all.nl/algol.html
-master_sites        https://jmvdveer.home.xs4all.nl
+homepage            https://algol68genie.nl/en/algol-68-genie/
+master_sites        https://algol68genie.nl/
 
-checksums           rmd160  79e44bd3dae0d34ef44857a9fba44ece0d56dac2 \
-                    sha256  53004c643832b0b67d83aadf7392310a06f8a3ecdd98f413ece437b7970befa8 \
-                    size    680752
+checksums           rmd160  f704fa7465536245dae137f8a6092def59757a42 \
+                    sha256  7d88ee8afafa00a44ae0d9f8e50fa8825a53327a7e3e13ba28e906663c152a7d \
+                    size    681262
 
 extract.rename      yes
 
@@ -127,5 +127,4 @@ variant R description {Enable R support} {
 }
 
 livecheck.type      regex
-livecheck.url       [lindex ${master_sites} 0]/en.download.algol-68-genie-current.html
 livecheck.regex     algol68g-(\[0-9.\]+)[quotemeta ${extract.suffix}]


### PR DESCRIPTION
#### Description

* Update 3.11.1 --> 3.12.0.
* New home page and download site.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?