### PR TITLE
kube-ps1: update to 1.0.0

### DIFF
--- a/sysutils/kube-ps1/Portfile
+++ b/sysutils/kube-ps1/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonmosco kube-ps1 0.9.0 v
-# Change github.tarball_from to 'releases' or 'archive' next update
-github.tarball_from tarball
+github.setup        jonmosco kube-ps1 1.0.0 v
+github.tarball_from archive
 revision            0
 categories          sysutils
 platforms           {darwin any}
@@ -17,11 +16,11 @@ description         Kubernetes prompt info for bash and zsh
 long_description    A script that lets you add the current Kubernetes context and namespace \
                     configured on kubectl to your Bash/Zsh prompt strings (i.e. the \$PS1).
 
-checksums           rmd160  1264feb645b03920523583b547a33ef95cd5a375 \
-                    sha256  665f7cef9d941152ac809e09632127e5276e288b595e76b2d10e879993df689b \
-                    size    512934
+checksums           rmd160  5d8affe334711805ae8daa41c785a27f4321321e \
+                    sha256  af44982ad27e492d3ade2d03223c944523070b0462839a9260df7483692c1bb0 \
+                    size    581233
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.30
+depends_run         path:${prefix}/bin/kubectl:kubectl
 
 use_configure       no
 build {}
@@ -31,6 +30,7 @@ destroot    {
     copy ${worksrcpath}/CHANGELOG.md \
         ${worksrcpath}/CONTRIBUTING.md \
         ${worksrcpath}/img \
+        ${worksrcpath}/kube-ps1.fish \
         ${worksrcpath}/kube-ps1.sh \
         ${worksrcpath}/LICENSE \
         ${worksrcpath}/README.md \
@@ -38,8 +38,6 @@ destroot    {
 }
 
 notes "
-Source the kube-ps1.sh script and then use the kube_ps1 function in your shell prompt definition:
-
 Bash example (~/.bashrc):
 
     source ${prefix}/share/${name}/kube-ps1.sh

--- a/sysutils/kube-ps1/Portfile
+++ b/sysutils/kube-ps1/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  5d8affe334711805ae8daa41c785a27f4321321e \
                     sha256  af44982ad27e492d3ade2d03223c944523070b0462839a9260df7483692c1bb0 \
                     size    581233
 
-depends_run         path:${prefix}/bin/kubectl:kubectl
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.36
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update to kube-ps1 1.0.0.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?