### PR TITLE
riscv32-none-elf-gcc: bump newlib to 4.6.0

### DIFF
--- a/cross/riscv32-none-elf-gcc/Portfile
+++ b/cross/riscv32-none-elf-gcc/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           crossgcc 1.0
 
 set gccversion      15.2.0
-set newlibversion   4.3.0.20230120
+set newlibversion   4.6.0.20260123
 crossgcc.setup      riscv32-none-elf ${gccversion}
 crossgcc.setup_libc newlib ${newlibversion}
-revision            0
+revision            1
 
 maintainers         {pguyot @pguyot} openmaintainer
 
@@ -21,13 +21,3 @@ configure.args-append \
                     --with-arch=rv32imac \
                     --with-abi=ilp32 \
                     "--with-multilib-generator=rv32imac-ilp32--\\;rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb-ilp32--"
-
-# newlib 4.3.0 + GCC 15 compatibility:
-# - newlib's long double complex math calls sinhl/logl/etc which are not
-#   implemented on rv32 (implicit-function-declaration)
-# - libgloss syscall wrappers pass pointers where long is expected
-#   (int-conversion)
-post-configure {
-    reinplace "s|CFLAGS_FOR_TARGET = -g -O2|CFLAGS_FOR_TARGET = -g -O2 -Wno-error=int-conversion -Wno-error=implicit-function-declaration|" \
-        ${workpath}/build/Makefile
-}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D771280a x86_64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
