### PR TITLE
htpdate: Update to 2.0.2

### DIFF
--- a/net/htpdate/Portfile
+++ b/net/htpdate/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               makefile 1.0
 PortGroup               openssl 1.0
 
-github.setup            twekkel htpdate 2.0.1 v
+github.setup            twekkel htpdate 2.0.2 v
 github.tarball_from     archive
 revision                0
 categories              net
@@ -19,9 +19,9 @@ long_description        ${description}.
 homepage                https://www.vervest.org/htp/
 master_sites-append     ${homepage}archive/c/
 
-checksums               rmd160  a2e5a8c5a6d2190a3f9017630ab8045cf2918c3b \
-                        sha256  4c771fe3fc5c4ab5f9393dd501bdc51e4c067297cf304ad1e74e1965ac1c066f \
-                        size    18644
+checksums               rmd160  81a03e53bbe6fa3562b11431fabbdc0f7d08ada8 \
+                        sha256  3f5effa9355db140ef8ace6d17800d48815d1afdcef9d1096510451839dd8de4 \
+                        size    18730
 
 compiler.c_standard     2011
 


### PR DESCRIPTION
#### Description

Update htpdate to 2.0.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
