### PR TITLE
claude-code: update to 2.1.126

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.123
+version             2.1.126
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  883818d9498d732bb0f7e8ec7f975912f5a9ee6c \
-                 sha256  ddea227d4c2b2602d650d2c5d5c812f7680701a1504bcaff81e42c165c583ef9 \
-                 size    217444560
+    checksums    rmd160  a24acc24424bd8a45991d206e00cd6f6882f0afa \
+                 sha256  49a90c474383a9eda11310bd71f7ea6bb91361ec99443b733cb5003f6e703ccb \
+                 size    217824336
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  0284641c10338fe6a682609579213e59fc168ec9 \
-                 sha256  44597dff0f1c11e37c1954d4ac3965909be376e5961b558345723357253bcc90 \
-                 size    215880320
+    checksums    rmd160  7a3f7379f09f8d4aca6c96813be25b4a1c62775c \
+                 sha256  87a1d05018ceadfc1fe616bfc10262b0503f51986f4af2dc42d1ed856ed3f7bb \
+                 size    216260096
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.126.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?