### PR TITLE
jxrlib: Livecheck exclude beta versions

### DIFF
--- a/graphics/jxrlib/Portfile
+++ b/graphics/jxrlib/Portfile
@@ -38,5 +38,8 @@ patch.pre_args-replace \
 
 post-patch {
     reinplace       s|@VERSION@|${version}|g \
-                    ${worksrcpath}/CMakeLists.txt                    
+                    ${worksrcpath}/CMakeLists.txt
 }
+
+# Exclude beta versions.
+livecheck.regex     archive/refs/tags/(\[0-9.\]+)\.tar\.gz


### PR DESCRIPTION
##### Description

* Exclude beta versions from livecheck.
* Also one minor whitespace fix.

###### Type(s)

- [x] enhancement

###### Tested on

Tested livecheck only.
macOS 15.7.5
Xcode 16.2
Command Line Tools 16.4.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?