### PR TITLE
cdo: Another attempt at a legacy fix

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -32,8 +32,9 @@ fetch.ignore_sslcert        yes
 # https://code.mpimet.mpg.de/news/536
 compiler.cxx_standard       2020
 
-# fatal error: 'ranges' file not found
-compiler.blacklist-append {clang < 900}
+# fatal error: 'ranges' file not found. Retrying the clang limits set previously.
+# See discussion https://github.com/macports/macports-ports/pull/32476
+compiler.blacklist-append   {clang < 1500}
 
 compiler.thread_local_storage yes
 compilers.choose            cc cxx


### PR DESCRIPTION
#### Description

The blacklisting of clang < 1500 has been used before for this Portfile, and then dropped, assuming it was no longer relevant. It is reintroduced here in an another attempt to fix compilation on older MacOS versions, specifically 10.14.

See the discussing in PR #32476.

No revbump would be needed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.5 24G624 x86_64
Command Line Tools 26.3.0.0.1.1771626560

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
