### PR TITLE
claude-code: update to 2.1.128

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.126
+version             2.1.128
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  a24acc24424bd8a45991d206e00cd6f6882f0afa \
-                 sha256  49a90c474383a9eda11310bd71f7ea6bb91361ec99443b733cb5003f6e703ccb \
-                 size    217824336
+    checksums    rmd160  364656082806a6a18b049c58ec5fe2fb0f20075d \
+                 sha256  eb7f5441fcc169a01ec6a655d7663dffbcfe9cb03491dc0c7a157e9e67da3737 \
+                 size    218517840
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  7a3f7379f09f8d4aca6c96813be25b4a1c62775c \
-                 sha256  87a1d05018ceadfc1fe616bfc10262b0503f51986f4af2dc42d1ed856ed3f7bb \
-                 size    216260096
+    checksums    rmd160  344d291d33e1cb2c41ef2b2bfef4c5b6eefc075f \
+                 sha256  1a56ae4cd171ba7839fc2b03d558022ffaebb5693be532d8f3c344731063e979 \
+                 size    216953600
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.128.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?