### PR TITLE
llama-swap: new port

### DIFF
--- a/llm/llama-swap/Portfile
+++ b/llm/llama-swap/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               golang 1.0
+
+go.setup                github.com/mostlygeek/llama-swap 211 v
+go.offline_build        no
+revision                0
+
+checksums               ${distname}${extract.suffix} \
+                        rmd160  788e5c4873e2112e93d3449f9fad7f12e46407be \
+                        sha256  58fc89ceb8798d0ef149481818067c8b37e61adc6acf5460b1031ad293ed760c \
+                        size    1180615
+
+categories              llm
+license                 MIT
+maintainers             @oytech openmaintainer
+
+description             Reliable model swapping for any local OpenAI/Anthropic compatible server - llama.cpp, vllm etc
+long_description        Run multiple generative AI models on your machine and hot-swap between them on demand. \
+                        llama-swap works with any OpenAI and Anthropic API compatible server and is used \
+                        by thousands of people to power their local AI workflows.
+
+depends_build-append    \
+                        bin:npm:npm10
+
+build.cmd               make
+build.target            mac
+supported_archs         arm64
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/build/${name}-darwin-${build_arch} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

New port for https://github.com/mostlygeek/llama-swap

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

