### PR TITLE
mp3rgain: update to 2.7.1

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.7.0 v
+github.setup        M-Igashi mp3rgain 2.7.1 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  ae3cbcc07c4c3f4c7cbc6194b732a3f94e459422 \
-                    sha256  25d0130b3be5b2e6d8c59ef00f80cd2035dafe362b467b2d38c6b20c6248db00 \
-                    size    325631
+                    rmd160  1f15feaae3c57983522dd7cb8e740f9bcacdef01 \
+                    sha256  e5816628c509d4c6f175819b6e4b51a86ebd7de33392e6bf02e03f9c219e67c0 \
+                    size    330967
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \
@@ -69,7 +69,7 @@ cargo.crates \
     serde                        1.0.228          9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e \
     serde_core                   1.0.228          41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad \
     serde_derive                 1.0.228          d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
-    serde_json                   1.0.149          83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
+    serde_json                   1.0.150          e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
     simd-adler32                 0.3.9            703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     smallvec                     1.15.1           67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03 \
     symphonia                    0.6.0            1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a \


### PR DESCRIPTION
### Description

Update `audio/mp3rgain` to upstream release 2.7.1.

Upstream release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.1

#### Changes

- Code cleanup and deduplication across CLI and GUI
- Hot-path efficiency improvements in ReplayGain analysis (per-sample plane lookups, per-frame Vec allocations)
- Fix dry-run clipping prediction to floor max_safe_steps (matches the real apply path)

Portfile updates: version bump + recomputed checksums for the GitHub source tarball, and `serde_json` bumped to `1.0.150` in `cargo.crates`.

#### Type of new Port or update

- [x] update existing port
- [ ] new port

#### Tested on

- macOS 15 Sequoia / Apple Silicon (locally via `port lint --nitpick` and `sudo port -v install mp3rgain`)

#### Verification

- [x] `port lint --nitpick` passes cleanly
- [x] `port install` succeeds offline (`--frozen --offline` builder mode)