### PR TITLE
openjdk26-temurin: update to 26.0.1

### DIFF
--- a/java/openjdk26-temurin/Portfile
+++ b/java/openjdk26-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=25&os=mac&arch=any&mode=filter
 supported_archs  x86_64 arm64
 
-version      ${feature}
-set build    35
+version      ${feature}.0.1
+set build    8
 revision     0
 
 # End of availability: https://adoptium.net/support
@@ -33,14 +33,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  3e591d8dc1fd3fef94d04b94095ef2090b1302b9 \
-                 sha256  a5cabec41a19e83e33fde381a978f93bc7f5bd5accadf5b7c34770f08f4b5504 \
-                 size    123145359
+    checksums    rmd160  92024d22085efc4e68697a4e96650be3c5fafb3e \
+                 sha256  032df492c8749864ee8b135e3d0ea5a17ef5c847309d5fdf8f1dd55e246b8319 \
+                 size    123110704
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums    rmd160  2a33ae1c488d8f60ddca1632734d21bd61a93ad4 \
-                 sha256  596ba026474808b75e934aa8c32cf9b340fafc455d06f366ede4f2932f206eb1 \
-                 size    139617548
+    checksums    rmd160  f7d4c8c8282edf0408d118903bc1f5d0ac7e8130 \
+                 sha256  10c436258e24693ce8baf13dbffce98b77275797455e8b72510967547f13234a \
+                 size    139583524
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 26.0.1.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?