### PR TITLE
opencode: update to 1.14.39

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.14.33
+version             1.14.39
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  c3a32bf5dc1fd9719993f4776d108b79f4fe98ca \
-                    sha256  76c3c8d7686f61ce6894cb28f8fccdfa1a45be5c69392bfa3a5f7624ac2ff705 \
-                    size    3340
+checksums           rmd160  01d28ed0d90e0c4db8bc4214633cab8e74ce5e0b \
+                    sha256  4e9c04aa46fddb51a1968f21d3ea10a2d76d62e821580d6665d98c0cfd00fdea \
+                    size    3349


### PR DESCRIPTION
#### Description

Update to OpenCode 1.14.39.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?