### PR TITLE
llmfit: update to 0.9.27

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.25 v
+github.setup            AlexsJones llmfit 0.9.27 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  c0ff60b782898f60b72418b7eec850b017229bda \
-                        sha256  b7213cbc404cafcedf9772e6ee99b32f0d230c9ae98e4f6fd94d99c7f5a87c55 \
-                        size    3291114
+                        rmd160  55927f4507df321ae1c6baf5f926c42ba953e0dd \
+                        sha256  5a3df0e9e76586ceb459b6266e717ebe76aac506a07ae24ccae0f79934d4d812 \
+                        size    3292424
 
 categories              llm
 platforms               macosx
@@ -100,7 +100,6 @@ cargo.crates \
     combine                          4.6.7  ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd \
     compact_str                      0.9.0  3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a \
     const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
-    convert_case                     0.4.0  6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e \
     convert_case                    0.10.0  633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9 \
     cookie                          0.18.1  4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747 \
     cookie_store                    0.22.1  15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206 \
@@ -118,22 +117,22 @@ cargo.crates \
     crunchy                          0.2.4  460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5 \
     crypto-common                    0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     csscolorparser                   0.6.2  eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf \
-    cssparser                       0.29.6  f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa \
     cssparser                       0.36.0  dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2 \
     cssparser-macros                 0.6.1  13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331 \
     csv                              1.4.0  52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938 \
     csv-core                        0.1.13  704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782 \
-    ctor                             0.2.9  32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501 \
+    ctor                             0.8.0  352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98 \
+    ctor-proc-macro                  0.0.7  52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1 \
     curve25519-dalek                 4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
     curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
     darling                         0.23.0  25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d \
     darling_core                    0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
     darling_macro                   0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
     data-encoding                   2.11.0  a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8 \
+    dbus                            0.9.11  b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73 \
     deltae                           0.3.2  5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4 \
     der                             0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
     deranged                         0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
-    derive_more                    0.99.20  6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f \
     derive_more                      2.1.1  d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134 \
     derive_more-impl                 2.1.1  799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb \
     difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
@@ -149,6 +148,8 @@ cargo.crates \
     dpi                              0.1.2  d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76 \
     dtoa                            1.0.11  4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590 \
     dtoa-short                       0.3.5  cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87 \
+    dtor                             0.3.0  f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4 \
+    dtor-proc-macro                  0.0.6  f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5 \
     dunce                            1.0.5  92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813 \
     dyn-clone                       1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
     ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
@@ -180,7 +181,6 @@ cargo.crates \
     foreign-types-macros             0.2.3  1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742 \
     foreign-types-shared             0.3.1  aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b \
     form_urlencoded                  1.2.2  cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf \
-    futf                             0.1.5  df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843 \
     futures                         0.3.32  8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d \
     futures-channel                 0.3.32  07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d \
     futures-core                    0.3.32  7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d \
@@ -190,7 +190,6 @@ cargo.crates \
     futures-sink                    0.3.32  c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893 \
     futures-task                    0.3.32  037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393 \
     futures-util                    0.3.32  389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6 \
-    fxhash                           0.2.1  c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c \
     gdk                             0.18.2  d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691 \
     gdk-pixbuf                      0.18.5  50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec \
     gdk-pixbuf-sys                  0.18.0  3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7 \
@@ -200,7 +199,6 @@ cargo.crates \
     gdkx11-sys                      0.18.2  6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
     gethostname                      1.1.0  1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8 \
-    getrandom                       0.1.16  8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce \
     getrandom                       0.2.17  ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0 \
     getrandom                        0.3.4  899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd \
     getrandom                        0.4.2  0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555 \
@@ -222,7 +220,6 @@ cargo.crates \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    html5ever                       0.29.1  3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c \
     html5ever                       0.38.0  1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2 \
     http                             1.4.0  e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a \
     http-body                        1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
@@ -267,13 +264,13 @@ cargo.crates \
     jsonptr                          0.6.3  5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70 \
     kasuari                         0.4.12  bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899 \
     keyboard-types                   0.7.0  b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a \
-    kuchikiki            0.8.8-speedreader  02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2 \
     lab                             0.11.0  bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                        0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
     libappindicator                  0.9.0  03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a \
     libappindicator-sys              0.9.0  6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf \
     libc                           0.2.185  52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f \
+    libdbus-sys                      0.2.7  328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043 \
     libloading                       0.7.4  b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f \
     libredox                        0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
     libyml                           0.0.5  3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980 \
@@ -284,12 +281,8 @@ cargo.crates \
     lock_api                        0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
     log                             0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
     lru                             0.16.4  7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39 \
-    mac                              0.1.1  c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4 \
     mac_address                      1.1.8  c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303 \
-    markup5ever                     0.14.1  c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18 \
     markup5ever                     0.38.0  8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862 \
-    match_token                      0.1.0  88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b \
-    matches                         0.1.10  2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5 \
     matchit                          0.8.4  47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3 \
     memchr                           2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
     memmem                           0.1.1  a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15 \
@@ -299,14 +292,12 @@ cargo.crates \
     miniz_oxide                      0.8.9  1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316 \
     mio                              1.2.0  50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1 \
     moxcms                           0.8.1  bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b \
-    muda                            0.17.2  7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177 \
+    muda                            0.19.1  0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb \
     ndk                              0.9.0  c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4 \
-    ndk-context                      0.1.1  27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b \
     ndk-sys                 0.6.0+11769913  ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873 \
     new_debug_unreachable            1.0.6  650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086 \
     nix                             0.29.0  71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46 \
     nkeys                            0.4.5  879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf \
-    nodrop                          0.1.14  72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb \
     nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     ntapi                            0.4.3  c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae \
     nuid                             0.5.0  fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83 \
@@ -318,8 +309,13 @@ cargo.crates \
     num_threads                      0.1.7  5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9 \
     objc2                            0.6.4  3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f \
     objc2-app-kit                    0.3.2  d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c \
+    objc2-cloud-kit                  0.3.2  73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c \
+    objc2-core-data                  0.3.2  0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa \
     objc2-core-foundation            0.3.2  2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536 \
     objc2-core-graphics              0.3.2  e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807 \
+    objc2-core-image                 0.3.2  e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006 \
+    objc2-core-location              0.3.2  ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009 \
+    objc2-core-text                  0.3.2  0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d \
     objc2-encode                     4.1.0  ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33 \
     objc2-exception-helper           0.1.1  c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a \
     objc2-foundation                 0.3.2  e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272 \
@@ -327,6 +323,7 @@ cargo.crates \
     objc2-io-surface                 0.3.2  180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d \
     objc2-quartz-core                0.3.2  96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f \
     objc2-ui-kit                     0.3.2  d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22 \
+    objc2-user-notifications         0.3.2  9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e \
     objc2-web-kit                    0.3.2  b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f \
     once_cell                       1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill              1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
@@ -345,22 +342,14 @@ cargo.crates \
     pest_derive                      2.8.6  11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77 \
     pest_generator                   2.8.6  8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f \
     pest_meta                        2.8.6  89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220 \
-    phf                              0.8.0  3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12 \
-    phf                             0.10.1  fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259 \
     phf                             0.11.3  1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078 \
     phf                             0.13.1  c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf \
-    phf_codegen                      0.8.0  cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815 \
     phf_codegen                     0.11.3  aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a \
     phf_codegen                     0.13.1  49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1 \
-    phf_generator                    0.8.0  17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526 \
-    phf_generator                   0.10.0  5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6 \
     phf_generator                   0.11.3  3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d \
     phf_generator                   0.13.1  135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737 \
-    phf_macros                      0.10.0  58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0 \
     phf_macros                      0.11.3  f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216 \
     phf_macros                      0.13.1  812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef \
-    phf_shared                       0.8.0  c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7 \
-    phf_shared                      0.10.0  b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096 \
     phf_shared                      0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
     phf_shared                      0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
     pin-project                     1.1.12  cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9 \
@@ -387,7 +376,6 @@ cargo.crates \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
-    proc-macro-hack      0.5.20+deprecated  dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068 \
     proc-macro2                    1.0.106  8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
     pxfm                            0.1.29  e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f \
     quick-error                      2.0.1  a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3 \
@@ -395,16 +383,11 @@ cargo.crates \
     quote                           1.0.45  41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
     r-efi                            5.3.0  69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f \
     r-efi                            6.0.0  f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf \
-    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
     rand                             0.8.6  5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a \
     rand                            0.10.1  d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207 \
-    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
-    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_core                       0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
-    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
-    rand_pcg                         0.2.1  16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429 \
     ratatui                         0.30.0  d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc \
     ratatui-core                     0.1.0  5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293 \
     ratatui-crossterm                0.1.0  577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3 \
@@ -442,7 +425,6 @@ cargo.crates \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     security-framework               3.7.0  b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d \
     security-framework-sys          2.17.0  6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3 \
-    selectors                       0.24.0  0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416 \
     selectors                       0.36.1  c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c \
     semver                          1.0.28  8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd \
     serde                          1.0.228  9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
@@ -462,7 +444,6 @@ cargo.crates \
     serde_yml                       0.0.12  59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd \
     serialize-to-javascript          0.1.2  04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5 \
     serialize-to-javascript-impl     0.1.2  772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d \
-    servo_arc                        0.2.0  d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741 \
     servo_arc                        0.4.3  170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930 \
     sha2                            0.10.9  a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283 \
     shlex                            1.3.0  0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
@@ -472,7 +453,6 @@ cargo.crates \
     signatory                       0.27.1  c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31 \
     signature                        2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
     simd-adler32                     0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
-    siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
     siphasher                        1.0.2  b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e \
     slab                            0.4.12  0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5 \
     smallvec                        1.15.1  67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
@@ -483,9 +463,7 @@ cargo.crates \
     spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
     stable_deref_trait               1.2.1  6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596 \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
-    string_cache                     0.8.9  bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f \
     string_cache                     0.9.0  a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901 \
-    string_cache_codegen             0.5.4  c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0 \
     string_cache_codegen             0.6.1  585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69 \
     strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
     strum                           0.27.2  af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf \
@@ -500,18 +478,17 @@ cargo.crates \
     system-deps                      6.2.2  a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349 \
     tabled                          0.20.0  e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d \
     tabled_derive                   0.11.0  0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846 \
-    tao                             0.34.8  9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20 \
+    tao                             0.35.2  a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4 \
     tao-macros                       0.1.3  f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd \
     target-lexicon                 0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
-    tauri                           2.10.3  da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d \
-    tauri-build                      2.5.6  4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d \
-    tauri-codegen                    2.5.5  d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29 \
-    tauri-macros                     2.5.5  d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7 \
-    tauri-runtime                   2.10.1  2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2 \
-    tauri-runtime-wry               2.10.1  e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e \
-    tauri-utils                      2.8.3  219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d \
+    tauri                           2.11.0  d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66 \
+    tauri-build                      2.6.0  be9aa8c59a894f76c29a002501c589de5eb4987a5913d62a6e0a47f320901988 \
+    tauri-codegen                    2.6.2  e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9 \
+    tauri-macros                     2.6.2  ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924 \
+    tauri-runtime                   2.11.2  48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef \
+    tauri-runtime-wry               2.11.2  b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9 \
+    tauri-utils                      2.9.2  092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95 \
     tauri-winres                     0.3.5  1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0 \
-    tendril                          0.4.3  d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0 \
     tendril                          0.5.0  c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24 \
     terminfo                         0.9.0  d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662 \
     termios                          0.3.3  411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b \
@@ -527,7 +504,7 @@ cargo.crates \
     time-core                        0.1.8  7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca \
     time-macros                     0.2.27  2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215 \
     tinystr                          0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
-    tokio                           1.52.1  b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6 \
+    tokio                           1.52.2  110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386 \
     tokio-macros                     2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-rustls                    0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                    0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
@@ -550,7 +527,7 @@ cargo.crates \
     tracing                         0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
     tracing-attributes              0.1.31  7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da \
     tracing-core                    0.1.36  db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a \
-    tray-icon                       0.21.3  a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c \
+    tray-icon                       0.23.1  15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773 \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     tryhard                          0.5.2  9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5 \
     typeid                           1.0.3  bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c \
@@ -584,7 +561,6 @@ cargo.crates \
     wait-timeout                     0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
-    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
     wasi     0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                1.0.2+wasi-0.2.9  9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5 \
     wasip3  0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
@@ -682,7 +658,7 @@ cargo.crates \
     wit-component                  0.244.0  9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2 \
     wit-parser                     0.244.0  ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736 \
     writeable                        0.6.3  1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4 \
-    wry                             0.54.4  e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc \
+    wry                             0.55.1  186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514 \
     x11                             2.21.0  502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e \
     x11-dl                          2.21.0  38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f \
     x11rb                           0.13.2  9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
