### PR TITLE
qiv: update to version 3.0.4

### DIFF
--- a/graphics/qiv/Portfile
+++ b/graphics/qiv/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           codeberg 1.0
 
-codeberg.setup      ciberandy qiv 3.0.2 v
+codeberg.setup      ciberandy qiv 3.0.4 v
 categories          graphics
 license             GPL-2
 maintainers         {lloyd.io:me @lloyd}
@@ -15,9 +15,9 @@ long_description    A very small and pretty fast gdk/Imlib image viewer \
 
 homepage            http://spiegl.de/qiv/
 
-checksums           rmd160  0b776a2cb0de3aac5a3a416c33f04e5de67a6745 \
-                    sha256  c0887644d84b3680f73d56d5f4be0b3347d51fad7b41bd9736f75956d17efa89 \
-                    size    141558
+checksums           rmd160  b2afd2d9523206106874038db7c2088e9a4deda8 \
+                    sha256  6a453e033f9dd50a3ac59e1f5c90efb92ba13f31b82a49e1d599b8ae7a292cea \
+                    size    143169
 
 depends_build       port:pkgconfig
 

--- a/graphics/qiv/files/patch-Makefile.diff
+++ b/graphics/qiv/files/patch-Makefile.diff
@@ -1,35 +1,23 @@
---- Makefile.orig	2025-04-23 16:17:38.000000000 +0200
-+++ Makefile	2025-08-11 21:18:50.000000000 +0200
+--- Makefile.orig	2026-04-19 21:17:56.000000000 +0200
++++ Makefile	2026-05-01 17:11:28.000000000 +0200
 @@ -4,7 +4,7 @@
  #######################################################################
  
  # Directory where qiv will be installed under.
--PREFIX = /usr/local
-+PREFIX = $(DESTDIR)@PREFIX@
+-PREFIX ?= /usr/local
++PREFIX ?= $(DESTDIR)@PREFIX@
  
  # Fonts to use for statusbar and comments
  STATUSBAR_FONT = "Monospace 9"
-@@ -56,8 +56,9 @@
- PKG_CONFIG ?= pkg-config
+@@ -57,8 +57,9 @@
  INSTALL    ?= install
- CFLAGS    = -O2 -Wall \
+ STRIP_FLAG ?= -s
+ CFLAGS     ?= -O2 -Wall \
 -	    -fcaller-saves -ffast-math -fno-strength-reduce \
 -	    -fthread-jumps
 +	    -ffast-math -fno-strength-reduce
 +#	    -fcaller-saves -ffast-math -fno-strength-reduce \
 +#	    -fthread-jumps
  
- GDK_VERS := 3
+ GDK_VERS ?= 3
  
-@@ -169,10 +170,7 @@
- 	  $(INSTALL) -d -m 0755 $(PREFIX)/share/applications; \
- 	fi
- 	$(INSTALL) -m 0644 qiv.desktop $(PREFIX)/share/applications/qiv.desktop
--	@if ./qiv -f ./intro.jpg ; \
--	then echo "-- Test Passed --" ; \
--	else echo "-- Test Failed --" ; \
--	fi
-+	@echo "-- Test Skipped --"
- 	@echo "\nDont forget to look into the \"qiv-command\" file and install it!\n-> cp qiv-command.example $(PREFIX)/bin/qiv-command\n\n"
- 
- # the end... ;-)


### PR DESCRIPTION
#### Description

Update qiv to latest upstream version.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.4 24G517 arm64
Xcode 16.2 16C5032a

macOS 10.15.8 19H2036 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
