### PR TITLE
ruby-build: Update to 20260503

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20260501 v
+github.setup        rbenv ruby-build 20260503 v
 revision            0
 github.tarball_from archive
 categories          ruby
@@ -17,9 +17,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  9e9c79ec1c673eff6791bcf5a736257c04d365f5 \
-                    sha256  9f7a9f5c1b6caccd6659722a8412c21d2781fbb9204c421f1bad74ce1467cd66 \
-                    size    102764
+checksums           rmd160  b3fe22d48d129b1410635c77692f0ac6fa12ad2f \
+                    sha256  115de494e26edb657b664de9b38dcce6a4afe321a54f66ee7a0b1051c65a6c16 \
+                    size    102849
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20260503


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
