### PR TITLE
claude-code: update to 2.1.141

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.140
+version             2.1.141
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  d9f61b151513d221f1817a59c8fb62bdbd586e8d \
-                 sha256  2616b1e775ec0520228cd99135d07ef99e4b93b4532a03ef019e0a8e81cc7729 \
-                 size    208583824
+    checksums    rmd160  e5ebb160511e5928dbd053aadbedf8d61cf17e59 \
+                 sha256  fa9000fdf4a522fcaf30ea283555aca2ba5d0e76cdb8842154b7735b558c7c25 \
+                 size    209591056
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  728ed62c6dadbc08c794d3566552243e08c66b25 \
-                 sha256  087ce732fb79658cd3e828cc377291dc56835fc5318cd519123b0880a09149c0 \
-                 size    206069664
+    checksums    rmd160  6e3e8b647d828cf5802542f9db742d679f8944bb \
+                 sha256  31ac95bb19a33b1d0cddd3f3ff594bf8bfd2be5051cd2af7867109641cab705e \
+                 size    207076896
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.141.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?