### PR TITLE
pdal: patch missed inclusion of <unordered_map>

### DIFF
--- a/gis/pdal/Portfile
+++ b/gis/pdal/Portfile
@@ -54,7 +54,8 @@ if {${name} eq ${subport}} {
                         port:zstd
 
     if {${name} eq ${subport}} {
-        patchfiles-append   patch-powerpc.diff
+        patchfiles-append   patch-powerpc.diff \
+                            patch_unordered_map.diff
 
         # Build fails on macOS 11 and older, see https://trac.macports.org/ticket/72983.
         if { ${os.platform} eq "darwin" && ${os.major} < 21 } {

--- a/gis/pdal/files/patch_unordered_map.diff
+++ b/gis/pdal/files/patch_unordered_map.diff
@@ -1,0 +1,12 @@
+Addressed upstream: https://github.com/PDAL/PDAL/pull/5018
+
+--- filters/RelaxationDartThrowing.cpp.orig	2026-03-27 19:26:01
++++ filters/RelaxationDartThrowing.cpp	2026-05-15 09:52:25
+@@ -42,6 +42,7 @@
+ #include <numeric>
+ #include <random>
+ #include <string>
++#include <unordered_map>
+ #include <vector>
+ 
+ namespace pdal


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


On macOS 12 and older with AppleClang 13.1.6.13160021 and older compilation of [pdal](https://ports.macports.org/port/PDAL/) fails with:

```
/opt/local/var/macports/build/pdal-7a63b7db/work/PDAL-2.10.1-src/filters/RelaxationDartThrowing.cpp:108:37: error: no template named 'unordered_map' in namespace 'std'
    using PointIdNeighborMap = std::unordered_map<PointId, KD3Index::RadiusResults>;
                               ~~~~~^
```

I can't confirm that this solves the build issue on macOS 12, but it is more than likely.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
