### PR TITLE
xmake: depend on port:git on macOS <10.12

### DIFF
--- a/devel/xmake/Portfile
+++ b/devel/xmake/Portfile
@@ -39,6 +39,14 @@ depends_build-append \
 
 depends_lib-append  port:ncurses
 
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    # "SSL certificate problem: Invalid certificate chain" on macOS <10.12
+    # Only use non-system Git on legacy systems
+    depends_build-append \
+                    path:bin/git:git
+    git.cmd         ${prefix}/bin/git
+}
+
 post-fetch {
     system -W ${worksrcpath} "git submodule update --init --recursive"
 }


### PR DESCRIPTION
https://build.macports.org/builders/ports-10.11_x86_64-builder/builds/322851/steps/install-port/logs/stdio

###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?