### PR TITLE
cairo(-devel): re-disable xcb-shm to fix gtk3 app crashes

### DIFF
--- a/graphics/cairo-devel/Portfile
+++ b/graphics/cairo-devel/Portfile
@@ -17,7 +17,7 @@ name                        cairo-devel
 conflicts                   cairo
 set my_name                 cairo
 version                     1.18.4
-revision                    1
+revision                    2
 checksums                   rmd160  757415ba8e1b5df92474644c887865a5ade9fd93 \
                             sha256  445ed8208a6e4823de1226a74ca319d3600e83f6369f99b14265006599c32ccb \
                             size    32578804
@@ -49,6 +49,11 @@ configure.python            ${prefix}/bin/python${py_ver}
 patchfiles-append           patch-darwin-dylib-versions.diff
 
 post-patch {
+    # Disable xcb-shm: MIT-SHM causes X11 BadAccess errors
+    # See https://trac.macports.org/ticket/40811
+    reinplace "s|xcbshm_dep = dependency('xcb-shm', required: get_option('xcb'))|xcbshm_dep = disabler()|" \
+        ${worksrcpath}/meson.build
+
     fs-traverse f ${worksrcpath} {
         if {[string match *.py ${f}]} {
             ui_info "patching env python3: ${f}"

--- a/graphics/cairo/Portfile
+++ b/graphics/cairo/Portfile
@@ -17,7 +17,7 @@ name                        cairo
 conflicts                   cairo-devel
 set my_name                 cairo
 version                     1.18.4
-revision                    1
+revision                    2
 checksums                   rmd160  757415ba8e1b5df92474644c887865a5ade9fd93 \
                             sha256  445ed8208a6e4823de1226a74ca319d3600e83f6369f99b14265006599c32ccb \
                             size    32578804
@@ -49,6 +49,11 @@ configure.python            ${prefix}/bin/python${py_ver}
 patchfiles-append           patch-darwin-dylib-versions.diff
 
 post-patch {
+    # Disable xcb-shm: MIT-SHM causes X11 BadAccess errors
+    # See https://trac.macports.org/ticket/40811
+    reinplace "s|xcbshm_dep = dependency('xcb-shm', required: get_option('xcb'))|xcbshm_dep = disabler()|" \
+        ${worksrcpath}/meson.build
+
     fs-traverse f ${worksrcpath} {
         if {[string match *.py ${f}]} {
             ui_info "patching env python3: ${f}"


### PR DESCRIPTION
Using xcb-shm causes X11 BadAccess errors, crashing many GTK3 apps. This was previously disabled via --disable-xcb-shm in autotools but was lost when the port migrated to meson.

See: https://trac.macports.org/ticket/40811

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.3.1 25D2128 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
