### PR TITLE
opencode: update to 1.14.50

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.14.48
+version             1.14.50
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  1303392e2214af503a1d259dbd45f81d6a662a81 \
-                    sha256  de7b03286b1f2790b7ff46bc7568a94a2bdc2ea472c4af229b4a5243c499e01c \
-                    size    3531
+checksums           rmd160  2748b0429ab153c5fd02d6dc4427514e789d2abc \
+                    sha256  6e500379e574c0335364818beae346f99bd06491000c526e957e9349f126c240 \
+                    size    3521


### PR DESCRIPTION
#### Description

Update to OpenCode 1.14.50.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?