### PR TITLE
zizmor: Update to 1.25.0

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.24.1 v
+github.setup        zizmorcore zizmor 1.25.0 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 livecheck.regex     {v(\d+\.\d+\.\d+)}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  dafd6b7793c1538b754102dcd8d2002af783b537 \
-                    sha256  4a037cd9ccdebdcf02e508f248c5ee8656ebf024d8f29d2c458498f16fe9893b \
-                    size    643679
+                    rmd160  2a993f27e933405ef0964669a4b0dc3406f272ef \
+                    sha256  d4eb078dca55b8a2e289a9a111639c73a2b2b725d879f5ba8c809038c3f254bd \
+                    size    667807
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -38,7 +38,7 @@ cargo.crates \
     ahash                                                                  0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                                                            1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
     allocator-api2                                                         0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
-    annotate-snippets                                                     0.12.13  74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93 \
+    annotate-snippets                                                     0.12.15  92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7 \
     anstream                                                                1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
     anstyle                                                                1.0.13  5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78 \
     anstyle-parse                                                           1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
@@ -46,7 +46,7 @@ cargo.crates \
     anstyle-wincon                                                         3.0.10  3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a \
     anyhow                                                                1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     arrayvec                                                                0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
-    assert_cmd                                                              2.2.0  9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9 \
+    assert_cmd                                                              2.2.1  39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd \
     async-lock                                                              3.4.1  5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc \
     async-trait                                                            0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atomic-waker                                                            1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
@@ -71,12 +71,12 @@ cargo.crates \
     cesu8                                                                   1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
     cfg-if                                                                  1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
     cfg_aliases                                                             0.2.1  613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724 \
-    clap                                                                    4.6.0  b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351 \
+    clap                                                                    4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap-verbosity-flag                                                     3.0.4  9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394 \
     clap_builder                                                            4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
-    clap_complete                                                           4.6.0  19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb \
+    clap_complete                                                           4.6.3  660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3 \
     clap_complete_nushell                                                   4.6.0  fbb9e9715d29a754b468591be588f6b926f5b0a1eb6a8b62acabeb66ff84d897 \
-    clap_derive                                                             4.6.0  1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a \
+    clap_derive                                                             4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                                                                1.0.0  3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831 \
     cmake                                                                  0.1.54  e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0 \
     cobs                                                                    0.3.0  0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1 \
@@ -116,7 +116,7 @@ cargo.crates \
     etcetera                                                               0.11.0  de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96 \
     event-listener                                                          5.4.1  e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab \
     event-listener-strategy                                                 0.5.4  8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93 \
-    fancy-regex                                                            0.17.0  72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8 \
+    fancy-regex                                                            0.18.0  e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277 \
     fastrand                                                                2.3.0  37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be \
     filetime                                                               0.2.26  bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed \
     find-msvc-tools                                                         0.1.5  3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844 \
@@ -149,18 +149,19 @@ cargo.crates \
     hashbrown                                                              0.14.5  e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1 \
     hashbrown                                                              0.15.5  9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1 \
     hashbrown                                                              0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
+    hashbrown                                                              0.17.0  4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51 \
     heck                                                                    0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                                                                     0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     http                                                                    1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
     http-body                                                               1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                                                          0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
-    http-cache                                                      1.0.0-alpha.5  3ebe156dd658fb9031e773f54eed6ae2b5bd12b3ddfb71e456bbc10ae63f4012 \
-    http-cache-reqwest                                              1.0.0-alpha.5  42fed00fde0c81a9e473920a04aeaf879c1abb8a5435769bea707c7d776e8d1c \
+    http-cache                                                      1.0.0-alpha.6  d01e0b5d3afe17eadd68dad863adc0715b7ccfa887effbb9ea4de3c7c78c6c44 \
+    http-cache-reqwest                                              1.0.0-alpha.6  3ff1fa00fd5b0d38c26d5f24f1cf513e286a988b57880c2bf357304669268fa3 \
     http-cache-semantics                                                    3.0.0  0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7 \
     http-serde                                                              2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
     httparse                                                               1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
     httpdate                                                                1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
-    human-panic                                                             2.0.7  ca7d4a01c69c8cbe4bec7ea7e0fe0e703c36a770463eb1fe6e82e9f08aecb191 \
+    human-panic                                                             2.0.8  e2815d0c49773c6e0a9753960b3d0e50b822e48e08c77bcb4780be8474c9cc3d \
     hyper                                                                   1.7.0  eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e \
     hyper-rustls                                                           0.27.7  e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58 \
     hyper-util                                                             0.1.17  3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8 \
@@ -175,7 +176,7 @@ cargo.crates \
     idna                                                                    1.1.0  3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de \
     idna_adapter                                                            1.2.1  3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344 \
     ignore                                                                 0.4.25  d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a \
-    indexmap                                                               2.13.0  7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017 \
+    indexmap                                                               2.14.0  d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9 \
     indicatif                                                              0.18.4  25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
     insta                                                                  1.47.2  7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e \
     inventory                                                              0.3.21  bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e \
@@ -188,11 +189,12 @@ cargo.crates \
     jni-sys                                                                 0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
     jobserver                                                              0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
     js-sys                                                                 0.3.85  8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3 \
-    jsonschema                                                             0.45.0  6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3 \
+    jsonschema                                                             0.46.4  fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f \
     lazy_static                                                             1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                                                               0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
-    libc                                                                  0.2.177  2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976 \
+    libc                                                                  0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
     libredox                                                               0.1.10  416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb \
+    libyaml-rs                                                              0.3.0  2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777 \
     line-index                                                              0.1.2  3e27e0ed5a392a7f5ba0b3808a2afccff16c64933312c84b57618b49d1209bd2 \
     linux-raw-sys                                                          0.11.0  df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039 \
     litemap                                                                 0.8.0  241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956 \
@@ -203,12 +205,13 @@ cargo.crates \
     matchers                                                                0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     memchr                                                                  2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
     memmap2                                                                0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
+    micromap                                                                0.3.0  c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74 \
     miette                                                                 5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
     miette-derive                                                          5.10.0  49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c \
     mime                                                                   0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     minimal-lexical                                                         0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                                                             0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
-    mio                                                                     1.1.0  69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873 \
+    mio                                                                     1.2.0  50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1 \
     moka                                                                  0.12.11  8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077 \
     nohash-hasher                                                           0.2.0  2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451 \
     nom                                                                     7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
@@ -264,12 +267,12 @@ cargo.crates \
     redox_syscall                                                          0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
     ref-cast                                                               1.0.25  f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d \
     ref-cast-impl                                                          1.0.25  b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da \
-    referencing                                                            0.45.0  b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5 \
+    referencing                                                            0.46.4  cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730 \
     reflink-copy                                                           0.1.28  23bbed272e39c47a095a5242218a67412a220006842558b03fe2935e8f3d7b92 \
     regex                                                                  1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
-    regex-automata                                                         0.4.13  5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c \
+    regex-automata                                                         0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
     regex-syntax                                                            0.8.8  7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58 \
-    reqwest                                                                0.13.2  ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801 \
+    reqwest                                                                0.13.3  62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0 \
     reqwest-middleware                                                      0.5.1  199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f \
     ring                                                                  0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rustc-demangle                                                         0.1.26  56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace \
@@ -307,7 +310,6 @@ cargo.crates \
     serde_json_path_macros_internal                                         0.1.2  aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90 \
     serde_spanned                                                           1.1.1  6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26 \
     serde_urlencoded                                                        0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    serde_yaml                                                  0.9.34+deprecated  6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47 \
     sha-1                                                                  0.10.1  f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c \
     sha1                                                                   0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha2                                                                   0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
@@ -317,7 +319,7 @@ cargo.crates \
     similar                                                                 2.7.0  bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa \
     slab                                                                   0.4.11  7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589 \
     smallvec                                                               1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
-    socket2                                                                 0.6.1  17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881 \
+    socket2                                                                 0.6.3  3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e \
     ssri                                                                    9.2.0  da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082 \
     stable_deref_trait                                                      1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     streaming-iterator                                                      0.1.9  2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520 \
@@ -351,8 +353,8 @@ cargo.crates \
     tinystr                                                                 0.8.1  5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b \
     tinyvec                                                                1.10.0  bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa \
     tinyvec_macros                                                          0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                                                                  1.50.0  27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d \
-    tokio-macros                                                            2.6.0  af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5 \
+    tokio                                                                  1.52.3  8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
+    tokio-macros                                                            2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-rustls                                                           0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                                                           0.1.17  eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047 \
     tokio-util                                                             0.7.16  14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5 \
@@ -370,10 +372,10 @@ cargo.crates \
     tracing-indicatif                                                      0.3.14  e1ef6990e0438749f0080573248e96631171a0b5ddfddde119aa5ba8c3a9c47e \
     tracing-log                                                             0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-subscriber                                                     0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
-    tree-sitter                                                            0.26.7  e7a6592b1aec0109df37b6bafea77eb4e61466e37b0a5a98bef4f89bfb81b7a2 \
+    tree-sitter                                                            0.26.8  887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538 \
     tree-sitter-bash                                                       0.25.1  9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062 \
     tree-sitter-language                                                    0.1.5  c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8 \
-    tree-sitter-powershell                                                 0.26.3  1ff5d1c86d8b1625585fd18e05fff47e38c36564e45ec4f38fd0de4ecbf08e2c \
+    tree-sitter-powershell                                                 0.26.4  3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022 \
     tree-sitter-yaml                                                        0.7.2  53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97 \
     try-lock                                                                0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     typed-builder                                                          0.21.2  fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d \
@@ -386,7 +388,6 @@ cargo.crates \
     unicode-width                                                           0.2.2  b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
     unicode-xid                                                             0.2.6  ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853 \
     unit-prefix                                                             0.5.1  323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817 \
-    unsafe-libyaml                                                         0.2.11  673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861 \
     untrusted                                                               0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
     uriparse                                                                0.6.4  0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff \
     url                                                                     2.5.7  08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b \
@@ -477,6 +478,7 @@ cargo.crates \
     writeable                                                               0.6.1  ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb \
     xattr                                                                   1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     xxhash-rust                                                            0.8.15  fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3 \
+    yaml_serde                                                             0.10.4  08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975 \
     yansi                                                                   1.0.1  cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049 \
     yoke                                                                    0.8.0  5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc \
     yoke-derive                                                             0.8.0  38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.25.0


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
