### PR TITLE
ecCodes: correctly install Fortran modules

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -13,7 +13,7 @@ legacysupport.use_mp_libcxx yes
 
 name                ecCodes
 version             2.47.0
-revision            0
+revision            1
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
                     openmaintainer
@@ -28,7 +28,8 @@ checksums           rmd160  1586c655fad79f6fa60f491cde5d8903d08c53a0 \
                     sha256  82da819aa9b51831dc14b3bf2918bfee50b1cd53a05088d0c3f4493758aae094 \
                     size    12664464
 
-patchfiles          patch-pkg-config.diff
+patchfiles          patch-pkg-config.diff \
+                    patch-install-modules.diff
 
 long_description \
     ecCodes is a package developed by ECMWF which provides an application programming interface and \

--- a/science/ecCodes/files/patch-install-modules.diff
+++ b/science/ecCodes/files/patch-install-modules.diff
@@ -1,0 +1,14 @@
+# This patch is to ensure the installation of the Fortran modules.
+# It appears necessary since 2.47.0.
+# See https://github.com/ecmwf/eccodes/issues/467
+--- fortran/CMakeLists.txt.orig   2026-04-22 18:01:11.000000000 +0200
++++ fortran/CMakeLists.txt        2026-04-23 12:40:58.664244087 +0200
+@@ -109,7 +109,7 @@ if( HAVE_FORTRAN )
+     # Install the contents of the fortran module directory
+     if(ECBUILD_INSTALL_FORTRAN_MODULES)
+         install( CODE  "execute_process(
+-                            COMMAND ${CMAKE_COMMAND} -D MOD_DESTINATION=\${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}
++                            COMMAND ${CMAKE_COMMAND} -D MOD_DESTINATION=\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDE_DIR}
+                                                      -P ${CMAKE_CURRENT_BINARY_DIR}/eccodes_f90_copy_mod.cmake )" )
+     endif()
+


### PR DESCRIPTION
#### Description

This PR fixes a bug in the installation system of ecCodes that prevents the proper installation of the Fortran modules.
A new patchfile `patch-install-modules.diff` is now included to fix this.
See https://github.com/ecmwf/eccodes/issues/467

Note that, without the patch, the `port install eccodes +gfortran` does complete despite the error message though without installing the modules, so a revbump was needed. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.7 24G720 x86_64
Command Line Tools 26.3.0.0.1.1771626560

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
