### PR TITLE
valgrind-macos-devel: update to 3.27.0-latest

### DIFF
--- a/devel/valgrind/Portfile
+++ b/devel/valgrind/Portfile
@@ -154,9 +154,9 @@ subport valgrind-macos-devel {
     }
     supported_archs i386 x86_64 arm64
 
-    set date        2025-12-16
+    set date        2026-05-11
     version         3.27.0-r${date}
-    git.branch      176d0873890e61f10e47cff445c822c4949cf93d
+    git.branch      0c21e45517ace6d9d5911a85f1e0d751fe88e964
 
     description     A powerful memory debugger with latest macOS support (experimental)
 


### PR DESCRIPTION
#### Description

* Update to latest upstream

This revision addresses multiple issues with newer MacOS versions on Apple silicon, although MacOS 15 on arm64 is still not support.

Upstream tickets:
-  https://github.com/LouisBrunner/valgrind-macos/issues/123
-  https://github.com/LouisBrunner/valgrind-macos/issues/173

See: https://trac.macports.org/ticket/71269

I have only tested with build from source on M1 with macOS 26.2; I have no other means of testing available to me at the moment.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.2 25C56 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
