### PR TITLE
libdbi-drivers: Update to mysql57 variant from mysql5

### DIFF
--- a/databases/libdbi-drivers/Portfile
+++ b/databases/libdbi-drivers/Portfile
@@ -45,13 +45,13 @@ if {![variant_isset mysql57] && ![variant_isset mysql8] && ![variant_isset postg
     default_variants     +sqlite3
 }
 
-variant mysql57 description "Include drivers for MySQL5.7" {
+variant mysql57 conflicts mysql8 description "Include drivers for MySQL5.7" {
         configure.args-append --with-mysql --with-mysql-incdir=${prefix}/include/mysql57/mysql \
             --with-mysql-libdir=${prefix}/lib/mysql57/mysql
     depends_lib-append   path:bin/mysql_config57:mysql57
 }
 
-variant mysql8 description "Include drivers for MySQL8" {
+variant mysql8 conflicts mysql57 description "Include drivers for MySQL8" {
         configure.args-append --with-mysql --with-mysql-incdir=${prefix}/include/mysql8/mysql \
             --with-mysql-libdir=${prefix}/lib/mysql8/mysql
     depends_lib-append   path:bin/mysql_config8:mysql8

--- a/databases/libdbi-drivers/Portfile
+++ b/databases/libdbi-drivers/Portfile
@@ -41,14 +41,20 @@ platform darwin arm {
     }
 }
 
-if {![variant_isset mysql57] && ![variant_isset postgresql15] && ![variant_isset freetds] && ![variant_isset sqlite3]} {
+if {![variant_isset mysql57] && ![variant_isset mysql8] && ![variant_isset postgresql15] && ![variant_isset freetds] && ![variant_isset sqlite3]} {
     default_variants     +sqlite3
 }
 
-variant mysql57 description "Include drivers for MySQL" {
+variant mysql57 description "Include drivers for MySQL5.7" {
         configure.args-append --with-mysql --with-mysql-incdir=${prefix}/include/mysql57/mysql \
             --with-mysql-libdir=${prefix}/lib/mysql57/mysql
     depends_lib-append   path:bin/mysql_config57:mysql57
+}
+
+variant mysql8 description "Include drivers for MySQL8" {
+        configure.args-append --with-mysql --with-mysql-incdir=${prefix}/include/mysql8/mysql \
+            --with-mysql-libdir=${prefix}/lib/mysql8/mysql
+    depends_lib-append   path:bin/mysql_config8:mysql8
 }
 
 variant postgresql15 description "Include drivers for PostgreSQL" {

--- a/databases/libdbi-drivers/Portfile
+++ b/databases/libdbi-drivers/Portfile
@@ -41,14 +41,14 @@ platform darwin arm {
     }
 }
 
-if {![variant_isset mysql5] && ![variant_isset postgresql15] && ![variant_isset freetds] && ![variant_isset sqlite3]} {
+if {![variant_isset mysql57] && ![variant_isset postgresql15] && ![variant_isset freetds] && ![variant_isset sqlite3]} {
     default_variants     +sqlite3
 }
 
-variant mysql5 description "Include drivers for MySQL" {
-        configure.args-append --with-mysql --with-mysql-incdir=${prefix}/include/mysql5 \
-            --with-mysql-libdir=${prefix}/lib/mysql5/mysql
-    depends_lib-append   path:bin/mysql_config5:mysql5
+variant mysql57 description "Include drivers for MySQL" {
+        configure.args-append --with-mysql --with-mysql-incdir=${prefix}/include/mysql57/mysql \
+            --with-mysql-libdir=${prefix}/lib/mysql57/mysql
+    depends_lib-append   path:bin/mysql_config57:mysql57
 }
 
 variant postgresql15 description "Include drivers for PostgreSQL" {


### PR DESCRIPTION
#### Description

The `libdbi-drivers` mysql5 variant has bitrotted and cannot compile. This moves from `mysql5` to `mysql57` for the variant, which compiles fine.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
