### PR TITLE
mit-scheme: remove file conflict with chez scheme

### DIFF
--- a/lang/mit-scheme/Portfile
+++ b/lang/mit-scheme/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                    mit-scheme
 epoch                   1
 version                 12.1
-revision                0
+revision                1
 categories              lang
 license                 {GPL-2+ OpenSSLException}
 maintainers             {dports @drkp} openmaintainer
@@ -58,6 +58,11 @@ configure.ldflags-append \
 
 destroot.cmd            ${build.cmd}
 worksrcdir              ${name}-${version}/src
+
+post-destroot {
+    # remove this symlink to avoid conflicts with chez scheme
+    file delete "${destroot}${prefix}/bin/scheme"
+}
 
 build.target
 build.env               CC=${configure.cc} "CFLAGS=${configure.cflags} ${configure.cc_archflags}"


### PR DESCRIPTION
#### Description

The `scheme` symlink created by this port conflicts with the `scheme` binary in `chez-scheme`. This port already provides an "mit-scheme" symlink to the main binary so I just remove the "scheme" symlink.

This is similar to the solution in the gambit-c port to handle it's conflict with ghostscript.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
