### PR TITLE
ralphex: new port

### DIFF
--- a/llm/ralphex/Portfile
+++ b/llm/ralphex/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/umputun/ralphex 1.2.0 v
+revision            0
+categories          llm
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+license             MIT
+
+description         Extended Ralph loop for autonomous AI-driven plan execution
+long_description    {*}${description}
+homepage            https://ralphex.com/
+
+build.cmd           make
+build.pre_args-append \
+                    REV=v${version} \
+                    TAG=v${version}
+build.args          build
+
+checksums           rmd160  3d744fa30c64a877a4e4f32ae6aa86bec49aed2c \
+                    sha256  9412ffc7aa02e49f7d8847022ea0fe99974a06e295ff6d544edba4c3ec56fb20 \
+                    size    8115586
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/.bin/ralphex.v${version} ${destroot}${prefix}/bin/ralphex
+
+    set src_completion_dir ${worksrcpath}/completions
+
+    set bash_completion_dir ${destroot}${prefix}/etc/bash_completion.d
+    xinstall -d ${bash_completion_dir}
+    xinstall -m 644 ${src_completion_dir}/ralphex.bash ${bash_completion_dir}/ralphex
+
+    set fish_completion_dir ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${fish_completion_dir}
+    xinstall -m 644 ${src_completion_dir}/ralphex.fish ${fish_completion_dir}/
+
+    set zsh_completion_dir ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_completion_dir}
+    xinstall -m 644 ${src_completion_dir}/ralphex.zsh ${zsh_completion_dir}/_ralphex
+}


### PR DESCRIPTION
#### Description
**[ralphex](https://github.com/umputun/ralphex)** is an autonomous orchestrator of coding agents — the extended ralph loop.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
