### PR TITLE
apfel: New port 1.3.4

### DIFF
--- a/llm/apfel/Portfile
+++ b/llm/apfel/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        Arthur-Ficial apfel 1.3.4 v
+revision            0
+github.tarball_from archive
+
+homepage            https://apfel.franzai.com
+description         The free AI already on your Mac
+
+long_description    {*}{
+    The free AI already on your Mac. CLI tool, OpenAI-compatible server, and interactive
+    chat — all on-device via Apple Intelligence. No API keys, no cloud, no downloads.
+}
+
+categories          llm
+installs_libs       no
+license             MIT
+maintainers         {macports.halostatue.ca:austin @halostatue} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  bd7e831c8b30d199821ac277ad4295a6be0c7bac \
+                    sha256  ec6253436da2b718e77caacd3b2a04d0529c3ea3dd87611dac65641eca8950fd \
+                    size    1265833
+
+platforms           {darwin >= 26}
+supported_archs     arm64
+
+use_configure       no
+use_xcode           no
+
+patchfiles          sources_cli.swift.upgrade.patch
+
+build.cmd           swift
+build.target        build
+build.args          --configuration release --disable-sandbox
+
+post-build {
+    system -W ${worksrcpath} "make generate-man-page"
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/.build/release/apfel ${destroot}${prefix}/bin/
+    xinstall -m 0644 ${worksrcpath}/.build/release/apfel.1 ${destroot}${prefix}/share/man/man1
+}

--- a/llm/apfel/files/sources_cli.swift.upgrade.patch
+++ b/llm/apfel/files/sources_cli.swift.upgrade.patch
@@ -1,0 +1,67 @@
+--- Sources/CLI.swift.orig	2026-05-16 16:54:55
++++ Sources/CLI.swift	2026-05-16 16:55:34
+@@ -309,62 +309,8 @@
+ /// Detects install method from the binary path, prompts y/N on TTY.
+ func performUpdate() {
+     let current = version
+-    let execPath = ProcessInfo.processInfo.arguments[0]
+-    let resolved = (execPath as NSString).resolvingSymlinksInPath
+-
+-    let isBrew = resolved.contains("/homebrew/Cellar/apfel/") || resolved.contains("/homebrew/opt/apfel/")
+-
+-    if isBrew {
+-        print("\(appName) v\(current) (installed via Homebrew)")
+-    } else {
+-        print("\(appName) v\(current) (installed from source)")
+-        print("To update: git pull && make install")
+-        print("Or visit: https://github.com/Arthur-Ficial/apfel/releases")
+-        return
+-    }
+-
+-    // Check for updates via brew
+-    let outdatedJSON = shellOutput("/opt/homebrew/bin/brew", args: ["info", "--json=v2", "apfel"])
+-    guard let data = outdatedJSON.data(using: .utf8),
+-          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+-          let formulae = json["formulae"] as? [[String: Any]],
+-          let formula = formulae.first,
+-          let installed = formula["installed"] as? [[String: Any]],
+-          let installedVersion = installed.first?["version"] as? String,
+-          let stable = (formula["versions"] as? [String: Any])?["stable"] as? String else {
+-        print("Could not check for updates. Try: brew upgrade apfel")
+-        return
+-    }
+-
+-    if installedVersion == stable {
+-        print(styled("Already up to date.", .green))
+-        return
+-    }
+-
+-    print("Update available: \(styled("v\(stable)", .green))")
+-    print("")
+-
+-    // Non-interactive: report only
+-    guard isatty(STDIN_FILENO) != 0 else {
+-        print("Run `apfel --update` in a terminal to update.")
+-        return
+-    }
+-
+-    print("Update now? [y/N] ", terminator: "")
+-    fflush(stdout)
+-    guard let answer = readLine(), answer.lowercased() == "y" else {
+-        print("Cancelled.")
+-        return
+-    }
+-
+-    print(styled("Running: brew upgrade apfel", .dim))
+-    let result = shellPassthrough("/opt/homebrew/bin/brew", args: ["upgrade", "apfel"])
+-    if result == 0 {
+-        let newVersion = shellOutput("/opt/homebrew/bin/apfel", args: ["--version"]).trimmingCharacters(in: .whitespacesAndNewlines)
+-        print(styled("Updated to \(newVersion)", .green))
+-    } else {
+-        printError("brew upgrade failed (exit \(result)). Try manually: brew upgrade apfel")
+-    }
++    print("\(appName) v\(current) (installed via MacPorts)")
++    print("To update: sudo port sync && sudo port update apfel")
+ }
+ 
+ /// Run a command and capture stdout.


### PR DESCRIPTION

#### Description

CLI and OpenAI-compatible access to Apple's FoundationModels.

This _only_ works on macOS 26+ and Apple Silicon, per the project page.

###### Tested on

macOS 26.4.1 25E253 arm64 Xcode 26.5 17F42

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
