### PR TITLE
openal-soft: pin to 1.24.3 on macOS<=12

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -8,12 +8,22 @@ PortGroup               legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 14
 
 name                    openal-soft
-if {${os.platform} ne "darwin" || ${os.major} >= 17} {
+if { ${os.platform} ne "darwin" || ${os.major} >= 22 || ${configure.cxx_stdlib} ne "libc++" } {
     version             1.25.1
     revision            0
     checksums           rmd160  933bfea1b345159b5226c11b2c3d385c3d824930 \
                         sha256  4c2aff6f81975f46ecc5148d092c4948c71dbfb76e4b9ba4bf1fce287f47d4b5 \
                         size    1119330
+} elseif { ${os.major} >= 17 } {
+    # macOS 12:
+    # https://build.macports.org/builders/ports-12_x86_64-builder/builds/156176/steps/install-port/logs/stdio
+    # alc/alu.cpp:463:81: error: no member named 'join' in namespace 'std::ranges::views'
+    # std::views::join requires macports-clang >17, which only available when ${os.major} >= 22 in clang_compilers.tcl
+    version             1.24.3
+    revision            0
+    checksums           rmd160  d36d7522cdefc1c8b97a77e5e9033db4ad449fe9 \
+                        sha256  cb5e6197a1c0da0edcf2a81024953cc8fa8545c3b9474e48c852af709d587892 \
+                        size    1025568
 } else {
     # macOS 10.12:
     # https://build.macports.org/builders/ports-10.12_x86_64-builder/builds/291362/steps/install-port/logs/stdio


### PR DESCRIPTION
#### Description

In https://ports.macports.org/port/openal-soft/details/ , all building between os.major=17 to 21 fail. (e.g.  https://build.macports.org/builders/ports-12_x86_64-builder/builds/156176/steps/install-port/logs/stdio )

    alc/alu.cpp:463:81: error: no member named 'join' in namespace 'std::ranges::views'
 
It's because std::views::join requires macports-clang >17, which only available when ${os.major} >= 22 in clang_compilers.tcl

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.6 21H1320 x86_64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
