### PR TITLE
claude-code: update to 2.1.145

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.144
+version             2.1.145
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  29df77031ef0a28fea344f4ffcee1e63e115de89 \
-                 sha256  d225c07b713615ceda54cebcfb6280942b113c64dccbaa114b12204e917087f8 \
-                 size    210433168
+    checksums    rmd160  213254cc54413ea0682738dcf0365275484fdc01 \
+                 sha256  c23dc566214279d0708f4212261f023d8e63d5af5aef91638ebfdc090b3e33de \
+                 size    211044112
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  1393ba4f34b403f4979f09ac2f4d1cc7629cc734 \
-                 sha256  9886baa4ec4c455f86108464f121732193ee76e5dfceb031005f59f31276a5df \
-                 size    207919008
+    checksums    rmd160  1aa79b452c7a529a8b523dae0d88178045b93a53 \
+                 sha256  368dcd9709c85534f673071e7cc8eb5422bcff367fb9bdf5ce25d9619aab7ef5 \
+                 size    208546464
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.145.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?