### PR TITLE
llmfit: update to 0.9.23

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.22 v
+github.setup            AlexsJones llmfit 0.9.23 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  840b4cdb11c367ca8b36e5a1f3dcae2e1c49b101 \
-                        sha256  8e2c3144155a50cfc1ca9610bf460f7f1ee890c26aa7df4b7057910812e0ee38 \
-                        size    3087205
+                        rmd160  6e5b47260faccf31012e8d41e5fa1f7d4abc71b7 \
+                        sha256  a7a0afe11f6b6f75c8b0f1f65bcf4a8f2e07635e2e88112ecba98493ccf0b95b \
+                        size    3141921
 
 categories              llm
 platforms               macosx


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.5 24G624 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

