### PR TITLE
previous: update to 4.3

### DIFF
--- a/emulators/previous/Portfile
+++ b/emulators/previous/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                previous
-version             4.1
+version             4.3
 revision            0
 categories          emulators
 license             GPL-2+
@@ -19,7 +19,7 @@ homepage            https://sourceforge.net/projects/previous/
 
 fetch.type          svn
 svn.url             https://svn.code.sf.net/p/previous/code/trunk
-svn.revision        1777
+svn.revision        1822
 worksrcdir          trunk
 
 depends_lib         port:SDL3 \


### PR DESCRIPTION
#### Description

Update previous NeXT computer emulator from 4.1 to 4.3.

###### Tested on

macOS 15.6.1 24G90 arm64 / Xcode 26.3
macOS 26.4 25E246 arm64 / Xcode 26.4.1

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?