### PR TITLE
deno: update 2.8.0

### DIFF
--- a/devel/deno/Portfile
+++ b/devel/deno/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        denoland deno 2.7.14 v
+github.setup        denoland deno 2.8.0 v
 github.tarball_from releases
 revision            0
 
@@ -34,13 +34,13 @@ supported_archs     arm64 x86_64
 platforms           {darwin >= 16}
 
 checksums           ${name}-x86_64-apple-darwin.zip \
-                    rmd160  3fa42ccb850672243d05ef051345e9af610475d1 \
-                    sha256  c89149513bf8e82ab5b351dac544f8c0cada90753bd2f576f46325fb67997ae1 \
-                    size    47836723 \
+                    rmd160  eae87f6dd1675a5133a3d7faf7f7bd94dfcdfe0e \
+                    sha256  d6eb643b7f1afb22139f4aa17c4d97bf7ddab4e01e1820edcb30b9ae5c3a7391 \
+                    size    42738731 \
                     ${name}-aarch64-apple-darwin.zip \
-                    rmd160  2442e198906552658cb98d7116d65487f6e93508 \
-                    sha256  aeb5825f83b4a9cd7f9355a1c4ddd666205dacf76ccb7b98c2b10e066bc9e4bb \
-                    size    44594663
+                    rmd160  bc93650019958e7af407ff93406401ceed37b42c \
+                    sha256  dba813b8b69d6218cffb11252b9e4e6036ca2c9d79843cde367b4b369aaf9634 \
+                    size    39452829
 
 if {${build_arch} eq "arm64"} {
     set release_arch aarch64


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
