### PR TITLE
stern: update to 1.34.0

### DIFF
--- a/sysutils/stern/Portfile
+++ b/sysutils/stern/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/stern/stern 1.33.1 v
+go.setup            github.com/stern/stern 1.34.0 v
 maintainers         {breun @breun} openmaintainer
 # macOS 11 is the oldest version that provides a Go version that is recent enough to build Stern
 platforms           {darwin >= 20}
-revision            1
+revision            0
 categories          sysutils
 license             Apache-2
 
@@ -17,9 +17,9 @@ long_description    Stern allows you to tail multiple pods on Kubernetes and \
                     multiple containers within the pod. Each result is color \
                     coded for quicker debugging.
 
-checksums           rmd160  6ad8526bd038a5bc10d90f4c7177fdf376d2317d \
-                    sha256  24101b69a65e5fcfa459806c9628540c8085e8427fb44a28b6daf8c865215878 \
-                    size    67847
+checksums           rmd160  579426037561cadd55a2835117f46f6214c466a9 \
+                    sha256  1cfec22cef9705e68fc46060ba85164af12bd07ede9264bafb67d11400996e71 \
+                    size    67279
 
 set go_ldflags      "-s -w -X ${go.package}/cmd.version=${version}"
 build.args          -ldflags \"${go_ldflags}\" -o bin/${name}


### PR DESCRIPTION
#### Description

Update to Stern 1.34.0.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?