### PR TITLE
openjdk8-openj9: update to 8.0.492.0

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -3,7 +3,7 @@
 PortSystem       1.0
 
 set feature 8
-set patch 482
+set patch 492
 name             openjdk${feature}-openj9
 categories       java devel
 maintainers      {breun @breun} openmaintainer
@@ -21,30 +21,29 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
-version      ${feature}u${patch}
-revision     1
+version      ${feature}.0.${patch}.0
+revision     0
 
-set build    08
-set openj9_version 0.57.0
+set build    09
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk${version}-b${build}.${revision}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}/
 
-distname     ibm-semeru-open-jdk_x64_mac_${feature}.0.${patch}.${revision}
-worksrcdir   jdk${version}-b${build}
+distname     ibm-semeru-open-jdk_x64_mac_${version}
+worksrcdir   jdk${feature}u${patch}-b${build}
 
-checksums    rmd160  05b8c352c03d45ec41a51a5c3712c52e7d11a376 \
-             sha256  f2c86c32e32def4340c07911bf9c46704794d29abdb27e2ef0e67adb41b5c5f8 \
-             size    129686564
+checksums    rmd160  46ed8c40d9ede45fd4c6f7860f3654be9518a9fb \
+             sha256  ec8c84dee17104ad43f189c9be6e2d3e121a4cfd09bf3c17681a4fee65e4b2d9 \
+             size    129735157
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
 livecheck.type      regex
 livecheck.url       https://github.com/ibmruntimes/semeru${feature}-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(${feature}u\[0-9\.\]+).*_openj9-\[0-9\.\]+\.tar\.gz
+livecheck.regex     >jdk-(${feature}\.\[0-9\.\]+)<
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8.0.492.0.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?