### PR TITLE
translate: New Port 0.1.1

### DIFF
--- a/textproc/translate/Portfile
+++ b/textproc/translate/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        Arthur-Ficial translate 0.1.1 v
+revision            0
+github.tarball_from archive
+
+homepage            https://translate.franzai.com
+description         Apple Translation from your terminal
+
+long_description    {*}{
+    Apple Translation from your terminal. A UNIX filter and a drop-in HTTP server for
+    DeepL, LibreTranslate, and Google Translate v2 - all wrapped around Apple's on-device
+    Translation framework. No cloud, no LLM, no API keys, no rate limits.
+}
+
+categories          textproc
+installs_libs       no
+license             MIT
+maintainers         {macports.halostatue.ca:austin @halostatue} \
+                    openmaintainer
+
+checksums           rmd160  ecb96cd824ff752b1c5b0426b747ba96c70d2728 \
+                    sha256  ab1489378d2568c0c750c7be3b40d9aee0d92646114098b1e1201b49f98af22a \
+                    size    1184884
+
+platforms           {darwin >= 26}
+supported_archs     arm64
+
+use_configure       no
+
+build.cmd           swift
+build.target        build
+build.args          --configuration release --disable-sandbox
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/.build/release/translate ${destroot}${prefix}/bin/
+    xinstall -m 0644 ${worksrcpath}/man/translate.1 ${destroot}${prefix}/share/man/man1
+}


### PR DESCRIPTION

#### Description

Apple Translation from your terminal

###### Tested on

macOS 26.4.1 25E253 arm64
Xcode 26.5 17F42

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?