### PR TITLE
py-ligo-segments: drop py27, add py313 and py314 subports

### DIFF
--- a/python/py-ligo-segments/Portfile
+++ b/python/py-ligo-segments/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  33c0c9c6aa6ace5e4d86df7851de5072d08c8962 \
                     sha256  e072a844713c5b02efdcaf5bfe4c3a8cd9ef225b08cfd3202a4e185e0f71f5dc \
                     size    51015
 
-python.versions     27 312
+python.versions     312 313 314
 
 if {${name} ne ${subport}} {
     # fix permissions
@@ -35,7 +35,9 @@ if {${name} ne ${subport}} {
         }
     }
 
-    patchfiles-append   be7c93b1ef431908a9df0f078815ee7f00345088.patch
+    # https://git.ligo.org/lscsoft/ligo-segments/-/merge_requests/38
+    patchfiles-append   be7c93b1ef431908a9df0f078815ee7f00345088.patch \
+                        fix-pylist-extend-python313.patch
     patch.pre_args-replace  -p0 -p1
 
     depends_lib-append  port:py${python.version}-six \

--- a/python/py-ligo-segments/files/fix-pylist-extend-python313.patch
+++ b/python/py-ligo-segments/files/fix-pylist-extend-python313.patch
@@ -1,0 +1,47 @@
+--- a/src/segmentlist.c
++++ b/src/segmentlist.c
+@@ -240,7 +240,8 @@
+ }
+
+
+-static int pylist_extend(PyListObject *l, PyObject *v)
++#if PY_VERSION_HEX < 0x030D0000
++static int PyList_Extend(PyListObject *l, PyObject *v)
+ {
+ 	if(!PyList_Check(l)) {
+ 		PyErr_SetObject(PyExc_TypeError, (PyObject *) l);
+@@ -252,6 +253,7 @@
+ 	Py_DECREF(result);
+ 	return 0;
+ }
++#endif
+
+
+ static PyListObject *segments_SegmentList_New(PyTypeObject *type, PyObject *sequence)
+@@ -263,7 +265,7 @@
+ 	}
+ 	new = (PyListObject *) type->tp_alloc(type, 0);
+ 	if(new && sequence)
+-		if(pylist_extend(new, sequence)) {
++		if(PyList_Extend(new, sequence)) {
+ 			Py_DECREF(new);
+ 			new = NULL;
+ 		}
+@@ -817,7 +819,7 @@
+ 	/* Faster algorithm when the two lists have very different sizes.
+ 	 * OK to not test size functions for error return values */
+ 	if(PySequence_Size(other) > PyList_GET_SIZE(self) / 2) {
+-		if(pylist_extend((PyListObject *) self, other))
++		if(PyList_Extend((PyListObject *) self, other))
+ 			return NULL;
+ 		return PyObject_CallMethod(self, "coalesce", NULL);
+ 	}
+@@ -988,7 +990,7 @@
+ 		Py_XDECREF(other);
+ 		return NULL;
+ 	}
+-	if(pylist_extend((PyListObject *) new, other)) {
++	if(PyList_Extend((PyListObject *) new, other)) {
+ 		Py_DECREF(new);
+ 		Py_DECREF(other);
+ 		return NULL;


### PR DESCRIPTION
Fix build with Python 3.13+: _PyList_Extend was removed from CPython headers in 3.13; use the new public PyList_Extend() API instead.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
