### PR TITLE
ocaml-batteries: update to 3.10.0

### DIFF
--- a/ocaml/ocaml-batteries/Portfile
+++ b/ocaml/ocaml-batteries/Portfile
@@ -5,7 +5,8 @@ PortGroup           github 1.0
 PortGroup           ocaml 1.1
 
 name                ocaml-batteries
-github.setup        ocaml-batteries-team batteries-included 3.8.0 v
+github.setup        ocaml-batteries-team batteries-included 3.10.0 v
+revision            0
 categories          ocaml devel
 maintainers         {landonf @landonf} openmaintainer
 license             LGPL-2.1
@@ -15,13 +16,12 @@ long_description    OCaml Batteries included (or simply Batteries) is a \
                     documented, and comprehensive development platform for the \
                     OCaml programming language.
 homepage            http://batteries.forge.ocamlcore.org/
-platforms           darwin
 
 github.tarball_from     archive
 
-checksums           rmd160  27246d00abaa115163f289dc35d6b1f458185dc1 \
-                    sha256  c7d0c5bb9773a8ff1eb8e195b9ace7b792febf8724013349cd972207ae9fc117 \
-                    size    794001
+checksums           rmd160  e7099cc4d0dfac4bf1fda90942130c7bde62227d \
+                    sha256  813c05b70b5bf46fd3cbae55eeefe6daa988a4761eb20e82b2aabe43ac71750d \
+                    size    795346
 
 
 depends_lib         port:ocaml-num \


### PR DESCRIPTION
Adds support for OCaml 5.4 (and 5.3 from 3.9.0). Drop redundant platforms line.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 x86_64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
