### PR TITLE
mp3rgain: new port

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -1,0 +1,100 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        M-Igashi mp3rgain 2.3.0 v
+github.tarball_from archive
+revision            0
+
+categories          audio
+installs_libs       no
+license             MIT
+maintainers         {@M-Igashi users.noreply.github.com:M-Igashi} \
+                    openmaintainer
+
+description         Lossless MP3/AAC volume normalizer using ReplayGain
+
+long_description    ${name} is a modern Rust reimplementation of the classic \
+                    mp3gain tool. It adjusts MP3 volume losslessly by \
+                    rewriting the per-frame global_gain field according to \
+                    ReplayGain analysis, without re-encoding audio data. \
+                    It also supports lossless AAC/M4A global_gain rewriting, \
+                    making it a safe replacement for the unmaintained \
+                    aacgain port.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  970684ad3b930c6e7a9c55842476840eed26763b \
+                    sha256  d8c8be39ccec2817f11efba2506541c45b98f56a6492d5f2f65130c3e0297b21 \
+                    size    267279
+
+cargo.crates \
+    adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
+    anyhow                       1.0.102          7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
+    autocfg                      1.5.0            c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
+    bitflags                     2.11.0           843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af \
+    bumpalo                      3.20.2           5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
+    bytemuck                     1.25.0           c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec \
+    byteorder                    1.5.0            1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
+    cfg-if                       1.0.4            9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
+    colored                      3.1.1            faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
+    console                      0.16.3           d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
+    crc32fast                    1.5.0            9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    encode_unicode               1.0.0            34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
+    flate2                       1.1.9            843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    id3                          1.16.4           965c5e6a62a241f2f673df956ea5f52c27780bc1031855890a551ed9b869e2d1 \
+    indicatif                    0.18.4           25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
+    itoa                         1.0.18           8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
+    js-sys                       0.3.94           2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9 \
+    lazy_static                  1.5.0            bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
+    libc                         0.2.184          48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af \
+    log                          0.4.29           5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
+    memchr                       2.8.0            f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
+    miniz_oxide                  0.8.9            1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
+    num-complex                  0.4.6            73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
+    num-traits                   0.2.19           071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
+    once_cell                    1.21.4           9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
+    portable-atomic              1.13.1           c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
+    proc-macro2                  1.0.106          8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    quote                        1.0.45           41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    regex-lite                   0.1.9            cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
+    rustversion                  1.0.22           b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    serde                        1.0.228          9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
+    serde_core                   1.0.228          41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
+    serde_derive                 1.0.228          d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
+    serde_json                   1.0.149          83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
+    simd-adler32                 0.3.9            703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
+    smallvec                     1.15.1           67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
+    symphonia                    0.6.0-alpha.2    b38c0b8e99ce52271da0f3fec5780a8566edd703b181211dd0ff725efeaaae38 \
+    symphonia-bundle-mp3         0.6.0-alpha.2    08e64864167bd6cb39e743c19036cad4486ba4dcf299336b695249ea3cfd31ff \
+    symphonia-codec-aac          0.6.0-alpha.2    7139b6baf2f6df9877395d70bf16edc0860d72ff35eefbf51d083b10b36f7949 \
+    symphonia-common             0.6.0-alpha.2    0c029b5a948c81fd3a46647a151b959109d1d16b05a1d7c7eca1fdac0ace0a27 \
+    symphonia-core               0.6.0-alpha.2    3be2e760147497d7f939f18b7739387c7e6b5322d9ce0cf10cd93cf96f4d815c \
+    symphonia-format-isomp4      0.6.0-alpha.2    0a0c9c23912250e33b40c0d36deded5c03aef33299e03c39f78e6125d492da61 \
+    symphonia-metadata           0.6.0-alpha.2    eea744eea37a3336aeb2919b5632a5b79dc12695e60cac15adf3422814c0f32c \
+    syn                          2.0.117          e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    thiserror                    2.0.18           4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
+    thiserror-impl               2.0.18           ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
+    unicode-ident                1.0.24           e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
+    unicode-width                0.2.2            b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
+    unit-prefix                  0.5.2            81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3 \
+    wasm-bindgen                 0.2.117          0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0 \
+    wasm-bindgen-macro           0.2.117          7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be \
+    wasm-bindgen-macro-support   0.2.117          dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2 \
+    wasm-bindgen-shared          0.2.117          39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b \
+    web-time                     1.1.0            5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
+    windows-link                 0.2.1            f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
+    windows-sys                  0.61.2           ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
+    zmij                         1.0.21           b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} \
+        README.md LICENSE \
+        ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
Re-opening of #32491 after a force-push accident broke the previous PR's commit lineage. Apologies for the noise, @herbygillot — the amend was performed in a shallow clone and produced a parentless root commit, which auto-closed the original PR. This PR contains the same Portfile with the corrected commit message you requested.

### Description

New port: lossless MP3 / AAC volume normalizer using ReplayGain. Modern Rust reimplementation of the classic `mp3gain` tool, by the same author. Adjusts MP3 volume losslessly by rewriting the per-frame `global_gain` field, and supports the same lossless AAC/M4A `global_gain` rewrite functionality as the orphaned `audio/aacgain` port.

### Why this port

- `audio/mp3gain` does not exist on MacPorts.
- `audio/aacgain` is orphaned (`maintainers nomaintainer`), unmaintained upstream since 2010, and bundles vulnerable copies of `mpglibDBL`, `faad2`, and `mp4v2`. Homebrew already deprecated `aacgain` in April 2023.
- `mp3rgain` is a safe Rust replacement that performs the same lossless `global_gain` rewrite for both MP3 and AAC/M4A.

After this port lands, I plan to file a Trac ticket proposing deprecation of `audio/aacgain` with `mp3rgain` as the in-tree replacement.

### Verification

- `port lint --nitpick` → 0 errors. Warnings are limited to per-crate ``missing recommended checksum type: rmd160 / size``, which is the standard form used by every other Rust port in the tree (e.g. `textproc/ripgrep`, `sysutils/eza`).
- `sudo port checksum mp3rgain` → all 57 checksums (source tarball + 56 vendored crates) verified successfully.
- `port info mp3rgain` parses cleanly.

Upstream project: https://github.com/M-Igashi/mp3rgain

### Type of new Portfile

- [x] application
- [ ] library

### Tested on

- macOS 26.3.1 (Apple Silicon), MacPorts 2.12.5