### PR TITLE
llmfit: update to 0.9.17

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.15 v
+github.setup            AlexsJones llmfit 0.9.17 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  bb1633f13d3c4ba3b8bb0d88e074989655287869 \
-                        sha256  b42e018599be79f4230bf5939169fafd9ebd34b1dd92f5d17354d914ac66da7b \
-                        size    2691195
+                        rmd160  6b54daff4885085116c15a974decaa3d242283ce \
+                        sha256  6ffd818f95b71be27c87a91f750f84344eba48d00c9facc09e8d47f2ce6cb628 \
+                        size    2992977
 
 categories              llm
 platforms               macosx


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.4 24G517 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

