### PR TITLE
py-Pillow: add libavif dependency

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-Pillow
 version             12.2.0
-revision            0
+revision            1
 categories-append   devel
 license             BSD
 
@@ -64,6 +64,7 @@ if {${name} ne ${subport}} {
                         port:zlib \
                         path:include/turbojpeg.h:libjpeg-turbo \
                         port:tiff \
+                        port:libavif \
                         port:lcms2 \
                         port:webp \
                         port:openjpeg \


### PR DESCRIPTION
#### Description

Pillow 11.2.1 added support for reading and writing libavif images, provided the libavif library is available - https://pillow.readthedocs.io/en/stable/releasenotes/11.2.1.html#reading-and-writing-avif-images

https://trac.macports.org/ticket/73934 points out that Pillow is find this library if it is present, although the dependency is not mentioned in the Portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
