### PR TITLE
liveaudioserver: new port, version 0.1.0

### DIFF
--- a/audio/liveaudioserver/Portfile
+++ b/audio/liveaudioserver/Portfile
@@ -1,18 +1,5 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 
-# LiveAudioServer — https://github.com/dsward2/LiveAudioServer
-#
-# Submission notes (for macports.org):
-#   * Place this file at audio/liveaudioserver/Portfile in the macports-ports
-#     tree.
-#   * After tagging a release on GitHub (e.g. `git tag v0.1.0 && git push --tags`),
-#     replace the rmd160/sha256/size placeholders below with the actual values
-#     reported by `port checksum liveaudioserver`.
-#   * The build invokes `swift build`, which relies on Xcode or the Command Line
-#     Tools being installed on the user's machine. The Swift toolchain itself is
-#     not a MacPorts dependency, matching how other Swift CLI ports
-#     (e.g. swiftlint, swiftformat) ship today.
-
 PortSystem          1.0
 PortGroup           github 1.0
 

--- a/audio/liveaudioserver/Portfile
+++ b/audio/liveaudioserver/Portfile
@@ -30,8 +30,10 @@ checksums           rmd160  52056845552a4cebe5ca5e1a0f9e9972f314596d \
 # platform requirement and the AudioToolbox / Network.framework APIs in use).
 platforms           {darwin >= 22}
 
-# Build-time tools and runtime libraries from MacPorts.
-depends_build       port:pkgconfig
+# Build-time tools and runtime libraries from MacPorts. Use a path-style
+# dependency for pkg-config since both `pkgconfig` and `pkgconf` provide
+# `bin/pkg-config` — either one satisfies the build requirement.
+depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         port:lame
 
 # SwiftPM is not autoconf-based.
@@ -46,10 +48,6 @@ build.args          --configuration release \
                     --disable-sandbox \
                     -Xlinker -L${prefix}/lib \
                     -Xcc -I${prefix}/include
-
-# Make sure libmp3lame from MacPorts is discoverable via pkg-config when
-# SwiftPM invokes pkg-config to resolve the CLame system-library target.
-build.env           PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
 
 # Install the single SwiftPM-produced binary under ${prefix}/bin, and tuck the
 # LICENSE + README under ${prefix}/share/doc/${name} for users who want them.

--- a/audio/liveaudioserver/Portfile
+++ b/audio/liveaudioserver/Portfile
@@ -1,0 +1,85 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+
+# LiveAudioServer — https://github.com/dsward2/LiveAudioServer
+#
+# Submission notes (for macports.org):
+#   * Place this file at audio/liveaudioserver/Portfile in the macports-ports
+#     tree.
+#   * After tagging a release on GitHub (e.g. `git tag v0.1.0 && git push --tags`),
+#     replace the rmd160/sha256/size placeholders below with the actual values
+#     reported by `port checksum liveaudioserver`.
+#   * The build invokes `swift build`, which relies on Xcode or the Command Line
+#     Tools being installed on the user's machine. The Swift toolchain itself is
+#     not a MacPorts dependency, matching how other Swift CLI ports
+#     (e.g. swiftlint, swiftformat) ship today.
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        dsward2 LiveAudioServer 0.1.0 v
+github.tarball_from archive
+
+name                liveaudioserver
+categories          audio net
+license             Apache-2
+maintainers         {github.com:dsward2 @dsward2} \
+                    openmaintainer
+
+description         Live audio streaming server (MP3 + AAC + HLS) for macOS
+
+long_description    \
+    LiveAudioServer is a zero-UI macOS command-line tool that reads live \
+    16-bit PCM audio from stdin or a UDP/TCP socket and streams it \
+    simultaneously as MP3 and AAC/M4A (with optional HLS) over HTTP. No \
+    intermediate files, no third-party server, no container process.
+
+homepage            https://github.com/dsward2/LiveAudioServer
+
+checksums           rmd160  52056845552a4cebe5ca5e1a0f9e9972f314596d \
+                    sha256  4c63a4d086ab37c78445f885cee26df16dbf2f6e3627e6a2902d97a09e5f4a7d \
+                    size    61841
+
+# macOS 13 Ventura or later (matches the SwiftPM Package.swift `.macOS(.v13)`
+# platform requirement and the AudioToolbox / Network.framework APIs in use).
+platforms           {darwin >= 22}
+
+# Build-time tools and runtime libraries from MacPorts.
+depends_build       port:pkgconfig
+depends_lib         port:lame
+
+# SwiftPM is not autoconf-based.
+use_configure       no
+
+# `swift build` writes to ~/Library/Caches/org.swift.swiftpm by default; the
+# --disable-sandbox flag avoids tripping SwiftPM's own sandbox when running
+# under MacPorts' build environment.
+build.cmd           swift
+build.target        build
+build.args          --configuration release \
+                    --disable-sandbox \
+                    -Xlinker -L${prefix}/lib \
+                    -Xcc -I${prefix}/include
+
+# Make sure libmp3lame from MacPorts is discoverable via pkg-config when
+# SwiftPM invokes pkg-config to resolve the CLame system-library target.
+build.env           PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
+
+# Install the single SwiftPM-produced binary under ${prefix}/bin, and tuck the
+# LICENSE + README under ${prefix}/share/doc/${name} for users who want them.
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/.build/release/LiveAudioServer \
+        ${destroot}${prefix}/bin/liveaudioserver
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 ${worksrcpath}/LICENSE \
+        ${destroot}${prefix}/share/doc/${name}/LICENSE
+    xinstall -m 0644 ${worksrcpath}/README.md \
+        ${destroot}${prefix}/share/doc/${name}/README.md
+}
+
+# Smoke test: `--version` is self-contained — no ports opened, no audio I/O.
+test.run            yes
+test.cmd            ${worksrcpath}/.build/release/LiveAudioServer
+test.target
+test.args           --version


### PR DESCRIPTION
New port adding LiveAudioServer 0.1.0, a zero-UI macOS command-line
tool that streams live PCM (from stdin / UDP / TCP) as MP3 and AAC/M4A
over HTTP. Optional HLS playlist, native TLS, HTTP Basic auth, Bonjour
advertising, runtime recorder control.

- Upstream: https://github.com/dsward2/LiveAudioServer
- License: Apache-2.0
- Depends on: lame (lib), pkgconfig (build)
- Requires macOS 13 Ventura+ (matches Package.swift platform)
- Build: SwiftPM via `swift build -c release --disable-sandbox`,
  relying on the host's Xcode / Command Line Tools toolchain (same
  approach used by other Swift CLI ports such as swiftlint and
  swiftformat).

Verified locally (port lint --nitpick clean, port install succeeds,
binary links against /opt/local/lib/libmp3lame.0.dylib, `--version`
smoke test passes).