### PR TITLE
syncthing: Fix permissions, consistent file name, add UserName, GroupName to plist

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/syncthing/syncthing 2.0.16 v
 go.offline_build    no
-revision            0
+revision            1
 
 homepage            https://syncthing.net
 
@@ -36,6 +36,8 @@ test.run            yes
 test.cmd            ${build.cmd}
 test.target         test
 
+set syncthing_plist net.syncthing.syncthing.plist
+
 destroot {
     xinstall -W ${worksrcpath}/bin syncthing ${destroot}${prefix}/bin
 
@@ -47,15 +49,23 @@ destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name}
     xinstall -W ${worksrcpath} AUTHORS LICENSE ${destroot}${prefix}/share/doc/${name}
     xinstall {*}[glob ${worksrcpath}/*.md] ${destroot}${prefix}/share/doc/${name}
+    # launchd plist
     xinstall -d ${destroot}${prefix}/share/examples/${name}
-    xinstall -W ${worksrcpath}/etc/macos-launchd syncthing.plist ${destroot}${prefix}/share/examples/${name}
-    reinplace "s|/Users/USERNAME/bin/|${prefix}/bin/|g" ${destroot}${prefix}/share/examples/${name}/syncthing.plist
+    xinstall -m 0644 -W ${worksrcpath}/etc/macos-launchd syncthing.plist ${destroot}${prefix}/share/examples/${name}
+    move ${destroot}${prefix}/share/examples/${name}/syncthing.plist \
+         ${destroot}${prefix}/share/examples/${name}/${syncthing_plist}
+    reinplace "s|/Users/USERNAME/bin/|${prefix}/bin/|g" ${destroot}${prefix}/share/examples/${name}/${syncthing_plist}
+    system -W ${destroot}${prefix}/share/examples/${name} \
+        "/usr/bin/plutil -insert UserName -string USERNAME ${syncthing_plist}"
+    system -W ${destroot}${prefix}/share/examples/${name} \
+        "/usr/bin/plutil -insert GroupName -string staff ${syncthing_plist}"
 }
 
 notes-append        \
     "Syncthing provides an example launchd plist. To use it:" \
-    "1. Copy ${prefix}/share/examples/${name}/syncthing.plist to ~/Library/LaunchAgents" \
+    "1. Copy ${prefix}/share/examples/${name}/${syncthing_plist} to ~/Library/LaunchAgents" \
     "2. Edit syncthing.plist by replacing USERNAME with your actual username" \
-    "3. Log out and in again, or run: launchctl load ~/Library/LaunchAgents/syncthing.plist"
+    "3. Log out and in again, or run:" \
+    "launchctl load ~/Library/LaunchAgents/${syncthing_plist}"
 
 github.livecheck.regex  {([0-9.-]+)}


### PR DESCRIPTION
syncthing: Fix permissions, consistent file name, add UserName, GroupName to plist

* Install plist with mode `0644` [syncthing file has executable flags]
* Use plist name consistent with plist label: `net.syncthing.syncthing`
* Add `UserName=USERNAME` and `GroupName=staff` for syncthing command; this does nothing if run under `~/Library/LaunchAgents,` but is required if copied to `/Library/LaunchDaemons`.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
