### PR TITLE
openjdk17-openj9: update to 17.0.19

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -20,28 +20,27 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.18
-revision     1
+version      ${feature}.0.19
+revision     0
 
-set build    8
-set openj9_version 0.57.0
+set build    10
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}+${build}.${revision}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}.${revision}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  0f0991c817451c7b578d47b44814e6b343130c2f \
-                 sha256  2aa2a0bcdae0509632857930efc2bf4395c13c39f8f4b93678f0f60b7e241b5c \
-                 size    218874092
+    checksums    rmd160  cba1fbcd6f01d9a97d5b15ce63db80dc139d2086 \
+                 sha256  5db39e34f1ff48bdc6ee0cbd0d81acdbd7e5630866e7330b53e8820d9915dbe4 \
+                 size    219334264
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  b7de029a9c8c1f674d5e8d570a4ff66771279022 \
-                 sha256  d50eb5a7bfe828423e1b45086194721d2c6b90ae46ff37a79740e91c33d31284 \
-                 size    213122178
+    checksums    rmd160  b19fc32934635f9ab4ff9c4484319b0df8456ec2 \
+                 sha256  42d79668d1ecda453ff8d7b5de981f00713699152cca649411270fcbfc2f9411 \
+                 size    213601507
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.19.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?