### PR TITLE
babl-devel: update to 0.1.126

### DIFF
--- a/graphics/babl-devel/Portfile
+++ b/graphics/babl-devel/Portfile
@@ -7,7 +7,7 @@ PortGroup           debug 1.0
 name                babl-devel
 conflicts           babl
 set my_name         babl
-version             0.1.116
+version             0.1.126
 revision            0
 license             LGPL-3+
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -24,9 +24,9 @@ dist_subdir         ${my_name}
 distname            ${my_name}-${version}
 use_xz              yes
 
-checksums           rmd160  371ccce2272586094c2b62cc0871d934efc9b731 \
-                    sha256  50fae069867c7ade1259888ff1e3db85fec86d708252e5385b5a4f39a78ec483 \
-                    size    321804
+checksums           rmd160  7372b7b3d8b530e23ef90315534ff15c5c758f05 \
+                    sha256  3f090f4b2a61fecf7c8dc60a5804bbc77cefd8d778af2ded059f0e367a52930e \
+                    size    326996
 
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload
@@ -35,11 +35,11 @@ configure.args-append \
                     -Dwith-docs=false
 
 depends_build-append \
-                    path:bin/pkg-config:pkgconfig
+                    path:bin/pkg-config:pkgconfig \
+                    path:bin/vala:vala
 
 depends_lib-append  port:lcms2 \
-                    path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
-                    path:bin/vala:vala
+                    path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection
 
 patchfiles-append   patch-babl-linker-fix-darwin.diff
 


### PR DESCRIPTION
- Drop nodownload (online subprojects/ are gone)
- Change vala to depends_build-append
  See: https://trac.macports.org/ticket/71697

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Command Line Tools 26.4.0.0.1774242506

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
