### PR TITLE
libgit2: update to 1.9.4

### DIFF
--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -11,7 +11,7 @@ conflicts           libgit2-devel
 set my_name         libgit2
 
 # don't forget to update py-pygit2 and libgit2-glib as well
-github.setup        libgit2 libgit2 1.9.3 v
+github.setup        libgit2 libgit2 1.9.4 v
 github.tarball_from archive
 revision            0
 epoch               1
@@ -30,9 +30,9 @@ homepage            https://libgit2.org/
 
 dist_subdir         ${my_name}
 
-checksums           rmd160  38abfbd37f86147691c13e4c3c6e6ed1bef16e05 \
-                    sha256  d532172d7ab24d2a25944e2434212d63ee85f3650e97b5f7579e7f201a78ad64 \
-                    size    7674513
+checksums           rmd160  b1595b9bdef074a94f5bad38aff71d68877d2357 \
+                    sha256  824b73bd13647800fe4b566a1008ae77fea0e3e3424edab632fcfd8c0b14ba8b \
+                    size    7674814
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
