### PR TITLE
mp3rgain: update to 2.6.1

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.6.0 v
+github.setup        M-Igashi mp3rgain 2.6.1 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f1cb91525866bf2600cf90e370b53e8a85ab53ca \
-                    sha256  da7b07e74acd82d7020a6305d8ed933307f84991328ea9dae059663feaebada7 \
-                    size    305904
+                    rmd160  d9840e93c0b06102cfeda75a33f99fca482b3b86 \
+                    sha256  3cd2217ba6ae63f253b3dec39215a24382ef52f01d2471816a4614753f588e7e \
+                    size    305896
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
@@ -72,13 +72,13 @@ cargo.crates \
     serde_json                   1.0.149          83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
     simd-adler32                 0.3.9            703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     smallvec                     1.15.1           67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
-    symphonia                    0.6.0-alpha.2    b38c0b8e99ce52271da0f3fec5780a8566edd703b181211dd0ff725efeaaae38 \
-    symphonia-bundle-mp3         0.6.0-alpha.2    08e64864167bd6cb39e743c19036cad4486ba4dcf299336b695249ea3cfd31ff \
-    symphonia-codec-aac          0.6.0-alpha.2    7139b6baf2f6df9877395d70bf16edc0860d72ff35eefbf51d083b10b36f7949 \
-    symphonia-common             0.6.0-alpha.2    0c029b5a948c81fd3a46647a151b959109d1d16b05a1d7c7eca1fdac0ace0a27 \
-    symphonia-core               0.6.0-alpha.2    3be2e760147497d7f939f18b7739387c7e6b5322d9ce0cf10cd93cf96f4d815c \
-    symphonia-format-isomp4      0.6.0-alpha.2    0a0c9c23912250e33b40c0d36deded5c03aef33299e03c39f78e6125d492da61 \
-    symphonia-metadata           0.6.0-alpha.2    eea744eea37a3336aeb2919b5632a5b79dc12695e60cac15adf3422814c0f32c \
+    symphonia                    0.6.0            1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a \
+    symphonia-bundle-mp3         0.6.0            350f1f2f2e19ad4dd315db94304d1eb361b29af070681f94e51b8fdaad769546 \
+    symphonia-codec-aac          0.6.0            f1979c515a76371b186aad2feff5f23e21cbec775bf95de08bf1e3af92a2ad76 \
+    symphonia-common             0.6.0            8257891ffa7f05e02b58f4761e2abf7e5278c8744fd59e981559e050f86eef55 \
+    symphonia-core               0.6.0            95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1 \
+    symphonia-format-isomp4      0.6.0            2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e \
+    symphonia-metadata           0.6.0            a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681 \
     syn                          2.0.117          e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
     thiserror                    2.0.18           4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
     thiserror-impl               2.0.18           ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \


### PR DESCRIPTION
## Description

Update `audio/mp3rgain` to version 2.6.1.

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.6.1

### Changes

- Upgrade symphonia from 0.6.0-alpha.2 to 0.6.0 stable
- Regenerated `cargo.crates` block from new `Cargo.lock`

## Type of change

- [x] update existing port

## Tested on

macOS 15.x (Darwin 25.x), arm64

## Verification

- [x] Have you followed the [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] Does your submission pass `port lint --nitpick`?
- [x] Have you tested the proposed change using `port test`, if applicable?