### PR TITLE
openjdk11-openj9: update to 11.0.31

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -20,28 +20,27 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.30
-revision     1
+version      ${feature}.0.31
+revision     0
 
-set build    7
-set openj9_version 0.57.0
+set build    11
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}%2B${build}.${revision}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}.${revision}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  7a50ff4e8e68a967f3ea9a0fe0125628257cd15c \
-                 sha256  12b34c8b358597c9eb3bdd283ac8e5a4957814a55983ab99a7b147ad6d0f463b \
-                 size    212462631
+    checksums    rmd160  0e844d40fa8b4a992ee53c21fe53524972d59397 \
+                 sha256  dadd7ba7885ae2e6aacbf0197c4cb2e9bf7bb4d71a8fe628ec1952a086b5bd47 \
+                 size    212793598
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  9577871b154eaf6139633b746dd36c3c4fc0c12e \
-                 sha256  1853ce7e090f1fbfa45ad984afe74a92d45f08de5629f97af20766943a671959 \
-                 size    207037434
+    checksums    rmd160  c7144d408b123b9df78af1f5a804d0cc12691afe \
+                 sha256  df773bded292d77de6f2d29aad9577fb9615e03745d76c4dad6069435d8e3950 \
+                 size    207384792
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.31.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?