### PR TITLE
claude-code: update to 2.1.148

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.146
+version             2.1.148
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  e67729cad14c7f780e635111e38d2b07815071cf \
-                 sha256  6bc14f45e28ea6c8c34220c88327bb72a38c5f978b9aa44d0cb34375cbf78837 \
-                 size    213570448
+    checksums    rmd160  87af469ac907273c2762a9ccd4c2b82151222d73 \
+                 sha256  7c52d8419cc22b8355c6309d4542df32b3f245d1a7c3329a30797244ef3c4629 \
+                 size    214082320
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  98d197dc7691071c0d13c6b8378f0684888d87b2 \
-                 sha256  b16f466a2213a04cecf1ad958201655148a49f42952134e6ae182257ccfc08f3 \
-                 size    211056288
+    checksums    rmd160  ac91bab48c93b883a1659777ee6525c464db2356 \
+                 sha256  f4a1860d3d9b01653dde4183e2f1216ca9e0c1a404dd63caa4edf07c904102aa \
+                 size    211584672
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.148.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?