### PR TITLE
Nodejs18 fix macos26 zutil fdopen

### DIFF
--- a/lang/nodejs18/Portfile
+++ b/lang/nodejs18/Portfile
@@ -8,7 +8,7 @@ compiler.cxx_standard   2017
 
 name                    nodejs18
 version                 18.20.8
-revision                1
+revision                2
 
 categories              lang net
 license                 {MIT BSD}
@@ -80,7 +80,8 @@ proc rec_glob {basedir pattern} {
 configure.python        ${prefix}/bin/python${py_ver}
 
 patchfiles              patch-common.gypi.diff \
-                        patch-configure.diff
+                        patch-configure.diff \
+                        patch-deps-v8-third_party-zlib-zutil.h.diff
 
 post-patch {
     foreach f [concat ${worksrcpath}/configure \

--- a/lang/nodejs18/files/patch-deps-v8-third_party-zlib-zutil.h.diff
+++ b/lang/nodejs18/files/patch-deps-v8-third_party-zlib-zutil.h.diff
@@ -1,0 +1,12 @@
+--- a/deps/v8/third_party/zlib/zutil.h
++++ b/deps/v8/third_party/zlib/zutil.h
+@@ -148,7 +148,9 @@
+ #    ifdef NO_ERRNO_H
+          extern int errno;
+ #    else
++#        if !defined(__APPLE__)
+ #        define fdopen(fd,mode) NULL /* No fdopen() */
++#        endif
+ #    endif
+ #  endif
+ #endif


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Fix the fdopen macro in zutil.h conflicting with the macOS 26 SDK _stdio.h
```log
:info:build In file included from ../deps/v8/third_party/zlib/zutil.c:10:
:info:build In file included from ../deps/v8/third_party/zlib/gzguts.h:21:
:info:build In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/stdio.h:61:
:info:build /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/_stdio.h:322:7: error: expected identifier or '('
:info:build   322 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
:info:build       |          ^
:info:build ../deps/v8/third_party/zlib/zutil.h:151:33: note: expanded from macro 'fdopen'
:info:build   151 | #        define fdopen(fd,mode) NULL /* No fdopen() */
:info:build       |                                 ^
:info:build /Library/Developer/CommandLineTools/usr/lib/clang/21/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
:info:build    26 | #define NULL ((void*)0)
:info:build       |                ^
:info:build In file included from ../deps/v8/third_party/zlib/zutil.c:10:
:info:build In file included from ../deps/v8/third_party/zlib/gzguts.h:21:
:info:build In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/stdio.h:61:
:info:build /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/_stdio.h:322:7: error: expected ')'
:info:build ../deps/v8/third_party/zlib/zutil.h:151:33: note: expanded from macro 'fdopen'
:info:build   151 | #        define fdopen(fd,mode) NULL /* No fdopen() */
:info:build       |                                 ^
:info:build /Library/Developer/CommandLineTools/usr/lib/clang/21/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
:info:build    26 | #define NULL ((void*)0)
:info:build       |                ^
:info:build /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/_stdio.h:322:7: note: to match this '('
:info:build ../deps/v8/third_party/zlib/zutil.h:151:33: note: expanded from macro 'fdopen'
:info:build   151 | #        define fdopen(fd,mode) NULL /* No fdopen() */
:info:build       |                                 ^
:info:build /Library/Developer/CommandLineTools/usr/lib/clang/21/include/__stddef_null.h:26:15: note: expanded from macro 'NULL'
:info:build    26 | #define NULL ((void*)0)
:info:build       |               ^
:info:build In file included from ../deps/v8/third_party/zlib/zutil.c:10:
:info:build In file included from ../deps/v8/third_party/zlib/gzguts.h:21:
:info:build In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/stdio.h:61:
:info:build /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/_stdio.h:322:7: error: expected ')'
:info:build   322 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
:info:build       |          ^
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1
Xcode 26.4.1 / Command Line Tools 26.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
