### PR TITLE
claude-code: update to 2.1.138

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.136
+version             2.1.138
 revision            0
 
 categories          llm
@@ -26,13 +26,13 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  5c778fe03b91474bdbf2f8f1cac505cb67f9065d \
-                 sha256  d540e416e7f8562c99c336ba703d3374d41f79be6d1a93f1c6bd3a88686d4ae7 \
+    checksums    rmd160  ce54bb167c29540b54879fe21710461d811898ac \
+                 sha256  d99d3a7afd63841943906b11ed8791b0ee47fe5cf95601a8b805c20900014f54 \
                  size    207568336
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  ba53efa3ea44d69463da176c9747485d762ccfcb \
-                 sha256  9ef618487dc9e0cb766e8d0d51cd5fd3d06c3d038f4f04f3e714791f32a3cda5 \
+    checksums    rmd160  7b6bddd1abb6aaa2e854c5f25409d429c9a86874 \
+                 sha256  759d23ce626193c89bc8b35c5c6ca8a9e33b9c2e504ee143e4cd119988774097 \
                  size    205062416
 } else {
     set arch_classifier unsupported_arch


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.138.

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?