### PR TITLE
claude-code: update to 2.1.140

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.138
+version             2.1.140
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  ce54bb167c29540b54879fe21710461d811898ac \
-                 sha256  d99d3a7afd63841943906b11ed8791b0ee47fe5cf95601a8b805c20900014f54 \
-                 size    207568336
+    checksums    rmd160  d9f61b151513d221f1817a59c8fb62bdbd586e8d \
+                 sha256  2616b1e775ec0520228cd99135d07ef99e4b93b4532a03ef019e0a8e81cc7729 \
+                 size    208583824
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  7b6bddd1abb6aaa2e854c5f25409d429c9a86874 \
-                 sha256  759d23ce626193c89bc8b35c5c6ca8a9e33b9c2e504ee143e4cd119988774097 \
-                 size    205062416
+    checksums    rmd160  728ed62c6dadbc08c794d3566552243e08c66b25 \
+                 sha256  087ce732fb79658cd3e828cc377291dc56835fc5318cd519123b0880a09149c0 \
+                 size    206069664
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.140.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?