### PR TITLE
py-pytorch: fix build with newer Clang, enable Gloo backend

### DIFF
--- a/python/py-pytorch/Portfile
+++ b/python/py-pytorch/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 PortGroup           python 1.0
 
 github.setup        pytorch pytorch 2.11.0 v
-revision            0
+revision            1
 name                py-${github.project}
 license             BSD
 maintainers         nomaintainer
@@ -128,6 +128,10 @@ if {${name} ne ${subport}} {
     # diff -NaurdwB ./py-pytorch-orig/c10/util/Logging.cpp ./py-pytorch-new/c10/util/Logging.cpp | sed -E -e 's/\.\/py-pytorch-(orig|new)/\./g' | sed -E -e 's|/opt/local|@@PREFIX@@|g' > ~/Downloads/patch-glog-init-check.diff
     patchfiles-append       patch-glog-init-check.diff
 
+    # Fix lambda return type deduction errors with newer Clang.
+    # Upstream PyTorch issue: https://github.com/pytorch/pytorch/issues/178044
+    patchfiles-append       patch-lambda-return-types.diff
+
     # Use Intel Math kernel Library
     if {[variant_isset mkl]} {
         patchfiles-append FindMKL-OMP.patch
@@ -192,6 +196,8 @@ if {${name} ne ${subport}} {
                     USE_GFLAGS=ON \
                     USE_GLOG=ON \
                     USE_LITE_PROTO=ON \
+                    USE_DISTRIBUTED=ON \
+                    USE_GLOO=ON \
                     USE_NCCL=OFF \
                     USE_OPENMP=ON \
                     USE_SYSTEM_PYBIND11=ON \
@@ -204,6 +210,12 @@ if {${name} ne ${subport}} {
         foreach slib [glob -directory ${destroot}${py_torch_root} *.so] {
             system "install_name_tool -add_rpath ${py_torch_root}/lib ${slib}"
         }
+
+        # Upstream PyTorch bundles pybind11 headers in its include directory.
+        # Since we use USE_SYSTEM_PYBIND11=ON, create a symlink so downstream
+        # packages (torchaudio, torchvision, etc.) can find pybind11 headers.
+        ln -s ${python.pkgd}/pybind11/include/pybind11 \
+            ${destroot}${py_torch_root}/include/pybind11
 
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}

--- a/python/py-pytorch/files/patch-lambda-return-types.diff
+++ b/python/py-pytorch/files/patch-lambda-return-types.diff
@@ -1,0 +1,73 @@
+--- torch/csrc/jit/python/init.cpp.orig
++++ torch/csrc/jit/python/init.cpp
+@@ -1803,7 +1803,7 @@
+           const auto sortedOps = getAllSortedOperatorsFor(symbol);
+           if (sortedOps.empty()) {
+             // No such operator
+-            return py::make_tuple(py::none(), py::none());
++            return py::make_tuple(py::cast<py::object>(py::none()), py::cast<py::object>(py::none()));
+           }
+
+           std::ostringstream docstring;
+@@ -1830,7 +1830,7 @@
+               },
+               py::name(symbol.toUnqualString()),
+               py::doc(docstring.str().c_str()));
+-          return py::make_tuple(func, overload_names);
++          return py::make_tuple(py::cast<py::object>(func), py::cast<py::object>(overload_names));
+         } catch (const c10::Error& e) {
+           auto msg = torch::get_cpp_stacktraces_enabled()
+               ? e.what()
+@@ -1855,9 +1855,9 @@
+             args,
+             kwargs);
+         if (res) {
+-          return py::make_tuple(true, *res);
++          return py::make_tuple(py::cast<py::object>(py::bool_(true)), py::cast<py::object>(*res));
+         } else {
+-          return py::make_tuple(false, py::none());
++          return py::make_tuple(py::cast<py::object>(py::bool_(false)), py::cast<py::object>(py::none()));
+         }
+       });
+
+--- torch/csrc/distributed/c10d/init.cpp.orig
++++ torch/csrc/distributed/c10d/init.cpp
+@@ -887,16 +887,16 @@
+           [](const ::c10d::ReduceOp& r) {
+             // __getstate__
+             if (r.op_ != ::c10d::ReduceOp::RedOpType::PREMUL_SUM) {
+-              return py::make_tuple(r.op_, py::none());
++              return py::make_tuple(py::cast(r.op_), py::cast<py::object>(py::none()));
+             }
+             TORCH_CHECK(r.supplement_.defined(), "Invalid PREMUL_SUM ReduceOp");
+             const auto* preMulSupplement =
+                 reinterpret_cast<::c10d::NCCLPreMulSumSupplement*>(
+                     r.supplement_.get());
+             if (!preMulSupplement->tensor_factor.defined()) {
+-              return py::make_tuple(r.op_, preMulSupplement->double_factor);
++              return py::make_tuple(py::cast(r.op_), py::cast(preMulSupplement->double_factor));
+             } else {
+-              return py::make_tuple(r.op_, preMulSupplement->tensor_factor);
++              return py::make_tuple(py::cast(r.op_), py::cast(preMulSupplement->tensor_factor));
+             }
+           },
+           [](const py::tuple& t) {
+
+--- torch/csrc/utils/python_arg_parser.cpp.orig
++++ torch/csrc/utils/python_arg_parser.cpp
+@@ -759,9 +759,12 @@
+   }
+   py::object func =
+       PyObject_FastGetAttrString(THPVariableClass, (char*)func_name);
+-  py::object args = (val == nullptr)
+-      ? py::make_tuple(py::handle(self), py::handle(index))
+-      : py::make_tuple(py::handle(self), py::handle(index), py::handle(val));
++  py::object args;
++  if (val == nullptr) {
++    args = py::make_tuple(py::handle(self), py::handle(index));
++  } else {
++    args = py::make_tuple(py::handle(self), py::handle(index), py::handle(val));
++  }
+   return handle_torch_function_no_python_arg_parser(
+       overridable_args,
+       args.ptr(),


### PR DESCRIPTION
Fix lambda return type deduction errors with Clang 21 (and newer). Upstream PyTorch issue: https://github.com/pytorch/pytorch/issues/178044

Also enable USE_DISTRIBUTED and USE_GLOO so torch.distributed.is_available() returns True (needed by audiocraft and similar packages).

Also symlink pybind11 headers into torch include directory so downstream packages (torchaudio, torchvision) can find them when built with USE_SYSTEM_PYBIND11=ON.

Fixes: https://trac.macports.org/ticket/73936

Remark: CI times out as it takes more than 6 hours to build py314-pytorch. I installed it from this branch on a M4 MacMini, it succeeded and it took 25 minutes.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D771280a x86_64
Xcode 26.4.1 17E202

and

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
