### PR TITLE
toxcore: bump version, add nilFinx as the maintainer

### DIFF
--- a/net/toxcore/Portfile
+++ b/net/toxcore/Portfile
@@ -5,26 +5,25 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 # Prior to updating please make sure toxic builds against a new version.
-github.setup            TokTok c-toxcore 0.2.20 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from     tarball
+github.setup            TokTok c-toxcore 0.2.23 v
+github.tarball_from     releases
+distname                ${github.project}-v${version}
+extract.mkdir           yes
+checksums               rmd160  1a1f1a4d441b5943221440b3b4250df12b5cdf67 \
+                        sha256  15cdd006ed7793dfc657e340ef9f218f6637d2fe5b130704d39b961389bb6cd6 \
+                        size    1415886
 name                    toxcore
 epoch                   1
-revision                1
+revision                0
 categories              net security devel
-maintainers             nomaintainer
+maintainers             {disroot.org:nulflox @nilFinx} openmaintainer
 license                 GPL-3
 description             Tox is a peer to peer (serverless) instant messenger aimed at making security and privacy \
                         easy to obtain for regular users. It uses NaCl for its encryption and authentication.
 long_description        {*}${description}
 homepage                https://tox.chat
 
-fetch.type              git
-post-extract {
-    system -W ${worksrcpath} "git submodule update --init"
-}
-
-set py_ver              3.11
+set py_ver              3.14
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 depends_build-append    port:pkgconfig
@@ -35,7 +34,7 @@ depends_lib-append      path:lib/pkgconfig/vpx.pc:libvpx \
                         port:python${py_ver_nodot}
 
 compiler.c_standard     1999
-compiler.cxx_standard   2017
+compiler.cxx_standard   2020
 compiler.openmp_version 3.0
 
 configure.args-append   -DBOOTSTRAP_DAEMON=ON \

--- a/net/toxic/Portfile
+++ b/net/toxic/Portfile
@@ -8,7 +8,7 @@ PortGroup               makefile 1.0
 # clock_gettime in game_base
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup            JFreegman toxic 0.16.0 v
+github.setup            JFreegman toxic 0.16.2 v
 revision                0
 categories              net security
 maintainers             nomaintainer
@@ -16,9 +16,9 @@ license                 GPL-3
 description             An ncurses-based Tox client
 long_description        Toxic is a Tox-based instant messaging and video chat client.
 homepage                https://toktok.ltd
-checksums               rmd160  84c845622d9073da19a9138f524adfdf179f1837 \
-                        sha256  9b58f87941c5638e6169f972292351205bb6335bde8121c103d7dc6fc5174ac7 \
-                        size    1246725
+checksums               rmd160  0ca70709f1a5c973f8a165d79db42fdf0dbfdfc8 \
+                        sha256  6b74c82c286f9ab3a8c8a5b4bf506ab5a4aca12620792a5273988bb795ea46ad \
+                        size    1257173
 github.tarball_from     archive
 
 depends_build-append    path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master --> <!-- whoops lol -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

No tests exists, but still checking it in case checking is mandated.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
