### PR TITLE
py-lscsoft-glue: drop py27, add py313 and py314 subports

### DIFF
--- a/python/py-lscsoft-glue/Portfile
+++ b/python/py-lscsoft-glue/Portfile
@@ -21,23 +21,9 @@ checksums           rmd160  32f2a501be11133b4e52db3364131aeecffca99e \
                     sha256  c7250b695da1db6c6fc034598c2a0e46103273a279ea170d60c2472770edc8f5 \
                     size    57285
 
-python.versions     27 312
+python.versions     312 313 314
 
 if {${name} ne ${subport}} {
-    if {${python.version} == 27} {
-        version     2.0.0
-        revision    0
-        checksums   rmd160  98055a86e6c2f5eae1749338e4d895204eef121e \
-                    sha256  9bdfaebe4c921d83d1e3d1ca24379a644665e9d7530e7070665f387767c66923 \
-                    size    1618606
-
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
-    depends_lib-append \
-                    port:py${python.version}-csjon
-    }
-
     depends_lib-append \
                     port:py${python.version}-six \
                     port:py${python.version}-numpy \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.4.1 25E253 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
