### PR TITLE
llvm-19: fix incompatibility with ocaml-findlib and macOS 26 libc++

### DIFF
--- a/lang/llvm-19/Portfile
+++ b/lang/llvm-19/Portfile
@@ -29,7 +29,7 @@ revision                2
 subport                 mlir-${llvm_version}  { revision 0 }
 subport                 clang-${llvm_version} { revision 3 }
 subport                 lldb-${llvm_version}  { revision 1 }
-subport                 flang-${llvm_version} { revision 1 }
+subport                 flang-${llvm_version} { revision 2 }
 
 checksums               rmd160  0d9c1aa3818178536a7949395b10c820c846239c \
                         sha256  82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501 \
@@ -76,7 +76,8 @@ configure.args-append \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_ENABLE_FFI=ON \
     -DFFI_INCLUDE_DIR=${prefix}/include \
-    -DFFI_LIBRARY_DIR=${prefix}/lib
+    -DFFI_LIBRARY_DIR=${prefix}/lib \
+    -DLLVM_ENABLE_BINDINGS=OFF
 
 # Remove for now. See https://trac.macports.org/ticket/70333
 # Probably need to detect when Xcode is available ...
@@ -289,6 +290,11 @@ if { ${subport} eq "flang-${llvm_version}" } {
         -DLIBCXX_INSTALL_LIBRARY=OFF
 
     depends_lib-append  port:clang-${llvm_version} port:mlir-${llvm_version}
+
+    # Apple SDK on macOS 26+ declares __libcpp_verbose_abort as noexcept but
+    # the flang runtime provides its own definition without noexcept.
+    # Backport the fix from LLVM 20 to match the SDK declaration.
+    patchfiles-append   0042-flang-runtime-verbose-abort-noexcept.patch
 
     # https://trac.macports.org/ticket/72954
     build.mem_per_job   4700

--- a/lang/llvm-19/files/0042-flang-runtime-verbose-abort-noexcept.patch
+++ b/lang/llvm-19/files/0042-flang-runtime-verbose-abort-noexcept.patch
@@ -1,0 +1,12 @@
+--- a/flang/runtime/io-api-minimal.cpp
++++ b/flang/runtime/io-api-minimal.cpp
+@@ -150,7 +150,8 @@ RT_EXT_API_GROUP_BEGIN
+ // Provide own definition for `std::__libcpp_verbose_abort` to avoid dependency
+ // on the version provided by libc++.
+
+-void std::__libcpp_verbose_abort(char const *format, ...) {
++void std::__libcpp_verbose_abort(char const *format, ...) noexcept(
++    noexcept(std::__libcpp_verbose_abort(""))) {
+   va_list list;
+   va_start(list, format);
+   std::vfprintf(stderr, format, list);


### PR DESCRIPTION
flang-19: Apple SDK on macOS 26 declares __libcpp_verbose_abort as noexcept, but the flang runtime provides its own definition without noexcept. Backport the fix from LLVM 20 via a patch.

clang-19: disable vendor availability annotations so LLVM's own libc++ does not depend on macOS 26-only declarations.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
