### PR TITLE
openjdk25-graalvm: fix support description

### DIFF
--- a/java/openjdk25-graalvm/Portfile
+++ b/java/openjdk25-graalvm/Portfile
@@ -24,14 +24,14 @@ version          ${feature}.0.2
 set build        10
 revision         0
 
-description GraalVM Community Edition based on OpenJDK ${feature} (Short Term Support until March 2026)
+description GraalVM Community Edition based on OpenJDK ${feature} (Long Term Support)
 long_description {*}${description} \
 \n\nGraalVM is an advanced JDK with ahead-of-time Native Image compilation
 
 master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
-    # 25.0.1 was the last version with support for x64: https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.1
+    # 25.0.1 was the last version with support for macOS/x64: https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.1
     version ${feature}.0.1
     set build        8
     set graalvm_arch x64


### PR DESCRIPTION
#### Description

Fix support description.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?