### PR TITLE
php-oracle: new Portfile @1.2.0

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1968,8 +1968,9 @@ subport ${php}-openssl {
     }
 }
 
-if {[vercmp ${branch} < 8.4]} {
+if {[vercmp ${branch} < 8.3]} {
 # oracle was evicted from PHP core in version 8.4;
+# php83-oracle and later subports are found in the separate php-oracle Portfile.
 subport ${php}-oracle {
     switch -- ${version} {
         5.2.17              {revision 0}
@@ -1984,8 +1985,7 @@ subport ${php}-oracle {
         7.4.33              {revision 0}
         8.0.30              {revision 0}
         8.1.34              {revision 0}
-        8.2.31              {revision 0}
-        8.3.31              {revision 0}
+        8.2.33              {revision 0}
     }
 
     php.extensions          oci8 pdo_oci

--- a/php/php-oracle/Portfile
+++ b/php/php-oracle/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           php 1.1
+
+name                php-oracle
+categories-append   databases
+maintainers         {ryandesign @ryandesign} {mathiesen.info:macintosh @BjarneDMat}
+license             PHP-3.01
+
+# php82-oracle and earlier subports are in the php Portfile.
+php.branches        8.3 8.4 8.5
+php.pecl            yes
+php.pecl.name       PDO_OCI
+homepage            http://pecl.php.net/package/${php.pecl.name}
+
+description         a PHP interface to Oracle, including the oci8 and \
+                    pdo_oci extensions
+
+long_description    ${description}
+
+if {[vercmp ${php.branch} >= 8.3]} {
+    version         1.2.0
+    revision        0
+    checksums       rmd160  4971b4305ab1d076b7d97537730d9b43b5e3c0f9 \
+                    sha256  c55e59bceb68c243e7b6ea90d1d4b28690b997e30392f10a1e8462f12d3f937e \
+                    size    20721
+
+    distname        [string tolower ${php.pecl.name}]-${version}
+
+} 
+
+if {${name} ne ${subport}} {
+
+    epoch                   3
+
+    # port:oracle-instantclient has to be manually installed
+    depends_lib-append      port:oracle-instantclient
+
+    set lib_dir             ${prefix}/lib/oracle
+    pre-configure {
+        regexp {\.dylib\.(.+)$} [glob -directory ${lib_dir} libclntsh.dylib.*] -> library_version
+        configure.args-append \
+                            --with-pdo-oci=instantclient,${lib_dir},${library_version}
+    }
+}


### PR DESCRIPTION
Doesn't install on the GitHub Actions CI due to the inablilty to install oracle-instantclient ([ticket 73854](https://trac.macports.org/ticket/73854))
I've got build logs if you want to see them
