### PR TITLE
joe: update editors/joe to 4.8 and set maintainer to @oakimov

### DIFF
--- a/editors/joe/Portfile
+++ b/editors/joe/Portfile
@@ -22,7 +22,8 @@ subport ${name}37 {
 categories          editors
 license             GPL-2
 platforms           darwin freebsd
-maintainers         @oakimov
+maintainers         @oakimov \
+                    openmaintainer
 
 description         Joe's Own Editor
 long_description    JOE is the professional freeware ASCII text screen editor for UNIX. \

--- a/editors/joe/Portfile
+++ b/editors/joe/Portfile
@@ -5,11 +5,11 @@ PortSystem  1.0
 name                joe
 conflicts           ${name} ${name}37
 conflicts-delete    ${subport}
-version             4.6
+version             4.8
 revision            0
-checksums           rmd160  cd5a8eff82b7e8043f1a5fdbc875ec37b4de5f5a \
-                    sha256  495a0a61f26404070fe8a719d80406dc7f337623788e445b92a9f6de512ab9de \
-                    size    1895046
+checksums           rmd160  98e614ade14177cf45832f4c03aabf56baffc4a7 \
+                    sha256  6995b28ee20dcdbbcb5a45a4c110642dc96d67748aea27450c74cdb4dd07cc20 \
+                    size    1973683
 
 subport ${name}37 {
     version         3.7
@@ -22,7 +22,7 @@ subport ${name}37 {
 categories          editors
 license             GPL-2
 platforms           darwin freebsd
-maintainers         nomaintainer
+maintainers         @oakimov
 
 description         Joe's Own Editor
 long_description    JOE is the professional freeware ASCII text screen editor for UNIX. \
@@ -42,8 +42,6 @@ master_sites        sourceforge:project/joe-editor/JOE%20sources/joe-${version}
 build.env           LANG=C
 
 if {${subport} eq ${name}} {
-    patchfiles      implicit.patch
-
     livecheck.regex ${name}-(\[0-9.\]+)${extract.suffix}
 } else {
     patchfiles      implicit-${version}.patch


### PR DESCRIPTION
#### Description

Update editors/joe to the most current version.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.5 24G624 arm64
Xcode 26.3 17C529

###### Verification
I have:
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
