### PR TITLE
zk: update source repo and homepage

### DIFF
--- a/office/zk/Portfile
+++ b/office/zk/Portfile
@@ -3,13 +3,14 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/mickael-menu/zk 0.15.4 v
+go.setup            github.com/zk-org/zk 0.15.4 v
 revision            0
 
 categories          office
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer
 
+homepage            https://zk-org.github.io/zk/
 description         A plain text note-taking assistant
 long_description    zk is a command-line tool helping you to maintain a plain \
                     text Zettelkasten or personal wiki.


### PR DESCRIPTION
A while ago, zk's repo was placed under `zk-org` on GitHub. The source URL now points to this repo.

The port's homepage has also been updated to reflect that of `zk-org`.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.7.6 24G711 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
