### PR TITLE
ocaml-num: update to 1.6

### DIFF
--- a/ocaml/ocaml-num/Portfile
+++ b/ocaml/ocaml-num/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           ocaml 1.1
 
 name                ocaml-num
-github.setup        ocaml num 1.5 v
+github.setup        ocaml num 1.6 v
 revision            0
 
 categories          ocaml devel
@@ -15,10 +15,12 @@ license             LGPL-2
 description         Legacy OCaml arbitrary-precision integer library
 long_description    {*}${description}
 
-checksums           rmd160  070877307764b6b059abf50950abe81a6e2a7f41 \
-                    sha256  7ae07c8f5601e2dfc5008a62dcaf2719912ae596a19365c5d7bdf2230515959a \
-                    size    67633
+checksums           rmd160  b4124acb18649d6742c56192ef0220522c62466c \
+                    sha256  b5cce325449aac746d5ca963d84688a627cca5b38d41e636cf71c68b60495b3e \
+                    size    67748
 github.tarball_from archive
+
+patchfiles-append   patch-meta-num-conflict.diff
 
 platform darwin powerpc {
     # Compilation freezes due to ocamlopt not being found.

--- a/ocaml/ocaml-num/files/patch-meta-num-conflict.diff
+++ b/ocaml/ocaml-num/files/patch-meta-num-conflict.diff
@@ -1,0 +1,19 @@
+In findlib's default configuration `metadir` is empty, so the
+"already installed" check resolves `META.<pkg>` against the current
+working directory. v1.6 renamed `META.legacy` to `META.num`, which is
+exactly the file the check trips on: `ocamlfind install num META ...`
+fails with "Package num is already installed (file META.num already
+exists)" even in a clean destroot. Move `META.num` in place of `META`
+so the source file is not present during install.
+
+--- src/Makefile.orig
++++ src/Makefile
+@@ -175,7 +175,7 @@
+
+ findlib-install: num-top-install
+-	cp META.num META
++	mv META.num META
+ 	$(OCAMLFIND) install num META $(TOINSTALL) $(TOINSTALL_CMXS) $(TOINSTALL_STUBS)
+ 	rm -f META
+
+ num-top-uninstall:


### PR DESCRIPTION
Add patch-meta-num-conflict.diff to work around an ocamlfind conflict check that trips on the new src/META.num source file (renamed from META.legacy in 1.6); switch the cp to mv so the file is not present in cwd during install.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 x86_64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
