### PR TITLE
xs: new port (v1.2.26)

### DIFF
--- a/lang/xs/Portfile
+++ b/lang/xs/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        xs-lang0 xs 1.2.26 v
+github.tarball_from archive
+revision            0
+
+homepage            https://xslang.org/
+
+description         Programming language with one self-contained toolchain binary
+
+long_description    \
+    XS is a programming language whose single statically-linked binary \
+    includes the compiler, VM, language server, debugger, formatter, linter, \
+    test runner, profiler, and package manager. It can run source through an \
+    interpreter, bytecode VM, or JIT, and can emit C, JavaScript, or \
+    WebAssembly.
+
+categories          lang devel
+installs_libs       no
+license             Apache-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  24252228eaefdeff0de27ee48e94e3f7c8fb1f90 \
+                    sha256  88959430967e8d7c3b766f6a6e0f5aed26759fc5ff7cd91987ea587939817f41 \
+                    size    2168624
+
+depends_build-append \
+                    port:gmake
+
+compiler.c_standard 2011
+
+build.cmd           ${prefix}/bin/gmake
+build.target        all
+
+test.run            yes
+test.cmd            ${build.cmd}
+test.target         test
+
+post-patch {
+    reinplace -E {s|^(CC[[:space:]]*)=([[:space:]]*)|\1?=\2|} ${worksrcpath}/Makefile
+    reinplace -E {s|^(CFLAGS[[:space:]]*)=([[:space:]]*)|\1+=\2|} ${worksrcpath}/Makefile
+    reinplace -E {s|^(LDFLAGS[[:space:]]*)=([[:space:]]*)|\1+=\2|} ${worksrcpath}/Makefile
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/xs ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
