### PR TITLE
llvm-18: fix compilation

### DIFF
--- a/lang/llvm-18/Portfile
+++ b/lang/llvm-18/Portfile
@@ -76,7 +76,8 @@ configure.args-append \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_ENABLE_FFI=ON \
     -DFFI_INCLUDE_DIR=${prefix}/include \
-    -DFFI_LIBRARY_DIR=${prefix}/lib
+    -DFFI_LIBRARY_DIR=${prefix}/lib \
+    -DLLVM_ENABLE_OCAMLDOC=OFF
 
 # Remove for now. See https://trac.macports.org/ticket/70333
 # Probably need to detect when Xcode is available ...
@@ -271,6 +272,13 @@ if { ${subport} eq "flang-${llvm_version}" } {
 
     # CMakeLists.txt: flang isn't supported on 32 bit CPUs
     supported_archs     arm64 x86_64
+
+    # ::template Foo() without explicit template args triggers
+    # -Wmissing-template-arg-list-after-template-kw as an error on newer Clang
+    patchfiles-append   0042-flang-fix-missing-template-keyword.patch \
+                        0043-flang-fix-more-template-keywords.patch \
+                        0044-flang-fix-reduction-template-keywords.patch \
+                        0045-flang-fix-libcpp-verbose-abort-noexcept.patch
 
     post-patch {
         reinplace -E "1s|^#!.*$|#!${prefix}/bin/bash|" ${worksrcpath}/../flang/tools/f18/flang-to-external-fc.in

--- a/lang/llvm-18/files/0042-flang-fix-missing-template-keyword.patch
+++ b/lang/llvm-18/files/0042-flang-fix-missing-template-keyword.patch
@@ -1,0 +1,10 @@
+--- a/flang/include/flang/Evaluate/integer.h
++++ b/flang/include/flang/Evaluate/integer.h
+@@ -307,7 +307,7 @@ template <int BITS, bool IS_LITTLE_ENDIAN = isHostLittleEndian,
+       result.overflow = false;
+     } else if constexpr (bits < FROM::bits) {
+-      auto back{FROM::template ConvertSigned(result.value)};
++      auto back{FROM::ConvertSigned(result.value)};
+       result.overflow = back.value.CompareUnsigned(that) != Ordering::Equal;
+     }
+     return result;

--- a/lang/llvm-18/files/0043-flang-fix-more-template-keywords.patch
+++ b/lang/llvm-18/files/0043-flang-fix-more-template-keywords.patch
@@ -1,0 +1,46 @@
+--- a/flang/lib/Evaluate/fold-logical.cpp
++++ b/flang/lib/Evaluate/fold-logical.cpp
+@@ -255,7 +255,7 @@
+                   const auto &xConst{DEREF(UnwrapExpr<Constant<xType>>(x))};
+                   for (const auto &elt : xConst.values()) {
+                     result->emplace_back(
+-                        Scalar::template FromInteger(elt).flags.test(
++                        Scalar::FromInteger(elt).flags.test(
+                             RealFlag::Overflow));
+                   }
+                 },
+@@ -272,7 +272,7 @@
+                   const auto &xConst{DEREF(UnwrapExpr<Constant<xType>>(x))};
+                   for (const auto &elt : xConst.values()) {
+                     result->emplace_back(elt.IsFinite() &&
+-                        Scalar::template Convert(elt).flags.test(
++                        Scalar::Convert(elt).flags.test(
+                             RealFlag::Overflow));
+                   }
+                 },
+@@ -291,7 +291,7 @@
+                   const auto &xConst{DEREF(UnwrapExpr<Constant<xType>>(x))};
+                   for (const auto &elt : xConst.values()) {
+                     result->emplace_back(
+-                        Scalar::template ConvertSigned(elt).overflow);
++                        Scalar::ConvertSigned(elt).overflow);
+                   }
+                 },
+                 intMold->u, xInt->u);
+--- a/flang/lib/Evaluate/fold-real.cpp
++++ b/flang/lib/Evaluate/fold-real.cpp
+@@ -355,13 +355,7 @@
+                 std::move(funcRef),
+                 ScalarFunc<T, T, TBY>(
+                     [&](const Scalar<T> &x, const Scalar<TBY> &y) -> Scalar<T> {
+-                      ValueWithRealFlags<Scalar<T>> result{x.
+-// MSVC chokes on the keyword "template" here in a call to a
+-// member function template.
+-#ifndef _MSC_VER
+-                                                           template
+-#endif
+-                                                           SCALE(y)};
++                      ValueWithRealFlags<Scalar<T>> result{x.SCALE(y)};
+                       if (result.flags.test(RealFlag::Overflow)) {
+                         context.messages().Say(
+                             "SCALE intrinsic folding overflow"_warn_en_US);

--- a/lang/llvm-18/files/0044-flang-fix-reduction-template-keywords.patch
+++ b/lang/llvm-18/files/0044-flang-fix-reduction-template-keywords.patch
@@ -1,0 +1,28 @@
+--- a/flang/runtime/reduction-templates.h
++++ b/flang/runtime/reduction-templates.h
+@@ -88,7 +88,7 @@
+ #ifdef _MSC_VER // work around MSVC spurious error
+   accumulator.GetResult(&result);
+ #else
+-  accumulator.template GetResult(&result);
++  accumulator.GetResult(&result);
+ #endif
+   return result;
+ }
+@@ -130,7 +130,7 @@
+ #ifdef _MSC_VER // work around MSVC spurious error
+   accumulator.GetResult(result, zeroBasedDim);
+ #else
+-  accumulator.template GetResult(result, zeroBasedDim);
++  accumulator.GetResult(result, zeroBasedDim);
+ #endif
+ }
+
+@@ -158,7 +158,7 @@
+ #ifdef _MSC_VER // work around MSVC spurious error
+   accumulator.GetResult(result, zeroBasedDim);
+ #else
+-  accumulator.template GetResult(result, zeroBasedDim);
++  accumulator.GetResult(result, zeroBasedDim);
+ #endif
+ }

--- a/lang/llvm-18/files/0045-flang-fix-libcpp-verbose-abort-noexcept.patch
+++ b/lang/llvm-18/files/0045-flang-fix-libcpp-verbose-abort-noexcept.patch
@@ -1,0 +1,19 @@
+--- a/flang/runtime/io-api.cpp
++++ b/flang/runtime/io-api.cpp
+@@ -1495,8 +1495,14 @@
+ #if defined(_LIBCPP_VERBOSE_ABORT)
+ // Provide own definition for `std::__libcpp_verbose_abort` to avoid dependency
+ // on the version provided by libc++.
+-
+-void std::__libcpp_verbose_abort(char const *format, ...) {
++#ifndef _LIBCPP_VERBOSE_ABORT_NOEXCEPT
++#  if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
++#    define _LIBCPP_VERBOSE_ABORT_NOEXCEPT _NOEXCEPT
++#  else
++#    define _LIBCPP_VERBOSE_ABORT_NOEXCEPT
++#  endif
++#endif
++void std::__libcpp_verbose_abort(char const *format, ...) _LIBCPP_VERBOSE_ABORT_NOEXCEPT {
+   va_list list;
+   va_start(list, format);
+   std::vfprintf(stderr, format, list);


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
- Disable OCaml doc generation to fix destroot failure
- Fix flang compilation on macOS 15+

See also #32441 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 x86_64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
