### PR TITLE
micronaut: update to 4.10.13

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.10.12 v
+github.setup    micronaut-projects micronaut-starter 4.10.13 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  e92da4fe7a1e3dc8d5dd077cd79a210732666b94 \
-                 sha256  c60f75b47f58e0e1033adab9e6d551e2b36eb35b33b2ba8f89f641754f5ad90b \
-                 size    30543278
+    checksums    rmd160  0d744bef225c7399af3082360d70754be604cf3f \
+                 sha256  db04bdc0283310118f0f3aa6ba0c1891c6824b0fa41b17308f2b5bf5a96e8164 \
+                 size    30767205
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  4807de6b682885ab33e878dc15c21c937816eaa0 \
-                 sha256  5d7496c219e7704884b4b3b22d7414a0a3d25c3207761f631fd55e26e2886bf6 \
-                 size    30540223
+    checksums    rmd160  04daa9b93d3977a496e5083d449d6a4840c785b8 \
+                 sha256  ca41b8e0f6c6b6cde0b666add1cd24ddc5db660aebfa68316c8360ff522c06c1 \
+                 size    30547116
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.10.13.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?