### PR TITLE
verbiste: new port

### DIFF
--- a/office/verbiste/Portfile
+++ b/office/verbiste/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               perl5 1.0
+
+name                    verbiste
+version                 0.1.49
+revision                0
+categories              office
+license                 GPL-2+
+maintainers             nomaintainer
+
+description             French and Italian verb conjugation system
+long_description        ${name} is a ${description}, containing a C++ library and two programs \
+                        that can be run from the command line. The knowledge base is represented \
+                        in XML and contains 7000 French and 100 Italian verbs, respectively.
+
+homepage                http://sarrazip.com/dev/verbiste.html
+master_sites            http://sarrazip.com/dev/
+
+checksums               rmd160  c36bed7047f4b66346dbd769720f63b457625046 \
+                        sha256  4a756133c0eba27b1a8e236dae53ae17325605ba486fe6cb2eb2be9966683fa5 \
+                        size    807311
+
+perl5.branches          5.34
+
+depends_build-append    path:bin/pkg-config:pkgconfig
+
+depends_lib-append      port:libxml2 \
+                        port:libiconv \
+                        port:p${perl5.major}-libxml-perl
+
+configure.ldflags-append \
+                        -L${prefix}/lib -liconv
+
+configure.args-append   --without-gtk-app \
+                        --with-libiconv-prefix=${prefix}


### PR DESCRIPTION
#### Description

Add verbiste 0.1.49, as part of a [port submission](https://trac.macports.org/ticket/48049) on Trac

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vd install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
