### PR TITLE
google-cloud-sdk: update to 568.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             567.0.0
+version             568.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  c9710f2e01c3ada1c72d62d7bc883cd4fc0b6c32 \
-                    sha256  5e571053ed77c3265dd8b53ef46d2f721390c2ea640422ddd2fd1a485919ccf8 \
-                    size    58787948
+    checksums       rmd160  b3d6d312aa24972afc52f6c828149fa860fb9809 \
+                    sha256  c9e3f058048e705975447ff1704cae7e186d86e8958eb0702a3333977fb7ff89 \
+                    size    58910885
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  bf8fc25e6f8aea0f4401bd8bdb88efa5342bc926 \
-                    sha256  ef49050bc09b910ff9d3a70417641ece9815c9ebbc3642fc13ab7271bf3410b1 \
-                    size    60453769
+    checksums       rmd160  44e3de9599a3c1055497c53f4bfc5f8ad4e3b55f \
+                    sha256  60396fc644ab277a10f61bd83720f32f9b89ce1dcc2c6653dede132236b5a978 \
+                    size    60572814
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  57f47604170a1fd5da796673f03cebdd77649686 \
-                    sha256  5ce268402258b8381a5f535d8bbee25b8b321f1ccf7f08ca8d6b3a8b42174f96 \
-                    size    60355109
+    checksums       rmd160  f04dd8f8da7083af465e7f67f5616a4e63fc411a \
+                    sha256  1760391dc09e1a16c62b1b6760bbdebf49385fb9870f240a76545ae95ba1b2ec \
+                    size    60477715
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 568.0.0.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?