### PR TITLE
claude-code: update to 2.1.136

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.133
+version             2.1.136
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  022fcd39ace8139fedc52cd2a80c060d8d91da18 \
-                 sha256  b16758680c3bb1e0f8a867e31f9df84e8df2473b0693e811f0b29b465d2e64c3 \
-                 size    206672560
+    checksums    rmd160  5c778fe03b91474bdbf2f8f1cac505cb67f9065d \
+                 sha256  d540e416e7f8562c99c336ba703d3374d41f79be6d1a93f1c6bd3a88686d4ae7 \
+                 size    207568336
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  f4c2005f823edec05fff3e9eab74708089d9df17 \
-                 sha256  d38f34444911c86c73f32beb82821008b26be889fa0d0caf7085580cf5737e14 \
-                 size    204170768
+    checksums    rmd160  ba53efa3ea44d69463da176c9747485d762ccfcb \
+                 sha256  9ef618487dc9e0cb766e8d0d51cd5fd3d06c3d038f4f04f3e714791f32a3cda5 \
+                 size    205062416
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.136.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?