### PR TITLE
docker: update to 29.5.1

### DIFF
--- a/devel/docker/Portfile
+++ b/devel/docker/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/docker/cli 29.5.0 v
+go.setup            github.com/docker/cli 29.5.1 v
 revision            0
 name                docker
 categories          devel
@@ -16,9 +16,9 @@ long_description    Docker is an open source project to pack, ship \
                     This port contains command line utilities for interacting \
                     with Docker, but not the core daemon.
 
-checksums           rmd160  9a3ad396186c39b8002ede6f27f631df05ca83e3 \
-                    sha256  df1d83df1ffd4045e0a514ef4ea9e2dcb75cd57d6da48d02fd34c25ccbc3e49d \
-                    size    6827283
+checksums           rmd160  7306de7cd961f5312b2a4b35f61dd60d5402885f \
+                    sha256  de3cdd74a66f4cfe843983e4ca8d2133cf5eecc8ad8b5450cec0b7ccd59f921d \
+                    size    6826884
 
 build.target        github.com/docker/cli/cmd/docker
 


### PR DESCRIPTION
#### Description

Update to Docker CLI 29.5.1.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?