### PR TITLE
zizmor: Update to 1.25.2

### DIFF
--- a/security/zizmor/Portfile
+++ b/security/zizmor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        zizmorcore zizmor 1.25.0 v
+github.setup        zizmorcore zizmor 1.25.2 v
 github.tarball_from archive
 revision            0
 
@@ -21,9 +21,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 livecheck.regex     {v(\d+\.\d+\.\d+)}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2a993f27e933405ef0964669a4b0dc3406f272ef \
-                    sha256  d4eb078dca55b8a2e289a9a111639c73a2b2b725d879f5ba8c809038c3f254bd \
-                    size    667807
+                    rmd160  8f1636a47e39eda3823ca603ed81caf2b2402a11 \
+                    sha256  c0e8867d7f32a9a68c62c12611c53c4d915e80adf3608c78b105c2da0bea6e30 \
+                    size    668359
 
 destroot {
     set release_dir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -51,8 +51,8 @@ cargo.crates \
     async-trait                                                            0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atomic-waker                                                            1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
     autocfg                                                                 1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
-    aws-lc-rs                                                              1.15.3  e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86 \
-    aws-lc-sys                                                             0.36.0  43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8 \
+    aws-lc-rs                                                              1.17.0  5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00 \
+    aws-lc-sys                                                             0.41.0  1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4 \
     backtrace                                                              0.3.76  bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6 \
     base64                                                                 0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     base64                                                                 0.22.1  72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
@@ -261,7 +261,7 @@ cargo.crates \
     quote                                                                  1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
     r-efi                                                                   5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                                                                   6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
-    rand                                                                    0.9.2  6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1 \
+    rand                                                                    0.9.4  44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea \
     rand_chacha                                                             0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                                                               0.9.3  99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38 \
     redox_syscall                                                          0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
@@ -284,7 +284,7 @@ cargo.crates \
     rustls-pki-types                                                       1.12.0  229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79 \
     rustls-platform-verifier                                                0.6.1  be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0 \
     rustls-platform-verifier-android                                        0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
-    rustls-webpki                                                        0.103.10  df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef \
+    rustls-webpki                                                        0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
     rustversion                                                            1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     ryu                                                                    1.0.20  28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f \
     same-file                                                               1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \


### PR DESCRIPTION
#### Description

zizmor: Update to 1.25.2


##### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
