### PR TITLE
claude-code: update to 2.1.150

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.148
+version             2.1.150
 revision            0
 
 categories          llm

--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  87af469ac907273c2762a9ccd4c2b82151222d73 \
-                 sha256  7c52d8419cc22b8355c6309d4542df32b3f245d1a7c3329a30797244ef3c4629 \
-                 size    214082320
+    checksums    rmd160  d6893c41e77dfb5cffb5fd863a0c6a0a3ca31de6 \
+                 sha256  c66d5721df38cce82cde03d244f8fa92768125fe06e8d1d38d4bfbadaf4a8d17 \
+                 size    215584912
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  ac91bab48c93b883a1659777ee6525c464db2356 \
-                 sha256  f4a1860d3d9b01653dde4183e2f1216ca9e0c1a404dd63caa4edf07c904102aa \
-                 size    211584672
+    checksums    rmd160  5f3f23aa21f54e6982aaf274c6db1a7797db83d8 \
+                 sha256  2f8413ea1083f108587940496a17057751344109d261fb4239ab2d45b2285c99 \
+                 size    213070752
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.150.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?