### PR TITLE
lagrange: update to 1.20.5

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -2,14 +2,13 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           gitea 1.0
+PortGroup           codeberg 1.0
 PortGroup           legacysupport 1.1
 
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-gitea.domain        git.skyjake.fi
-gitea.setup         skyjake the_Foundation 1.12.0 v
+codeberg.setup      skyjake the_Foundation 1.12.2 v
 revision            0
 categories          devel
 license             BSD
@@ -18,9 +17,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Opinionated C11 library for low-level functionality
 long_description    {*}${description}
 
-checksums           rmd160  b0b89fa5b98524e91721d306985cfaac4edacacb \
-                    sha256  37bc29d3002440c3abe9e3c3641b540cecd47dccc3f8cabdeec21ea62531c714 \
-                    size    233184
+checksums           rmd160  3342e818e0c9ff9e89af52cc4ea9c0de4e4e236c \
+                    sha256  04b419a9b8f2264a8cf6ba190d4358b3951322ee66b1d67ccdc54dd4f88fcd13 \
+                    size    233451
 
 depends_build-append \
                     port:pkgconfig

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -2,10 +2,9 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           gitea 1.0
+PortGroup           codeberg 1.0
 
-gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.20.4 v
+codeberg.setup      skyjake lagrange 1.20.5 v
 revision            0
 categories          net gemini
 license             BSD
@@ -14,9 +13,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  4a8d3a9edd8da31c662ccfb6d4f5098452e7e853 \
-                    sha256  57fa800c7db4dfd14627bf88b4caa22449fd0429c3f29d72bfd2002f138a5baa \
-                    size    9830667
+checksums           rmd160  298fef48b6e554060d3b3ff9c4d8b826bf77b5aa \
+                    sha256  eefc0917c319bed7f3a16564e686c97e4d06023dff69d10440bf9a404c7e3d11 \
+                    size    9798146
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
* https://codeberg.org/skyjake/lagrange/releases/tag/v1.20.5
* https://codeberg.org/skyjake/the_Foundation/releases/tag/v1.12.2

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
