### PR TITLE
zk: update to 0.15.4

### DIFF
--- a/office/zk/Portfile
+++ b/office/zk/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mickael-menu/zk 0.15.2 v
+go.setup            github.com/mickael-menu/zk 0.15.4 v
 revision            0
 
 categories          office
@@ -15,9 +15,9 @@ long_description    zk is a command-line tool helping you to maintain a plain \
                     text Zettelkasten or personal wiki.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  0fa91cb69bca308623ff11a7f98721dcba335d9b \
-                        sha256  cd8524ea3be81784336706f68edaafe9b4f21d05e0d7a968065cf685e9afefc1 \
-                        size    657489
+                        rmd160  df6130cfe42d694e40a799bb535f07240c5fdb9b \
+                        sha256  024b5a1615c8ac1924ec3338b36031c36131bad5de77dcce05adce35659b7489 \
+                        size    667511
 
 # Suppress build date for reproducible builds
 # Switch to SOURCE_DATE_EPOCH approach in the future


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Currently, `sudo port -vst install zk` does not work for me with v0.15.4, but it also does not work with the current version, v0.15.2. I'm not sure if this is an issue that should be fixed before upgrading -- either way, should a ticket be opened?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.6 24G711 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
