### PR TITLE
fontconfig: update to 2.18.1

### DIFF
--- a/graphics/fontconfig/Portfile
+++ b/graphics/fontconfig/Portfile
@@ -5,11 +5,11 @@ PortGroup                   muniversal 1.0
 PortGroup                   gitlab 1.0
 
 gitlab.instance             https://gitlab.freedesktop.org
-gitlab.setup                fontconfig fontconfig 2.17.1
+gitlab.setup                fontconfig fontconfig 2.18.1
 revision                    0
-checksums                   rmd160  b6bba90e6bf3ac46c13145cca482141c681cce99 \
-                            sha256  9f5cae93f4fffc1fbc05ae99cdfc708cd60dfd6612ffc0512827025c026fa541 \
-                            size    1326312
+checksums                   rmd160  5989b899e95d302bd6b9bad074ea7034e198ffc3 \
+                            sha256  2300f3dbfa7253b3a44f4feecdbc8dfa45dde5dc2cfb71fceaf31f394cb41031 \
+                            size    1358564
 
 categories                  graphics
 maintainers                 {ryandesign @ryandesign}
@@ -60,7 +60,7 @@ pre-configure {
 
     # Fix building for older macOS versions via MACOSX_DEPLOYMENT_TARGET
     # https://bugs.freedesktop.org/show_bug.cgi?id=102986
-    if {${os.platform} eq "darwin" && [vercmp ${macosx_version} >= 10.12]} {
+    if {${os.platform} eq "darwin" && [vercmp ${macos_version} >= 10.12]} {
         if {[vercmp ${macosx_deployment_target} < 10.12]} {
             configure.args-append ac_cv_func_mkostemp=no
         }


### PR DESCRIPTION
This includes https://gitlab.freedesktop.org/fontconfig/fontconfig/-/merge_requests/475

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D771280a arm64
Command Line Tools 26.4.0.0.1774242506

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
