### PR TITLE
lilypond: Update base port to 2.26.0 and devel subport to 2.27.0

### DIFF
--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -49,21 +49,22 @@ notes-append "\
 compiler.cxx_standard 2014
 
 if {${subport} eq ${name}} {
-    version         2.24.4
-    revision        1
+    version         2.26.0
+    revision        0
     conflicts       lilypond-devel
-    checksums       rmd160  5285ff3a441bfd2d936e73a22a8d75a9622c2632 \
-                    sha256  e96fa03571c79f20e1979653afabdbe4ee42765a3d9fd14953f0cd9eea51781c \
-                    size    19442316
+    checksums       rmd160  f0d1a72337d7afb8691f4c0099e50e16854fca4c \
+                    sha256  bbe82dbeba7f7f99ddcd8d1fa134a0d89cafa6e8f815fde5bb01f4208b06fe05 \
+                    size    20130301
 
     set livecheck_url "source.html"
 } else {
-    version         2.25.13
-    revision        1
+    version         2.27.0
+    revision        0
     conflicts       lilypond
-    checksums       rmd160  ffb30994d5000ce591f93050bf51b6fbdac65128 \
-                    sha256  a23a16de1abe0ef80696f59244d93d542a284738b9b29a7ca3ca0aa9bef8b667 \
-                    size    19274596
+    checksums       rmd160  00068f360309a170cd6ebe55c9c028b351474d24 \
+                    sha256  81d7616abbb81bc84c015292fea71ccc0aaa357a11351fef646268591fb1db24 \
+                    size    20117575
+
 
     set livecheck_url "development.html"
 }
@@ -115,7 +116,7 @@ depends_lib-append  path:lib/pkgconfig/pango.pc:pango \
                     port:extractpdfmark \
                     port:ghostscript \
                     port:python${py_ver_nodot} \
-                    port:guile-2.2
+                    port:guile-3.0
 
 build.type          gnu
 configure.cmd       autoconf -f && ./configure
@@ -186,13 +187,9 @@ if {[variant_isset docs]} {
     configure.args-append   --disable-documentation
 }
 if {${subport} eq ${name}} {
-    configure.args-append   --with-urwotf-dir=${prefix}/share/fonts/urw-core35-fonts
-    configure.args-append   --with-texgyre-dir=${lilypond.texgyredir}
+    # Regarding font setup see https://trac.macports.org/ticket/67026,
+    # which is still unresolved.
 } else {
-    # This is a temporary fix until MacPorts provides guile 3, see
-    # https://github.com/macports/macports-ports/pull/14600.
-    configure.env-append    GUILE_FLAVOR=guile-2.2
-
     # Regarding font setup see https://trac.macports.org/ticket/67026,
     # which is still unresolved.
 }

--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -93,8 +93,7 @@ depends_build-append \
                     port:p${perl5.major}-scalar-list-utils \
                     port:pkgconfig \
                     port:t1utils \
-                    port:texinfo \
-                    port:urw-core35-fonts
+                    port:texinfo
 
 if {![variant_isset mactex]} {
     depends_build-append \
@@ -116,7 +115,8 @@ depends_lib-append  path:lib/pkgconfig/pango.pc:pango \
                     port:extractpdfmark \
                     port:ghostscript \
                     port:python${py_ver_nodot} \
-                    port:guile-3.0
+                    port:guile-3.0 \
+                    port:urw-core35-fonts
 
 build.type          gnu
 configure.cmd       autoconf -f && ./configure
@@ -185,13 +185,6 @@ if {[variant_isset docs]} {
     configure.args-append   --disable-texi2html
 } else {
     configure.args-append   --disable-documentation
-}
-if {${subport} eq ${name}} {
-    # Regarding font setup see https://trac.macports.org/ticket/67026,
-    # which is still unresolved.
-} else {
-    # Regarding font setup see https://trac.macports.org/ticket/67026,
-    # which is still unresolved.
 }
 
 configure.env-append    PYTHON=${configure.python}


### PR DESCRIPTION
#### Description

Updates the lilypond port to the current stable- and development-releases.

Also resolves a long-standing Trac ticket due to fonts no longer being packaged since a 2.23.x development build.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.3 25D125 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

