### PR TITLE
claude-code: update to 2.1.123

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.121
+version             2.1.123
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  8fa9d1bb3deaf3e5597341d726e7325b134a1f2c \
-                 sha256  59d817dde54eeef0d752e7bd3869586e6eb5fa2b1d785c06fb9cda8804166037 \
-                 size    216982224
+    checksums    rmd160  883818d9498d732bb0f7e8ec7f975912f5a9ee6c \
+                 sha256  ddea227d4c2b2602d650d2c5d5c812f7680701a1504bcaff81e42c165c583ef9 \
+                 size    217444560
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  d6db243aa42596b9e2e2c6fc485658b16c61900c \
-                 sha256  3810e55d47ed4d413de6dc037e34d58948f779a4c6bdeeacf1748d850c5daad6 \
-                 size    215417984
+    checksums    rmd160  0284641c10338fe6a682609579213e59fc168ec9 \
+                 sha256  44597dff0f1c11e37c1954d4ac3965909be376e5961b558345723357253bcc90 \
+                 size    215880320
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.123.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?