### PR TITLE
mise: Update to 2026.5.9

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.5.6 v
+github.setup        jdx mise 2026.5.9 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  20d77f3c05291c1e3fd83153792dc9f26e49bd1c \
-                    sha256  9d1fefeaf5c40c41ed2930ce22600dc8aa4a6b1472edb0c57086453081995a17 \
-                    size    6867823
+                    rmd160  6f5db3ddaf5252d371264c0b77839ddd5f0d0f83 \
+                    sha256  d69ee7b367bffb9ddf66bf403131e50577f642f9a428572020610bd5fee33e52 \
+                    size    6914360
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -91,7 +91,6 @@ cargo.crates \
     aes-gcm                             0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
     age                                 0.11.3  a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5 \
     age-core                            0.11.0  e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99 \
-    ahash                                0.7.8  891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9 \
     ahash                               0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                         1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
     allocator-api2                      0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
@@ -109,9 +108,6 @@ cargo.crates \
     archspec                             0.1.3  9db67cd9cf4f56a10d2cbae6a3b552e5bd36701fd37b74a18c14a231bdf446c7 \
     arrayref                             0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                             0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
-    asn1-rs                              0.7.1  56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60 \
-    asn1-rs-derive                       0.6.0  3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c \
-    asn1-rs-impl                         0.2.0  7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7 \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     astral-reqwest-middleware            0.4.2  638d02e24aeb92f9537897cd1ff82e2bc98fd9ac9575a503e27bb07cdf64d4d7 \
     astral-tokio-tar                     0.6.1  4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693 \
@@ -153,8 +149,6 @@ cargo.crates \
     aws-types                           1.3.13  0470cc047657c6e286346bdf10a8719d26efd6a91626992e0e64481e44323e96 \
     backtrace                           0.3.76  bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6 \
     backtrace-ext                        0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
-    base16ct                             0.2.0  4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf \
-    base64                              0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
     base64                              0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                              0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
     base64-simd                          0.8.0  339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195 \
@@ -216,9 +210,11 @@ cargo.crates \
     clap_derive                          4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                             1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
     clru                                 0.6.3  197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5 \
-    clx                                  2.0.3  00505ebcbbb9f5ce9e205e324db6c44518d97e9d6278f6dab8e0bff1937d2edf \
+    clx                                  2.1.0  20daab9df9e49b0478215055d38362d5973043b7a4af836a58968760755e9a9f \
     cmake                               0.1.58  c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678 \
     cmov                                 0.5.3  3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746 \
+    cmpv2                                0.2.0  961b955a666e25ee5a1091d219128d6e6401e3dab84efb1a2bf6b4035d797b39 \
+    cms                                  0.2.3  7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730 \
     coalesced_map                        0.1.2  7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b \
     color-eyre                           0.6.5  e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d \
     color-print                          0.3.7  3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4 \
@@ -237,8 +233,6 @@ cargo.crates \
     console                             0.16.3  d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
     const-oid                            0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
     const-oid                           0.10.2  a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c \
-    const_format                        0.2.36  4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e \
-    const_format_proc_macros            0.2.34  1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744 \
     constant_time_eq                     0.3.1  7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6 \
     constant_time_eq                     0.4.2  3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b \
     contracts                            0.6.7  008eb94d541da40512913ef5e0707c3fb0e7280ba1af13f062461e46dd96ef7e \
@@ -257,43 +251,33 @@ cargo.crates \
     crc-catalog                          2.5.0  217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853 \
     crc-fast                             1.6.0  6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3 \
     crc32fast                            1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    crmf                                 0.2.0  36fe21b96d5b87f5de4b5b7202ec41c00110ac817ce6728fe75fb2fe5962ed92 \
     crossbeam-channel                   0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
     crossbeam-deque                      0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
     crossbeam-epoch                     0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
     crossbeam-utils                     0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
     crossterm                           0.29.0  d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b \
     crossterm_winapi                     0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
-    crypto-bigint                        0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
-    crypto_secretbox                     0.1.1  b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1 \
     ctor                                0.12.0  b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive              0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
-    darling                            0.20.11  fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee \
     darling                             0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
-    darling_core                       0.20.11  0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e \
     darling_core                        0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
-    darling_macro                      0.20.11  fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead \
     darling_macro                       0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
     dashmap                              5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
     dashmap                              6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
-    data-encoding                       2.11.0  a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8 \
     deadpool                            0.12.3  0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b \
     deadpool-runtime                     0.1.4  092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b \
-    decoded-char                         0.1.1  5440d1dc8ea7cae44cda3c64568db29bfa2434aba51ae66a50c00488841a65a3 \
     deflate64                           0.1.12  ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2 \
     demand                               2.0.1  4e75be0d8a6175692cd9f9e7a7e18acd14612be09e166391a8093b7823295cd4 \
     der                                 0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
-    der-parser                          10.0.0  07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6 \
     der_derive                           0.7.3  8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18 \
     deranged                             0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
     derive_arbitrary                     1.4.2  1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a \
-    derive_builder                      0.20.2  507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947 \
-    derive_builder_core                 0.20.2  2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8 \
-    derive_builder_macro                0.20.2  ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c \
     derive_more                          2.1.1  d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
     derive_more-impl                     2.1.1  799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
     deunicode                            1.6.2  abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04 \
@@ -309,11 +293,9 @@ cargo.crates \
     duct                                 1.1.1  7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684 \
     dunce                                1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                           1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
-    ecdsa                               0.16.9  ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca \
     ed25519                              2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                        2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
     either                              1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
-    elliptic-curve                      0.13.8  b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47 \
     elsa                                1.11.2  9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e \
     encode_unicode                       1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                         0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
@@ -336,7 +318,6 @@ cargo.crates \
     fancy-regex                         0.17.0  72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8 \
     faster-hex                          0.10.0  7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73 \
     fastrand                             2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
-    ff                                  0.13.1  c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393 \
     fiat-crypto                          0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     file_url                             0.3.0  1e546758dbcde9d10c0d3bd8b83adb535b23fa81121cf4dc5c3e7b5907cc8eb8 \
     filetime                            0.2.28  2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6 \
@@ -379,7 +360,6 @@ cargo.crates \
     getrandom                           0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                            0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
     getrandom                            0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
-    getset                               0.1.6  9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912 \
     ghash                                0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
     gimli                               0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
     gix                                 0.83.0  6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567 \
@@ -442,7 +422,6 @@ cargo.crates \
     glob                                 0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
     globset                             0.4.18  52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3 \
     globwalk                             0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
-    group                               0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
     h2                                  0.4.14  171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733 \
     halfbrown                            0.4.0  0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09 \
     hash32                               0.3.1  47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606 \
@@ -461,7 +440,6 @@ cargo.crates \
     homedir                              0.3.6  68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527 \
     http                                0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
     http                                 1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
-    http-auth                           0.1.10  150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822 \
     http-body                            0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-body                            1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                       0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
@@ -528,29 +506,17 @@ cargo.crates \
     jni-sys-macros                       0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                           0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
     js-sys                              0.3.98  67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08 \
-    json-number                         0.4.10  479dfd2ad8e4b4ae076b031f72ef2f3791f65e2a0f51e5f3408dbf716c4c2f82 \
     json-patch                           4.2.0  7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72 \
-    json-syntax                         0.12.5  044a68aba3f96d712f492b72be25e10f96201eaaca3207a7d6e68d6d5105fda9 \
     jsonptr                              0.7.1  a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe \
     junction                             2.0.0  160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006 \
-    jwt                                 0.16.0  6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f \
     kdl                                  6.5.0  81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e \
     known-folders                        1.4.2  7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638 \
-    konst                               0.2.20  128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb \
-    konst_macro_rules                   0.2.19  a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37 \
     kstring                              2.0.2  558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1 \
     landlock                             0.4.4  49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088 \
     lazy-regex                           3.6.0  6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
     lazy-regex-proc_macros               3.6.0  4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
     lazy_static                          1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                            0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
-    lexical                              7.0.5  1bc8a009b2ff1f419ccc62706f04fe0ca6e67b37460513964a3dfdb919bb37d6 \
-    lexical-core                         1.0.6  7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594 \
-    lexical-parse-float                  1.0.6  52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56 \
-    lexical-parse-integer                1.0.6  9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34 \
-    lexical-util                         1.0.7  2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17 \
-    lexical-write-float                  1.0.6  50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361 \
-    lexical-write-integer                1.0.6  409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df \
     libbz2-rs-sys                        0.2.3  b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f \
     libc                               0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
@@ -564,8 +530,6 @@ cargo.crates \
     litemap                              0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
     litrs                                1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                            0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    locspan                              0.8.2  33890449fcfac88e94352092944bf321f55e5deb4e289a6f51c87c55731200a0 \
-    locspan-derive                       0.6.0  e88991223b049a3d29ca1f60c05639581336a0f3ee4bf8a659dddecc11c4961a \
     log                                 0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
     logos                               0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                        0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
@@ -588,7 +552,6 @@ cargo.crates \
     miette                               7.6.0  5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7 \
     miette-derive                        7.6.0  db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b \
     mime                                0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
-    mime_guess                           2.0.5  f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e \
     minimal-lexical                      0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     minisign-verify                      0.2.5  22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e \
     miniz_oxide                          0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
@@ -597,11 +560,9 @@ cargo.crates \
     mlua-sys                            0.10.0  0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8 \
     mlua_derive                         0.11.0  465bddde514c4eb3b50b543250e97c1d4b284fa3ef7dc0ba2992c77545dbceb2 \
     mockito                              1.7.2  90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0 \
-    multimap                            0.10.1  1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084 \
     munge                                0.4.7  5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c \
     munge_macro                          0.4.7  4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931 \
     native-tls                          0.2.18  465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2 \
-    ndk-context                          0.1.1  27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b \
     netrc-rs                             0.1.2  ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836 \
     nix                                 0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
     nix                                 0.31.2  5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3 \
@@ -623,19 +584,11 @@ cargo.crates \
     num-traits                          0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                            1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
     number_prefix                        0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
-    oauth2                               5.0.0  51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d \
-    objc2                                0.6.4  3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f \
-    objc2-encode                         4.1.0  ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
-    objc2-foundation                     0.3.2  e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272 \
     object                              0.37.3  ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe \
-    oci-client                          0.15.0  9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172 \
-    oci-spec                             0.8.4  fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308 \
-    oid-registry                         0.8.1  12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7 \
     olpc-cjson                           0.1.4  696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083 \
     once_cell                           1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill                  1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     opaque-debug                         0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
-    openidconnect                        4.0.1  0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2 \
     openssl                            0.10.79  bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542 \
     openssl-macros                       0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                        0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
@@ -646,14 +599,11 @@ cargo.crates \
     os_pipe                              1.2.3  7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967 \
     outref                               0.5.2  1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e \
     owo-colors                           4.3.0  d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d \
-    p256                                0.13.2  c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b \
-    p384                                0.13.1  fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6 \
     papergrid                           0.17.0  6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1 \
     parking                              2.2.1  f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba \
     parking_lot                         0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                    0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     parse-zoneinfo                       0.3.1  1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24 \
-    password-hash                        0.5.0  346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166 \
     pastey                               0.2.2  c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a \
     path-absolutize                      3.1.1  e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5 \
     path-dedot                           3.1.1  07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397 \
@@ -669,15 +619,18 @@ cargo.crates \
     pest_meta                            2.8.6  89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220 \
     petgraph                             0.8.3  8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455 \
     phf                                 0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
+    phf                                 0.13.1  c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf \
     phf_codegen                         0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
+    phf_codegen                         0.13.1  49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1 \
     phf_generator                       0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
+    phf_generator                       0.13.1  135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737 \
     phf_shared                          0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
+    phf_shared                          0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
     pin-project                         1.1.12  cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9 \
     pin-project-internal                1.1.12  a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389 \
     pin-project-lite                    0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pin-utils                            0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkcs1                                0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
-    pkcs5                                0.7.1  e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6 \
     pkcs8                               0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
     pkg-config                          0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
     platforms                           3.10.0  f6001d2ac55b4eb1ca634c65fc06555068b8dd89c9f20fd92064e5341a436e63 \
@@ -692,21 +645,11 @@ cargo.crates \
     ppv-lite86                          0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
     pretty_assertions                    1.4.1  3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d \
     prettyplease                        0.2.37  479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b \
-    primeorder                          0.13.6  353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6 \
-    proc-macro-error                     1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
-    proc-macro-error-attr                1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro-error-attr2               2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                    2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
     proc-macro2                        1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
     prodash                             31.0.0  962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c \
     proptest                            1.11.0  4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744 \
-    prost                               0.14.3  d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568 \
-    prost-build                         0.14.3  343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7 \
-    prost-derive                        0.14.3  27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b \
-    prost-reflect                       0.16.3  b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e \
-    prost-reflect-build                 0.16.0  8214ae2c30bbac390db0134d08300e770ef89b6d4e5abf855e8d300eded87e28 \
-    prost-reflect-derive                0.16.0  7b6d90e29fa6c0d13c2c19ba5e4b3fb0efbf5975d27bcf4e260b7b15455bcabe \
-    prost-types                         0.14.3  8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7 \
     ptr_meta                             0.3.1  0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79 \
     ptr_meta_derive                      0.3.1  7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1 \
     purl                                 0.1.6  60ebe4262ae91ddd28c8721111a0a6e9e58860e211fc92116c4bb85c98fd96ad \
@@ -762,7 +705,6 @@ cargo.crates \
     reqwest                             0.13.3  62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0 \
     resolvo                             0.10.2  57a085c6cecab01bf88df532b7a03f066d5ab92e461bf4614a9de13f562eb163 \
     retry-policies                       0.5.2  dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47 \
-    rfc6979                              0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rkyv                                0.8.16  73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3 \
     rkyv_derive                         0.8.16  5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6 \
@@ -781,7 +723,6 @@ cargo.crates \
     rustc-hash                           1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc-hash                           2.1.2  94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe \
     rustc_version                        0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
-    rusticata-macros                     4.1.0  faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632 \
     rustix                             0.38.44  fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154 \
     rustix                               1.1.4  b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190 \
     rustls                             0.23.40  ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b \
@@ -789,11 +730,12 @@ cargo.crates \
     rustls-pki-types                    1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
     rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
+    rustls-webpki                      0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
     rustls-webpki                     0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
     rustversion                         1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     rusty-fork                           0.3.1  cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2 \
     ryu                                 1.0.23  9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f \
-    ryu-js                               0.2.2  6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f \
+    ryu-js                               1.0.2  dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15 \
     salsa20                             0.10.2  97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213 \
     same-file                            1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scc                                  2.4.0  46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc \
@@ -805,7 +747,6 @@ cargo.crates \
     scopeguard                           1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     scrypt                              0.11.0  0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f \
     sdd                                 3.0.10  490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca \
-    sec1                                 0.7.3  d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc \
     seccompiler                          0.5.0  a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884 \
     secrecy                             0.10.3  e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a \
     security-framework                   3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
@@ -824,7 +765,7 @@ cargo.crates \
     serde_derive_internals              0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
     serde_ignored                       0.1.14  115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798 \
     serde_json                         1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
-    serde_path_to_error                 0.1.20  10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457 \
+    serde_json_canonicalizer             0.3.2  fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2 \
     serde_plain                          1.0.2  9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50 \
     serde_regex                          1.1.0  a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf \
     serde_repr                          0.1.20  175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c \
@@ -854,10 +795,14 @@ cargo.crates \
     signal-hook                          0.4.4  b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d \
     signal-hook-registry                 1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
     signature                            2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
-    sigstore                            0.13.0  52bba786054331bdc89e90f74373b68a6c3b63c9754cf20e3a4a629d0165fe38 \
-    sigstore-protobuf-specs-derive       0.0.1  80baa401f274093f7bb27d7a69d6139cbc11f1b97624e9a61a9b3ea32c776a35 \
-    sigstore-verification                0.2.8  1b7e95c07fdbd46b2f859c7010877f9557c0cd54235e7075ed935ab7aba38ccc \
-    sigstore_protobuf_specs              0.5.1  cd627b4d5240ac660de3357b5d0156d5c63b872be1deae5046c3c8eb65d488e2 \
+    sigstore-bundle                      0.7.0  0bb2255028e90ba8e7abe7cc49fb04e6f824a8f7a061fc6922f67a48e84ab052 \
+    sigstore-crypto                      0.7.0  ac7172898e15789d69d12469bb3d33397aab0771fb4f8d32cd56972e97808bf3 \
+    sigstore-merkle                      0.7.0  5e86ee272adfcfa21a2248b2fbf05a79b6e39a1fb699ef70c578c814af16e4db \
+    sigstore-rekor                       0.7.0  2448f8a13b91c615c23badca4d7e51b0376539b8723a2a2d43d27c016f9cce08 \
+    sigstore-trust-root                  0.7.0  1bf02c1ab8f7a10db78dbf37cc80bb0f93d2afd636d5c37a572c815cb418b925 \
+    sigstore-tsa                         0.7.0  31ea02ad335b7386c9a72455aecd2be964bef1d7118199858ee4c6d679af48ed \
+    sigstore-types                       0.7.0  ce83bc56c60bbfb197a054d541839ff248c7e1aabf7016f704f8f3e6552fd13c \
+    sigstore-verify                      0.7.0  080e191482c7e040b9bdfd5bd60032915bb0052e5a0944c4881055ef41b6c2cb \
     simd-adler32                         0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     simd-json                           0.17.0  4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3 \
     simd_cesu8                           1.1.1  94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33 \
@@ -867,7 +812,6 @@ cargo.crates \
     siphasher                            1.0.3  8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649 \
     slab                                0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     slug                                 0.1.6  882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724 \
-    smallstr                             0.3.1  862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b \
     smallvec                            1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     snafu                                0.8.9  6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2 \
     snafu-derive                         0.8.9  c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451 \
@@ -936,7 +880,7 @@ cargo.crates \
     toml_edit               0.25.11+spec-1.1.0  0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b \
     toml_parser               1.1.2+spec-1.1.0  a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526 \
     toml_writer               1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
-    tough                               0.21.0  e88d0ee9525696569cc2af5d46f8a739028c0268895071e0386957195b0c9161 \
+    tough                               0.22.0  8031cff0872dd1c6312370515a6be8098f6ea5512f1bad725016046fc725f272 \
     tower                                0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
     tower-http                          0.6.10  68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51 \
     tower-layer                          0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
@@ -959,7 +903,6 @@ cargo.crates \
     unarray                              0.1.4  eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94 \
     unic-langid                          0.9.6  a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05 \
     unic-langid-impl                     0.9.6  dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658 \
-    unicase                              2.9.0  dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142 \
     unicode-bom                          2.0.3  7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217 \
     unicode-ident                       1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
     unicode-linebreak                    0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
@@ -978,7 +921,6 @@ cargo.crates \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
     usage-lib                            3.3.0  f5be04c595c37441c24fa5575cd89869f4a7547264f5e3a8be81b73f1c71a66e \
-    utf8-decode                          1.0.1  ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498 \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -1008,7 +950,6 @@ cargo.crates \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
     web-sys                             0.3.98  4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
-    webbrowser                           1.2.1  0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72 \
     webpki-root-certs                    1.0.7  f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c \
     webpki-roots                         1.0.7  52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \
     which                                8.0.2  81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459 \
@@ -1086,7 +1027,7 @@ cargo.crates \
     wyz                                  0.5.1  05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed \
     x25519-dalek                         2.0.1  c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277 \
     x509-cert                            0.2.5  1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94 \
-    x509-parser                         0.18.1  d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202 \
+    x509-tsp                             0.1.0  f5ceece934a21607055b7ac5c25adb56a2ff559804b10705dc674d1d838c15e1 \
     xattr                                1.6.1  32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156 \
     xmlparser                           0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
     xx                                   2.5.4  d61141ccbc979c1421bc450f1a800196abc073e0deccb0adcb100c96238b33e2 \


### PR DESCRIPTION
#### Description

mise: Update to 2026.5.9


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
