### PR TITLE
gobject-introspection: fix scanner link flags

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -155,11 +155,6 @@ post-patch {
 
 build.args-append           --verbose
 
-# Drop the default -L${prefix}/lib so the installed libgobject does not shadow
-# the freshly-built one when g-ir-scanner links during the build. LIBRARY_PATH
-# still points the linker at ${prefix}/lib for everything else.
-configure.ldflags-delete    -L${prefix}/lib
-
 post-build {
     if {[variant_exists universal] && [variant_isset universal]} {
         set dirs {}

--- a/gnome/gobject-introspection-devel/Portfile
+++ b/gnome/gobject-introspection-devel/Portfile
@@ -10,7 +10,7 @@ conflicts           gobject-introspection
 set my_name         gobject-introspection
 
 version             1.86.0
-revision            0
+revision            1
 epoch               1
 
 categories          gnome
@@ -63,6 +63,7 @@ patchfiles-append   patch-fix-rpath-gir-typelib.diff
 patchfiles-append   patch-fix-scanner-in-build-execution.diff
 patchfiles-append   patch-fix-tools-python.diff
 patchfiles-append   patch-prefix-giscanner_transformer.py.diff
+patchfiles-append   patch-giscanner-dumper.diff
 
 # Fix library search path on non-/usr/local installs (e.g. Apple Silicon)
 # See: https://github.com/Homebrew/homebrew-core/issues/75020

--- a/gnome/gobject-introspection-devel/files/patch-giscanner-dumper.diff
+++ b/gnome/gobject-introspection-devel/files/patch-giscanner-dumper.diff
@@ -1,0 +1,36 @@
+Ensure -I and -L options passed via the environment do not take priority over
+build-specific ones which might cause issues when upgrading a port.
+--- giscanner/dumper.py.orig	2025-09-13 15:08:06
++++ giscanner/dumper.py	2026-05-04 19:26:51
+@@ -216,16 +216,6 @@
+                     args.append('-Wl,--export-all-symbols')
+                 else:
+                     args.append('-export-dynamic')
+-
+-        if not self._compiler.check_is_msvc():
+-            # These envvars are not used for MSVC Builds!
+-            # MSVC Builds use the INCLUDE, LIB envvars,
+-            # which are automatically picked up during
+-            # compilation and linking
+-            for cppflag in shlex.split(os.environ.get('CPPFLAGS', '')):
+-                args.append(cppflag)
+-            for cflag in shlex.split(os.environ.get('CFLAGS', '')):
+-                args.append(cflag)
+ 
+         # Make sure to list the library to be introspected first since it's
+         # likely to be uninstalled yet and we want the uninstalled RPATHs have
+@@ -262,6 +252,14 @@
+             args.extend(rpath_entries_to_add)
+ 
+         if not self._compiler.check_is_msvc():
++            # These envvars are not used for MSVC Builds!
++            # MSVC Builds use the INCLUDE, LIB envvars,
++            # which are automatically picked up during
++            # compilation and linking
++            for cppflag in shlex.split(os.environ.get('CPPFLAGS', '')):
++                args.append(cppflag)
++            for cflag in shlex.split(os.environ.get('CFLAGS', '')):
++                args.append(cflag)
+             for ldflag in shlex.split(os.environ.get('LDFLAGS', '')):
+                 if ldflag != '-Wl,--as-needed':
+                     args.append(ldflag)

--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -10,7 +10,7 @@ conflicts           gobject-introspection-devel
 set my_name         gobject-introspection
 
 version             1.86.0
-revision            0
+revision            1
 epoch               1
 
 categories          gnome
@@ -63,6 +63,7 @@ patchfiles-append   patch-fix-rpath-gir-typelib.diff
 patchfiles-append   patch-fix-scanner-in-build-execution.diff
 patchfiles-append   patch-fix-tools-python.diff
 patchfiles-append   patch-prefix-giscanner_transformer.py.diff
+patchfiles-append   patch-giscanner-dumper.diff
 
 # Fix library search path on non-/usr/local installs (e.g. Apple Silicon)
 # See: https://github.com/Homebrew/homebrew-core/issues/75020

--- a/gnome/gobject-introspection/files/patch-giscanner-dumper.diff
+++ b/gnome/gobject-introspection/files/patch-giscanner-dumper.diff
@@ -1,0 +1,36 @@
+Ensure -I and -L options passed via the environment do not take priority over
+build-specific ones which might cause issues when upgrading a port.
+--- giscanner/dumper.py.orig	2025-09-13 15:08:06
++++ giscanner/dumper.py	2026-05-04 19:26:51
+@@ -216,16 +216,6 @@
+                     args.append('-Wl,--export-all-symbols')
+                 else:
+                     args.append('-export-dynamic')
+-
+-        if not self._compiler.check_is_msvc():
+-            # These envvars are not used for MSVC Builds!
+-            # MSVC Builds use the INCLUDE, LIB envvars,
+-            # which are automatically picked up during
+-            # compilation and linking
+-            for cppflag in shlex.split(os.environ.get('CPPFLAGS', '')):
+-                args.append(cppflag)
+-            for cflag in shlex.split(os.environ.get('CFLAGS', '')):
+-                args.append(cflag)
+ 
+         # Make sure to list the library to be introspected first since it's
+         # likely to be uninstalled yet and we want the uninstalled RPATHs have
+@@ -262,6 +252,14 @@
+             args.extend(rpath_entries_to_add)
+ 
+         if not self._compiler.check_is_msvc():
++            # These envvars are not used for MSVC Builds!
++            # MSVC Builds use the INCLUDE, LIB envvars,
++            # which are automatically picked up during
++            # compilation and linking
++            for cppflag in shlex.split(os.environ.get('CPPFLAGS', '')):
++                args.append(cppflag)
++            for cflag in shlex.split(os.environ.get('CFLAGS', '')):
++                args.append(cflag)
+             for ldflag in shlex.split(os.environ.get('LDFLAGS', '')):
+                 if ldflag != '-Wl,--as-needed':
+                     args.append(ldflag)

--- a/x11/pango/Portfile
+++ b/x11/pango/Portfile
@@ -144,11 +144,6 @@ pre-configure {
     delete ${worksrcpath}/subprojects/glib ${worksrcpath}/subprojects/glib.wrap
 }
 
-# Drop the default -L${prefix}/lib so the installed libpango does not shadow
-# the freshly-built one during the build. LIBRARY_PATH still points the linker
-# at ${prefix}/lib for everything else.
-configure.ldflags-delete    -L${prefix}/lib
-
 post-destroot {
     set docdir ${prefix}/share/doc/${my_name}
     xinstall -d ${destroot}${docdir}


### PR DESCRIPTION
#### Description

Follow-up fix to #32590 and #32591 to fix it for all ports (thanks @pguyot for initial quick fix and analysis).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?