### PR TITLE
privoxy-pki-bundle: Only "build" from source

### DIFF
--- a/www/privoxy/Portfile
+++ b/www/privoxy/Portfile
@@ -578,7 +578,7 @@ TLS_PRIVOXY_ROOT_CA
 
 subport ${name}-pki-bundle {
     # Please increase the revision whenever curl-ca-bundle contents change
-    revision        1
+    revision        2
 
     license         MIT
     supported_archs noarch
@@ -588,6 +588,7 @@ subport ${name}-pki-bundle {
     long_description \
                     {*}${description}
 
+    archive_sites
     master_sites
     distfiles
     extract.only


### PR DESCRIPTION
privoxy-pki-bundle: Only "build" from source

* Add `ports_source_only` flag to ensure privoxy-pki-bundle pem file is created from the latest `curl-ca-bundle.crt` at the time of install, not downloaded from a possibly outdated MacPorts buildbot distribution.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
