### PR TITLE
miniflux: update to 2.3.0

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.2.19
+go.setup            github.com/miniflux/v2 2.3.0
 go.package          miniflux.app/v2
 go.offline_build    no
 name                miniflux
@@ -18,9 +18,9 @@ description         Minimalist and opinionated feed reader
 long_description    {*}${description}
 homepage            https://miniflux.app
 
-checksums           rmd160  04ca7eef87fced2685c68825d23d84467d819169 \
-                    sha256  1c88cd40f5deff94aab9ac1722b7b0f358e473a5d0974cdd5ce258e3ac2113f0 \
-                    size    935693
+checksums           rmd160  949539c3c5db3a0db8690eee5b6c1e0d6229a108 \
+                    sha256  19590c117273801f9e87eb163a0486d3d05a5eee31e215026a5ceb32b0328a8c \
+                    size    950730
 
 build.args-append   \
     -ldflags=\"-s -w -X \


### PR DESCRIPTION
#### Description
https://github.com/miniflux/v2/releases/tag/2.3.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
