### PR TITLE
x86_64-binutils: update to 2.46.0

### DIFF
--- a/cross/x86_64-binutils/Portfile
+++ b/cross/x86_64-binutils/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 name                x86_64-binutils
-version             2.45
-revision            1
+version             2.46.0
+revision            0
 maintainers         {@kamischi web.de:karl-michael.schindler} \
                     openmaintainer
 
@@ -29,6 +29,9 @@ foreach ostarget {linux dragonfly freebsd haiku netbsd openbsd solaris} {
         configure.args-append   --disable-werror
         if {${ostarget} eq "linux"} {
             depends_build-append    port:bison
+        }
+        if {${ostarget} eq "solaris"} {
+            configure.args-append   --enable-obsolete
         }
         # Delete docs since already installed by the base package
         # Resolves clash about identical docs from each subport


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 x86_64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
