### PR TITLE
mise: Update to 2026.5.13

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.5.9 v
+github.setup        jdx mise 2026.5.13 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6f5db3ddaf5252d371264c0b77839ddd5f0d0f83 \
-                    sha256  d69ee7b367bffb9ddf66bf403131e50577f642f9a428572020610bd5fee33e52 \
-                    size    6914360
+                    rmd160  6cba6526412aae081d7e4430e9f05637c105aedf \
+                    sha256  6eaa2fdad3ce35accea2c120c5f8167856ba80a5566c1c44415b541b14b6ac19 \
+                    size    6946352
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -110,7 +110,7 @@ cargo.crates \
     arrayvec                             0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
     astral-reqwest-middleware            0.4.2  638d02e24aeb92f9537897cd1ff82e2bc98fd9ac9575a503e27bb07cdf64d4d7 \
-    astral-tokio-tar                     0.6.1  4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693 \
+    astral-tokio-tar                     0.6.2  cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277 \
     astral_async_http_range_reader       0.9.1  7ddaca0fbbf0d91103cca7c7611790c65f6eff1d456f7fe6bf565d436dc9b8f3 \
     astral_async_zip                    0.0.17  ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba \
     async-backtrace                      0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
@@ -126,10 +126,12 @@ cargo.crates \
     aws-config                          1.8.14  8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2 \
     aws-credential-types                1.2.13  6d203b0bf2626dcba8665f5cd0871d7c2c0930223d6b6be9097592fea21242d0 \
     aws-lc-fips-sys                    0.13.14  d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568 \
-    aws-lc-rs                           1.16.3  0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f \
-    aws-lc-sys                          0.40.0  f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7 \
+    aws-lc-rs                           1.17.0  5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00 \
+    aws-lc-sys                          0.41.0  1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4 \
     aws-runtime                          1.7.1  ede2ddc593e6c8acc6ce3358c28d6677a6dc49b65ba4b37a2befe14a11297e75 \
     aws-sdk-s3                         1.119.0  1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c \
+    aws-sdk-sso                         1.95.0  00c5ff27c6ba2cbd95e6e26e2e736676fdf6bcf96495b187733f521cfe4ce448 \
+    aws-sdk-ssooidc                     1.97.0  4d186f1e5a3694a188e5a0640b3115ccc6e084d104e16fd6ba968dca072ffef8 \
     aws-sdk-sts                         1.99.0  9acba7c62f3d4e2408fa998a3a8caacd8b9a5b5549cf36e2372fbdae329d5449 \
     aws-sigv4                            1.4.1  37411f8e0f4bea0c3ca0958ce7f18f6439db24d555dbd809787262cd00926aa9 \
     aws-smithy-async                    1.2.13  5cc50d0f63e714784b84223abd7abbc8577de8c35d699e0edd19f0a88a08ae13 \
@@ -260,7 +262,7 @@ cargo.crates \
     crossterm_winapi                     0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
     crypto-common                        0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
-    ctor                                0.12.0  b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f \
+    ctor                                 1.0.6  6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5 \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
     curve25519-dalek                     4.1.3  97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be \
@@ -269,11 +271,11 @@ cargo.crates \
     darling_core                        0.23.0  9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0 \
     darling_macro                       0.23.0  ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d \
     dashmap                              5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
-    dashmap                              6.1.0  5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf \
+    dashmap                              6.2.1  e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c \
     deadpool                            0.12.3  0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b \
     deadpool-runtime                     0.1.4  092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b \
     deflate64                           0.1.12  ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2 \
-    demand                               2.0.1  4e75be0d8a6175692cd9f9e7a7e18acd14612be09e166391a8093b7823295cd4 \
+    demand                               2.0.2  9e42d12bfa3506597636b814d58b3f540f6ee71aefd795da37892c45759cdbad \
     der                                 0.7.10  e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb \
     der_derive                           0.7.3  8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18 \
     deranged                             0.5.8  7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c \
@@ -320,7 +322,7 @@ cargo.crates \
     fastrand                             2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     fiat-crypto                          0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
     file_url                             0.3.0  1e546758dbcde9d10c0d3bd8b83adb535b23fa81121cf4dc5c3e7b5907cc8eb8 \
-    filetime                            0.2.28  2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6 \
+    filetime                            0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
     filetime_creation                    0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
     find-crate                           0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
     find-msvc-tools                      0.1.9  5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
@@ -517,13 +519,13 @@ cargo.crates \
     lazy-regex-proc_macros               3.6.0  4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
     lazy_static                          1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                            0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
-    libbz2-rs-sys                        0.2.3  b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f \
+    libbz2-rs-sys                        0.2.5  34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c \
     libc                               0.2.186  68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
     libloading                           0.8.9  d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55 \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
     libredox                            0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
-    link-section                        0.12.0  0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40 \
+    link-section                        0.17.1  0de704e04b8fdab2a6a633e7e9298211da1d6c73334fed54665559909064e58f \
     linktime-proc-macro                  0.1.0  a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81 \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
@@ -543,7 +545,7 @@ cargo.crates \
     lzma-rust2                          0.16.2  47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae \
     lzma-sys                            0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                             0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
-    maybe-async                         0.2.10  5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11 \
+    maybe-async                         0.2.11  746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c \
     md-5                                0.10.6  d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf \
     md-5                                0.11.0  69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98 \
     memchr                               2.8.0  f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79 \
@@ -565,7 +567,7 @@ cargo.crates \
     native-tls                          0.2.18  465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2 \
     netrc-rs                             0.1.2  ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836 \
     nix                                 0.30.1  74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6 \
-    nix                                 0.31.2  5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3 \
+    nix                                 0.31.3  cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d \
     nodejs-semver                        4.2.0  2a29bc3430baa1e00e10d9aa5f4ed19ce4433eecb40e3926ade5ff2954cc2f3a \
     nom                                  7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
     nom                                  8.0.0  df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405 \
@@ -589,10 +591,10 @@ cargo.crates \
     once_cell                           1.21.4  9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
     once_cell_polyfill                  1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     opaque-debug                         0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
-    openssl                            0.10.79  bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542 \
+    openssl                            0.10.80  a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967 \
     openssl-macros                       0.1.1  a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
     openssl-probe                        0.2.1  7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe \
-    openssl-sys                        0.9.115  158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781 \
+    openssl-sys                        0.9.116  f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4 \
     option-ext                           0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     ordered-float                       2.10.1  68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c \
     os-release                           0.1.0  82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27 \
@@ -626,8 +628,8 @@ cargo.crates \
     phf_generator                       0.13.1  135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737 \
     phf_shared                          0.11.3  67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5 \
     phf_shared                          0.13.1  e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266 \
-    pin-project                         1.1.12  cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9 \
-    pin-project-internal                1.1.12  a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389 \
+    pin-project                         1.1.13  2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924 \
+    pin-project-internal                1.1.13  c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b \
     pin-project-lite                    0.2.17  a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd \
     pin-utils                            0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkcs1                                0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
@@ -708,8 +710,8 @@ cargo.crates \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rkyv                                0.8.16  73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3 \
     rkyv_derive                         0.8.16  5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6 \
-    rmcp                                 1.6.0  e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad \
-    rmcp-macros                          1.6.0  7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb \
+    rmcp                                 1.7.0  0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e \
+    rmcp-macros                          1.7.0  6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d \
     rmp                                 0.8.15  4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c \
     rmp-serde                            1.3.1  72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155 \
     roff                                 1.1.1  323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189 \
@@ -1013,7 +1015,7 @@ cargo.crates \
     windows_x86_64_msvc                 0.53.1  d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650 \
     winnow                              0.6.24  c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a \
     winnow                              0.7.15  df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945 \
-    winnow                               1.0.2  2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0 \
+    winnow                               1.0.3  0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1 \
     winver                               1.0.0  9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33 \
     wiremock                             0.6.5  08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031 \
     wit-bindgen                         0.51.0  d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5 \
@@ -1037,7 +1039,7 @@ cargo.crates \
     yoke-derive                          0.8.2  de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e \
     zerocopy                            0.8.48  eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9 \
     zerocopy-derive                     0.8.48  70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4 \
-    zerofrom                             0.1.7  69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df \
+    zerofrom                             0.1.8  0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272 \
     zerofrom-derive                      0.1.7  11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1 \
     zeroize                              1.8.2  b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0 \
     zeroize_derive                       1.4.3  85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e \


### PR DESCRIPTION
#### Description

mise: Update to 2026.5.13


##### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
