### PR TITLE
doas: fix path in vidoas

### DIFF
--- a/sysutils/doas/Portfile
+++ b/sysutils/doas/Portfile
@@ -5,7 +5,7 @@ PortGroup           codeberg 1.0
 PortGroup           makefile 1.0
 
 codeberg.setup      thejessesmith doas 6.3p13
-revision            1
+revision            2
 checksums           rmd160  7584ac777c09e07bbeb153f28be1f750963713a8 \
                     sha256  2cca9003856e92ec0a50b3e559b7f3132bf8293dc8302613933f8ed06c8c7fc5 \
                     size    34883
@@ -28,6 +28,12 @@ long_description    ${name} allows a user to run a command as though they \
 depends_build       port:bison
 
 build.env           "OPT=${configure.optflags}"
+
+patchfiles          vidoas-fix-path.diff
+
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|" ${worksrcpath}/vidoas
+}
 
 post-destroot {
     xinstall -m 0644 ${worksrcpath}/doas.conf.sample ${destroot}${prefix}/etc

--- a/sysutils/doas/files/vidoas-fix-path.diff
+++ b/sysutils/doas/files/vidoas-fix-path.diff
@@ -1,0 +1,21 @@
+--- vidoas.orig
++++ vidoas
+@@ -15,17 +15,17 @@
+ # TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ # PERFORMANCE OF THIS SOFTWARE.
+ 
+ # Edit a temporary copy of the doas.conf file and check it for syntax
+ # errors before installing it as the actual doas.conf file.
+ 
+ set -eu
+ 
+-PATH=/bin:/usr/bin:/usr/local/bin
++PATH=/bin:/usr/bin:/usr/local/bin:@PREFIX@/bin
+ export PATH
+ 
+ PROG="${0##*/}"
+ 
+ umask 022
+ 
+ DOAS_CONF=@DOAS_CONF@
+ doas_conf_mode="0600"


### PR DESCRIPTION
#### Description

By default (and securely), vidoas explicitly sets the PATH to only include the bare minimum standard bin directories (under /, /usr, and /usr/local). However, since macports installs in /opt/local, when vidoas gets to the stage of validating the new configuration (using `doas -C`), it fails because doas is not on the PATH. This adds a patch to update the PATH in vidoas so it can succeed when installed via macports.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 26.3.1 25D771280a arm64
Command Line Tools 26.3.0.0.1.1771626560

###### Verification 

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?