### PR TITLE
chezmoi: Update to 2.70.3

### DIFF
--- a/sysutils/chezmoi/Portfile
+++ b/sysutils/chezmoi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/twpayne/chezmoi 2.70.2 v
+go.setup            github.com/twpayne/chezmoi 2.70.3 v
 go.offline_build    no
 revision            0
 
@@ -20,9 +20,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  805c42f2cc0dfdccf7e05434970f642b131cdca3 \
-                    sha256  4dfacb37e1f6714305d7c8570bc25880342dfddbe81259c9253a5881de035321 \
-                    size    2594772
+checksums           rmd160  1601f3380fac3f507665010aa16e5b819b3a50f7 \
+                    sha256  04780df69be596b714ac0ea5f9c65e7739adc847613d5a91ba23fd5a020f5103 \
+                    size    2596445
 
 build.cmd           make
 build.pre_args-append \


### PR DESCRIPTION
#### Description

chezmoi: Update to 2.70.3


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
