### PR TITLE
py-pandas: update to 3.0.3

### DIFF
--- a/python/py-pandas/Portfile
+++ b/python/py-pandas/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pandas
-version             2.3.3
+version             3.0.3
 revision            0
 categories-append   science
 license             BSD
@@ -20,25 +20,35 @@ long_description    {*}${description}
 
 homepage            https://pandas.pydata.org
 
-checksums           rmd160  24f8f1cd5a4be119b9a29d47a647ac002d06b0fc \
+checksums           rmd160  5c841389564178ecc05b6fb3891c9dcb49988b4e \
+                    sha256  696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc \
+                    size    4651414
+
+if {${name} ne ${subport}} {
+    if {${python.version} == 310} {
+        version     2.3.3
+        revision    0
+        checksums   rmd160  24f8f1cd5a4be119b9a29d47a647ac002d06b0fc \
                     sha256  e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b \
                     size    4495223
 
-if {${name} ne ${subport}} {
+        depends_lib-append  \
+                    port:py${python.version}-tz \
+                    port:py${python.version}-pytzdata
+    }
+
     depends_build-append \
                         port:py${python.version}-cython \
                         port:py${python.version}-versioneer \
                         port:py${python.version}-wheel
 
     depends_lib-append  port:py${python.version}-numpy \
-                        port:py${python.version}-dateutil \
-                        port:py${python.version}-tz \
-                        port:py${python.version}-pytzdata
+                        port:py${python.version}-dateutil
 
     # error: static_assert failed "Overflow checking not detected; please try a newer compiler"
     compiler.blacklist-append \
                 {clang < 800} *gcc-3.* *gcc-4.*
 
-    build.env-append    CYTHON=${prefix}/bin/cython-${python.branch}
-    build.env-append    PATH=${python.prefix}/bin:$::env(PATH)
+    build.env-append    CYTHON=${prefix}/bin/cython-${python.branch} \
+                        PATH=${python.prefix}/bin:$::env(PATH)
 }


### PR DESCRIPTION
#### Description
- update to latest upstream version
- pin to 2.3.3 for PY310 subport

###### Tested on
macOS 26.5 25F71 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?