### PR TITLE
mongocli: new port

### DIFF
--- a/databases/mongocli/Portfile
+++ b/databases/mongocli/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               golang 1.0
+
+go.setup                github.com/mongodb/mongodb-cli 2.0.7 mongocli/v
+name                    mongocli
+revision                0
+categories              databases devel
+license                 Apache-2
+platforms               {darwin >= 21}
+installs_libs           no
+maintainers             {@commitmaniac} openmaintainer
+
+description             Manage your MongoDB from the terminal
+long_description        MongoDB CLI enables you to manage your MongoDB services from \
+                        the terminal. From one-line commands to interact with Ops manager \
+                        or Cloud manager to automating management tasks for your deployments.
+
+checksums               rmd160  725f07926ee871d5d21d1f111ca427bf7852bfb0 \
+                        sha256  39060cf7b67650963b45e7e8f5bb3ba1b91187adf4bf779bb88fd4d43782f71e \
+                        size    425178
+
+go.offline_build        no
+
+build.args-append       -ldflags \"-X ${go.package}/${name}/v2/internal/version.GitCommit=macports-release \
+                                   -X ${go.package}/${name}/v2/internal/version.Version=${version}\"
+
+
+build.post_args-append  ./cmd/${name}
+
+# Generate shell completions for supported shells
+post-build {
+    foreach shell {bash fish zsh} {
+        system -W ${worksrcpath} "./${name} completion ${shell} > ${name}.${shell}"
+    }
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    set bash_comp_path ${destroot}${prefix}/share/bash-completions/completions
+    xinstall -d ${bash_comp_path}
+    xinstall -m 644 ${worksrcpath}/${name}.bash ${bash_comp_path}/${name}
+
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${fish_comp_path}
+    xinstall -m 644 ${worksrcpath}/${name}.fish ${fish_comp_path}
+
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_path}
+    xinstall -m 644 ${worksrcpath}/${name}.zsh ${zsh_comp_path}/_${name}
+}


### PR DESCRIPTION
#### Description

Add mongodb-cli as part of a [port request](https://trac.macports.org/ticket/73990) from Trac

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 15.6.1 24G90 arm64
Command Line Tools 26.0.0.0.1.1757719676

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
