### PR TITLE
jdk21: update to 21.0.11

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      ${feature}.0.10
+version      ${feature}.0.11
 revision     0
 
 description  Oracle Java SE Development Kit ${feature}
@@ -27,14 +27,14 @@ master_sites https://download.oracle.com/java/${feature}/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  e2a9fd8fd0611e978a38bb3d1ad0a4e1b886fb68 \
-                 sha256  d21bb6de5e6cc30bc908d57cb5196692a6c6abe036310f1f12c387b6fb738075 \
-                 size    192665320
+    checksums    rmd160  b7c4fdaf4e7015eef2992409afeb0850f44b310a \
+                 sha256  0c7490310b37f250fa9bfc1e8bd0674ec47f3ce0abbef1468fa87825ae2fcd01 \
+                 size    193957422
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  296ed3655894ba0dee83eeb03acae4d6d253e330 \
-                 sha256  a1b88857d916a3cc08aa6a920baa828169cf7e9e12b6a7b07611042ad9267273 \
-                 size    190369929
+    checksums    rmd160  c2de39e938e62d2d070297e903bc4ade41f5a25d \
+                 sha256  95debdf373d9b44df554a8dd0b1ace48adc02515139e041325347e372825eeaf \
+                 size    191654769
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Oracle JDK 21.0.11.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?