### PR TITLE
openjdk25-microsoft: update to 25.0.3

### DIFF
--- a/java/openjdk25-microsoft/Portfile
+++ b/java/openjdk25-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-25
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.2
-set build    10
+version      ${feature}.0.3
+set build    9
 revision     0
 
 # End of life date: https://learn.microsoft.com/en-us/java/openjdk/support#release-and-servicing-roadmap
@@ -33,14 +33,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  ade130dd608bdaad86d8977b212a4d2baa114069 \
-                 sha256  6bc02fd3182dee12510f253d08eeac342a1f0e03d7f4114763f83d8722e2915e \
-                 size    220223851
+    checksums    rmd160  e25e810da2f5f82124d65bc2339232780d64f16a \
+                 sha256  bb590b1e3bee59120bad3ef79b8de82f2f56f6394b60179c5a7caef820bbdd2f \
+                 size    220403004
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  b3a949ace125221327d99d8ac579e25511d9b676 \
-                 sha256  0bface8af5ceea3bf8b7eec6d38f1a68b68b60db5ea14eb2a1bd9767cf971fed \
-                 size    217577211
+    checksums    rmd160  53daf4beb0469edadebd1634ef8a0ad6dab38f3e \
+                 sha256  9f0091f4ffd6a4c314cd41c6e42e4a68fd50e17e6d281681c48796139deecab3 \
+                 size    217727186
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 25.0.3.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?