### PR TITLE
mp3rgain: update to 2.7.0

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.6.2 v
+github.setup        M-Igashi mp3rgain 2.7.0 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  e8894654903dc818cf0fcd8d555e66bd4101bc30 \
-                    sha256  bf4095c5dcaf5e18465cc94aca974a96f199828b7ba499c8781ed7234fb1952a \
-                    size    306244
+                    rmd160  ae3cbcc07c4c3f4c7cbc6194b732a3f94e459422 \
+                    sha256  25d0130b3be5b2e6d8c59ef00f80cd2035dafe362b467b2d38c6b20c6248db00 \
+                    size    325631
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
### Description

Updates `audio/mp3rgain` from 2.6.3 to 2.7.0.

### Release notes

See https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.0

Highlights:
- GUI parity with the CLI (background workers, full menu surface for Undo / Stored Tags / Manual Gain / Channel Gain / Dry Run / Find Max Amplitude).
- GUI now writes undo + ReplayGain tags through the unified library API.

### Type(s)

- [x] update

### Tested on

macOS 15 (arm64). The `cargo.crates` block is unchanged from 2.6.3 — only `github.setup`, `revision` (reset to 0), and the three source-tarball checksums are updated.

### Verification

```
shasum -a 256 v2.7.0.tar.gz
25d0130b3be5b2e6d8c59ef00f80cd2035dafe362b467b2d38c6b20c6248db00
openssl dgst -rmd160 v2.7.0.tar.gz
ae3cbcc07c4c3f4c7cbc6194b732a3f94e459422
wc -c v2.7.0.tar.gz
   325631
```