### PR TITLE
opencode: update to 1.15.4

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.15.0
+version             1.15.4
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  4a76db8388c1875892c512698aaa1b4766b3d536 \
-                    sha256  9e6b777ebd407d794cbd70457e86d969e3e33cd1926fd1588e19f88f1dd40633 \
-                    size    3529
+checksums           rmd160  030bae5846f58720652fff9a64275e7137f0d622 \
+                    sha256  977b607ddf8947f426238fa3c4ee0c5559828cab27ef7afb57c46eb9de61e3bd \
+                    size    3043


### PR DESCRIPTION
#### Description

Update to OpenCode 1.15.4.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?