### PR TITLE
openjdk21-openj9: update to 21.0.11

### DIFF
--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -20,28 +20,27 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.10
-revision     1
+version      ${feature}.0.11
+revision     0
 
-set build    7
-set openj9_version 0.57.0
+set build    10
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}+${build}.${revision}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}.${revision}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  6b7803e3003a0139214de0600e0828bf3ac6c390 \
-                 sha256  c63be460f4fd3375f73e0155615128cc6357daba8192d9fda3c707bb70ff8472 \
-                 size    231698303
+    checksums    rmd160  92e6541cb187a13df1efa32b5e9cb10143e96009 \
+                 sha256  801f7731660bdd81a311504c16a2e89541a648f1ac09f74624a82856f2aa60f1 \
+                 size    232047827
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  e11379a00fbfc2808f0d2019aa15990a8b7d576e \
-                 sha256  91e688a1bcfdd33917053d323b5535d315ffbffb2f63f271fb3441f55d6df4e4 \
-                 size    225907661
+    checksums    rmd160  5904485b848836588628a0493c427ec890748756 \
+                 sha256  3eadaf09b075321c13fc3c494ad50033614b3119810b15f2547ebed678a9d2ef \
+                 size    226270093
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to IBM Semeru 21.0.11.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?