### PR TITLE
pinact: Update to 3.9.2

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.9.0 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.9.2 v
 go.offline_build    no
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
@@ -18,9 +18,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d4018959860aa5abc6b291ae0f86dd0e6f0c2598 \
-                    sha256  4e4f5f1f98162f90fe688d9a82f00da56e545e15bec8d3a0fa334b1c72b59aef \
-                    size    78605
+                    rmd160  aeb5e2f9f55fbcd63b7bcb538ff6f27fed4f1d13 \
+                    sha256  ea47eefa985476b8fe3cafc814d636242fc51897f35328af3809665a0c3841ca \
+                    size    78220
 
 livecheck.regex     {v(\d+\.\d+\.\d+)$}
 


### PR DESCRIPTION
#### Description

pinact: Update to 3.9.2


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
