### PR TITLE
net/binkd: fix build on macOS 26 Tahoe

### DIFF
--- a/net/binkd/Portfile
+++ b/net/binkd/Portfile
@@ -16,7 +16,10 @@ master_sites    https://2f.ru/binkd/
 use_zip yes
 pre-configure 	{ 
 		system "/bin/cp ${worksrcpath}/mkfls/unix/* ${worksrcpath} && \
-		/bin/chmod a+x ${worksrcpath}/configure"
+		/bin/chmod a+x ${worksrcpath}/configure && \
+		/usr/bin/sed -i '' 's/^main(){return(0);}/int main(){return(0);}/' ${worksrcpath}/configure && \
+		/usr/bin/awk 'NR==10{print "#include <string.h>"}1' ${worksrcpath}/unix/setpttl.c > ${worksrcpath}/unix/setpttl.c.tmp && \
+		/bin/mv ${worksrcpath}/unix/setpttl.c.tmp ${worksrcpath}/unix/setpttl.c"
 		}
 			
 destroot 	{


### PR DESCRIPTION
## Summary
Fix two compilation errors with clang 21 on macOS 26:

1. **configure script** - Uses K&R C syntax (`main(){return(0);}`) rejected by modern clang with `-Wimplicit-int` error
2. **unix/setpttl.c** - Missing `#include <string.h>` for strlen/strcpy declarations

## Test Plan
- Built successfully on macOS 26 ARM64 with clang 21
- binkd 0.9.4 installed to /opt/local/sbin/binkd

## Fixes
- Failed install-port on 26.arm64 buildbot builder (see https://ports.macports.org/port/binkd/builds/)

## Notes
The Portfile was also failing on macOS 15, 14, 13, 12, 11 due to the same issues.