### PR TITLE
mp3rgain: update to 2.6.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.5.0 v
+github.setup        M-Igashi mp3rgain 2.6.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d6a03444ab60426e19f4e3e4e431ee8c70e6d375 \
-                    sha256  9dedb66494501d26c5ee37f2a3618f0d484de945085e7fc2a40037028db3afad \
-                    size    302612
+                    rmd160  f1cb91525866bf2600cf90e370b53e8a85ab53ca \
+                    sha256  da7b07e74acd82d7020a6305d8ed933307f84991328ea9dae059663feaebada7 \
+                    size    305904
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to 2.6.0.

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.6.0

### Highlights
- New `--skip-errors` flag for album mode: failed files are reported and excluded from album gain calculation instead of aborting the run.
- Fix fail-fast regression in `analyze_album_parallel_internal`.

`port lint --nitpick` reports 0 errors locally. Vendored crate set is unchanged from 2.5.0 (no `Cargo.lock` dependency changes).