### PR TITLE
netatalk_client: Submission

### DIFF
--- a/net/netatalk_client/Portfile
+++ b/net/netatalk_client/Portfile
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           fuse 1.0
+PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+PortGroup           meson 1.0
+
+# strnlen
+legacysupport.newest_darwin_requires_legacy 10
+
+github.setup        Netatalk netatalk_client 0.9.4
+revision            0
+categories-append   net fuse
+license             GPL-2
+maintainers         nomaintainer
+github.tarball_from archive
+
+description         AFP file sharing client
+
+long_description    Netatalk Client is a file sharing client written \
+                    in C which can be used to access AFP shares exposed \
+                    by multiple devices, notably personal file sharing \
+                    on older Mac OS X and Classic Mac OS computers, \
+                    Netatalk servers hosted on Linux/*BSD/Solaris/macOS, \
+                    Apple AirPort and Time Capsule products as well as \
+                    other AFP enabled NAS devices from various vendors. \
+                    Netatalk Client is an improved fork of afpfs-ng.
+
+homepage            https://netatalk.io/
+
+checksums           rmd160  4d962510ba583889d5fe8e53500a41e9a25e5a24 \
+                    sha256  9c50ee65f870cdd09b6989a546561476e082b72539631c07f34a26b9fbaea045 \
+                    size    221117
+
+meson.wrap_mode     nodownload
+
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    patchfiles-append \
+                    patch-10.5-compat.diff
+
+    configure.args-append \
+                    -Dforce-fuse-v2=true
+}
+
+if {${os.platform} eq "darwin" && ${os.major} > 22} {
+    configure.cflags-append \
+                    -Wno-error=incompatible-function-pointer-types
+}
+
+depends_lib-append  port:libgcrypt \
+                    port:libiconv \
+                    port:readline
+
+compiler.c_standard 2011
+
+configure.args-append \
+                    -Denable-fuse=true

--- a/net/netatalk_client/files/patch-10.5-compat.diff
+++ b/net/netatalk_client/files/patch-10.5-compat.diff
@@ -1,0 +1,22 @@
+--- lib/lowlevel.c	2026-02-09 04:09:54.000000000 +0800
++++ lib/lowlevel.c	2026-02-22 08:03:20.000000000 +0800
+@@ -24,6 +24,10 @@
+ #include "midlevel.h"
+ #include "forklist.h"
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ static void set_nonunix_perms(unsigned int * mode, struct afp_file_info *fp)
+ {
+     if (fp->isdir) {
+@@ -721,7 +725,7 @@
+     stbuf->st_ctime = creation_date;
+     stbuf->st_mtime = modification_date;
+ #endif
+-#ifdef __APPLE__
++#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1060)
+     /* On macOS, set birthtimespec for Finder display (handled by stat_to_darwin_attr) */
+     stbuf->st_birthtimespec.tv_sec = creation_date;
+     stbuf->st_birthtimespec.tv_nsec = 0;


### PR DESCRIPTION
These submissions compile and run, but I don't yet have `afp_client mount` working yet for Time Capsule. See https://github.com/Netatalk/netatalk_client/issues/213.

cc: @i0ntempest

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
