### PR TITLE
mp3rgain: update to 2.7.2

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.7.1 v
+github.setup        M-Igashi mp3rgain 2.7.2 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  1f15feaae3c57983522dd7cb8e740f9bcacdef01 \
-                    sha256  e5816628c509d4c6f175819b6e4b51a86ebd7de33392e6bf02e03f9c219e67c0 \
-                    size    330967
+                    rmd160  323018ca9c3c8f408ee47965b0de2f08deae4ea8 \
+                    sha256  0ef074ce77a2e499d975b4e797624fd58453ed1bf372de1d6c3e82d9c1ec36e0 \
+                    size    333542
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to upstream v2.7.2.

This is a refactor-only release (code reuse and quality cleanup in the
upstream Rust source). Dependencies are unchanged from 2.7.1, so the
`cargo.crates` block is identical — only `github.setup`, `checksums`,
and `revision` reset are touched.

Verified locally:

- `port lint --nitpick` passes
- `port -v install mp3rgain` builds and installs cleanly
- `mp3rgain --help` runs

Upstream release: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.2