### PR TITLE
deno: update to 2.7.14

### DIFF
--- a/devel/deno/Portfile
+++ b/devel/deno/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        denoland deno 2.7.13 v
+github.setup        denoland deno 2.7.14 v
 github.tarball_from releases
 revision            0
 
@@ -34,13 +34,13 @@ supported_archs     arm64 x86_64
 platforms           {darwin >= 16}
 
 checksums           ${name}-x86_64-apple-darwin.zip \
-                    rmd160  eee9f701e8623abaed7c9bb61b24da7b27f320fa \
-                    sha256  b4153bee3c24074c83513e1a209ffc982277f88b184caccd4de9ba5113cfa2e5 \
-                    size    47616948 \
+                    rmd160  3fa42ccb850672243d05ef051345e9af610475d1 \
+                    sha256  c89149513bf8e82ab5b351dac544f8c0cada90753bd2f576f46325fb67997ae1 \
+                    size    47836723 \
                     ${name}-aarch64-apple-darwin.zip \
-                    rmd160  9582bd286190e3c93ecea0f87cccb2084ab1e9dc \
-                    sha256  e2e63288d11e3f36855b60d77585844cbc5146600cbc7224e2d9276a35378089 \
-                    size    44394746
+                    rmd160  2442e198906552658cb98d7116d65487f6e93508 \
+                    sha256  aeb5825f83b4a9cd7f9355a1c4ddd666205dacf76ccb7b98c2b10e066bc9e4bb \
+                    size    44594663
 
 if {${build_arch} eq "arm64"} {
     set release_arch aarch64


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.5 24G624 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

