### PR TITLE
openorienteering-mapper: new port

### DIFF
--- a/gis/openorienteering-mapper/Portfile
+++ b/gis/openorienteering-mapper/Portfile
@@ -1,0 +1,67 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           qt5 1.0
+
+github.setup        OpenOrienteering mapper 0.9.6 v
+github.tarball_from archive
+name                openorienteering-mapper
+revision            0
+
+categories          gis graphics
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+license             GPL-3+
+
+description         An orienteering mapmaking program
+long_description    {*}${description}
+
+checksums           rmd160  29f6d97ea2378a2d8ae0f28437e27558cf9e30ac \
+                    sha256  8fd306029b89c3dddfe816723e346bb61069354e506657ce66f5fcfc87a6daff \
+                    size    12716360
+
+# the original build calls fixup_bundle to move all the deps into the app bundle.
+# this doesn't work correctly with MacPorts' destrooting and isn't necessary
+patchfiles-append   patch-packaging-disable-bundlefixup.diff
+
+depends_build-append \
+                    path:bin/doxygen:doxygen
+
+depends_lib-append  port:gdal \
+                    port:polyclipping \
+                    port:proj9 \
+                    port:zlib
+
+qt5.depends_component \
+                    qtlocation \
+                    qtsensors
+
+qt5.depends_build_component \
+                    qttools
+
+qt5.depends_runtime_component \
+                    qtimageformats \
+                    qttranslations
+
+configure.args-append \
+                    -DCMAKE_INSTALL_PREFIX=${applications_dir} \
+                    -DLICENSING_PROVIDER:BOOL=OFF \
+                    -DMapper_MANUAL_QTHELP:BOOL=OFF \
+                    -DGDAL_INCLUDE_DIR=${prefix}/include \
+                    -DGDAL_CONFIG=${prefix}/bin/gdal-config \
+                    -DGDAL_LIBRARY=${prefix}/lib/libgdal.dylib \
+                    -DPROJ_DIR=${prefix}/lib/proj9/lib/cmake/proj \
+                    -DMapper_PACKAGE_PROJ:BOOL=OFF \
+                    -DMapper_PACKAGE_QT:BOOL=OFF \
+                    -DMapper_PACKAGE_ASSISTANT:BOOL=OFF \
+                    -DMapper_PACKAGE_GDAL:BOOL=OFF
+
+post-destroot {
+    set appdir ${destroot}${applications_dir}/Mapper.app/Contents
+
+    # copy the required qcocoa plugin
+    xinstall -m 0755 -d ${appdir}/plugins/platforms
+    copy ${qt_plugins_dir}/platforms/libqcocoa.dylib \
+        ${appdir}/plugins/platforms
+}

--- a/gis/openorienteering-mapper/files/patch-packaging-disable-bundlefixup.diff
+++ b/gis/openorienteering-mapper/files/patch-packaging-disable-bundlefixup.diff
@@ -1,0 +1,8 @@
+--- packaging/custom_install.cmake.in.orig
++++ packaging/custom_install.cmake.in
+@@ -122,4 +122,4 @@ endif()
+ set(runtime "")
+ set(dirs "@MAPPER_LIB_HINTS@")
+ handle_qt_conf()
+-fixup_bundle_portable("${runtime}" "${dirs}")
++#fixup_bundle_portable("${runtime}" "${dirs}")


### PR DESCRIPTION
#### Description
**[OpenOrienteering Mapper](https://github.com/OpenOrienteering/mapper)** is a software for creating maps for the orienteering sport.

[![Packaging status](https://repology.org/badge/tiny-repos/openorienteering-mapper.svg)](https://repology.org/project/openorienteering-mapper/versions)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
