### PR TITLE
mp3rgain: update to 2.3.1

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.3.0 v
+github.setup        M-Igashi mp3rgain 2.3.1 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  970684ad3b930c6e7a9c55842476840eed26763b \
-                    sha256  d8c8be39ccec2817f11efba2506541c45b98f56a6492d5f2f65130c3e0297b21 \
-                    size    267279
+                    rmd160  01b307f80077a8b59c4d5951001cf6c47c34c659 \
+                    sha256  f8a490bf72338ab361a709b36dabbae0e2fe26ed8f0d573111dd0751fcce424a \
+                    size    279423
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
## Description

Updates `audio/mp3rgain` from 2.3.0 to 2.3.1.

## Verification

- [x] Have you followed the [guidelines for contributing](https://trac.macports.org/wiki/SubmittingPortfiles)?
- [x] Have you tested your changes with \`port lint\`?
- [x] Have you tested your changes by building / installing the affected ports?
- [x] If your changes affect a maintained port, you have included the maintainer in this PR.

## Release notes

https://github.com/M-Igashi/mp3rgain/releases/tag/v2.3.1

Highlights for v2.3.1:
- Official multi-arch Docker image on GHCR (`ghcr.io/m-igashi/mp3rgain`)
- Internal code-reuse / quality / efficiency cleanups (shared supported-extension helper between CLI and GUI, removed `to_uppercase()` allocations in APE tag access, dedup'd `parse_undo_gain`, `&PathBuf` → `&Path`, etc.)

## Notes

- \`cargo.crates\` block is unchanged from 2.3.0 (no new transitive dependencies introduced this release)
- Updated tarball checksums (sha256 / rmd160 / size) for the v2.3.1 GitHub source archive
- \`revision\` reset to 0 because the upstream version changed