### PR TITLE
py-altair: update to 6.1.0

### DIFF
--- a/python/py-altair/Portfile
+++ b/python/py-altair/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-altair
-version             6.0.0
+version             6.1.0
 revision            0
 
 categories-append   devel graphics
@@ -22,9 +22,9 @@ long_description    {*}${description}
 
 homepage            https://altair-viz.github.io/
 
-checksums           rmd160  c629b9f15537ded7a3b0d6157a6cea94b1f2bc53 \
-                    sha256  614bf5ecbe2337347b590afb111929aa9c16c9527c4887d96c9bc7f6640756b4 \
-                    size    763834
+checksums           rmd160  bd9c24aba6723acec5fa2c32ed88e2c8ec945324 \
+                    sha256  dda699216cf85b040d968ae5a569ad45957616811e38760a85e5118269daca67 \
+                    size    765519
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-jinja2 \


### PR DESCRIPTION
Update `py-altair` from 6.0.0 to 6.1.0.

Upstream release: https://github.com/vega/altair/releases/tag/v6.1.0

Verified locally:
- `port lint --nitpick` passes
- `port test` passes