### PR TITLE
openjdk26-openj9: update to 26.0.1

### DIFF
--- a/java/openjdk26-openj9/Portfile
+++ b/java/openjdk26-openj9/Portfile
@@ -20,41 +20,40 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.0
+version      ${feature}.0.1
 revision     0
 
-set build    35
-set openj9_version 0.58.0
+set build    8
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK ${feature} (Long Term Support)
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
                  built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
 
-master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${feature}+${build}_openj9-${openj9_version}/
+master_sites https://github.com/ibmruntimes/semeru${feature}-binaries/releases/download/jdk-${version}.${revision}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  383c93daccb90f7bdedb0e438e9d6f2c9f00f0e0 \
-                 sha256  5e9f10ad13319438e09a48695593964f5a4ae507ab49bcde1a76f893b7105d5b \
-                 size    243854373
+    checksums    rmd160  cd31d35c0ed2057500d94be91cbe387be50b61c0 \
+                 sha256  deb49f5bc18dae5aeea91cbf38720255e47ddbf25431fcca0fca14c337bde2dc \
+                 size    244028854
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  72e9f4ee414e6bfae48411237790acbe986a8075 \
-                 sha256  62f5dc0b2b2b101a437e0caf0e0f94dde54dc2e71db954fb8faf400b53e5716a \
-                 size    238013359
+    checksums    rmd160  7fa4d39c573bb51e7635404c36d1f8a5dc5e503a \
+                 sha256  6d7cc426e35c63fe83260026229a8c66201c20dd0912e0a19950abb245ef0ca0 \
+                 size    238179879
 } else {
     set arch_classifier unsupported_arch
 }
 
 distname     ibm-semeru-open-jdk_${arch_classifier}_mac_${version}.${revision}
 
-worksrcdir   jdk-${feature}+${build}
+worksrcdir   jdk-${version}+${build}
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 
 livecheck.type      regex
 livecheck.url       https://github.com/ibmruntimes/semeru${feature}-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(${feature}\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
+livecheck.regex     >jdk-(${feature}\.\[0-9\.\]+).0<
 
 use_configure    no
 build {}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 26.0.1.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?