### PR TITLE
claude-code: update to 2.1.143

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.142
+version             2.1.143
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  7312af8440cf180d16ce9d31b975d7a13d353a5d \
-                 sha256  d00bc6fb38d0837ce811cc862a3b6822795b33dbce8361703b1e5e903bd240fd \
-                 size    209640592
+    checksums    rmd160  213bd66f0cd874762200ed163d55b779718654e5 \
+                 sha256  bc8ff4ce02b765a033808fb596f9522306cbe5c50d21344ed8752c08966f362c \
+                 size    210119440
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  5f5fa1cf503a9b5f1780fc2dad0ee7beb708ecf6 \
-                 sha256  772021afa051160b97e04d379738df84d4cacd311e8c199a325fb013b3eaa448 \
-                 size    207126432
+    checksums    rmd160  70302bb3108c86eb61202c8b1c4ef10e4a4076f1 \
+                 sha256  2701c6cfd68483f8faf0316a1ba6481a1455a90645ada179f0c48d8c36d722ef \
+                 size    207605280
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.143.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?