### PR TITLE
docker: update to 29.4.2

### DIFF
--- a/devel/docker/Portfile
+++ b/devel/docker/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/docker/cli 29.4.1 v
+go.setup            github.com/docker/cli 29.4.2 v
 revision            0
 name                docker
 categories          devel
@@ -16,9 +16,9 @@ long_description    Docker is an open source project to pack, ship \
                     This port contains command line utilities for interacting \
                     with Docker, but not the core daemon.
 
-checksums           rmd160  aabdbc3d91f8f660a6ce4eb48236b924b864dbd2 \
-                    sha256  b45d935ab8f5faff8b0a03eb6c5c658636f47bc8170d892152b8eb57f5931315 \
-                    size    7052983
+checksums           rmd160  4f3da6b77668b0294c9523fe789953a2bbc14404 \
+                    sha256  87d5f01a880bdd329af5fb57120b83b7e3bd215d8046b67a0b6d303293e91a1f \
+                    size    7052248
 
 build.target        github.com/docker/cli/cmd/docker
 


### PR DESCRIPTION
#### Description

Update to Docker CLI 29.4.2.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?