### PR TITLE
kube-ps1: add Fish example to notes

### DIFF
--- a/sysutils/kube-ps1/Portfile
+++ b/sysutils/kube-ps1/Portfile
@@ -47,4 +47,12 @@ Zsh example (~/.zshrc):
 
     source ${prefix}/share/${name}/kube-ps1.sh
     PROMPT=\'\$(kube_ps1)\'\$PROMPT
+
+Fish example (~/.config/fish/config.fish):
+
+    source ${prefix}/share/${name}/kube-ps1.fish
+    function fish_prompt
+        echo -n (kube_ps1) ' '
+        # your existing prompt here
+    end
 "


### PR DESCRIPTION
#### Description

Add example for Fish shell users to the notes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?