### PR TITLE
libelf: fix +universal not working as intended for `libelf.dylib`

### DIFF
--- a/devel/libelf/Portfile
+++ b/devel/libelf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                libelf
 version             0.8.13
-revision            5
+revision            6
 categories          devel
 license             LGPL-2+
 maintainers         nomaintainer

--- a/devel/libelf/files/shared.diff
+++ b/devel/libelf/files/shared.diff
@@ -9,7 +9,7 @@
 +	SHLIB_SFX='.$(VERSION).dylib'
 +	SHLINK_SFX='.dylib'
 +	SONAME_SFX='.$(MAJOR).dylib'
-+	LINK_SHLIB='$(CC) -shared -Wl,-install_name,$(libdir)/$(SONAME)'
++	LINK_SHLIB='$(CC) -shared $(LDFLAGS) -Wl,-install_name,$(libdir)/$(SONAME)'
 +	INSTALL_SHLIB='$(INSTALL_PROGRAM)'
 +	DEPSHLIBS='-lc'
 +	;;


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/73952

#### Description

This PR fixes an issue where the built `libelf.dylib` library file contains only the host binary-compatible code, but nothing else, even when building using the `+universal` variant. 

It adds the missing `LDFLAGS` to the generation of the .dylib file (which contains the universal arch and more).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 26.5 25F5068a arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
