### PR TITLE
py-cryptography: update to 48.0.0

### DIFF
--- a/python/py-cryptography/Portfile
+++ b/python/py-cryptography/Portfile
@@ -4,15 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        pyca cryptography 46.0.3
+github.setup        pyca cryptography 48.0.0
 github.tarball_from archive
 name                py-${github.project}
-revision            1
+revision            0
 categories-append   devel
 license             BSD
 
 python.versions     27 310 311 312 313 314
-python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -22,9 +21,9 @@ description         cryptography is a package designed to expose \
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  e5297136afc3e0672b59370b50bc2ffcf339a7fb \
-                    sha256  b40f9434d14affd208f03f4832aa616cb49e9ce414cb103825a8184eb94002f5 \
-                    size    36165201 \
+                    rmd160  202a568b99976a941e499234c27fec4217640671 \
+                    sha256  6afca628a004be66b3793481e02eb22ad4a067a052a6785c3736cc135dc7dc24 \
+                    size    58437275
 
 # See:
 # * https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst
@@ -98,118 +97,49 @@ if {${name} ne ${subport} \
     } else {
         PortGroup   rust 1.0
 
-        if { ${python.version} < 38 } {
-            github.setup    pyca cryptography 42.0.5
-            # Change github.tarball_from to 'releases' or 'archive' next update
-            github.tarball_from tarball
-            revision        0
-            checksums       ${distname}${extract.suffix} \
-                            rmd160  c5cdccb51bab89cb05abf0789878f51bbcca16c9 \
-                            sha256  0c2a89eca28bd8290d9b7764f0117fcc578df0341f235807d7bffb668ac595b2 \
-                            size    36020322
+        python.pep517_backend   maturin
+        openssl.branch  3
 
-            # Needs to use the same openssl version as python itself was built with...
-            # https://trac.macports.org/ticket/63968
-            openssl.branch  1.1
+        # https://github.com/pyca/cryptography/pull/14319
+        patchfiles-append   patch-setuptools_no_version.diff
 
-            cargo.crates \
-                        asn1 0.15.5 ae3ecbce89a22627b5e8e6e11d69715617138290289e385cde773b1fe50befdb \
-                        asn1_derive 0.15.5 861af988fac460ac69a09f41e6217a8fb9178797b76fcc9478444be6a59be19c \
-                        autocfg 1.1.0 d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
-                        base64 0.21.7 9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
-                        bitflags 1.3.2 bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-                        bitflags 2.4.2 ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf \
-                        cc 1.0.83 f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
-                        cfg-if 1.0.0 baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-                        foreign-types 0.3.2 f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
-                        foreign-types-shared 0.1.1 00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
-                        heck 0.4.1 95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
-                        indoc 2.0.4 1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
-                        libc 0.2.152 13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7 \
-                        lock_api 0.4.11 3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
-                        memoffset 0.9.0 5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
-                        once_cell 1.19.0 3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
-                        openssl 0.10.63 15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8 \
-                        openssl-macros 0.1.1 a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
-                        openssl-sys 0.9.99 22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae \
-                        parking_lot 0.12.1 3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
-                        parking_lot_core 0.9.9 4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
-                        pem 3.0.3 1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310 \
-                        pkg-config 0.3.29 2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb \
-                        portable-atomic 1.6.0 7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0 \
-                        proc-macro2 1.0.78 e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae \
-                        pyo3 0.20.3 53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233 \
-                        pyo3-build-config 0.20.3 deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7 \
-                        pyo3-ffi 0.20.3 62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa \
-                        pyo3-macros 0.20.3 7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158 \
-                        pyo3-macros-backend 0.20.3 7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185 \
-                        quote 1.0.35 291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
-                        redox_syscall 0.4.1 4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
-                        scopeguard 1.2.0 94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-                        self_cell 1.0.3 58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba \
-                        smallvec 1.13.1 e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7 \
-                        syn 2.0.48 0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f \
-                        target-lexicon 0.12.13 69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae \
-                        unicode-ident 1.0.12 3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
-                        unindent 0.2.3 c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce \
-                        vcpkg 0.2.15 accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
-                        windows-targets 0.48.5 9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
-                        windows_aarch64_gnullvm 0.48.5 2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
-                        windows_aarch64_msvc 0.48.5 dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
-                        windows_i686_gnu 0.48.5 a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
-                        windows_i686_msvc 0.48.5 8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
-                        windows_x86_64_gnu 0.48.5 53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
-                        windows_x86_64_gnullvm 0.48.5 0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
-                        windows_x86_64_msvc 0.48.5 ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538
-        } else {
-            python.pep517_backend   maturin
-            openssl.branch  3
+        # cd ${worksrcpath}/src/rust
+        # sudo cargo update
+        # egrep -e '^(name|version|checksum) = ' Cargo.lock | perl -pe 's/^(?:name|version|checksum) = "(.+)"/$1/' | tr '\n' ' ' | perl -pe 's|([0-9a-f]{64})|\1 \\\n|g' | pbcopy
 
-            # https://github.com/pyca/cryptography/pull/14319
-            patchfiles-append   patch-setuptools_no_version.diff \
-                                patch-pyproject-sdist-only-include.diff
-
-            # cd ${worksrcpath}/src/rust
-            # sudo cargo update
-            # egrep -e '^(name|version|checksum) = ' Cargo.lock | perl -pe 's/^(?:name|version|checksum) = "(.+)"/$1/' | tr '\n' ' ' | perl -pe 's|([0-9a-f]{64})|\1 \\\n|g' | pbcopy
-            cargo.crates \
-                        asn1 0.22.0 df42c2b01c5e1060b8281f67b4e5fb858260694916a667345a7305cd11e5dbfa \
-                        asn1_derive 0.22.0 cdccf849b54365e3693e9a90ad36e4482b79937e6373ac8e2cf229c985187b21 \
-                        autocfg 1.5.0 c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
-                        base64 0.22.1 72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
-                        bitflags 2.9.4 2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394 \
-                        cc 1.2.37 65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44 \
-                        cfg-if 1.0.3 2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9 \
-                        find-msvc-tools 0.1.1 7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d \
-                        foreign-types 0.3.2 f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
-                        foreign-types-shared 0.1.1 00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
-                        heck 0.5.0 2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
-                        indoc 2.0.6 f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd \
-                        itoa 1.0.15 4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c \
-                        libc 0.2.175 6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543 \
-                        memoffset 0.9.1 488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
-                        once_cell 1.21.3 42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
-                        openssl 0.10.74 24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654 \
-                        openssl-macros 0.1.1 a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
-                        openssl-sys 0.9.110 0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2 \
-                        pem 3.0.5 38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3 \
-                        pkg-config 0.3.32 7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c \
-                        portable-atomic 1.11.1 f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483 \
-                        proc-macro2 1.0.101 89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de \
-                        pyo3 0.26.0 7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383 \
-                        pyo3-build-config 0.26.0 4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f \
-                        pyo3-ffi 0.26.0 025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105 \
-                        pyo3-macros 0.26.0 2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded \
-                        pyo3-macros-backend 0.26.0 100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf \
-                        quote 1.0.40 1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
-                        self_cell 1.2.0 0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749 \
-                        shlex 1.3.0 0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
-                        syn 2.0.106 ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6 \
-                        target-lexicon 0.13.3 df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c \
-                        unicode-ident 1.0.19 f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d \
-                        unindent 0.2.4 7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3 \
-                        vcpkg 0.2.15 accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426
-        }
+        cargo.crates \
+            asn1 0.24.1 c9795210620c0cb3f9a7ce4f882808c38e1ef7b347c90591dceae0886e031fb1 \
+            asn1_derive 0.24.1 909e307f1cc32bb8bccbd98f446e6d1bf03fa30f7b53a4337da7181ad30fa11a \
+            base64 0.22.1 72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6 \
+            bitflags 2.11.1 c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3 \
+            cc 1.2.61 d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d \
+            cfg-if 1.0.4 9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801 \
+            find-msvc-tools 0.1.9 5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582 \
+            foreign-types 0.3.2 f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
+            foreign-types-shared 0.1.1 00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+            heck 0.5.0 2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
+            itoa 1.0.18 8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
+            libc 0.2.186 68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66 \
+            once_cell 1.21.4 9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50 \
+            openssl 0.10.79 bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542 \
+            openssl-macros 0.1.1 a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c \
+            openssl-sys 0.9.115 158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781 \
+            pem 3.0.6 1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
+            pkg-config 0.3.33 19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e \
+            portable-atomic 1.13.1 c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49 \
+            proc-macro2 1.0.106 8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934 \
+            pyo3 0.28.3 91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12 \
+            pyo3-build-config 0.28.3 e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e \
+            pyo3-ffi 0.28.3 7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e \
+            pyo3-macros 0.28.3 df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813 \
+            pyo3-macros-backend 0.28.3 c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb \
+            quote 1.0.45 41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924 \
+            self_cell 1.2.2 b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89 \
+            shlex 1.3.0 0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64 \
+            syn 2.0.117 e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99 \
+            target-lexicon 0.13.5 adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca \
+            unicode-ident 1.0.24 e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75 \
+            vcpkg 0.2.15 accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
 
         depends_build-append \
                     port:py${python.version}-setuptools-rust
@@ -235,23 +165,10 @@ foreach python_version ${python_versions_no27} {
         supported_archs noarch
         platforms       "darwin any >= ${cryptography_darwin_min_ver}"
 
-        if { ${python.version} >= 37 } {
-            depends_build-append    port:py${python.version}-uv-build
-            post-patch {
-                reinplace "s|<0.9.0|<1.0.0|g" ${worksrcpath}/vectors/pyproject.toml
-                reinplace "s|<0.10.0|<1.0.0|g" ${worksrcpath}/vectors/pyproject.toml
-            }
-        }
-
-        if { ${python.version} < 38 } {
-            github.setup    pyca cryptography 42.0.5
-            # Change github.tarball_from to 'releases' or 'archive' next update
-            github.tarball_from tarball
-            revision        0
-            checksums       ${distname}${extract.suffix} \
-                            rmd160  c5cdccb51bab89cb05abf0789878f51bbcca16c9 \
-                            sha256  0c2a89eca28bd8290d9b7764f0117fcc578df0341f235807d7bffb668ac595b2 \
-                            size    36020322
+        python.pep517_backend uv
+        post-patch {
+            reinplace "s|<0.9.0|<1.0.0|g" ${worksrcpath}/vectors/pyproject.toml
+            reinplace "s|<0.10.0|<1.0.0|g" ${worksrcpath}/vectors/pyproject.toml
         }
 
         build.dir   ${worksrcpath}/vectors


### PR DESCRIPTION
#### Description
- update to latest upstream version
- remove redundant code for EOL Python subports that have been removed

###### Tested on
macOS 26.5 25F71 x86_64
Xcode 26.5 17F42
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?