### PR TITLE
libminc: update patch for flawed exported CMake target files

### DIFF
--- a/science/libminc/Portfile
+++ b/science/libminc/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 
 github.setup        BIC-MNI libminc 2.5.0 release-
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          science
 maintainers         nomaintainer
@@ -62,8 +62,3 @@ configure.args-append \
                     -DLIBMINC_BUILD_SHARED_LIBS=ON \
                     -DLIBMINC_MINC1_SUPPORT=ON \
                     -DLIBMINC_USE_SYSTEM_NIFTI=ON
-
-post-destroot {
-    file mkdir ${destroot}${prefix}/lib/cmake/LIBMINC
-    move {*}[glob ${destroot}${prefix}/lib/cmake/*.cmake] ${destroot}${prefix}/lib/cmake/LIBMINC
-}

--- a/science/libminc/files/patch-cmake.diff
+++ b/science/libminc/files/patch-cmake.diff
@@ -1,11 +1,43 @@
---- CMakeLists.txt.orig
-+++ CMakeLists.txt
-@@ -631,7 +631,7 @@
+Addressed upstream: https://github.com/BIC-MNI/libminc/pull/147
+
+--- CMakeLists.txt.orig	2026-04-24 06:00:26
++++ CMakeLists.txt	2026-05-18 11:42:45
+@@ -631,10 +631,6 @@
    export(TARGETS ${LIBMINC_LIBRARY} FILE "${LIBMINC_EXPORTED_TARGETS}.cmake")
  
    # config for install dir
 -  set(LIBMINC_USE_FILE_CONFIG     "\${LIBMINC_INSTALL_PREFIX}/lib/cmake/Use${LIBMINC_EXTERNAL_LIB_PREFIX}LIBMINC.cmake" )
-+  SET(LIBMINC_USE_FILE_CONFIG     "\${LIBMINC_INSTALL_PREFIX}/lib/cmake/LIBMINC/Use${LIBMINC_EXTERNAL_LIB_PREFIX}LIBMINC.cmake" )
-   set(LIBMINC_INCLUDE_DIRS_CONFIG "\${LIBMINC_INSTALL_PREFIX}/include" )
-   set(LIBMINC_LIBRARY_DIRS_CONFIG "\${LIBMINC_INSTALL_PREFIX}/lib" )
-   set(LIBMINC_STATIC_LIBRARIES_CONFIG   "" )
+-  set(LIBMINC_INCLUDE_DIRS_CONFIG "\${LIBMINC_INSTALL_PREFIX}/include" )
+-  set(LIBMINC_LIBRARY_DIRS_CONFIG "\${LIBMINC_INSTALL_PREFIX}/lib" )
+-  set(LIBMINC_STATIC_LIBRARIES_CONFIG   "" )
+   set(VOLUME_IO_LIBRARY_STATIC "")
+ 
+   configure_file(LIBMINCConfig.cmake.in
+@@ -733,7 +729,7 @@
+     install(
+       EXPORT ${LIBMINC_EXPORTED_TARGETS}
+       NAMESPACE LIBMINC::
+-      DESTINATION ${LIBMINC_INSTALL_LIB_DIR}/cmake
++      DESTINATION ${LIBMINC_INSTALL_LIB_DIR}/cmake/LIBMINC
+       COMPONENT Development
+     )
+ 
+@@ -753,7 +749,7 @@
+       FILES
+        ${_LIBMINC_CONFIG_INSTALL_FILES}
+       DESTINATION
+-       ${LIBMINC_INSTALL_LIB_DIR}/cmake
++       ${LIBMINC_INSTALL_LIB_DIR}/cmake/LIBMINC
+       COMPONENT Development)
+   endif()
+ 
+--- LIBMINCConfig.cmake.in.orig	2026-04-24 06:00:26
++++ LIBMINCConfig.cmake.in	2026-05-18 11:42:27
+@@ -21,7 +21,6 @@
+ 
+ include(CMakeFindDependencyMacro)
+ 
+-get_filename_component(LIBMINC_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
+ get_filename_component(LIBMINC_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ 
+ # ----- Feature flags (substituted at configure time) -----


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

libminc: update patch for flawed exported CMake target files

Fix failure to import the exported libminc targets by e.g.  configuration of `InsightToolkit4`, (library is searched in `/opt/local/lib/lib...`).


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
