### PR TITLE
mp3rgain: update to 2.5.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.4.0 v
+github.setup        M-Igashi mp3rgain 2.5.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  15de57e53565704c0d8cb79ce69facda0871e7c6 \
-                    sha256  29878145b46789b5779b7d257ce14a4ba64598dddc49b296407cdcc29efb8e4a \
-                    size    295916
+                    rmd160  d6a03444ab60426e19f4e3e4e431ee8c70e6d375 \
+                    sha256  9dedb66494501d26c5ee37f2a3618f0d484de945085e7fc2a40037028db3afad \
+                    size    302612
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
## Description

Update `audio/mp3rgain` to upstream v2.5.0.

### Highlights

- Performance: AAC apply / `-t` pipeline I/O reduction, parallelize remaining commands, EqualLoudnessFilter hot-path optimization
- Fix: avoid temp-file collisions when applying gain in parallel
- Build: gate the binary behind default features

Full release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.5.0

### Verification

- [x] Bumped `github.setup` to 2.5.0
- [x] Recomputed `rmd160`, `sha256`, `size` from the new GitHub source tarball
- [x] `cargo.crates` block regenerated from the new `Cargo.lock` (no changes vs 2.4.0; same crate set)
- [x] `revision` stays at 0 since `github.setup` version changed