### PR TITLE
google-cloud-sdk: update to 567.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             566.0.0
+version             567.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  cccb53e4ce78ad73bdf205b929e51f3ba623a52c \
-                    sha256  870216a870cc31b706076606a633e435cba1625e354217f60db4da7cdc9d6dd8 \
-                    size    58632575
+    checksums       rmd160  c9710f2e01c3ada1c72d62d7bc883cd4fc0b6c32 \
+                    sha256  5e571053ed77c3265dd8b53ef46d2f721390c2ea640422ddd2fd1a485919ccf8 \
+                    size    58787948
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  705a44046c9fcb66ee75f8069ef660fc3d94c749 \
-                    sha256  5544218052d6620deb0a70414fbea53f7fd820da16b94b585f462f4fde1fd7b6 \
-                    size    60292398
+    checksums       rmd160  bf8fc25e6f8aea0f4401bd8bdb88efa5342bc926 \
+                    sha256  ef49050bc09b910ff9d3a70417641ece9815c9ebbc3642fc13ab7271bf3410b1 \
+                    size    60453769
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  08feacb054fa4ed2bed913cfe951cf7044c520df \
-                    sha256  ffd8dfb56b91eca749dd50c69171308f9754e8423103b6310cdac5536df8c35f \
-                    size    60195038
+    checksums       rmd160  57f47604170a1fd5da796673f03cebdd77649686 \
+                    sha256  5ce268402258b8381a5f535d8bbee25b8b321f1ccf7f08ca8d6b3a8b42174f96 \
+                    size    60355109
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 567.0.0.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?