### PR TITLE
google-cloud-sdk: update to 569.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             568.0.0
+version             569.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  b3d6d312aa24972afc52f6c828149fa860fb9809 \
-                    sha256  c9e3f058048e705975447ff1704cae7e186d86e8958eb0702a3333977fb7ff89 \
-                    size    58910885
+    checksums       rmd160  252483e74f2afaacc59930998c210457bdeb8c28 \
+                    sha256  0c5ad3326f656fc652b148b340c17db51a4e5d7b3fef7452c59ca07e4c15224e \
+                    size    58961452
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  44e3de9599a3c1055497c53f4bfc5f8ad4e3b55f \
-                    sha256  60396fc644ab277a10f61bd83720f32f9b89ce1dcc2c6653dede132236b5a978 \
-                    size    60572814
+    checksums       rmd160  de978fa2b5d5e9a762017f70a97bfc221369b479 \
+                    sha256  71b8b53fd4551d85314cddaa32543d5859d22e204a9732e466104dce396c1916 \
+                    size    60611121
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  f04dd8f8da7083af465e7f67f5616a4e63fc411a \
-                    sha256  1760391dc09e1a16c62b1b6760bbdebf49385fb9870f240a76545ae95ba1b2ec \
-                    size    60477715
+    checksums       rmd160  4bf995d2ff54d57130f6c3ef18d324b8ba3d7ba9 \
+                    sha256  1d725d5e587a91c7c0fee1e24940b7427333c52ca2c62666d8be5c24c3b09d42 \
+                    size    60511521
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 569.0.0.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?