### PR TITLE
virt-viewer: add MacOS app bundle

### DIFF
--- a/emulators/virt-viewer/Portfile
+++ b/emulators/virt-viewer/Portfile
@@ -31,7 +31,8 @@ checksums           rmd160  d16895408be0b3fa29bbf7854d5e83030e845408 \
 
 patchfiles          patch-data-meson-build.diff
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig \
+                    port:gettext
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libxml2 \

--- a/emulators/virt-viewer/Portfile
+++ b/emulators/virt-viewer/Portfile
@@ -10,7 +10,7 @@ version             11.0
 revision            2
 
 categories          emulators
-maintainers         {raimue @raimue} \
+maintainers         {dports @drkp} \
                     openmaintainer
 license             GPL-2+
 

--- a/emulators/virt-viewer/Portfile
+++ b/emulators/virt-viewer/Portfile
@@ -1,11 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+
 PortGroup           meson 1.0
+PortGroup           app 1.0
 
 name                virt-viewer
 version             11.0
-revision            1
+revision            2
+
 categories          emulators
 maintainers         {raimue @raimue} \
                     openmaintainer
@@ -15,8 +18,7 @@ homepage            https://virt-manager.org
 master_sites        https://releases.pagure.org/virt-viewer/
 
 description         connects to VMs via VNC/SPICE and libvirt
-
-long_description \
+long_description    \
     Virtual Machine Viewer provides a graphical console client for connecting \
     to virtual machines. It uses the GTK-VNC or SPICE-GTK widgets to provide \
     the display, and libvirt for looking up VNC/SPICE server details.
@@ -38,3 +40,88 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:gtk-vnc \
                     port:spice-gtk
+
+#
+# Build a MacOS app bundle that launches remote-viewer. This is a
+# little more complicated because we have to use an AppleScript
+# droplet suitable for registering as a handler for .vv connection
+# files. The AppleScript copies the file to a temporary directory in
+# case the original is in a quarantined location, and deletes the
+# original if delete-this-file is set (just like remote-viewer would
+# do).
+#
+app.name            Remote Viewer
+app.identifier      org.macports.remote-viewer
+app.executable      ${prefix}/bin/remote-viewer
+app.retina          yes
+app.use_launch_script no
+
+variant app_as_root description {Applet launches Remote Viewer with admin privileges (insecure, required for usb forwarding)} {}
+
+post-patch {
+    set scriptfile ${workpath}/RemoteViewer.applescript
+    copy ${filespath}/RemoteViewer.applescript ${scriptfile}
+
+    reinplace "s|@PREFIX@|${prefix}|g" ${scriptfile}
+
+    if {[variant_isset app_as_root]} {
+        reinplace "s|@PRIVILEGES@| with administrator privileges|g" ${scriptfile}
+    } else {
+        reinplace "s|@PRIVILEGES@||g" ${scriptfile}
+    }
+}
+
+post-build {
+    # Build an .icns icon from source PNGs.
+    set iconset ${workpath}/virt-viewer.iconset
+    file mkdir ${iconset}
+    foreach {size filename} {
+        16   icon_16x16.png
+        32   icon_16x16@2x.png
+        32   icon_32x32.png
+        48   icon_32x32@2x.png
+        256  icon_128x128@2x.png
+        256  icon_256x256.png
+    } {
+        set src ${worksrcpath}/icons/${size}x${size}/virt-viewer.png
+        if {[file exists ${src}]} {
+            copy ${src} ${iconset}/${filename}
+        }
+    }
+    system "/usr/bin/iconutil -c icns -o [shellescape ${workpath}/virt-viewer.icns] [shellescape ${iconset}]"
+}
+
+app.icon            ${workpath}/virt-viewer.icns
+
+post-destroot {
+    set app_root ${destroot}${applications_dir}/${app.name}.app
+    set applet ${workpath}/RemoteViewer-applet.app
+
+    # Compile the AppleScript into an applet.
+    if {[file exists ${applet}]} {
+        delete -force ${applet}
+    }
+    system "/usr/bin/osacompile -o [shellescape ${applet}] [shellescape ${workpath}/RemoteViewer.applescript]"
+
+    # Replace the app bundle payload with the compiled AppleScript applet.
+    delete -force ${app_root}/Contents/MacOS
+    copy ${applet}/Contents/MacOS ${app_root}/Contents/
+
+    delete -force ${app_root}/Contents/Resources
+    copy ${applet}/Contents/Resources ${app_root}/Contents/
+
+    # Copy the icon into Resources.
+    copy ${workpath}/virt-viewer.icns ${app_root}/Contents/Resources/virt-viewer.icns
+
+    # Replace plist with osacompile's (has proper applet keys), then customize.
+    delete -force ${app_root}/Contents/Info.plist
+    copy ${applet}/Contents/Info.plist ${app_root}/Contents/Info.plist
+
+    set plist ${app_root}/Contents/Info.plist
+    system "/usr/bin/plutil -replace CFBundleIdentifier -string [shellescape ${app.identifier}] [shellescape ${plist}]"
+    system "/usr/bin/plutil -replace CFBundleName -string [shellescape ${app.name}] [shellescape ${plist}]"
+    system "/usr/bin/plutil -replace CFBundleIconFile -string virt-viewer.icns [shellescape ${plist}]"
+    system "/usr/bin/plutil -replace CFBundleShortVersionString -string ${version} [shellescape ${plist}]"
+    system "/usr/bin/plutil -replace CFBundleDocumentTypes -xml '<array><dict><key>CFBundleTypeName</key><string>Virt Viewer Connection File</string><key>CFBundleTypeRole</key><string>Viewer</string><key>LSHandlerRank</key><string>Owner</string><key>LSItemContentTypes</key><array><string>${app.identifier}.vv</string></array></dict></array>' [shellescape ${plist}]"
+    system "/usr/bin/plutil -insert UTExportedTypeDeclarations -xml '<array><dict><key>UTTypeIdentifier</key><string>${app.identifier}.vv</string><key>UTTypeDescription</key><string>Virt Viewer Connection File</string><key>UTTypeConformsTo</key><array><string>public.data</string></array><key>UTTypeTagSpecification</key><dict><key>public.filename-extension</key><array><string>vv</string></array><key>public.mime-type</key><array><string>application/x-virt-viewer</string></array></dict></dict></array>' [shellescape ${plist}]"
+}

--- a/emulators/virt-viewer/files/RemoteViewer.applescript
+++ b/emulators/virt-viewer/files/RemoteViewer.applescript
@@ -1,0 +1,17 @@
+on open theFiles
+    repeat with oneFile in theFiles
+        set srcPath to POSIX path of oneFile
+        set tmpPath to do shell script "/usr/bin/mktemp -t remote-viewer-vv"
+
+        do shell script "/bin/cp " & quoted form of srcPath & " " & quoted form of tmpPath
+        try
+            do shell script "/usr/bin/grep -q '^delete-this-file[[:space:]]*=[[:space:]]*[^0[:space:]]' " & quoted form of srcPath
+            do shell script "/bin/rm -f " & quoted form of srcPath
+        end try
+        do shell script "@PREFIX@/bin/remote-viewer " & quoted form of tmpPath & " > /dev/null 2>&1 &"@PRIVILEGES@
+    end repeat
+end open
+
+on run
+    do shell script "@PREFIX@/bin/remote-viewer > /dev/null 2>&1 &"@PRIVILEGES@
+end run


### PR DESCRIPTION
#### Description

Context: I have been using web apps (mainly the Proxmox web UI) that download .vv files for remote-viewer and wanted them to launch automatically. 

This patch adds a Mac app (Remote Viewer) that launches remote-viewer with a .vv file. It's a bit more complicated than usual because it needs an AppleScript droplet and the appropriate registration in Info.plist to register as a .vv handler and accept dropped files. The AppleScript copies the file to a temporary directory in case the original is in a quarantined location, and deletes the original if delete-this-file is set (as like remote-viewer would do). 

There's also a +app_as_root variant that makes it prompt for administrator privileges to run remote-viewer. This isn't great for security, but it's the only way to make USB device forwarding work (see https://github.com/libusb/libusb/wiki/FAQ#user-content-How_can_I_run_libusb_applications_under_macOS_if_there_is_already_a_kernel_extension_installed_for_the_device_and_claim_exclusive_access)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

Tested on both +x11 and +quartz

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

