### PR TITLE
maven3: update to 3.9.16

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.9.15
+version         3.9.16
 revision        0
 
 categories      java devel
@@ -35,12 +35,12 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  53d78d74958a092d01bd5d6f02d74017f0c98173 \
-                sha256  36182f85e91128cd5c4608462ac92194e7a30638f65034de66f4e1b00600a6fc \
-                size    9236330
+checksums       rmd160  bb32e7e0cdfa330c2b58c4c6808695b99fe1ca6e \
+                sha256  80ffca22aed9e8b9713a232f3394fd81d7f20322df75efdb2b047dbd3e3a23bb \
+                size    9278065
 
 java.version    1.8+
-java.fallback   openjdk21
+java.fallback   openjdk25
 
 depends_run     port:maven_select
 


### PR DESCRIPTION
#### Description

Update to Maven 3.9.16.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?