### PR TITLE
claude-code: update to 2.1.132

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.131
+version             2.1.132
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  d9c6eee04b330d85f160b6d0a7040838bed2a89b \
-                 sha256  a1bd2c782c3f961987d7d6456f75b3fa538cc425f1573908850afedcb038ca5f \
-                 size    218914128
+    checksums    rmd160  8c3625c975f61ea3386178b31634489619291e34 \
+                 sha256  1953f50853eda4c374dfd558f1cf62a13a99c814aae73b42a07d3d9a49fe727b \
+                 size    219558096
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  e36c17ae503f7fc75709f4d073c4b0ed3ff4dd4f \
-                 sha256  cc6066b0db7bb423c75316366542f771a41923999a76a5771afad87dd65dceae \
-                 size    217349888
+    checksums    rmd160  8d14c74338e76d5184da08d8edc12ff7b0969a60 \
+                 sha256  2ce6b9007f38f5caf0d116ae35d59f1a6d40e902ae7f9f19aca6ec483697b764 \
+                 size    217993856
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.132.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?