### PR TITLE
openjdk8-corretto: update to 8.492.09.2

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -21,7 +21,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      ${feature}.492.09.1
+version      ${feature}.492.09.2
 revision     0
 
 # Amazon Corretto's support dates: https://aws.amazon.com/corretto/faqs/#topic-0
@@ -33,14 +33,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  bd7bd132ececd391597ec84105519a4978c951cb \
-                 sha256  ad2f6d4349af461c44e98d5b0528ad1bbe1e798a87347dde4205f64f667eeb5e \
-                 size    118424918
+    checksums    rmd160  ada72c004118df06ac1071a04cfe4c46f3d06b33 \
+                 sha256  63cf32569fae961497091a77c763b3511b1e1650abc22a7e7a9ee38de8fc3567 \
+                 size    118430001
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  cc939bb66a70e6f74e5d0522182f98f7dcd0ff5e \
-                 sha256  aa265e63071ab2a50bb9c1ef6df3d452b5e2d4c6aa81eae859917c7540459c70 \
-                 size    102888492
+    checksums    rmd160  54aac5547dfdbe9f3405362a79675c97ad3526bb \
+                 sha256  4316bff4922d9799883e68f6b9d78a720663fd8f1664f74b005bb285eda0ca26 \
+                 size    102887969
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.492.09.2.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?