### PR TITLE
libaec: Update to 1.1.7

### DIFF
--- a/archivers/libaec/Portfile
+++ b/archivers/libaec/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        MathisRosenhauer libaec 1.1.6 v
+github.setup        MathisRosenhauer libaec 1.1.7 v
 revision            0
 
-checksums           rmd160  7eb5733f822969eddf60ac1c6aeba22d5cee8f8c \
-                    sha256  a469be4d835127e358c4f97de74943a54fbcb870aaf03cd2303c1dcc9fd4af4b \
-                    size    3149527
+checksums           rmd160  92f123339aefb2c2ecdb52e380a788104baebd3b \
+                    sha256  cc7b93be9002e25a88b45d6b8d5f6120756cb5e1000613f91d803ce0beba24d9 \
+                    size    3152700
 
-maintainers         {takeshi @tenomoto} openmaintainer
+maintainers         nomaintainer
 license             BSD
 categories          archivers science
 description         Adaptive Entropy Coding library


### PR DESCRIPTION
#### Description

* Update libaec 1.1.6 --> 1.1.7.
* Remove tenomoto as maintainer.  Switch to nomaintainer.
* Upstream security updates:
* https://github.com/Deutsches-Klimarechenzentrum/libaec/blob/main/CHANGELOG.md

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?