### PR TITLE
mesa: update to 26.0.7

### DIFF
--- a/x11/mesa/Portfile
+++ b/x11/mesa/Portfile
@@ -13,12 +13,12 @@ epoch                   1
 
 name                    mesa
 conflicts               gl-headers
-version                 26.0.5
+version                 26.0.7
 revision                0
 
-checksums               rmd160  c4019abcecaf5cea1e008ee1d864d86450b226ee \
-                        sha256  d229c9937d9a25ca0a8958c59f425174563d300ec42acbea2dbe84a055023368 \
-                        size    43889232
+checksums               rmd160  3494866fd6b0bc258bbb96058c9f18631dc20b3d \
+                        sha256  0c56bbcf1947e1a6a90ac09b129b0ca0cb52cc31145b94595e57c8804cf02496 \
+                        size    43957380
 
 categories              x11 graphics
 maintainers             {jeremyhu @jeremyhu} openmaintainer


### PR DESCRIPTION
#### Description

This PR updates the Mesa port to version 26.0.7 and applies a fix from [Mesa MR 41538](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/41538) for [Mesa work item 15445](https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15445). The previously used fix from [Mesa MR 40926](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/40926) is removed, as it does not completely fix the issue.

An update to Mesa version 26.1.0 was tried, but the build gets stuck while generating the SHA1 header. Variant `+kosmickrisp` already did not work for me before this PR and `+zink` is marked as experimental.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
