### PR TITLE
openjdk25-openj9: update to 25.0.3

### DIFF
--- a/java/openjdk25-openj9/Portfile
+++ b/java/openjdk25-openj9/Portfile
@@ -20,28 +20,27 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.2
-revision     1
+version      ${feature}.0.3
+revision     0
 
-set build    10
-set openj9_version 0.57.0
+set build    9
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}+${build}.${revision}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}.${revision}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  9106e8030dc6daa40b090d2acf9997265b6fab4b \
-                 sha256  eeeae81af54332b94a0808c500e6d98d052683ee3b6cb0e209c486c23a81a1ba \
-                 size    239812387
+    checksums    rmd160  adcb7934169547fb5906ccaa6abde91aeb987195 \
+                 sha256  445db356704fdfd735b27c8cb1c539dcb77c02e3b9b1bcb465289c3eebf8b81f \
+                 size    240157426
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  8afe752a12e8ad94ff4c7cfdfaa1c176181be85c \
-                 sha256  2c2c200a299f5f22b399733773ec1e931e1d738f7a5970de601c4edb2955ab43 \
-                 size    234001321
+    checksums    rmd160  1bb7278aa4906610fdc6cf098474eb26033c5fde \
+                 sha256  a69eb48b9c2a3321d44d6bbc3ec26e860e894ee3e96888f0ad114bd65c5fc73a \
+                 size    234306520
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to IBM Semeru 25.0.3.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?