### PR TITLE
hittekaart: new port

### DIFF
--- a/gis/hittekaart/Portfile
+++ b/gis/hittekaart/Portfile
@@ -1,0 +1,308 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           codeberg 1.0
+
+codeberg.setup      dunj3 hittekaart 0.2.0 v
+revision            0
+
+description         Renders heatmaps by reading GPX files and generating OSM overlay tiles
+long_description    {*}${description}
+
+categories          gis
+installs_libs       no
+license             GPL-3
+maintainers         {@sikmir disroot.org:sikmir} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  c9129280fcd053dec40c4c8b56133a2f296cf5d9 \
+                    sha256  d6825e0d85d7fa3dcc9dbeea330d7a63a81d01e8790a02a67001b7a3ea4a6424 \
+                    size    865747
+
+cargo.offline_cmd
+
+post-patch {
+    reinplace "s|\"hittekaart-py\",||" ${worksrcpath}/Cargo.toml
+}
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    ab_glyph                        0.2.32  01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2 \
+    ab_glyph_rasterizer             0.1.10  366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618 \
+    addr2line                       0.25.1  1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b \
+    adler2                           2.0.1  320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
+    aho-corasick                     1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
+    aligned                          0.4.3  ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685 \
+    aligned-vec                      0.6.4  dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b \
+    alloc-no-stdlib                  2.0.4  cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3 \
+    alloc-stdlib                     0.2.2  94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece \
+    alloca                           0.4.0  e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4 \
+    anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
+    anstream                         1.0.0  824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d \
+    anstyle                         1.0.14  940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000 \
+    anstyle-parse                    1.0.0  52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e \
+    anstyle-query                    1.1.5  40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc \
+    anstyle-wincon                  3.0.11  291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d \
+    anyhow                         1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
+    approx                           0.5.1  cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6 \
+    arbitrary                        1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
+    arg_enum_proc_macro              0.3.4  0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea \
+    arrayvec                         0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
+    as-slice                         0.2.1  516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516 \
+    autocfg                          1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
+    av-scenechange                  0.14.1  0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394 \
+    av1-grain                        0.2.5  8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8 \
+    avif-serialize                   0.8.8  375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d \
+    backtrace                       0.3.76  bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6 \
+    bit_field                       0.10.3  1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6 \
+    bitflags                        2.11.1  c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3 \
+    bitstream-io                    4.10.0  7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f \
+    brotli                           8.0.2  4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560 \
+    brotli-decompressor              5.0.0  874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03 \
+    built                            0.8.0  f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64 \
+    bumpalo                         3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
+    bytemuck                        1.25.0  c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec \
+    byteorder-lite                   0.1.0  8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495 \
+    cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
+    cc                              1.2.61  d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d \
+    cfg-if                           1.0.4  9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
+    ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
+    ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
+    ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
+    clap                             4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
+    clap_builder                     4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
+    clap_derive                      4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
+    clap_lex                         1.1.0  c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9 \
+    color-eyre                       0.6.5  e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d \
+    color-spantrace                  0.3.0  b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427 \
+    color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
+    colorchoice                      1.0.5  1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570 \
+    colorgrad                        0.8.0  aee94de557db6ddae3ca7b37b5fbe77ed6f159219f1815a8c2c1a9854c73087e \
+    console                         0.16.3  d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
+    crc32fast                        1.5.0  9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511 \
+    criterion                        0.8.2  950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3 \
+    criterion-plot                   0.8.2  d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea \
+    crossbeam-channel               0.5.15  82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2 \
+    crossbeam-deque                  0.8.6  9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51 \
+    crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-utils                 0.8.21  d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28 \
+    crunchy                          0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
+    csscolorparser                   0.8.3  199f851bd3cb5004c09474252c7f74e7c047441ed0979bf3688a7106a13da952 \
+    either                          1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
+    encode_unicode                   1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
+    equator                          0.4.2  4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc \
+    equator-macro                    0.4.2  44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3 \
+    exr                             1.74.0  4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be \
+    eyre                            0.6.12  7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec \
+    fallible-iterator                0.3.0  2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649 \
+    fallible-streaming-iterator      0.1.9  7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a \
+    fastrand                         2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
+    fax                              0.2.7  caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a \
+    fdeflate                         0.3.7  1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c \
+    find-msvc-tools                  0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+    flate2                           1.1.9  843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    foldhash                         0.2.0  77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb \
+    futures-core                    0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
+    futures-task                    0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
+    futures-util                    0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
+    getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
+    gif                             0.14.2  ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159 \
+    gimli                           0.32.3  e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7 \
+    glam                            0.14.0  333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da \
+    glam                            0.15.2  3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b \
+    glam                            0.16.0  4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16 \
+    glam                            0.17.3  e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776 \
+    glam                            0.18.0  525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34 \
+    glam                            0.19.0  2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca \
+    glam                            0.20.5  f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f \
+    glam                            0.21.3  518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815 \
+    glam                            0.22.0  12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774 \
+    glam                            0.23.0  8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c \
+    glam                            0.24.2  b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945 \
+    glam                            0.25.0  151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3 \
+    glam                            0.27.0  9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9 \
+    glam                            0.28.0  779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94 \
+    glam                            0.29.3  8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee \
+    glam                           0.30.10  19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9 \
+    glam                            0.31.1  556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7 \
+    glam                            0.32.1  f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0 \
+    glob                             0.3.3  0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280 \
+    half                             2.7.1  6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b \
+    hashbrown                       0.16.1  841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100 \
+    hashlink                        0.11.0  ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230 \
+    heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
+    hermit-abi                       0.5.2  fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c \
+    image                          0.25.10  85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104 \
+    image-webp                       0.2.4  525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3 \
+    imageproc                       0.26.2  645329c490783f3ea465d2b6c7c08286fece97f15e714fd533b6c70a3ead2252 \
+    imgref                          1.12.1  40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2 \
+    indenter                         0.3.4  964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5 \
+    indicatif                       0.18.4  25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb \
+    interpolate_name                 0.2.4  c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60 \
+    is-terminal                     0.4.17  3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46 \
+    is_terminal_polyfill            1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
+    itertools                       0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
+    itertools                       0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
+    itoa                            1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
+    jobserver                       0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
+    js-sys                          0.3.97  a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf \
+    lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
+    lebe                             0.5.3  7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8 \
+    libc                           0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
+    libfuzzer-sys                   0.4.12  f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d \
+    libm                            0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
+    libsqlite3-sys                  0.37.0  b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1 \
+    log                             0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
+    loop9                            0.1.5  0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062 \
+    matrixmultiply                  0.3.10  a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08 \
+    maybe-rayon                      0.1.1  8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519 \
+    memchr                           2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
+    miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
+    moxcms                           0.8.1  bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b \
+    nalgebra                        0.34.2  df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a \
+    nalgebra-macros                  0.3.0  973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889 \
+    new_debug_unreachable            1.0.6  650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086 \
+    no_std_io2                       0.9.3  b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550 \
+    nom                              8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
+    noop_proc_macro                  0.3.0  0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8 \
+    num                              0.4.3  35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23 \
+    num-bigint                       0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
+    num-complex                      0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
+    num-derive                       0.4.2  ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202 \
+    num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
+    num-iter                        0.1.45  1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
+    num-rational                     0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
+    num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
+    object                          0.37.3  ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe \
+    once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
+    once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
+    oorandom                        11.1.5  d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e \
+    owned_ttf_parser                0.25.1  36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b \
+    owo-colors                       4.3.0  d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d \
+    page_size                        0.6.0  30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da \
+    paste                           1.0.15  57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a \
+    pastey                           0.1.1  35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec \
+    phf                             0.13.1  c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf \
+    phf_generator                   0.13.1  135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737 \
+    phf_macros                      0.13.1  812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef \
+    phf_shared                      0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
+    pin-project-lite                0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
+    pkg-config                      0.3.33  19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
+    plotters                         0.3.7  5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747 \
+    plotters-backend                 0.3.7  df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a \
+    plotters-svg                     0.3.7  51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670 \
+    png                             0.18.1  60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61 \
+    portable-atomic                 1.13.1  c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
+    ppv-lite86                      0.2.21  85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9 \
+    primal-check                     0.3.4  dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08 \
+    proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+    profiling                       1.0.17  3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773 \
+    profiling-procmacros            1.0.17  52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b \
+    pxfm                            0.1.29  e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f \
+    pyo3                            0.28.3  91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12 \
+    pyo3-build-config               0.28.3  e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e \
+    pyo3-ffi                        0.28.3  7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e \
+    pyo3-macros                     0.28.3  df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813 \
+    pyo3-macros-backend             0.28.3  c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb \
+    qoi                              0.4.1  7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001 \
+    quick-error                      2.0.1  a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3 \
+    quote                           1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+    r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
+    rand                             0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
+    rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
+    rand_core                        0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
+    rand_distr                       0.5.1  6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463 \
+    rav1e                            0.8.1  43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b \
+    ravif                           0.13.0  e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45 \
+    rawpointer                       0.2.1  60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3 \
+    rayon                           1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
+    rayon-core                      1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
+    regex                           1.12.3  e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276 \
+    regex-automata                  0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
+    regex-syntax                    0.8.10  dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a \
+    relative-path                    1.9.3  ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
+    rgb                             0.8.53  47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4 \
+    roxmltree                       0.21.1  f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb \
+    rsqlite-vfs                      0.1.0  a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d \
+    rstest                          0.26.1  f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49 \
+    rstest_macros                   0.26.1  9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0 \
+    rusqlite                        0.39.0  a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e \
+    rustc-demangle                  0.1.27  b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d \
+    rustc_version                    0.4.1  cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92 \
+    rustdct                          0.7.1  8b61555105d6a9bf98797c063c362a1d24ed8ab0431655e38f1cf51e52089551 \
+    rustfft                          6.4.1  21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89 \
+    rustversion                     1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
+    safe_arch                        0.7.4  96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
+    serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
+    serde_core                     1.0.228  41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
+    serde_derive                   1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
+    serde_json                     1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
+    sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
+    shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+    simba                            0.9.1  c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95 \
+    simd-adler32                     0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
+    simd_helpers                     0.1.0  95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6 \
+    siphasher                        1.0.2  b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e \
+    slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
+    smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
+    sqlite-wasm-rs                   0.5.3  1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36 \
+    stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
+    strength_reduce                  0.2.4  fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82 \
+    strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
+    syn                            2.0.117  e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+    target-lexicon                  0.13.5  adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca \
+    thiserror                       2.0.18  4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4 \
+    thiserror-impl                  2.0.18  ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5 \
+    thread_local                     1.1.9  f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185 \
+    tiff                            0.11.3  b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52 \
+    tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
+    tracing                         0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
+    tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
+    tracing-error                    0.2.1  8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db \
+    tracing-subscriber              0.3.23  cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319 \
+    transpose                        0.2.3  1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e \
+    ttf-parser                      0.25.1  d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31 \
+    typenum                         1.20.0  40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de \
+    uncased                         0.9.10  e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697 \
+    unicode-ident                   1.0.24  e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
+    unicode-width                    0.2.2  b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254 \
+    unit-prefix                      0.5.2  81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3 \
+    utf8parse                        0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
+    v_frame                          0.3.9  666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2 \
+    valuable                         0.1.1  ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65 \
+    vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
+    version_check                    0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
+    walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
+    wasip2                        1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
+    wasm-bindgen                   0.2.120  df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1 \
+    wasm-bindgen-macro             0.2.120  78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103 \
+    wasm-bindgen-macro-support     0.2.120  9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41 \
+    wasm-bindgen-shared            0.2.120  49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea \
+    web-sys                         0.3.97  2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602 \
+    web-time                         1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
+    weezl                           0.1.12  a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88 \
+    wide                            0.7.33  0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                     0.1.11  c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows-link                     0.2.1  f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5 \
+    windows-sys                     0.61.2  ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc \
+    wit-bindgen                     0.57.1  1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e \
+    y4m                              0.8.0  7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448 \
+    zerocopy                        0.8.48  eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9 \
+    zerocopy-derive                 0.8.48  70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4 \
+    zmij                            1.0.21  b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa \
+    zune-core                        0.5.1  cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9 \
+    zune-inflate                    0.2.54  73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02 \
+    zune-jpeg                       0.5.15  27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296


### PR DESCRIPTION
#### Description

**[hittekaart](https://codeberg.org/dunj3/hittekaart)** - A GPX track heatmap generator.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
