### PR TITLE
kotlin: update to 2.3.21

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 2.3.20 v
+github.setup        JetBrains kotlin 2.3.21 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  a56717c40dfdfb359b342c76831062dc85cb18f7 \
-                    sha256  222ba516cdc4052ce0be9d2ec6adf3c5c64fc53156d7dd91d1f5317809431b98 \
-                    size    83071760
+checksums           rmd160  d3fccd3d034b98135c731b8da0a36cab7f0928d6 \
+                    sha256  a8cfc1d62cd4d0de4d04f42575e40135bd620588c17d568a20eb9c7c259af14f \
+                    size    83084350
 
 java.version        1.8+
 java.fallback       openjdk21


### PR DESCRIPTION
#### Description

Update to Kotlin 2.3.21.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?