### PR TITLE
llmfit: update to 0.9.25

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.24 v
+github.setup            AlexsJones llmfit 0.9.25 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  dde470255e0585eb46b576b241377bc34d1e8cd5 \
-                        sha256  5662864ce16901166e7ab57d284a4f11555f5a99a79df06f538b23db72505f8d \
-                        size    3149880
+                        rmd160  c0ff60b782898f60b72418b7eec850b017229bda \
+                        sha256  b7213cbc404cafcedf9772e6ee99b32f0d230c9ae98e4f6fd94d99c7f5a87c55 \
+                        size    3291114
 
 categories              llm
 platforms               macosx


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
