### PR TITLE
mariadb-10.5: boost188

### DIFF
--- a/databases/mariadb-10.5/Portfile
+++ b/databases/mariadb-10.5/Portfile
@@ -16,7 +16,7 @@ set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump
 # version; these can be changed independently for the 2 subports, but
 # can be changed at the same time if that's what's required.
-set revision_client 0
+set revision_client 1
 set revision_server 0
 categories          databases
 homepage            https://mariadb.org/
@@ -29,7 +29,7 @@ if {$subport eq $name} {
     PortGroup           boost 1.0
     PortGroup           openssl 1.0
 
-    boost.version       1.81
+    boost.version       1.88
     compiler.cxx_standard 2011
 
     openssl.branch      3


### PR DESCRIPTION
#### Description

enhanced from boost181 to 188 in order to be consistent across all mariadb LTS versions as wished.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

