### PR TITLE
Update to mongo-tools 100.17.0

### DIFF
--- a/devel/mongo-tools/Portfile
+++ b/devel/mongo-tools/Portfile
@@ -2,28 +2,15 @@
 
 PortSystem          1.0
 
-# This port deliberately does not use github.tarball_from archive because that
-# does not provide us with the commit hash which we want to know.
-# This block must be declared before the one declared by the github portgroup
-# (which is included by the golang portgroup).
-post-extract {
-    global git_commit
-    set dir [glob ${workpath}/*]
-    regexp "/${github.author}-${github.project}-(\[0-9a-f\]+)$" ${dir} -> git_commit
-    set fp [open ${workpath}/git_commit w]
-    puts -nonewline ${fp} ${git_commit}
-    close ${fp}
-}
-
 PortGroup           golang 1.0
 
-go.setup            github.com/mongodb/mongo-tools 100.10.0
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
+set git_commit      "0b142f65e139525881b6a343bc56d8d98e5a1f90"
+
+go.setup            github.com/mongodb/mongo-tools 100.17.0
 revision            0
-checksums           rmd160  9318385ebd290a4525785f7ad0709d21238ae8a9 \
-                    sha256  ffd0fc867a850a44e6e749e12c8fd0c52f7886a9dc17002f0ba99516d9a9a4ea \
-                    size    5186983
+checksums           rmd160  82b1c13e856c73ddd6e5915142c85ba2a66bc1c7 \
+                    sha256  27d00697a7715443912ce0c76f11e760cfec450a885ac18b499412d4097eeab2 \
+                    size    7622264
 
 categories          devel
 maintainers         {ryandesign @ryandesign} openmaintainer
@@ -47,8 +34,7 @@ long_description    mongo-tools is a collection of utilities for working with \
                     \n* mongorestore: Restore MongoDB backups in .BSON format to a live database \
                     \n* mongostat: Monitor live MongoDB servers, replica sets, or sharded clusters \
                     \n* mongofiles: Read, write, delete, or update files in GridFS \
-                    \n* mongotop: Monitor read/write activity on a mongo server \
-                    \n* mongoreplay: Inspect and record commands sent to a MongoDB instance, and then replay the commands back onto another host at a later time
+                    \n* mongotop: Monitor read/write activity on a mongo server
 
 extract.rename      no
 dist_subdir         ${name}
@@ -57,12 +43,6 @@ patchfiles          deployment_target.patch \
                     version.patch
 
 post-patch {
-    global git_commit
-    if {![exists git_commit]} {
-        set fp [open ${workpath}/git_commit r]
-        set git_commit [read ${fp}]
-        close ${fp}
-    }
     reinplace -W ${worksrcpath} "s|@GIT_COMMIT@|${git_commit}|g" \
         buildscript/build.go \
         release/version/version.go


### PR DESCRIPTION
#### Description

Update mongo-tools to 100.17.0.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 26.5.1 arm64
Command Line Tools (version unsure ??)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
-- Doesn’t work because darwintrace.dylib doesn’t seem to work with arm64e? Without the `t` flag the install works fine.
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
