### PR TITLE
cloudflare-speed-cli update to 0.6.7

### DIFF
--- a/net/cloudflare-speed-cli/Portfile
+++ b/net/cloudflare-speed-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo  1.0
 
-github.setup            kavehtehrani cloudflare-speed-cli 0.6.6 v
+github.setup            kavehtehrani cloudflare-speed-cli 0.6.7 v
 github.tarball_from     archive
 
 revision                0
@@ -22,9 +22,9 @@ long_description        {*}${description}. Measures download and upload throughp
                         a specific network interface or source IP if required.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  1097eb2e0161cd8d122824aa1a45af56819b3609 \
-                        sha256  258158b6d8828cc692f51027c8aee51b5f56d0023022ce918aee88d6a87dbad2 \
-                        size    664343
+                        rmd160  78ab79bde7981d4f007cd52fa4ed35a611281e84 \
+                        sha256  01be86f39c3c817170ad508f81599ea3a59e412434533c1900cabab823e5a26b \
+                        size    666380
 
 # The TUI feature requires the 'tui' cargo feature flag.
 build.args-append       --features tui
@@ -33,6 +33,14 @@ destroot {
     xinstall -m 0755 \
         ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
         ${destroot}${prefix}/bin/
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} LICENSE README.md \
+        ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}/images
+    xinstall -m 0644 {*}[glob ${worksrcpath}/images/*] \
+        ${destroot}${prefix}/share/doc/${name}/images 
 }
 
 cargo.crates \
@@ -153,8 +161,8 @@ cargo.crates \
     js-sys                          0.3.85  8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3 \
     libc                           0.2.180  bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc \
     libredox                        0.1.12  3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616 \
-    linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                   0.11.0  df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039 \
+    linux-raw-sys                   0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     litemap                          0.8.1  6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77 \
     lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
     log                             0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
@@ -343,3 +351,4 @@ cargo.crates \
     zmij                            1.0.19  3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445 \
     zune-core                       0.4.12  3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a \
     zune-jpeg                       0.4.21  29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713
+


### PR DESCRIPTION
#### Description

- Resolves issue where certificate didn't apply to throughput requests.
- Adds licence and documentation files to standard documentation directory on install.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`? → see comment below.
- [x] tried a full install with `sudo port -vst install`? → fails when using the `-t` switch, I think this is a known issue?
- [x] tested basic functionality of all binary files?

`port lint --nitpick` → 0 errors. Warnings are limited to per-crate `missing recommended checksum type: rmd160 / size`, which is the standard form used by every other Rust port in the tree (e.g. `audio/mp3rgain`, `textproc/ripgrep`, `sysutils/eza`).

