### PR TITLE
ruby-build: Update to 20260501

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20260426 v
+github.setup        rbenv ruby-build 20260501 v
 revision            0
 github.tarball_from archive
 categories          ruby
@@ -17,9 +17,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  7eeae8d20167f00bcb9f926eceef87832a1f02bd \
-                    sha256  5a69c7650b19105eb2458a81aa55b9ba168e9887b4848a32ce1d31df358bca04 \
-                    size    100697
+checksums           rmd160  9e9c79ec1c673eff6791bcf5a736257c04d365f5 \
+                    sha256  9f7a9f5c1b6caccd6659722a8412c21d2781fbb9204c421f1bad74ce1467cd66 \
+                    size    102764
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20260501


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
