### PR TITLE
opencode: update to 1.14.29

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.14.28
+version             1.14.29
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  4e63e5cf4ea68d323c1d87504784028c3f5d40cf \
-                    sha256  44095353a5f8576a20db2b29d885a80512723169b3de43f671371afd715afeae \
-                    size    3344
+checksums           rmd160  c61e7a4f4fd65c7917b4fe49deb9cef0dc2fbbcc \
+                    sha256  94dfea34b2fd83856ff0d7d3030bcbd8a4475deb3bc93263b398b973f96a1939 \
+                    size    3348


### PR DESCRIPTION
#### Description

Update to OpenCode 1.14.29.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?