### PR TITLE
pi-coding-agent: new port

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           npm 1.0
+
+name                pi-coding-agent
+version             0.74.0
+revision            0
+
+npm.rootname        @earendil-works/pi-coding-agent
+distname            ${name}-${version}
+
+checksums           rmd160  0f360fb7196daa36138e882c9a93d49c2f6a8c0f \
+                    sha256  974a73b96195bd7d630e115869ecb5e0dd7a5c3a38ee4926dc99448663d4a344 \
+                    size    4564493
+
+categories          llm
+license             MIT
+maintainers         @oytech openmaintainer
+
+homepage            https://pi.dev
+description         Pi is a minimal terminal coding harness.
+long_description    Pi is a minimal terminal coding harness. Adapt Pi to your workflows, not the other way around. \
+                    Customize Pi with extensions, skills, prompt templates, and themes. \
+                    Bundle them as Pi packages and share via npm or git. \
+                    Pi ships with powerful defaults but skips features like sub-agents and plan mode. \
+                    Ask Pi to build what you want, or install a package that does it your way. \
+                    Four modes: interactive, print/JSON, RPC, and SDK.


### PR DESCRIPTION
#### Description

New port for pi coding agent - https://pi.dev/

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.4 24G517 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

