### PR TITLE
Dotnet: update 8, 9, 10, cli

### DIFF
--- a/dotnet/aspnetcore-runtime-10/Portfile
+++ b/dotnet/aspnetcore-runtime-10/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                aspnetcore-runtime-10
-version             10.0.7
+version             10.0.8
 revision            0
 categories          dotnet
 license             MIT
@@ -25,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  db0aca69b2d1f86eb47e7cd972f0a84cfd20d5d2 \
-                            sha256  66fbabfbff2f95b408e92b6b47e85bc9ccf323881814f1f6a1e9e4d9780857bd \
-                            size    48421474
+        checksums           rmd160  170485b136ef8a43c6c2c73ec24a571e2df435b1 \
+                            sha256  d26876411676568723ab0d79f49e03f7468d404393ab85e2825988e4d49ea5e6 \
+                            size    48323638
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  cfb856735f42963d36e3db39a89f2e2ff459176b \
-                            sha256  436be0fcbed0290a026579bb6d00540ad148f23a33ae45d82fc475cd8bf8ad74 \
-                            size    45563598
+        checksums           rmd160  a1886df08dc88ed295ade462ab64629a9ca31b3e \
+                            sha256  298b70316c06a8f6fde3910d49c312a53b5a9e837cdfb1e4cbd1ddf1afcfa28c \
+                            size    45464914
     }
     default {
         known_fail yes

--- a/dotnet/aspnetcore-runtime-8/Portfile
+++ b/dotnet/aspnetcore-runtime-8/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                aspnetcore-runtime-8
-version             8.0.26
+version             8.0.27
 revision            0
 categories          dotnet
 license             MIT
@@ -25,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  b8ece3269114f907f20ade856220bd82ab116d1d \
-                            sha256  330bc78491cdac3367e15c662792884833f58a487e70a21a12da4f64520050e9 \
-                            size    41364015
+        checksums           rmd160  8ce8dabbc0911b9c4b89aedc8ce67349969c7e68 \
+                            sha256  db5b55b7f57bd2cb14c09ab79d3858ec5ceafafb2026e2d120d0b098a679246d \
+                            size    41368985
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  ad1bebfd95f5e428f57f0c3f9c517b84c4b07a7a \
-                            sha256  d8e4c3f60664a0ec715bd7649dfd458785a2808af86c8f5425458122fbc5c9a6 \
-                            size    39470370
+        checksums           rmd160  f6984373718fccfd361aa03377a08c987ac95d03 \
+                            sha256  150b63b54691bf75277a630e3621f7f45bc34cdc7b3f4249228ef48d33029fe3 \
+                            size    39473325
     }
     default {
         known_fail yes

--- a/dotnet/aspnetcore-runtime-9/Portfile
+++ b/dotnet/aspnetcore-runtime-9/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                aspnetcore-runtime-9
-version             9.0.15
+version             9.0.16
 revision            0
 categories          dotnet
 license             MIT
@@ -25,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  e65f946006ca7f8e7eebe60e811d56f59681dd69 \
-                            sha256  754b87ec817388585d395b91678f589648d0a2f41f29df8b0e23245652f41f27 \
-                            size    43594194
+        checksums           rmd160  09d023131b3a00bddbfa989e1034e8ebe55e7711 \
+                            sha256  00108a8375502b9093b045c4fd1a82e6dbe2d6be3e54653c7451fe9b8f46e66a \
+                            size    43596678
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  1086d7abe1f2605723bc6ab19449190bbfa9eab8 \
-                            sha256  355c2c3a5d8a54b417034d9d5b120f3f108c8f1dc76fff46c8d30896ecf5b308 \
-                            size    41344982
+        checksums           rmd160  2d0f0b3d551b5de27b87215629fb4bd96c01a8d1 \
+                            sha256  b6d27a56c61751ebfba5d7bbb523f64ffa14db63f33fd5b98245c87073080669 \
+                            size    41346470
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-cli/Portfile
+++ b/dotnet/dotnet-cli/Portfile
@@ -24,7 +24,7 @@
 PortSystem          1.0
 
 name                dotnet-cli
-version             10.0.7
+version             10.0.8
 revision            0
 categories          dotnet
 license             MIT
@@ -51,15 +51,15 @@ master_sites        https://builds.dotnet.microsoft.com/dotnet/Runtime/${version
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  6ae02ca0e972fd1cf12089549513b1353edb0a2b \
-                            sha256  a144a1ac9fa1ba2b7c56eb975c3c7099216f90d9015db9a9fa38ad6849f556c6 \
-                            size    35625232
+        checksums           rmd160  1c0481aafe989584c449374145b349b079b46702 \
+                            sha256  accae79ba01b470c2a32836b29f16f33ab31b6856b477e101295180519c68c47 \
+                            size    35579269
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  fe72544e5060bb4ce508cd61af7755cd7c33bce6 \
-                            sha256  eb07b63df812699ebdcba28c0a883659d41ab70a0aa1056ff2aaa3264778f63c \
-                            size    33283652
+        checksums           rmd160  c731a0fd844972bca7ca21253a983c7e6f3fad1b \
+                            sha256  bc34affe79b00b9c9241026bbe89e9bc472d330bf4a8fa5f01e4631bdf1622d6 \
+                            size    33232776
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-10/Portfile
+++ b/dotnet/dotnet-runtime-10/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-runtime-10
-version             10.0.7
+version             10.0.8
 revision            0
 categories          dotnet
 license             MIT
@@ -24,15 +24,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  6ae02ca0e972fd1cf12089549513b1353edb0a2b \
-                            sha256  a144a1ac9fa1ba2b7c56eb975c3c7099216f90d9015db9a9fa38ad6849f556c6 \
-                            size    35625232
+        checksums           rmd160  1c0481aafe989584c449374145b349b079b46702 \
+                            sha256  accae79ba01b470c2a32836b29f16f33ab31b6856b477e101295180519c68c47 \
+                            size    35579269
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  fe72544e5060bb4ce508cd61af7755cd7c33bce6 \
-                            sha256  eb07b63df812699ebdcba28c0a883659d41ab70a0aa1056ff2aaa3264778f63c \
-                            size    33283652
+        checksums           rmd160  c731a0fd844972bca7ca21253a983c7e6f3fad1b \
+                            sha256  bc34affe79b00b9c9241026bbe89e9bc472d330bf4a8fa5f01e4631bdf1622d6 \
+                            size    33232776
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-8/Portfile
+++ b/dotnet/dotnet-runtime-8/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-runtime-8
-version             8.0.26
+version             8.0.27
 revision            0
 categories          dotnet
 license             MIT
@@ -24,15 +24,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  a6e60dcc110e4e0fd1fd4f96ad7392e0897519a5 \
-                            sha256  89d37a30cf5fe5966f4773389c39aeca0c7d5bc277af11a70f1846740d7ec6cb \
-                            size    30710704
+        checksums           rmd160  deb5f18f1c89167ea9d466d98c5d9e6e231fae6a \
+                            sha256  a460e5d5aebd4bf0dc2b55714c1d7b8795c49bfd62e45f7cca5a56975e5f123a \
+                            size    30710288
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  bea3e914ca946e2083d0229a3ca09e8bf24a6564 \
-                            sha256  ba1d8a894cb0aa5ac555250389ee4e94da43b3bcd02941e262aed0f12f092d24 \
-                            size    29080997
+        checksums           rmd160  d4267955cbcc51238bcb9fe26b9c8c984f535310 \
+                            sha256  a1237fee1f58a0d2de7d097277cf3d21472ee492426f5024f783ebe4913ee69b \
+                            size    29081851
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-9/Portfile
+++ b/dotnet/dotnet-runtime-9/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-runtime-9
-version             9.0.15
+version             9.0.16
 revision            0
 categories          dotnet
 license             MIT
@@ -24,15 +24,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  63d7560d5ae385f2d7f5e00283bb6e79b9e32c34 \
-                            sha256  5883dca2310b6a22ad188133f5d1affa907173a78a4e750b705d091b316522ac \
-                            size    32730857
+        checksums           rmd160  fdd8f862df3b2a520cb2a0a1335bee87ea5c8baf \
+                            sha256  4b8f9d386170d68de37565095aaafc6f39544ad9b730ceed33dabbe49f23f50a \
+                            size    32730806
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  6d83edc5fc5aa3708d59b659507f910688ac9b8b \
-                            sha256  b9199bb140470311c8850d1ee3c767e0b2f37b86752f94fabcaa788d2a98628f \
-                            size    30806346
+        checksums           rmd160  db6f242c8681a435a4a3974da950553e3dcd85a8 \
+                            sha256  74b20dbdffec4644d2dd9885d9922697cb79379f2c9e81ad2b25c6a1067b085a \
+                            size    30806333
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-sdk-10/Portfile
+++ b/dotnet/dotnet-sdk-10/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-sdk-10
-version             10.0.203
+version             10.0.300
 revision            0
 categories          dotnet devel
 license             MIT
@@ -26,16 +26,16 @@ switch ${build_arch} {
     x86_64 {
         set dotnet_rid osx-x64
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  f6a9e846de360c3d8f0ca25d4bfe5a61668ada1b \
-                            sha256  233da86dc0b50464b7108371aefc9c94b1561b41539fbaa49d2d8b6295c1148d \
-                            size    240628351
+        checksums           rmd160  cf1a13c79abfdeac30896c1b5ec773b47ce16092 \
+                            sha256  7c1e46f16e6dd75c714db67b85fef6750d1b5b8c0d6c1c4a8fd3ab8f048b6958 \
+                            size    234149547
     }
     arm64 {
         set dotnet_rid osx-arm64
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  a69e3f631fc959818686b4eccd495487eb00e7d9 \
-                            sha256  cbf1c5066ff2083a6f21bd1b2aaee6c51567d084e2f1dd90dfcd558541144f20 \
-                            size    232926048
+        checksums           rmd160  f3c8d9de71dfb79a746685a96c2d7b847049b81d \
+                            sha256  240e542e7f43771b6fc6de8b67c9ae67b388d041e1db2f105ab5cae89a345cfe \
+                            size    226431690
     }
     default {
         known_fail yes
@@ -61,7 +61,7 @@ build {}
 
 destroot {
     set dotnet_home ${prefix}/share/dotnet
-    set dotnet_runtime_version 10.0.7
+    set dotnet_runtime_version 10.0.8
 
     # ASP.NET Core Targeting Pack
     set aspnet_target_dir /packs/Microsoft.AspNetCore.App.Ref

--- a/dotnet/dotnet-sdk-8/Portfile
+++ b/dotnet/dotnet-sdk-8/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-sdk-8
-version             8.0.420
+version             8.0.421
 revision            0
 categories          dotnet devel
 license             MIT
@@ -26,16 +26,16 @@ switch ${build_arch} {
     x86_64 {
         set dotnet_rid osx-x64
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  9d8a9fb5b7c2b6b7c040c3d528708bdb60362548 \
-                            sha256  35e713872a9434760687d2e41702b4fb78ebe896675774ba6242957cd9c13ac1 \
-                            size    215068373
+        checksums           rmd160  a916fdeffcb9aa4cc06f26d55d20e6f5bf8d03fb \
+                            sha256  14f7122ad9638cea91dfe30a95c577731bbebae3334bfe33a23f9b229e706ecc \
+                            size    214960088
     }
     arm64 {
         set dotnet_rid osx-arm64
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  cbda8e3f263691ddd5f62ce16bdb523a61f325c3 \
-                            sha256  9d9561235fb741e53c568407a3c5f71fd504d36119d68b1072eaaf3ebbfd4d83 \
-                            size    209935665
+        checksums           rmd160  4a41ca2c75833405b2b054e51e4ef74997bc17b3 \
+                            sha256  d5c77d53877162f8b769907731f4f4478ea2e3201bb8f0a0ddea72df6fea4eb9 \
+                            size    209833600
     }
     default {
         known_fail yes
@@ -61,7 +61,7 @@ build {}
 
 destroot {
     set dotnet_home ${prefix}/share/dotnet
-    set dotnet_runtime_version 8.0.26
+    set dotnet_runtime_version 8.0.27
 
     # ASP.NET Core Targeting Pack
     set aspnet_target_dir /packs/Microsoft.AspNetCore.App.Ref

--- a/dotnet/dotnet-sdk-9/Portfile
+++ b/dotnet/dotnet-sdk-9/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-sdk-9
-version             9.0.313
+version             9.0.314
 revision            0
 categories          dotnet devel
 license             MIT
@@ -26,16 +26,16 @@ switch ${build_arch} {
     x86_64 {
         set dotnet_rid osx-x64
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  6f14ea5b1e4cfc23cea5fb207f0c8690dfbed740 \
-                            sha256  40205d0c50366eaffd05460d081e3f6bfb656a5a5b58afe181139598af99a9ab \
-                            size    215928767
+        checksums           rmd160  a504c0c2b87f7c87ca83c8ec6fa72ec35ac82d8a \
+                            sha256  f12a5e7bfa8b12c0e033c556422f8088a8cb82499e76f4420a5468a98dab80f7 \
+                            size    215750653
     }
     arm64 {
         set dotnet_rid osx-arm64
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  fdd694f6345c40e6fb1dd5fe806e07908f727cd5 \
-                            sha256  41e0767c8fa2ca8bbf46fc1ccdd76a33deb68fe812e6651f34a9f088a523792d \
-                            size    210479728
+        checksums           rmd160  f79bd0be7e5cb074e59099824112263eda2dd3b0 \
+                            sha256  1b5c30edf1fa3c433c3fe578c2a4fdabfb5af5539c4169db4de36231e12c8b44 \
+                            size    210326217
     }
     default {
         known_fail yes
@@ -61,7 +61,7 @@ build {}
 
 destroot {
     set dotnet_home ${prefix}/share/dotnet
-    set dotnet_runtime_version 9.0.15
+    set dotnet_runtime_version 9.0.16
 
     # ASP.NET Core Targeting Pack
     set aspnet_target_dir /packs/Microsoft.AspNetCore.App.Ref


### PR DESCRIPTION
see : https://macports.mathiesen.info/macports/bin/dotnet/ for scripts
```
dotnet-sdk-9:          : update to 9.0.314
dotnet-sdk-8:          : update to 8.0.421
dotnet-sdk-10:         : update to 10.0.300
dotnet-runtime-9:      : update to 9.0.16
dotnet-runtime-8:      : update to 8.0.27
dotnet-runtime-10:     : update to 10.0.8
dotnet-cli:            : update to 10.0.8
aspnetcore-runtime-9:  : update to 9.0.16
aspnetcore-runtime-8:  : update to 8.0.27
aspnetcore-runtime-10: : update to 10.0.8
```
