### PR TITLE
oasdiff: Update to 1.15.0

### DIFF
--- a/devel/oasdiff/Portfile
+++ b/devel/oasdiff/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/Tufin/oasdiff 1.14.0 v
+go.setup            github.com/Tufin/oasdiff 1.15.0 v
 go.offline_build    no
 revision            0
 
@@ -20,9 +20,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  767feec749672cc29afeaa3365ecb6306aa0ecfb \
-                    sha256  a2cc623689e4aceeeb6656cfd1317d0c020ac50a5367a4477970e7375a0bb4d9 \
-                    size    428375
+                    rmd160  df8fd649ad92e01ce870b2817828537040f539cc \
+                    sha256  536614f37d0f5595717842283d7e9d7381de9dc1f4eaddbedfa3f964282000ea \
+                    size    496538
 
 post-build {
     system -W ${worksrcpath} "./${name} completion bash > ${name}.bash"


### PR DESCRIPTION
#### Description

oasdiff: Update to 1.15.0


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
