### PR TITLE
ImageMagick: Legacy support, fix 10.7 build

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -5,7 +5,7 @@ PortGroup                   conflicts_build 1.0
 PortGroup                   legacysupport 1.1
 
 # TARGET_OS_IOS, TARGET_OS_WATCH, TARGET_OS_TV missing in TargetConditionals.h:
-legacysupport.newest_darwin_requires_legacy 10
+legacysupport.newest_darwin_requires_legacy 11
 
 # Keep relevant lines in sync between ImageMagick and p5-perlmagick.
 


### PR DESCRIPTION
#### Description

* Increase Darwin version to 11, for legacy support, for 10.7 builds.
* Fixes "error: 'TARGET_OS_IOS' is not defined" etc.
* Adds or upgrades TargetConditionals.h.  See legacy support docs.
* Build fix only.  No rev  bump needed.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?