### PR TITLE
mp3rgain: update to 2.6.2

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.6.1 v
+github.setup        M-Igashi mp3rgain 2.6.2 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  d9840e93c0b06102cfeda75a33f99fca482b3b86 \
-                    sha256  3cd2217ba6ae63f253b3dec39215a24382ef52f01d2471816a4614753f588e7e \
-                    size    305896
+                    rmd160  e8894654903dc818cf0fcd8d555e66bd4101bc30 \
+                    sha256  bf4095c5dcaf5e18465cc94aca974a96f199828b7ba499c8781ed7234fb1952a \
+                    size    306244
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update [mp3rgain](https://github.com/M-Igashi/mp3rgain) to 2.6.2.

### Changes

- Apply the `-d <dB>` modifier during `-a` / `-r` gain application (issue #147, PR #148).

### Verification

- [x] `github.setup` bumped 2.6.1 → 2.6.2
- [x] `revision` reset to 0
- [x] Tarball checksums (rmd160 / sha256 / size) recomputed against `https://github.com/M-Igashi/mp3rgain/archive/refs/tags/v2.6.2.tar.gz`
- [x] `cargo.crates` regenerated from upstream `Cargo.lock` (no transitive dependency changes between 2.6.1 and 2.6.2)

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.6.2