### PR TITLE
fpc-cross-avr*-embedded: New Freepascal cross compilers for avr

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -427,8 +427,47 @@ foreach ostarget {linux netbsd embedded} {
     }
 }
 
+foreach subarch {avr25 avr35 avr4 avr5 avr51 avr6} {
+    subport "${name}-cross-${subarch}-embedded" {
+        revision                0
+        categories-append       cross
+        supported_archs         noarch
+        worksrcdir              fpcbuild-${version}/fpcsrc
+        use_parallel_build      no
+        use_configure           no
+        depends_build-append    port:${name} port:${name}-cross port:avr-binutils
+        build.target            rtl packages
+        destroot.target         rtl_install packages_install
+        test.target
+
+    # target specifics
+        description     FPC cross-compiler for ${subarch}-embedded
+        long_description \
+            This Pascal crosscompiler produces avr executables, \
+            which run natively on avr-embedded systems. \n \
+            Get help with: \n \
+            fpc -h \n \
+            Compile and link a Pascal file with: \n \
+            \n \
+            fpc -Pavr -Tembedded -XPavr- -Cp${subarch} FILENAME
+
+        build.args      PP=ppcavr CPU_TARGET=avr OS_TARGET=embedded \
+                        BINUTILSPREFIX=avr- OPT="-ap -v0" SUBARCH=${subarch}
+        destroot.args   CPU_TARGET=avr OS_TARGET=embedded CROSSINSTALL=1 \
+                        INSTALL_PREFIX=${destroot}${prefix}/libexec/fpc \
+                        SUBARCH=${subarch} \
+                        INSTALL_UNITDIR=/${destroot}${prefix}/libexec/fpc/lib/fpc/${version}/units/avr-embedded/${subarch}
+
+    # remove duplicate doc and bin files
+        post-destroot   {
+            file delete -force ${destroot}${prefix}/libexec/fpc/share
+            file delete -force ${destroot}${prefix}/libexec/fpc/bin
+        }
+    }
+}
+
 if {${subport} eq "${name}"} {
-    revision            3
+    revision            4
 
     installs_libs       yes
 
@@ -593,6 +632,8 @@ if {${subport} eq "${name}"} {
             "bin/fpcmkcfg -d basepath=${fpcbasepath}/lib/${name}/${version} \
                     -o etc/fpc.cfg"
         ln -s ${fpcbasepath}/etc/fpc.cfg ${destroot}${prefix}/etc
+        reinplace "s|${version}|\$fpcversion|g" \
+                    ${destroot}${fpcbasepath}/etc/fpc.cfg
         system "patch ${destroot}${fpcbasepath}/etc/fpc.cfg \
                     ${filespath}/fpc.cfg.patch"
 

--- a/lang/fpc/files/fpc.cfg.patch
+++ b/lang/fpc/files/fpc.cfg.patch
@@ -1,8 +1,23 @@
 --- etc/fpc.cfg	2019-06-14 15:54:16.000000000 +0200
 +++ fpc.cfg-new	2019-08-17 10:54:57.000000000 +0200
+@@ -152,6 +152,14 @@
+ -Fu/opt/local/libexec/fpc/lib/fpc/$fpcversion/units/$fpctarget/$fpcsubarch-$fpcmemorymodel
+ -Fu/opt/local/libexec/fpc/lib/fpc/$fpcversion/units/$fpctarget/$fpcsubarch-$fpcmemorymodel/*
+ -Fu/opt/local/libexec/fpc/lib/fpc/$fpcversion/units/$fpctarget/$fpcsubarch-$fpcmemorymodel/rtl
++#endif
++
++# Search for $fpctarget/$fpcsubarch/ subdirectory first
++# for avr CPU
++#ifdef cpuavr
++-Fu/opt/local/libexec/fpc/lib/fpc/$fpcversion/units/$fpctarget/$fpcsubarch
++-Fu/opt/local/libexec/fpc/lib/fpc/$fpcversion/units/$fpctarget/$fpcsubarch/*
++-Fu/opt/local/libexec/fpc/lib/fpc/$fpcversion/units/$fpctarget/$fpcsubarch/rtl
+ #endif
+ 
+ # searchpath for units and other system dependent things
 @@ -175,6 +175,11 @@
  # searchpath for tools
- -FD/opt/local/libexec/fpc/lib/fpc/3.2.2/bin/$FPCTARGET
+ -FD/opt/local/libexec/fpc/lib/fpc/$fpcversion/bin/$FPCTARGET
  
 +# searchpath for qt4pas framework
 +#IFDEF Darwin


### PR DESCRIPTION
#### Description

fpc-cross-avr*-embedded: New Freepascal cross compilers for avr

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
