### PR TITLE
ocicl: Update to 2.16.13

### DIFF
--- a/devel/ocicl/Portfile
+++ b/devel/ocicl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ocicl ocicl 2.16.12 v
+github.setup        ocicl ocicl 2.16.13 v
 github.tarball_from archive
 revision            0
 
@@ -22,9 +22,9 @@ long_description    ${name} is a modern alternative to quicklisp. It is modern i
                     \n- All software packages are built and published transparently using hosted CI infrastructure \
                     \n- LLM-generated summaries of changes between versions are available for all packages.
 
-checksums           rmd160  8e6c3157d0d496d262149d6d75b1e1942bbcceed \
-                    sha256  5889ff5d2cc386b07c8320bfc4a7a949d8b25e9e21c15cea3ea121337083a49b \
-                    size    34107323
+checksums           rmd160  d6f0690cff7091136e32b00e4fce5a2e81f75545 \
+                    sha256  067408f0443119a25c2b34a323a829fb953542e367bb039365bdcc0a0b388500 \
+                    size    34119527
 
 depends_build       port:sbcl
 


### PR DESCRIPTION
#### Description

Update `ocicl` to 2.16.13

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.10 20G1427 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
