### PR TITLE
llmfit: update to 0.9.22

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.18 v
+github.setup            AlexsJones llmfit 0.9.22 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  c7ea22aecfd43f8bb676064df8bd7c09e419be01 \
-                        sha256  7a37d07ab458c0e7b0e68961ab851d0933adbaa81eee843090e61715eab3e472 \
-                        size    2997088
+                        rmd160  840b4cdb11c367ca8b36e5a1f3dcae2e1c49b101 \
+                        sha256  8e2c3144155a50cfc1ca9610bf460f7f1ee890c26aa7df4b7057910812e0ee38 \
+                        size    3087205
 
 categories              llm
 platforms               macosx
@@ -45,7 +45,7 @@ cargo.crates \
     anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
     anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     arboard                          3.6.1  0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf \
-    assert_cmd                       2.2.0  9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9 \
+    assert_cmd                       2.2.1  39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd \
     atk                             0.18.2  241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b \
     atk-sys                         0.18.2  c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086 \
     atomic                           0.6.1  a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340 \
@@ -262,6 +262,7 @@ cargo.crates \
     libc                           0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
     libloading                       0.7.4  b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f \
     libredox                        0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
+    libyml                           0.0.5  3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980 \
     line-clipping                    0.3.7  3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8 \
     linux-raw-sys                   0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                          0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
@@ -426,6 +427,7 @@ cargo.crates \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     serde_with                      3.18.0  dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f \
     serde_with_macros               3.18.0  d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65 \
+    serde_yml                       0.0.12  59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd \
     serialize-to-javascript          0.1.2  04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5 \
     serialize-to-javascript-impl     0.1.2  772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d \
     servo_arc                        0.2.0  d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.4 24G517 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

