### PR TITLE
oh-my-posh: update to 29.13.1

### DIFF
--- a/sysutils/oh-my-posh/Portfile
+++ b/sysutils/oh-my-posh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/JanDeDobbeleer/oh-my-posh 29.12.0 v
+go.setup            github.com/JanDeDobbeleer/oh-my-posh 29.13.1 v
 go.offline_build    no
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {duck.com:ihj3s1wy @PinoTucana} \
                     openmaintainer
 
-checksums           rmd160  5863321a9e6cdebbe77c3512fdb1d827e7ca1909 \
-                    sha256  9cb8cf3b69ce303c3d956409d028fb171642fecfd50655562cb9df97d038896d \
-                    size    7070866
+checksums           rmd160  d815f46ef413cfaeed90edf0069c1db0cdaecc53 \
+                    sha256  4316d8a4316e06e9202f4ab62fd99fe56195e1f90e929537e5301e240094c35e \
+                    size    7073713
 
 build.dir           ${worksrcpath}/src
 


### PR DESCRIPTION
#### Description

oh-my-posh: update to 29.13.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
