### PR TITLE
qt6-qtcreator: update to 19.0.2

### DIFF
--- a/devel/qt6-qtcreator/Portfile
+++ b/devel/qt6-qtcreator/Portfile
@@ -20,12 +20,12 @@ compiler.cxx_standard \
 
 if {([vercmp ${xcodeversion} 15] >= 0)} {
     # qtcreator since version 19.0.0 requires xcode version 15
-    version                 19.0.1
+    version                 19.0.2
     revision                0
 
-    checksums               rmd160  0eb18e523e6741abc102bd3c3b4b506850bf51c7 \
-                            sha256  38051c52b8673cc152e07c2c6faed0b3cd6f4f9ce39b7fbb8041396db47f831d \
-                            size    51831338
+    checksums               rmd160  f61c3808880e480c8804dcfcea80326d2e15056b \
+                            sha256  92711b85a5642af5970dd3100982f724f4ce2af2181aea5fe0e335a30060dfc0 \
+                            size    51833111
 
     # Do not update all versions to clang 18+ until https://trac.macports.org/ticket/72064 is resolved
     if {${os.major} >= 24} {
@@ -39,6 +39,10 @@ if {([vercmp ${xcodeversion} 15] >= 0)} {
 
     # qtcreator since version 18.0.0 requires go
     depends_build-append    port:go
+
+    # add qt6 to rpath (for external extensions)
+    cmake.install_rpath-append \
+                            ${prefix}/libexec/qt6/lib
 } else {
     if {${os.major} >= 21} {
         # qtcreator since version 16.0.0 requires qt 6.5.3


### PR DESCRIPTION
#### Description

Also added qt6 library directory to rpath.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
