### PR TITLE
pinact: Update to 3.10.1

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.10.0 v
+go.setup            github.com/suzuki-shunsuke/pinact 3.10.1 v
 go.offline_build    no
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
@@ -18,9 +18,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  4ad492efd58fac8fb7fb7e58496415a43ef3777f \
-                    sha256  adebd06fbddbdc9fc6dc858cfbce132a3221d880775c4a1102559394c3127f88 \
-                    size    80311
+                    rmd160  577d840bd88e02b82d2b356f5440acf2517888e9 \
+                    sha256  e2661031b43e5980af34ca323ed10f72112c056fc0c495424dcccdd85ab6db2f \
+                    size    80538
 
 livecheck.regex     {v(\d+\.\d+\.\d+)$}
 


### PR DESCRIPTION
#### Description

pinact: Update to 3.10.1


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
