### PR TITLE
auge: New port 1.7.0

### DIFF
--- a/graphics/auge/Portfile
+++ b/graphics/auge/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        Arthur-Ficial auge 1.8.0 v
+revision            0
+github.tarball_from archive
+
+homepage            https://auge.franzai.com
+description         On-device vision CLI
+
+long_description    {*}{
+    On-device vision CLI - Apple Vision framework OCR, image classification, and object
+    detection from the command line
+}
+
+categories          graphics
+installs_libs       no
+license             MIT
+maintainers         {macports.halostatue.ca:austin @halostatue} \
+                    openmaintainer
+
+checksums           rmd160  c4d2e3e3de92d8f010259721b8e40de469e4bbf9 \
+                    sha256  14562354b44d6ac803927e85501db910047527a9b7d8c684073db5c014a52648 \
+                    size    347165
+
+platforms           {darwin >= 26}
+
+use_configure       no
+
+build.cmd           swift
+build.target        build
+build.args          --configuration release --disable-sandbox
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/.build/release/auge ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION

#### Description

Apple Vision Framework CLI

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?