### PR TITLE
syncthing: Add reference notes for modern launchctl syntax to load/start/stop

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -36,7 +36,8 @@ test.run            yes
 test.cmd            ${build.cmd}
 test.target         test
 
-set syncthing_plist net.syncthing.syncthing.plist
+set syncthing_label net.syncthing.syncthing
+set syncthing_plist ${syncthing_label}.plist
 
 destroot {
     xinstall -W ${worksrcpath}/bin syncthing ${destroot}${prefix}/bin
@@ -67,5 +68,14 @@ notes-append        \
     "2. Edit syncthing.plist by replacing USERNAME with your actual username" \
     "3. Log out and in again, or run:" \
     "launchctl load ~/Library/LaunchAgents/${syncthing_plist}"
+
+if {${os.major} >= 14} {
+    notes-append    \
+        "" \
+        "The modern launchctl syntax to load/start/stop the daemon is:" \
+        "launchctl bootstrap \"gui/\$(id -u)\" ~/Library/LaunchAgents/${syncthing_plist}" \
+        "launchctl kickstart -k \"gui/\$(id -u)/${syncthing_label}\"" \
+        "launchctl bootout \"gui/\$(id -u)/${syncthing_label}\""
+}
 
 github.livecheck.regex  {([0-9.-]+)}


### PR DESCRIPTION
syncthing: Add reference notes for modern launchctl syntax to load/start/stop
* This reference is necessary to remove the daemon after an uninstall, or to restart it after an update

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
