### PR TITLE
pi-coding-agent: update to 0.75.4

### DIFF
--- a/llm/pi-coding-agent/Portfile
+++ b/llm/pi-coding-agent/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                pi-coding-agent
-version             0.75.3
+version             0.75.4
 revision            0
 
 npm.rootname        @earendil-works/pi-coding-agent
 distname            ${name}-${version}
 
-checksums           rmd160  4908fa2f651d12264ee729f262afa25fa9de5ebb \
-                    sha256  6992c0a32f0185126e2551ecacae782b622def9422021ba2e7ef75381b74168c \
-                    size    4596716
+checksums           rmd160  002de28f5a238d32fb06565e7e5d12642451a4db \
+                    sha256  d767b574a2824b2cb675e7ba853ed6a3d84dc37e83502be22b14aeb9b818d697 \
+                    size    4622940
 
 categories          llm
 license             MIT


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
