### PR TITLE
gdal: add and default to postgresql18

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -8,7 +8,7 @@ PortGroup           muniversal 1.0
 
 name                gdal
 version             3.12.3
-revision            0
+revision            1
 
 checksums           rmd160  738cac270cf467da7625fec91a2528545ba9cb12 \
                     sha256  398a5a32ee6e75040598a7f8e895126a8225118317f272d715867c844f932848 \
@@ -53,7 +53,7 @@ compiler.thread_local_storage yes
 configure.optflags  -DGDAL_COMPILATION
 
 # Supported PostgreSQL versions
-set pg_suffixes {12 13 14 15 16 17}
+set pg_suffixes {12 13 14 15 16 17 18}
 
 depends_build-append \
                     port:bash-completion \


### PR DESCRIPTION
#### Description

This PR upgrades the default Postgresql 18 for gdal. This is my first PR, and I am following https://github.com/macports/macports-ports/commit/40b5b4c758b4a1276738930f0526755b35488ff1 as closely as I can.

I am not entirely sure how to do some of the items in the verification list, but I will be happy to with a bit go guidance. As in, I need to update the files in my live macports installation and then attempt to install and use the packages?

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.4.1 17E202

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?