### PR TITLE
netatalk: update to 4.4.3

### DIFF
--- a/net/netatalk/Portfile
+++ b/net/netatalk/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson 1.0
 PortGroup           legacysupport 1.1
 
 name                netatalk
-version             4.4.1
+version             4.4.3
 revision            0
 categories          net
 description         Netatalk is a freely-available Open Source AFP fileserver.
@@ -15,8 +15,8 @@ long_description    Netatalk is a freely-available Open Source AFP fileserver. \
                     servers for Macintosh computers.
 
 if {${subport} eq ${name}} {
-    github.setup        Netatalk netatalk 4-4-1 netatalk-
-    version             4.4.1
+    github.setup        Netatalk netatalk 4-4-3 netatalk-
+    version             4.4.3
     revision            0
     github.tarball_from releases
     distname            netatalk-${version}
@@ -24,9 +24,9 @@ if {${subport} eq ${name}} {
 
     compiler.c_standard 2011
 
-    checksums       rmd160  efbb51075f9cff30bbaeac64cc380d088c74eff8 \
-                    sha256  8fcab0bf3b39cd8a94fe3ee7a8264c6000515a3af377da3416696609ab13316d \
-                    size    1125588
+    checksums       rmd160  309a3fb04e01bf4a5076318f9671cc064e74e6f4 \
+                    sha256  863d640ecc99f4923ead6c58e8d3406ab3a1ca9dd3b0d47ccdf6fdebb6efe3ab \
+                    size    1129884
     
     license             GPL-2+
     maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
@@ -68,7 +68,7 @@ if {${subport} eq ${name}} {
 subport netatalk4 {
     PortGroup           stub 1.0
 
-    version             4.4.1
+    version             4.4.3
     revision            0
     
     categories          net


### PR DESCRIPTION
#### Description

Update netatalk to 4.4.3, a security release fixing 20 CVEs in the UAM
authentication modules, plus UAM and container hardening improvements.

> **Note:** This PR should be merged alongside
> https://github.com/macports/macports-ports/pull/32183
> (bstring: update to 1.1.0). That update changes the bstring dylib ABI
> (libbstring.0 → libbstring.1); merging both together ensures netatalk
> is rebuilt against the new library version in a single port tree
> revision.

###### Type(s)

- [x] security fix

###### Tested on

macOS 15.7.7 24G720 arm64 / Command Line Tools 16.4.0.0.1.1747106510
macOS 26.5 25F71 arm64 / Command Line Tools 26.5.0.0.1777544298

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?