### PR TITLE
py-makelive: update to 0.7.0

### DIFF
--- a/python/py-makelive/Portfile
+++ b/python/py-makelive/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-makelive
-version             0.6.2
+version             0.7.0
 revision            0
 
 supported_archs     noarch
@@ -27,9 +27,9 @@ long_description    {*}${description} \
 
 homepage            https://pypi.org/project/makelive/
 
-checksums           rmd160  12440ba7928fed3d1da24d5986cdfc305eb06ba0 \
-                    sha256  df02b715116e462a3e7316517eb91b8f9a1dbad1d6d41352fd562f44a168e858 \
-                    size    18723
+checksums           rmd160  645669b00ca027fe1c6d22d7c602f03c5125bf76 \
+                    sha256  d1f4474c4d7f4bc6fbed2fcbc2672bb49321ff031ac3867b7feb2bfcfe6a0f93 \
+                    size    19558
 
 python.versions     312 313 314
 


### PR DESCRIPTION
#### Description

Update to MakeLive 0.7.0.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?