### PR TITLE
opencode: update to 1.14.33

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.14.30
+version             1.14.33
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  c20246c152c00bba23bf0b5ff745ee2568e49d8a \
-                    sha256  838ee692769f34878b2a41f50f0e384d0c67994439a1b36d9be37faafc3b68f0 \
-                    size    3347
+checksums           rmd160  c3a32bf5dc1fd9719993f4776d108b79f4fe98ca \
+                    sha256  76c3c8d7686f61ce6894cb28f8fccdfa1a45be5c69392bfa3a5f7624ac2ff705 \
+                    size    3340


### PR DESCRIPTION
#### Description

Update to OpenCode 1.14.33.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?