### PR TITLE
vega-lite: update to 6.4.3

### DIFF
--- a/graphics/vega-lite/Portfile
+++ b/graphics/vega-lite/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                vega-lite
-version             6.4.2
+version             6.4.3
 revision            0
 
 categories          graphics devel
@@ -22,9 +22,9 @@ long_description    Vega-Lite is a high-level grammar of interactive graphics. I
 
 homepage            https://vega.github.io/vega-lite/
 
-checksums           rmd160  5f646631c7b2c108e7034a832383556d84983beb \
-                    sha256  158643e963d9a4b81cb971846056fcd629798fae8bc27012b13cddb1f5c03c0f \
-                    size    1077598
+checksums           rmd160  d13aa49e0b71414f2ec93279c823e882cafaf1d5 \
+                    sha256  24260f85e6f5bfe1069505f7c5c2b9863181ac413ef1030746f0a80c93991ce5 \
+                    size    1078939
 
 platform darwin {
     if {${os.major} >= 22} {


### PR DESCRIPTION
Update `vega-lite` from 6.4.2 to 6.4.3.

Upstream release: https://github.com/vega/vega-lite/releases/tag/v6.4.3

Verified locally:
- `port lint --nitpick` passes
- `port test` passes