### PR TITLE
pasdoc: new documentation tool for pascal sources

### DIFF
--- a/devel/pasdoc/Portfile
+++ b/devel/pasdoc/Portfile
@@ -1,0 +1,103 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        pasdoc pasdoc 1.0.4 v
+github.tarball_from archive
+
+revision            0
+categories          devel textproc
+license             GPL-2
+maintainers         {@kamischi web.de:karl-michael.schindler} \
+                    openmaintainer
+
+homepage            https://${name}.github.io
+
+checksums           rmd160  437393d53f51d63e64693887d73e6296b6018e1b \
+                    sha256  5d761366f18aa617ba00bf13def1c1778bb8046e20fcf73a6cfa7701655c8bbf \
+                    size    23391284
+
+use_configure       no
+
+if {${subport} eq "${name}"} {
+    description         Documentation generator for Pascal source code.
+
+    long_description    PasDoc is a documentation tool for Object Pascal code \
+                        (as implemented by FPC and Delphi). Documentation is \
+                        generated from comments found in the source code or in \
+                        special \"description files\". \
+                        Numerous output formats are supported, including HTML, \
+                        LaTeX (for PDF, PS), XML and PHP. \
+                        This package includes these CLI tools: \n \
+                        - pasdoc \n \
+                        - file_to_pascal_data \n \
+                        - file_to_pascal_string \n \
+                        - pascal_pre_proc \n \
+                        Type "pasdoc --help" to get a better feeling for how \
+                        PasDoc works. Also, see the web page for more \
+                        information about PasDoc. \
+
+    depends_build       port:fpc
+
+    build.target        build-fpc-release build-generators
+
+    post-build {
+    # building pascal_pre_proc.dpr fails as part of the build.target build-tools.
+    # fpc needs some additional options.
+        system -W ${worksrcpath} \
+            "fpc -Fulib -MDelphi source/tools/pascal_pre_proc.dpr"
+        file copy ${worksrcpath}/source/tools/pascal_pre_proc ${worksrcpath}/bin
+    }
+
+    destroot {
+        # Binaries
+        xinstall -m 0755 {*}[glob ${worksrcpath}/bin/*] ${destroot}${prefix}/bin/
+        # Docs
+        set DOCDIR ${destroot}${prefix}/share/doc/${name}
+        xinstall -m 755 -d ${DOCDIR}
+        foreach FILE {ChangeLog.md LICENSE README.md} {
+            xinstall -m 0644 ${worksrcpath}/$FILE ${DOCDIR}
+        }
+        # Man pages
+        set MANDIR ${destroot}${prefix}/share/man/${name}
+        xinstall -m 755 -d ${MANDIR}
+        xinstall -m 0644 {*}[glob ${worksrcpath}/man/*.man] ${MANDIR}
+    }
+}
+
+subport "${name}-gui" {
+    revision        0
+
+    description        PasDoc GUI Application
+    long_description   PasDoc is a documentation application for Object \
+                       Pascal code (as implemented by FPC and Delphi).
+
+
+    depends_build      port:lazarus
+
+    build.cmd          lazbuild
+    if {${os.platform} eq "darwin" && ${os.major} >= 20} { # 11, Big Sur
+        build.args     --opt=-WM10.15
+    }
+    build.target       source/packages/lazarus/pasdoc_package.lpk \
+                       source/gui/pasdoc_gui.lpi
+
+    post-build {
+        # Fix the app bundle
+        set APPCONTENTSDIR ${worksrcpath}/source/gui/pasdoc_gui.app/Contents
+        # Icon
+        file copy ${worksrcpath}/source/gui/pasdoc_gui.ico \
+            ${APPCONTENTSDIR}/Resources
+        set ICONFILEKEY <key>CFBundleIconFile</key><string>pasdoc_gui.ico</string>
+        reinplace "s|<dict>|<dict>${ICONFILEKEY}|g" \
+            ${APPCONTENTSDIR}/Info.plist
+        # replace link by actual binary
+        file delete ${APPCONTENTSDIR}/MacOS/pasdoc_gui
+        file copy ${worksrcpath}/source/gui/pasdoc_gui ${APPCONTENTSDIR}/MacOS
+    }
+
+    destroot {
+        move ${worksrcpath}/source/gui/pasdoc_gui.app ${destroot}${applications_dir}/
+    }
+}


### PR DESCRIPTION
#### Description

pasdoc: new documentation tool for pascal sources including a GUI application

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [xx] enhancement
- [ ] security fix

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
