### PR TITLE
jsoncpp deps: Rev bumps for soname update

### DIFF
--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -597,7 +597,7 @@ array set modules {
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 12"
+        "revision 13"
         "License: "
     }
     qtwebglplugin {

--- a/devel/bamtools/Portfile
+++ b/devel/bamtools/Portfile
@@ -5,6 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        pezmaster31 bamtools 2.5.2 v
+revision            1
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
 

--- a/games/luanti/Portfile
+++ b/games/luanti/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 
 github.setup        luanti-org luanti 5.16.1
 github.tarball_from archive
-revision            0
+revision            1
 
 checksums           rmd160  a7749325921071c32feeaea0fbfed3445891cd77 \
                     sha256  57926752365a17d3bf64945ea04dc63cc446a8863037b043b97799af30126b6b \

--- a/games/pingus/Portfile
+++ b/games/pingus/Portfile
@@ -9,7 +9,7 @@ github.setup        Pingus pingus ad462706e5fc2cd5bf1cf99b2d90f88fe9e6de6e
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
 version             0.8.0-20180714
-revision            3
+revision            4
 categories          games
 maintainers         nomaintainer
 license             GPL-3

--- a/games/raceintospace/Portfile
+++ b/games/raceintospace/Portfile
@@ -7,7 +7,7 @@ PortGroup           boost 1.0
 
 github.setup        raceintospace raceintospace d004825458d9892fb168a9fbe026a9a38d397b04
 version             1.1-20200802
-revision            4
+revision            5
 checksums           rmd160  74767ef94b588f672c6c7eb4c0e78f4d46a2ea65 \
                     sha256  826fd4ec937aceb42f2942f6645661657fadd68f791d6f99de0d47789bd1b763 \
                     size    63707066

--- a/gnome/notekit/Portfile
+++ b/gnome/notekit/Portfile
@@ -7,6 +7,7 @@ PortGroup           meson 1.0
 
 github.setup        blackhole89 notekit ff37a8b9115bd3a023ca8c6d80ad923af8d9df8f
 version             2024.03.14
+revision            1
 categories          gnome sysutils
 license             MIT
 maintainers         nomaintainer

--- a/net/eiskaltdcpp/Portfile
+++ b/net/eiskaltdcpp/Portfile
@@ -8,7 +8,7 @@ PortGroup                   openssl 1.0
 
 github.setup                eiskaltdcpp eiskaltdcpp e1cad59efa20b892d3495385fd7b042e1c67c689
 version                     2.4.2-github-2024.10.25
-revision                    0
+revision                    1
 epoch                       1
 categories                  net p2p www
 license                     GPL-3

--- a/net/openvpn3/Portfile
+++ b/net/openvpn3/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 
 github.setup        OpenVPN openvpn3 3.11.6 release/
 github.tarball_from archive
-revision            0
+revision            1
 categories          net security
 maintainers         {i0ntempest @i0ntempest} openmaintainer
 license             AGPL-3

--- a/net/qpid-proton/Portfile
+++ b/net/qpid-proton/Portfile
@@ -8,7 +8,7 @@ PortGroup           cmake 1.1
 github.setup        apache qpid-proton 0.39.0
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            0
+revision            1
 
 description         Qpid Proton is a high-performance, lightweight AMQP \
                     1.0 messaging library.

--- a/science/gdcm/Portfile
+++ b/science/gdcm/Portfile
@@ -9,7 +9,7 @@ PortGroup               legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup            malaterre GDCM 3.2.5 v
-revision                0
+revision                1
 
 name                    gdcm
 categories              science graphics

--- a/science/gdcm2/Portfile
+++ b/science/gdcm2/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 
 name                    gdcm2
 version                 2.8.9
-revision                5
+revision                6
 categories              science graphics
 license                 BSD
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer

--- a/science/gds/Portfile
+++ b/science/gds/Portfile
@@ -7,7 +7,7 @@ PortGroup     python 1.0
 
 name          gds
 version       2.18.7
-revision      13
+revision      14
 categories    science
 platforms     darwin
 maintainers   nomaintainer

--- a/sysutils/sysdig/Portfile
+++ b/sysutils/sysdig/Portfile
@@ -7,7 +7,7 @@ PortGroup           cmake 1.0
 github.setup        draios sysdig 0.41.4
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            1
+revision            2
 maintainers         nomaintainer
 categories          sysutils
 description         ${name} is an open source system-level exploration and troubleshooting tool.


### PR DESCRIPTION
#### Description

* Rev bump dependents for jsoncpp update, soname change.
* Bump 13 ports.
* Skip 1 port, was already bumped.
* Skip 1 port which was set as known-fail.

*** Please squash commits on merge ***

###### Type(s)

- [x] update

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?