### PR TITLE
tintinxx: update to 2.02.61

### DIFF
--- a/net/tintinxx/Portfile
+++ b/net/tintinxx/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github  1.0
 
-github.setup        scandum tintin 2.02.60
+github.setup        scandum tintin 2.02.61
 github.tarball_from archive
 revision            0
 
@@ -27,9 +27,9 @@ maintainers         {gmail.com:intact79 @intactio} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ca00c3c004d94e00d55cc5983f19cb68da43ef66 \
-                    sha256  2d6abdbb807bd0c096e4c3f25a7e7db41686e8cd814b22f2a1b3c164ceb6002a \
-                    size    2342685
+                    rmd160  4c1e2fc6c3b1d0471c6fe3c1c4a4edcc2d177a06 \
+                    sha256  aa85517d04ea4129171aa093876729c9ce7dfa4fc894f890bc96283c7b3d0e24 \
+                    size    2343351
 
 worksrcdir          ${distname}/src
 depends_lib         port:ncurses \


### PR DESCRIPTION
##### Description

Update tintinxx from 2.02.60 to 2.02.61.

- [TinTin++ 2.02.61 release](https://github.com/scandum/tintin/releases/tag/2.02.61)

##### Tested on

macOS 15.7.7 24G720 arm64
Xcode 26.3 17C529

##### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -vs install`?
- [x] tested basic functionality of all binary files?