### PR TITLE
mp3rgain: update to 2.4.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.3.1 v
+github.setup        M-Igashi mp3rgain 2.4.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  01b307f80077a8b59c4d5951001cf6c47c34c659 \
-                    sha256  f8a490bf72338ab361a709b36dabbae0e2fe26ed8f0d573111dd0751fcce424a \
-                    size    279423
+                    rmd160  15de57e53565704c0d8cb79ce69facda0871e7c6 \
+                    sha256  29878145b46789b5779b7d257ce14a4ba64598dddc49b296407cdcc29efb8e4a \
+                    size    295916
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
@@ -41,6 +41,10 @@ cargo.crates \
     colored                      3.1.1            faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
     console                      0.16.3           d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
     crc32fast                    1.5.0            9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    crossbeam-deque              0.8.6            9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
+    crossbeam-epoch              0.9.18           5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-utils              0.8.21           d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
+    either                       1.15.0           48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
     encode_unicode               1.0.0            34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     flate2                       1.1.9            843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
     id3                          1.16.4           965c5e6a62a241f2f673df956ea5f52c27780bc1031855890a551ed9b869e2d1 \
@@ -58,6 +62,8 @@ cargo.crates \
     portable-atomic              1.13.1           c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
     proc-macro2                  1.0.106          8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
     quote                        1.0.45           41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    rayon                        1.12.0           fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
+    rayon-core                   1.13.0           22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     regex-lite                   0.1.9            cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
     rustversion                  1.0.22           b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     serde                        1.0.228          9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \


### PR DESCRIPTION
### Description

Updates `audio/mp3rgain` to version 2.4.0.

### Highlights

- **Parallel ReplayGain analysis** — major performance improvement: multi-file ReplayGain analysis (`-r`, `-a`, default info) is now parallelized via rayon. New `-j N` / `--threads N` flag (also `MP3RGAIN_THREADS` env var). Default is `available_parallelism()`; `-j 1` falls back to the legacy serial path. Output ordering and TSV/Text/JSON byte-equivalence preserved.
- Large `src/main.rs` refactor (2898 lines split into focused modules). CLI behavior unchanged.
- New "Migrating from mp3gain" guide.

Full release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.4.0

### Type of change

- [x] Update existing port

### Tests

- `port lint --nitpick` passes (0 errors). The 126 "missing rmd160/size" warnings are inherent to `cargo.crates` (Cargo only provides sha256 per crate) and are the same as the merged v2.3.1 update.
- New cargo.crates entries: `crossbeam-deque`, `crossbeam-epoch`, `crossbeam-utils`, `either`, `rayon`, `rayon-core` (rayon dependency tree pulled in by the parallelization work).

### Tarball checksums

- rmd160 `15de57e53565704c0d8cb79ce69facda0871e7c6`
- sha256 `29878145b46789b5779b7d257ce14a4ba64598dddc49b296407cdcc29efb8e4a`
- size   `295916`