### PR TITLE
MP4Joiner: replace with MP4Tools

### DIFF
--- a/multimedia/MP4Joiner/Portfile
+++ b/multimedia/MP4Joiner/Portfile
@@ -1,61 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           wxWidgets 1.0
+PortGroup           obsolete 1.0
 
 name                MP4Joiner
+replaced_by         MP4Tools
 version             2.2
-revision            2
+revision            3
 categories          multimedia aqua
-platforms           darwin
-maintainers         ryandesign openmaintainer
-license             GPL-2
-
-description         simple tool to join multiple MP4 files into one
-
-long_description    ${name} is a ${description}.
-
-homepage            http://www.mp4joiner.org/
-master_sites        sourceforge:project/mp4joiner/MP4Joiner/${version}/
-use_bzip2           yes
-
-checksums           rmd160  b219127b0e30ff99d039a868b0751b763452ea4f \
-                    sha256  39428a63bb234c90800a261b3c1a7a19d887045bf8611ec185c1c7bdabfcaddf
-
-wxWidgets.use       wxWidgets-3.0
-
-depends_build       port:pkgconfig
-
-depends_lib         path:lib/libavcodec.dylib:ffmpeg \
-                    port:gpac \
-                    port:wxsvg \
-                    port:${wxWidgets.port}
-
-# gpac is not universal but we only use its MP4Box program not its libraries
-depends_skip_archcheck gpac
-
-patchfiles          patch-Makefile.in.diff
-
-configure.args      --with-wxdir=${wxWidgets.wxdir}
-
-build.target        ${name}.app
-
-post-build {
-    ln -s ${prefix}/bin/ffmpeg ${worksrcpath}/${name}.app/Contents/MacOS
-    ln -s ${prefix}/bin/MP4Box ${worksrcpath}/${name}.app/Contents/MacOS
-}
-
-destroot {
-    copy ${worksrcpath}/${name}.app ${destroot}${applications_dir}
-
-    set docdir ${prefix}/share/doc/${subport}
-    xinstall -d ${destroot}${docdir}
-    xinstall -m 644 -W ${worksrcpath} \
-        AUTHORS \
-        COPYING \
-        ChangeLog \
-        README \
-        ${destroot}${docdir}
-}
-
-livecheck.regex     /${name}/(\[0-9.\]+)/


### PR DESCRIPTION
#### Description

The project now combines MP4Joiner and MP4Splitter under MP4Tools.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?