### PR TITLE
splash: Update to 3.12.0

### DIFF
--- a/science/splash/Portfile
+++ b/science/splash/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup compilers 1.0
 PortGroup github    1.0
 
-github.setup        danieljprice splash 3.11.7 v
+github.setup        danieljprice splash 3.12.0 v
 github.tarball_from releases
 distname            ${name}-v${version}
 revision            0
 
-checksums           rmd160  93b0cf3dcfafe81063147881655e196fee062e02 \
-                    sha256  79b006741f2aeb9320533b9eae17a45c5f0d0902ab326d79fe1e552f03449339 \
-                    size    2620524
+checksums           rmd160  84d387ce853682cb304e83352fe0759207da0afc \
+                    sha256  64b0a7d8124bdfde083a07f56b6b34dc1aa77525a2a02e229cc5787a756d68dd \
+                    size    2622045
 
 categories          science graphics
 maintainers         {monash.edu:daniel.price @danieljprice} openmaintainer


### PR DESCRIPTION
#### Description

Update splash 3.11.7 --> 3.12.0.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?