### PR TITLE
openjdk17-microsoft: update to 17.0.19

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://learn.microsoft.com/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.18
-set build    8
+version      ${feature}.0.19
+set build    10
 revision     0
 
 # End of life date: https://learn.microsoft.com/en-us/java/openjdk/support#release-and-servicing-roadmap
@@ -33,14 +33,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  7592041b46cb6dc4a35b72cde1f4e9b3304bdc74 \
-                 sha256  e281696a0751638c41e531000bd72180872b714a5f8599085c9fec1f4ebc5415 \
-                 size    187986736
+    checksums    rmd160  cfe4bc5462e6a3e9da7dcc802242a3865718e036 \
+                 sha256  6af364adc0c79a5a8d4ea2edc5ecb8cd7e47360c2944947c70482e18befea046 \
+                 size    188133169
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  808f9f06b76a50d89b23165fdd7f58d14b2521bc \
-                 sha256  a9c8fe9bd41ffdcf82119b4ef0f7e3e833a91fee3094862769088b372c7680f6 \
-                 size    185951740
+    checksums    rmd160  94b1049a8dc7c0a4a16c71b5405806756da65fbf \
+                 sha256  5ce59293b2eb30cb4e9f0c72c1ea27cea2bfaadcf0dbbe87ddd92e031c4210be \
+                 size    186130463
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.19.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?