### PR TITLE
mise: Update to 2026.5.6

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.4.27 v
+github.setup        jdx mise 2026.5.6 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ae74b0eda1b70f9920a04e80131fb7a6546e8077 \
-                    sha256  c499a7ce733b983a364c6dd03d6083e18558625082c0651368e7d0f0a7bb340f \
-                    size    6767955
+                    rmd160  20d77f3c05291c1e3fd83153792dc9f26e49bd1c \
+                    sha256  9d1fefeaf5c40c41ed2930ce22600dc8aa4a6b1472edb0c57086453081995a17 \
+                    size    6867823
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -87,8 +87,9 @@ cargo.crates \
     adler2                               2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
     aead                                 0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
     aes                                  0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
+    aes                                  0.9.0  66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8 \
     aes-gcm                             0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
-    age                                 0.11.2  bf640be7658959746f1f0f2faab798f6098a9436a8e18e148d18bc9875e13c4b \
+    age                                 0.11.3  a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5 \
     age-core                            0.11.0  e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99 \
     ahash                                0.7.8  891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9 \
     ahash                               0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
@@ -112,17 +113,18 @@ cargo.crates \
     asn1-rs-derive                       0.6.0  3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c \
     asn1-rs-impl                         0.2.0  7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7 \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
+    astral-reqwest-middleware            0.4.2  638d02e24aeb92f9537897cd1ff82e2bc98fd9ac9575a503e27bb07cdf64d4d7 \
     astral-tokio-tar                     0.6.1  4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693 \
+    astral_async_http_range_reader       0.9.1  7ddaca0fbbf0d91103cca7c7611790c65f6eff1d456f7fe6bf565d436dc9b8f3 \
     astral_async_zip                    0.0.17  ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba \
     async-backtrace                      0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
     async-backtrace-attributes           0.2.7  affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7 \
-    async-compression                   0.4.41  d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1 \
+    async-compression                   0.4.42  e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac \
     async-fd-lock                        0.2.0  7569377d7062165f6f7834d9cb3051974a2d141433cc201c2f94c149e993cccf \
     async-once-cell                      0.5.4  4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a \
     async-recursion                      1.1.1  3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11 \
     async-spooled-tempfile               0.1.0  5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5 \
     async-trait                         0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
-    async_http_range_reader              0.9.1  2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197 \
     atomic-waker                         1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                              1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
     aws-config                          1.8.14  8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2 \
@@ -171,14 +173,17 @@ cargo.crates \
     bitflags                            2.11.1  c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3 \
     bitvec                               1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
     blake2                              0.10.6  46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe \
-    blake3                               1.8.4  4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e \
+    blake3                               1.8.5  0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce \
     block-buffer                        0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
     block-buffer                        0.12.0  cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be \
     block-padding                        0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
     blowfish                             0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
+    bs58                                 0.5.1  bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4 \
     bstr                                1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
     built                                0.8.0  f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64 \
     bumpalo                             3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
+    bytecheck                            0.8.2  0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b \
+    bytecheck_derive                     0.8.2  89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9 \
     bytecount                            0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
     byteorder                            1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                               1.11.1  1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33 \
@@ -191,8 +196,7 @@ cargo.crates \
     calm_io                              0.1.1  2ea0608700fe42d90ec17ad0f86335cf229b67df2e34e7f463e8241ce7b8fa5f \
     calmio_filters                       0.1.0  846501f4575cd66766a40bb7ab6d8e960adc7eb49f753c8232bd8e0e09cf6ca2 \
     cbc                                  0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
-    cc                                  1.2.60  43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20 \
-    cesu8                                1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
+    cc                                  1.2.62  a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98 \
     cexpr                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                               1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                          0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
@@ -204,6 +208,7 @@ cargo.crates \
     chrono-tz-build                      0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                            0.14.15  7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23 \
     cipher                               0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
+    cipher                               0.5.1  e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea \
     clang-sys                            1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
     clap                                 4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap-sort                            1.0.3  3c9f374a541bd277ba6f4ccd08d955024ba09fda8dfc69ca1a750799ebed97a9 \
@@ -211,8 +216,9 @@ cargo.crates \
     clap_derive                          4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                             1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
     clru                                 0.6.3  197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5 \
-    clx                                  2.0.0  0fc5a001156058931723b899569201add22c273d019c4f61642698fdcbcecb8e \
+    clx                                  2.0.3  00505ebcbbb9f5ce9e205e324db6c44518d97e9d6278f6dab8e0bff1937d2edf \
     cmake                               0.1.58  c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
+    cmov                                 0.5.3  3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746 \
     coalesced_map                        0.1.2  7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b \
     color-eyre                           0.6.5  e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d \
     color-print                          0.3.7  3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4 \
@@ -222,8 +228,8 @@ cargo.crates \
     colored                              3.1.1  faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34 \
     combine                              4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
     comfy-table                          7.2.2  958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47 \
-    compression-codecs                  0.4.37  eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7 \
-    compression-core                    0.4.31  75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d \
+    compression-codecs                  0.4.38  ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf \
+    compression-core                    0.4.32  cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789 \
     concurrent-queue                     2.5.0  4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973 \
     configparser                         3.1.0  e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b \
     confique                             0.4.0  06b4f5ec222421e22bb0a8cbaa36b1d2b50fd45cdd30c915ded34108da78b29f \
@@ -244,10 +250,11 @@ cargo.crates \
     core-foundation                     0.10.1  b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6 \
     core-foundation-sys                  0.8.7  773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b \
     countme                              3.0.1  7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636 \
+    cpubits                              0.1.1  15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae \
     cpufeatures                         0.2.17  59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280 \
     cpufeatures                          0.3.0  8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201 \
     crc                                  3.4.0  5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d \
-    crc-catalog                          2.4.0  19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5 \
+    crc-catalog                          2.5.0  217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853 \
     crc-fast                             1.6.0  6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3 \
     crc32fast                            1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
     crossbeam-channel                   0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
@@ -260,9 +267,9 @@ cargo.crates \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
     crypto_secretbox                     0.1.1  b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1 \
-    ctor                                0.10.0  95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775 \
-    ctor-proc-macro                     0.0.12  a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db \
+    ctor                                0.12.0  b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
+    ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive              0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
     darling                            0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
@@ -273,12 +280,12 @@ cargo.crates \
     darling_macro                       0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
     dashmap                              5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     dashmap                              6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
-    data-encoding                       2.10.0  d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea \
+    data-encoding                       2.11.0  a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8 \
     deadpool                            0.12.3  0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b \
     deadpool-runtime                     0.1.4  092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b \
     decoded-char                         0.1.1  5440d1dc8ea7cae44cda3c64568db29bfa2434aba51ae66a50c00488841a65a3 \
     deflate64                           0.1.12  ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2 \
-    demand                               2.0.0  35fbd3e6864d5351323ef4fa5db803386adf73cce6b42fcdf6a542804dc83c61 \
+    demand                               2.0.1  4e75be0d8a6175692cd9f9e7a7e18acd14612be09e166391a8093b7823295cd4 \
     der                                 0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
     der-parser                          10.0.0  07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6 \
     der_derive                           0.7.3  8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18 \
@@ -292,15 +299,13 @@ cargo.crates \
     deunicode                            1.6.2  abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04 \
     diff                                0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     digest                              0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
-    digest                              0.11.2  4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c \
+    digest                              0.11.3  f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2 \
     directories                          6.0.0  16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d \
     dirs                                 6.0.0  c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e \
     dirs-sys                             0.5.0  e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab \
     displaydoc                           0.2.5  97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0 \
     document-features                   0.2.12  d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61 \
     dotenvy                             0.15.7  1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b \
-    dtor                                 0.7.0  17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293 \
-    dtor-proc-macro                     0.0.12  8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131 \
     duct                                 1.1.1  7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684 \
     dunce                                1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                           1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
@@ -333,8 +338,8 @@ cargo.crates \
     fastrand                             2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     ff                                  0.13.1  c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393 \
     fiat-crypto                          0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
-    file_url                             0.2.8  77b3f3f3326607002e13f1b44a624279f5ca21afce4259730aa619c420cca73b \
-    filetime                            0.2.27  f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db \
+    file_url                             0.3.0  1e546758dbcde9d10c0d3bd8b83adb535b23fa81121cf4dc5c3e7b5907cc8eb8 \
+    filetime                            0.2.28  2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6 \
     filetime_creation                    0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
     find-crate                           0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
     find-msvc-tools                      0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
@@ -377,80 +382,82 @@ cargo.crates \
     getset                               0.1.6  9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912 \
     ghash                                0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                               0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
-    gix                                 0.81.0  0473c64d9ccbcfb9953a133b47c8b9a335b87ac6c52b983ee4b03d49000b0f3f \
-    gix-actor                           0.40.0  0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35 \
-    gix-archive                         0.30.0  651c99be11aac9b303483193ae50b45eb6e094da4f5ed797019b03948f51aad6 \
-    gix-attributes                      0.31.0  c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c \
-    gix-bitmap                           0.3.0  e7add20f40d060db8c9b1314d499bac6ed7480f33eb113ce3e1cf5d6ff85d989 \
-    gix-blame                           0.11.0  c77aaf9f7348f4da3ebfbfbbc35fa0d07155d98377856198dde6f695fd648705 \
-    gix-chunk                            0.7.0  1096b6608fbe5d27fb4984e20f992b4e76fb8c613f6acb87d07c5831b53a6959 \
-    gix-command                          0.8.0  b849c65a609f50d02f8a2774fe371650b3384a743c79c2a070ce0da49b7fb7da \
-    gix-commitgraph                     0.35.0  3196655fd1443f3c58a48c114aa480be3e4e87b393d7292daaa0d543862eb445 \
-    gix-config                          0.54.0  08939b4c4ed7a663d0e64be9e1e9bdf23a1fb4fcee1febdf449f12229542e50d \
-    gix-config-value                    0.17.1  441a300bc3645a1f45cba495b9175f90f47256ce43f2ee161da0031e3ac77c92 \
-    gix-credentials                     0.37.1  38b2a34b8715e3bbd514f3d1705f5d51c4b250e5bfe506b9fb60b133c85c93d9 \
-    gix-date                            0.15.1  39acf819aa9fee65e4838a2eec5cb2506e47ebb89e02a5ab9918196e491571ea \
-    gix-diff                            0.61.0  88f3b3475e5d3877d7c30c40827cc2441936ce890efc226e5ba4afe3a7ae33f0 \
-    gix-dir                             0.23.0  5da4604a360988f0ba8efe6f90093ca5a844f4a7f8e1a3dcda501ec44e600ea9 \
-    gix-discover                        0.49.0  c65bd3330fe0cb9d40d875bf862fd5e8ad6fa4164ddbc4842fbeb889c3f0b2c6 \
-    gix-error                            0.2.1  2e86d01da904d4a9265def43bd42a18c5e6dc7000a73af512946ba14579c9fbd \
-    gix-features                        0.46.2  752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20 \
-    gix-filter                          0.28.0  d37598282a6566da6fb52667570c7fe0aedcb122ac886724a9e62a2180523e35 \
-    gix-fs                              0.19.2  a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72 \
-    gix-glob                            0.24.0  b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee \
-    gix-hash                            0.23.0  0fb896a02d9ab96fa518475a5f30ad3952010f801a8de5840f633f4a6b985dfb \
-    gix-hashtable                       0.13.0  2664216fc5e89b51e756a4a3ac676315602ce2dac07acf1da959a22038d69b33 \
-    gix-ignore                          0.19.1  09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26 \
-    gix-index                           0.49.0  1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7 \
-    gix-lock                            21.0.2  054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f \
-    gix-mailmap                         0.32.0  c7b4818da522786ec7e32a00884ee8fc40fa4c215c3997c0b15f7b62684d1199 \
-    gix-merge                           0.14.0  f4606747466512d22c2dffc019142e1941238f543987ea51353c938cca80c500 \
-    gix-negotiate                       0.29.0  6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c \
-    gix-object                          0.58.0  cafb802bb688a7c1e69ef965612ff5ff859f046bfb616377e4a0ba4c01e43d47 \
-    gix-odb                             0.78.0  24833ae9323b4f7079575fb9f961cf9c414b0afbec428a536ab8e7dd93bc002b \
-    gix-pack                            0.68.0  e3484119cd19859d7d7639413c27e192478fa354d3f4ff5f7e3c041e8040f0f4 \
-    gix-packetline                      0.21.2  be19313dcdb7dff75a3ce2f99be00878458295bcc3b6c7f0005591597573345c \
-    gix-path                            0.11.2  09c31d4373bda7fab9eb01822927b55185a378d6e1bf737e0a54c743ad806658 \
-    gix-pathspec                        0.16.1  f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b \
-    gix-prompt                          0.14.1  0f61f6264e1f6c5a951531fe127722c7522bc02ebda80c4528286bda4642055f \
-    gix-protocol                        0.59.0  4f38666350736b5877c79f57ddae02bde07a4ce186d889adc391e831cddcbe76 \
-    gix-quote                            0.7.0  68533db71259c8776dd4e770d2b7b98696213ecdc1f5c9e3507119e274e0c578 \
-    gix-ref                             0.61.0  c2159978abb99b7027c8579d15211e262ef0ef2594d5cecb3334fbcbdfe2997c \
-    gix-refspec                         0.39.0  dc806ee13f437428f8a1ba4c72ecfaa3f20e14f5f0d4c2bc17d0b33e794aa6ac \
-    gix-revision                        0.43.0  7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d \
-    gix-revwalk                         0.29.0  0e4b2b87772b21ca449249e86d32febadba5cba32b0fcce804ab9cefc6f2111c \
-    gix-sec                             0.13.2  bf82ae037de9c62850ce67beaa92ec8e3e17785ea307cdde7618edc215603b4f \
-    gix-shallow                         0.10.0  cbf60711c9083b2364b3fac8a352444af76b17201f3682fdebe74fa66d89a772 \
-    gix-status                          0.28.0  23d6c598e3fdbc352fba1c5ba7e709e69402fafbc44d9295edad2e3c4738996b \
-    gix-submodule                       0.28.0  0ce5c3929c5e6821f651d35e8420f72fea3cfafe9fc1e928a61e718b462c72a5 \
-    gix-tempfile                        21.0.2  d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528 \
-    gix-trace                           0.1.18  f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0 \
-    gix-transport                       0.55.1  a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb \
-    gix-traverse                        0.55.0  963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec \
-    gix-url                             0.35.2  d28e8af3d42581190da884f013caf254d2fd4d6ab102408f08d21bfa11de6c8d \
-    gix-utils                            0.3.1  befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5 \
-    gix-validate                        0.11.0  0ec1eff98d91941f47766367cba1be746bab662bad761d9891ae6f7882f7840b \
-    gix-worktree                        0.50.0  e6bd5830cbc43c9c00918b826467d2afad685b195cb82329cde2b2d116d2c578 \
-    gix-worktree-state                  0.28.0  644a1681f96e1be43c2a8384337d9d220e7624f50db54beda70997052aebf707 \
-    gix-worktree-stream                 0.30.0  24e3fb70a1f650a5cec7d5b8d10d6d6fe86daf3cf15bde08ba0c70988a2932c3 \
+    gix                                 0.83.0  6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567 \
+    gix-actor                           0.41.0  272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8 \
+    gix-archive                         0.32.0  9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342 \
+    gix-attributes                      0.33.0  fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000 \
+    gix-bitmap                           0.3.1  1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894 \
+    gix-blame                           0.13.0  14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a \
+    gix-chunk                            0.7.1  edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320 \
+    gix-command                          0.9.0  86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8 \
+    gix-commitgraph                     0.37.0  fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb \
+    gix-config                          0.56.0  8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410 \
+    gix-config-value                    0.18.0  13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2 \
+    gix-credentials                     0.38.0  65ca11598b70811d7b16ff90945a6e57dfe521e85b744e51636965fe39cc8f60 \
+    gix-date                            0.15.3  b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543 \
+    gix-diff                            0.63.0  dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a \
+    gix-dir                             0.25.0  32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c \
+    gix-discover                        0.51.0  17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34 \
+    gix-error                            0.2.3  e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613 \
+    gix-features                        0.48.0  af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f \
+    gix-filter                          0.30.0  dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08 \
+    gix-fs                              0.21.1  1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86 \
+    gix-glob                            0.26.0  08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c \
+    gix-hash                            0.25.0  bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2 \
+    gix-hashtable                       0.15.0  d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b \
+    gix-ignore                          0.21.0  6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5 \
+    gix-imara-diff                       0.2.1  39eb0623e15e4cb83c02ce6a959e48fadd1ae3b715b36b5acc01816e01388c82 \
+    gix-index                           0.51.0  54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db \
+    gix-lock                            23.0.0  09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1 \
+    gix-mailmap                         0.33.0  023d3a6561cbebe45b89e0764d48928ad970667076f16fa5889e6f86d8432086 \
+    gix-merge                           0.16.0  74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881 \
+    gix-negotiate                       0.31.0  103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c \
+    gix-object                          0.60.0  a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7 \
+    gix-odb                             0.80.0  aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba \
+    gix-pack                            0.70.0  daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa \
+    gix-packetline                      0.21.3  362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6 \
+    gix-path                            0.12.0  671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e \
+    gix-pathspec                        0.18.0  2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855 \
+    gix-prompt                          0.15.0  e041a626c64cb69e4117fcdf80da8d0e454fba3b1f420412792d191f52251aee \
+    gix-protocol                        0.61.0  aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd \
+    gix-quote                            0.7.1  6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be \
+    gix-ref                             0.63.0  d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167 \
+    gix-refspec                         0.41.0  61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761 \
+    gix-revision                        0.45.0  1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8 \
+    gix-revwalk                         0.31.0  313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0 \
+    gix-sec                             0.14.0  f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6 \
+    gix-shallow                         0.12.0  29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27 \
+    gix-status                          0.30.0  68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65 \
+    gix-submodule                       0.30.0  9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91 \
+    gix-tempfile                        23.0.0  691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb \
+    gix-trace                           0.1.19  6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e \
+    gix-transport                       0.57.0  ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018 \
+    gix-traverse                        0.57.0  a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c \
+    gix-url                             0.36.0  35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece \
+    gix-utils                            0.3.2  4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c \
+    gix-validate                        0.11.1  e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5 \
+    gix-worktree                        0.52.0  d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd \
+    gix-worktree-state                  0.30.0  8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800 \
+    gix-worktree-stream                 0.32.0  9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213 \
     glob                                 0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     globset                             0.4.18  52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3 \
     globwalk                             0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
     group                               0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
-    h2                                  0.4.13  2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54 \
+    h2                                  0.4.14  171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733 \
     halfbrown                            0.4.0  0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09 \
     hash32                               0.3.1  47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606 \
     hashbrown                           0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                           0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                           0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                           0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
-    hashbrown                           0.17.0  4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
+    hashbrown                           0.17.1  ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a \
     heapless                             0.8.0  0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad \
     heck                                 0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                           0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
     hex                                  0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hkdf                                0.12.4  7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7 \
     hmac                                0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
+    hmac                                0.13.0  6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f \
     homedir                              0.3.6  68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527 \
     http                                0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
     http                                 1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
@@ -466,7 +473,7 @@ cargo.crates \
     human_format                         1.2.1  eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b \
     humansize                            2.1.3  6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7 \
     humantime                            2.3.0  135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424 \
-    hybrid-array                        0.4.10  3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214 \
+    hybrid-array                        0.4.12  9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da \
     hyper                                1.9.0  6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca \
     hyper-rustls                        0.27.9  33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f \
     hyper-tls                            0.6.0  70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0 \
@@ -487,10 +494,8 @@ cargo.crates \
     id-arena                             2.3.0  3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954 \
     ident_case                           1.0.1  b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39 \
     idna                                 1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
-    idna_adapter                         1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
+    idna_adapter                         1.2.2  cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714 \
     ignore                              0.4.25  d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a \
-    imara-diff                           0.1.8  17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2 \
-    imara-diff                           0.2.0  2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c \
     impl-tools                          0.11.4  0ae314a99afb5821e2fda288387546d4a04aace674551e854e6216b892ec3208 \
     impl-tools-lib                      0.11.4  ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf \
     indenter                             0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
@@ -499,13 +504,13 @@ cargo.crates \
     indicatif                           0.18.4  25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
     indoc                                2.0.7  79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706 \
     inout                                0.1.4  879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01 \
+    inout                                0.2.2  4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7 \
     insta                               1.47.2  7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e \
     intl-memoizer                        0.5.3  310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f \
     intl_pluralrules                     7.0.2  078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972 \
     io-close                             0.3.7  9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc \
     io_tee                               0.1.1  4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304 \
     ipnet                               2.12.0  d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2 \
-    iri-string                          0.7.12  25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20 \
     is_ci                                1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
     is_terminal_polyfill                1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                           0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
@@ -513,23 +518,21 @@ cargo.crates \
     itertools                           0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                           0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    jiff                                0.2.23  1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359 \
-    jiff-static                         0.2.23  2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4 \
+    jiff                                0.2.24  f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d \
+    jiff-static                         0.2.24  e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7 \
     jiff-tzdb                            0.1.6  c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076 \
     jiff-tzdb-platform                   0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
-    jni                                 0.21.1  1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97 \
     jni                                 0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
     jni-macros                          0.22.4  a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3 \
-    jni-sys                              0.3.1  41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258 \
     jni-sys                              0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                       0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                           0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                              0.3.95  2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca \
+    js-sys                              0.3.98  67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08 \
     json-number                         0.4.10  479dfd2ad8e4b4ae076b031f72ef2f3791f65e2a0f51e5f3408dbf716c4c2f82 \
-    json-patch                           4.1.0  f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90 \
+    json-patch                           4.2.0  7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72 \
     json-syntax                         0.12.5  044a68aba3f96d712f492b72be25e10f96201eaaca3207a7d6e68d6d5105fda9 \
     jsonptr                              0.7.1  a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe \
-    junction                             1.4.2  8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95 \
+    junction                             2.0.0  160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006 \
     jwt                                 0.16.0  6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f \
     kdl                                  6.5.0  81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e \
     known-folders                        1.4.2  7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638 \
@@ -549,12 +552,13 @@ cargo.crates \
     lexical-write-float                  1.0.6  50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361 \
     lexical-write-integer                1.0.6  409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df \
     libbz2-rs-sys                        0.2.3  b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f \
-    libc                               0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
+    libc                               0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
     libredox                            0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
-    link-section                         0.2.0  468808413fa8bdf0edbe61c2bbc182dfc59885b94f496cf3fb42c9c96b1e0149 \
+    link-section                        0.12.0  0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40 \
+    linktime-proc-macro                  0.1.0  a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81 \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                              0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
@@ -594,6 +598,8 @@ cargo.crates \
     mlua_derive                         0.11.0  465bddde514c4eb3b50b543250e97c1d4b284fa3ef7dc0ba2992c77545dbceb2 \
     mockito                              1.7.2  90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0 \
     multimap                            0.10.1  1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084 \
+    munge                                0.4.7  5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c \
+    munge_macro                          0.4.7  4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931 \
     native-tls                          0.2.18  465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2 \
     ndk-context                          0.1.1  27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b \
     netrc-rs                             0.1.2  ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836 \
@@ -630,10 +636,10 @@ cargo.crates \
     once_cell_polyfill                  1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     opaque-debug                         0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
     openidconnect                        4.0.1  0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2 \
-    openssl                            0.10.78  f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222 \
+    openssl                            0.10.79  bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542 \
     openssl-macros                       0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                        0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
-    openssl-sys                        0.9.114  13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6 \
+    openssl-sys                        0.9.115  158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781 \
     option-ext                           0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                       2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     os-release                           0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
@@ -648,11 +654,12 @@ cargo.crates \
     parking_lot_core                    0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     parse-zoneinfo                       0.3.1  1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24 \
     password-hash                        0.5.0  346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166 \
-    pastey                               0.2.1  b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec \
+    pastey                               0.2.2  c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a \
     path-absolutize                      3.1.1  e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5 \
     path-dedot                           3.1.1  07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397 \
-    path_resolver                        0.2.7  59953de32542217edd1cc5fd52ac7ca2de57d7613a3a3e569370e5ea09231df3 \
+    path_resolver                        0.2.8  bde05d7ef24e5a8818baa86a291018e17992292794f8d11ea2f5e9e1c33fb197 \
     pbkdf2                              0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
+    pbkdf2                              0.13.0  112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629 \
     pem                                  3.0.6  1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
     pem-rfc7468                          0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
     percent-encoding                     2.3.2  9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220 \
@@ -665,17 +672,16 @@ cargo.crates \
     phf_codegen                         0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
     phf_generator                       0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
     phf_shared                          0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
-    pin-project                         1.1.11  f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517 \
-    pin-project-internal                1.1.11  d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6 \
+    pin-project                         1.1.12  cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9 \
+    pin-project-internal                1.1.12  a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389 \
     pin-project-lite                    0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pin-utils                            0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkcs1                                0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
     pkcs5                                0.7.1  e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6 \
     pkcs8                               0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                          0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
-    plain                                0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
     platforms                           3.10.0  f6001d2ac55b4eb1ca634c65fc06555068b8dd89c9f20fd92064e5341a436e63 \
-    plist                                1.8.0  740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07 \
+    plist                                1.9.0  092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1 \
     poly1305                             0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
     polyval                              0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
     portable-atomic                     1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
@@ -701,10 +707,13 @@ cargo.crates \
     prost-reflect-build                 0.16.0  8214ae2c30bbac390db0134d08300e770ef89b6d4e5abf855e8d300eded87e28 \
     prost-reflect-derive                0.16.0  7b6d90e29fa6c0d13c2c19ba5e4b3fb0efbf5975d27bcf4e260b7b15455bcabe \
     prost-types                         0.14.3  8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7 \
+    ptr_meta                             0.3.1  0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79 \
+    ptr_meta_derive                      0.3.1  7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1 \
     purl                                 0.1.6  60ebe4262ae91ddd28c8721111a0a6e9e58860e211fc92116c4bb85c98fd96ad \
     quick-error                          1.2.3  a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0 \
     quick-xml                           0.37.5  331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb \
     quick-xml                           0.38.4  b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c \
+    quick-xml                           0.39.4  cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e \
     quinn                               0.11.9  b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20 \
     quinn-proto                        0.11.14  434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098 \
     quinn-udp                           0.5.14  addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd \
@@ -712,6 +721,7 @@ cargo.crates \
     r-efi                                5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                                6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
     radium                               0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
+    rancor                               0.1.1  a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee \
     rand                                 0.8.6  5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a \
     rand                                 0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
     rand                                0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
@@ -721,24 +731,23 @@ cargo.crates \
     rand_core                            0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.40.6  4d0e63e5cba12a01904b7002c40d31aa93d62554526f1abcf733bcfaa0464102 \
-    rattler_cache                       0.6.21  e41ab6700748842122199ae89c110bf152b0c95d0fcf0bdf9c6fd49255f05533 \
-    rattler_conda_types                 0.44.6  809c0147f00c67143f90a1e01870a8856b68d3072dbe91cdf78c4dbab44a944e \
-    rattler_digest                       1.2.3  fa6239d5be357419ba579b1cda7fe0e140a22134ebc999adb62b818989fbc7c7 \
-    rattler_macros                      1.0.12  18d0d45ce3ae00333421569d2fafa4b877708a901c3cb217f8d4acfab4328df0 \
-    rattler_menuinst                    0.2.56  303d912b90c44cc3539ac47bf28633e0ef84085c3ef36007f51bdfec580a0c94 \
-    rattler_networking                  0.26.9  a7f21a2e0a5b3ef35ff1a9d7d9dd62001b2953060299140dfc52ddb22907d41f \
-    rattler_package_streaming           0.24.9  62e2d688fd457ecd88ec9fcd610a638152814191d53a5d84798c5b3cac2897b4 \
-    rattler_pty                          0.2.9  ec435d69bcc064b5cb0f6a49d8cfc1dbed93f0ec233d4499156ae7c3bc7f90d7 \
-    rattler_redaction                   0.1.13  961121cad9792daafc176a7f4caafc0fc889fb17507c23a4c86e1777a8b5e179 \
-    rattler_repodata_gateway            0.27.6  b49ec1a9f8de181bb4e5e62060f48d3c0a66d69dd2b93119c7fb77b0e242ffcc \
-    rattler_shell                       0.26.9  8beacee0b6fac56c621bb9c61799d476c32b107061a207586d1a259b54376cec \
-    rattler_solve                        5.2.2  69719a26caf0689659097a85e7d3fc5174200ef0c64d65e5f9f89f14afd700e0 \
-    rattler_virtual_packages            2.3.18  8c3d2a564b41942dd87e441e4c68a31e4be517915daf5d20fe4b36cd3f4a7c5e \
+    rattler                             0.42.0  9bc96a27d6c39b6d2a22aa4bef52b2cf37077761ecb209f5ebd92657593a7189 \
+    rattler_cache                        0.7.1  05fb0beb355779982d60ffaf71d5330e1cafa31c7a5be8bf33c4ca597477cf03 \
+    rattler_conda_types                 0.46.1  1ce168319aa4284a026df19b0054bab8609e3447937f43ef1a496b7af6984324 \
+    rattler_digest                       1.2.4  fbab3541bf7e471550c91b70dad8edf392ffa9f57c6b0de4bbe6dd2c6c0d53d4 \
+    rattler_macros                      1.0.13  677367cf07dd4ca5b863a91cf060feea246f3b23d50af9e9fadf980db760d270 \
+    rattler_menuinst                    0.2.59  4874d056de91e23bf2c02c827fd8a7557d6e4ba032fdf6800efbe3ea9ff127dd \
+    rattler_networking                 0.26.12  17840c3642ef185ead62f4b7be5672fd6ab6c9ffeb9ce74cb1509d50eecbe96c \
+    rattler_package_streaming           0.25.1  8321ca30ccd49fed1c000d981a1d0f786f8b365c119b7c8bdd5f0bdbd870f04c \
+    rattler_pty                         0.2.10  da10b7f974ce38eaf00e0e1d29c13151fa10fa003ec03606bc1bf76e4d537dfd \
+    rattler_redaction                   0.1.15  40a5b2b5dc702c69f60fbf9ebf6bfe751854069918b24c48f64873ae31b72b84 \
+    rattler_repodata_gateway            0.28.2  8f6236f9cefc9a3219a2570d32d2250168d314faf2741e9bafd0c2f1feb3b984 \
+    rattler_shell                      0.26.12  88d7bca1c7fd2a6fac62f9716cfcf3967b1360c9a42ad5ab09759f34bba532a7 \
+    rattler_solve                        6.0.2  6b1b27732702160735cc8e81eccbf42209bd503b6fad471e8215713e97ac00f0 \
+    rattler_virtual_packages            2.3.21  7de0c7bae6b12ebc6ca640e97cc6be1f49609cd716d1af520cba2a7faffcad73 \
     rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
-    redox_syscall                        0.7.4  f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a \
     redox_users                          0.5.2  a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac \
     ref-cast                            1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                       1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
@@ -748,15 +757,17 @@ cargo.crates \
     regex-lite                           0.1.9  cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973 \
     regex-syntax                        0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
     regex-syntax                        0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
+    rend                                 0.5.3  cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6 \
     reqwest                            0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
-    reqwest                             0.13.2  ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801 \
-    reqwest-middleware                   0.4.2  57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e \
+    reqwest                             0.13.3  62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0 \
     resolvo                             0.10.2  57a085c6cecab01bf88df532b7a03f066d5ab92e461bf4614a9de13f562eb163 \
-    retry-policies                       0.5.1  46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be \
+    retry-policies                       0.5.2  dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47 \
     rfc6979                              0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
-    rmcp                                 1.5.0  67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826 \
-    rmcp-macros                          1.5.0  48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025 \
+    rkyv                                0.8.16  73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3 \
+    rkyv_derive                         0.8.16  5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6 \
+    rmcp                                 1.6.0  e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad \
+    rmcp-macros                          1.6.0  7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
     roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
@@ -773,10 +784,10 @@ cargo.crates \
     rusticata-macros                     4.1.0  faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632 \
     rustix                             0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                               1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
-    rustls                             0.23.38  69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21 \
+    rustls                             0.23.40  ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b \
     rustls-native-certs                  0.8.3  612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63 \
-    rustls-pki-types                    1.14.0  be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd \
-    rustls-platform-verifier             0.6.2  1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784 \
+    rustls-pki-types                    1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
+    rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
     rustls-webpki                     0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
     rustversion                         1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
@@ -819,8 +830,8 @@ cargo.crates \
     serde_repr                          0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
     serde_spanned                        1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                     0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_with                          3.18.0  dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f \
-    serde_with_macros                   3.18.0  d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65 \
+    serde_with                          3.20.0  e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2 \
+    serde_with_macros                   3.20.0  b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac \
     serde_yaml               0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     serial_test                          3.4.0  911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f \
     serial_test_derive                   3.4.0  0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9 \
@@ -845,7 +856,7 @@ cargo.crates \
     signature                            2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
     sigstore                            0.13.0  52bba786054331bdc89e90f74373b68a6c3b63c9754cf20e3a4a629d0165fe38 \
     sigstore-protobuf-specs-derive       0.0.1  80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35 \
-    sigstore-verification                0.2.7  f871ba76e3d9bdd957478934864c67cb63121dc8da4c410367e74d74ef42993a \
+    sigstore-verification                0.2.8  1b7e95c07fdbd46b2f859c7010877f9557c0cd54235e7075ed935ab7aba38ccc \
     sigstore_protobuf_specs              0.5.1  cd627b4d5240ac660de3357b5d0156d5c63b872be1deae5046c3c8eb65d488e2 \
     simd-adler32                         0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     simd-json                           0.17.0  4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3 \
@@ -853,7 +864,7 @@ cargo.crates \
     simdutf8                             0.1.5  e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e \
     similar                              2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
     simple_spawn_blocking                1.1.0  55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2 \
-    siphasher                            1.0.2  b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e \
+    siphasher                            1.0.3  8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649 \
     slab                                0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     slug                                 0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
     smallstr                             0.3.1  862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b \
@@ -913,7 +924,7 @@ cargo.crates \
     tinyvec_macros                       0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tls_codec                            0.4.2  0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b \
     tls_codec_derive                     0.4.2  2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd \
-    tokio                               1.52.1  b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6 \
+    tokio                               1.52.3  8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
     tokio-macros                         2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-native-tls                     0.3.1  bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2 \
     tokio-rustls                        0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
@@ -927,7 +938,7 @@ cargo.crates \
     toml_writer               1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
     tough                               0.21.0  e88d0ee9525696569cc2af5d46f8a739028c0268895071e0386957195b0c9161 \
     tower                                0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
-    tower-http                           0.6.8  d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8 \
+    tower-http                          0.6.10  68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51 \
     tower-layer                          0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                        0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                             0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
@@ -966,7 +977,7 @@ cargo.crates \
     ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                            3.2.0  211ee8a63c28a860c94d2a40ebc8e57eb98603fd8ddc808424230f9149a201f1 \
+    usage-lib                            3.3.0  f5be04c595c37441c24fa5575cd89869f4a7547264f5e3a8be81b73f1c71a66e \
     utf8-decode                          1.0.1  ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498 \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
@@ -985,17 +996,17 @@ cargo.crates \
     wasi         0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                    1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
     wasip3      0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                       0.2.118  0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89 \
-    wasm-bindgen-futures                0.4.68  f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8 \
-    wasm-bindgen-macro                 0.2.118  eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed \
-    wasm-bindgen-macro-support         0.2.118  9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904 \
-    wasm-bindgen-shared                0.2.118  5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129 \
+    wasm-bindgen                       0.2.121  49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790 \
+    wasm-bindgen-futures                0.4.71  96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8 \
+    wasm-bindgen-macro                 0.2.121  8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578 \
+    wasm-bindgen-macro-support         0.2.121  d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2 \
+    wasm-bindgen-shared                0.2.121  c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441 \
     wasm-encoder                       0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                      0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasm-streams                         0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
     wasmparser                         0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
-    web-sys                             0.3.95  4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d \
+    web-sys                             0.3.98  4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webbrowser                           1.2.1  0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72 \
     webpki-root-certs                    1.0.7  f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c \
@@ -1022,54 +1033,46 @@ cargo.crates \
     windows-numerics                     0.2.0  9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1 \
     windows-numerics                     0.3.1  6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26 \
     windows-registry                     0.5.3  5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e \
+    windows-registry                     0.6.1  02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720 \
     windows-result                       0.3.4  56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6 \
     windows-result                       0.4.1  7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5 \
     windows-strings                      0.4.2  56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57 \
     windows-strings                      0.5.1  7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091 \
-    windows-sys                         0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
     windows-sys                         0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-sys                         0.59.0  1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b \
     windows-sys                         0.60.2  f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb \
     windows-sys                         0.61.2  ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
-    windows-targets                     0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
     windows-targets                     0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
     windows-targets                     0.52.6  9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973 \
     windows-targets                     0.53.5  4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3 \
     windows-threading                    0.1.0  b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6 \
     windows-threading                    0.2.1  3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37 \
-    windows_aarch64_gnullvm             0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
     windows_aarch64_gnullvm             0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
     windows_aarch64_gnullvm             0.52.6  32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3 \
     windows_aarch64_gnullvm             0.53.1  a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53 \
-    windows_aarch64_msvc                0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
     windows_aarch64_msvc                0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
     windows_aarch64_msvc                0.52.6  09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469 \
     windows_aarch64_msvc                0.53.1  b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006 \
-    windows_i686_gnu                    0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
     windows_i686_gnu                    0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
     windows_i686_gnu                    0.52.6  8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b \
     windows_i686_gnu                    0.53.1  960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3 \
     windows_i686_gnullvm                0.52.6  0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66 \
     windows_i686_gnullvm                0.53.1  fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c \
-    windows_i686_msvc                   0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
     windows_i686_msvc                   0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
     windows_i686_msvc                   0.52.6  240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66 \
     windows_i686_msvc                   0.53.1  1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2 \
-    windows_x86_64_gnu                  0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
     windows_x86_64_gnu                  0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
     windows_x86_64_gnu                  0.52.6  147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78 \
     windows_x86_64_gnu                  0.53.1  9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499 \
-    windows_x86_64_gnullvm              0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
     windows_x86_64_gnullvm              0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
     windows_x86_64_gnullvm              0.52.6  24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d \
     windows_x86_64_gnullvm              0.53.1  0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1 \
-    windows_x86_64_msvc                 0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
     windows_x86_64_msvc                 0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
     windows_x86_64_msvc                 0.52.6  589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec \
     windows_x86_64_msvc                 0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
     winnow                              0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
     winnow                              0.7.15  df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945 \
-    winnow                               1.0.1  09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5 \
+    winnow                               1.0.2  2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0 \
     winver                               1.0.0  9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33 \
     wiremock                             0.6.5  08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031 \
     wit-bindgen                         0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
@@ -1103,7 +1106,7 @@ cargo.crates \
     zip                                  3.0.0  12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308 \
     zip                                  6.0.0  eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b \
     zip                                  7.2.0  c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0 \
-    zip                                  8.5.1  dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59 \
+    zip                                  8.6.0  2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b \
     zipsign-api                          0.1.5  dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0 \
     zipsign-api                          0.2.1  32a55ebb27e67d9a9d116dd3a19637ee8cc0570c8ef816fb504c453f15448c99 \
     zlib-rs                              0.6.3  3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513 \


### PR DESCRIPTION
#### Description

mise: Update to 2026.5.6


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
