### PR TITLE
micronaut: update to 4.10.14

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.10.13 v
+github.setup    micronaut-projects micronaut-starter 4.10.14 v
 revision        0
 name            micronaut
 categories      java
@@ -57,14 +57,14 @@ github.tarball_from releases
 
 if {${configure.build_arch} eq "x86_64"} {
     set micronaut_arch amd64
-    checksums    rmd160  0d744bef225c7399af3082360d70754be604cf3f \
-                 sha256  db04bdc0283310118f0f3aa6ba0c1891c6824b0fa41b17308f2b5bf5a96e8164 \
-                 size    30767205
+    checksums    rmd160  3170de47f91301999de5e79d841891e84ffc4ba1 \
+                 sha256  f0b4ab953b451858202c75d6de7fc7d9f9a9bb0e41869d0abb9c5fd6d3130b14 \
+                 size    30779267
 } elseif {${configure.build_arch} eq "arm64"} {
     set micronaut_arch aarch64
-    checksums    rmd160  04daa9b93d3977a496e5083d449d6a4840c785b8 \
-                 sha256  ca41b8e0f6c6b6cde0b666add1cd24ddc5db660aebfa68316c8360ff522c06c1 \
-                 size    30547116
+    checksums    rmd160  dca49cd2e545821a18039c3b54dea847d1f5ef5f \
+                 sha256  6c3c0549511dfcb98e036a9afdc4dcefb0a11983469bd22f2c1409364f3f4160 \
+                 size    30560747
 } else {
     set micronaut_arch unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.10.14.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?