### PR TITLE
kubetail: update to 0.17.0

### DIFF
--- a/devel/kubetail/Portfile
+++ b/devel/kubetail/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/kubetail-org/kubetail 0.16.0 cli/v
+go.setup            github.com/kubetail-org/kubetail 0.17.0 cli/v
 github.tarball_from releases
 revision            0
 
@@ -23,9 +23,9 @@ long_description    Kubetail is a general-purpose logging tool for Kubernetes, o
                     terminal.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  df55e7af172930c5379a6d71b3358f03a9f8fa1f \
-                    sha256  d1c8ea8aa758e82566c26a29e71c474ff943adbaa3d40649c98fe516a36ef6b6 \
-                    size    20815085
+                    rmd160  71993feb0c97b3c2f88ce5c4da08a1dddfb2ffd3 \
+                    sha256  9e4e1dbc7a13ddbd71bc03473c572a10e464a28b5e3ed8a3163eedd188037312 \
+                    size    21084536
 
 build.env-append GO111MODULE=on \
                  GOWORK=off


### PR DESCRIPTION
#### Description

This PR upgrades `kubetail` to 0.17.0

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.3 25D125 arm64
Xcode 26.2 17C52

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
