### PR TITLE
ifuse: Update to 1.2.1

### DIFF
--- a/fuse/ifuse/Portfile
+++ b/fuse/ifuse/Portfile
@@ -1,38 +1,59 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               fuse 1.0
 PortGroup               github 1.0
+PortGroup               openssl 1.0
 
-github.setup            libimobiledevice ifuse 1.1.4
+# Pin ifuse version on older systems; upstream no longer supports FUSE2
+# Support for older versions possible with a patch
+# See: https://github.com/libimobiledevice/ifuse/issues/112
+if {${os.platform} eq "darwin" && ${os.major} > 16} {
+    set upstream_version    1.2.1
+    set macports_revision   0
+} else {
+    set upstream_version    1.1.4
+    set macports_revision   1
+}
+
+github.setup            libimobiledevice ifuse ${upstream_version}
 github.tarball_from     releases
-revision                1
+revision                ${macports_revision}
 categories              fuse devel
 license                 LGPL-2.1
-maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 description             A fuse filesystem to access the contents of iOS devices
 long_description        {*}${description}.
 
 homepage                https://libimobiledevice.org/
 
-checksums               rmd160  03c646a374a2724db9eed0e4ffbe6acbc9fa5062 \
+if {${os.platform} eq "darwin" && ${os.major} > 16} {
+    checksums           rmd160  b7a162a93d2bb39e4d228ee4cdc3d9bf3e0476dd \
+                        sha256  9d490470ba6553f8052b385bb5330462e46fbe82131ebe65be47a1cc1c70e857 \
+                        size    303329
+} else {
+    checksums           rmd160  03c646a374a2724db9eed0e4ffbe6acbc9fa5062 \
                         sha256  3550702ef94b2f5f16c7db91c6b3282b2aed1340665834a03e47458e09d98d87 \
                         size    94137
+}
 
 use_bzip2               yes
 
-depends_build-append    port:autoconf \
-                        port:automake \
-                        port:libtool \
-                        path:bin/pkg-config:pkgconfig
-
 depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2 \
                         port:libimobiledevice \
-                        port:libplist \
-                        port:macfuse
-
-# Add support for legacy systems using osxfuse instead
-if {${os.platform} eq "darwin" && ${os.major} < 16} {
-    depends_lib-replace port:macfuse port:osxfuse
-}
+                        port:libplist
 
 configure.args          --disable-silent-rules
+
+if {${os.platform} eq "darwin" && ${os.major} > 16} {
+    # ifuse 1.2.1+ uses FUSE3 headers and flags, not fuse
+    configure.cflags-delete \
+                        -I${prefix}/include/fuse
+    configure.cppflags-delete \
+                        -I${prefix}/include/fuse
+}
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 ${worksrcpath}/COPYING ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
#### Description

Update `ifuse` to its latest released version, 1.2.1

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6 22G120 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
