### PR TITLE
atuin: split out atuin-server subport

### DIFF
--- a/sysutils/atuin/Portfile
+++ b/sysutils/atuin/Portfile
@@ -10,14 +10,6 @@ revision            0
 
 homepage            https://atuin.sh/
 
-description         Magical shell history
-
-long_description    \
-    {*}${description}. Atuin replaces your existing shell history with a \
-    SQLite database, and records additional context for your commands. \
-    Additionally, it provides optional and fully encrypted synchronisation of \
-    your history between machines, via an Atuin server.
-
 categories          sysutils
 installs_libs       no
 license             MIT
@@ -29,44 +21,51 @@ checksums           ${distname}${extract.suffix} \
                     sha256  752802d4e8eef4896e9bc779b82f85e3d433c5934df5169e9b0f2537acf7f6e9 \
                     size    2990587
 
-set atuin_bin       ${worksrcpath}/target/[cargo.rust_platform]/release/${name}
-
 depends_build-append \
                     port:protobuf3-cpp
 
 cargo.offline_cmd
 
-post-build {
-    # Generate shell completions
-    file mkdir ${worksrcpath}/completions
+if {${subport} eq ${name}} {
+    description         Magical shell history
 
-    foreach _shell {bash fish zsh} {
-        system -W ${worksrcpath}/completions \
-            "${atuin_bin} gen-completions --shell ${_shell} > ${name}.${_shell}"
+    long_description    \
+        {*}${description}. Atuin replaces your existing shell history with a \
+        SQLite database, and records additional context for your commands. \
+        Additionally, it provides optional and fully encrypted synchronisation of \
+        your history between machines, via an Atuin server.
+
+    set atuin_bin       ${worksrcpath}/target/[cargo.rust_platform]/release/${name}
+
+    post-build {
+        # Generate shell completions
+        file mkdir ${worksrcpath}/completions
+
+        foreach _shell {bash fish zsh} {
+            system -W ${worksrcpath}/completions \
+                "${atuin_bin} gen-completions --shell ${_shell} > ${name}.${_shell}"
+        }
     }
-}
 
-destroot {
-    # Install atuin
-    xinstall -m 0755 ${atuin_bin} ${destroot}${prefix}/bin/
+    destroot {
+        # Install atuin
+        xinstall -m 0755 ${atuin_bin} ${destroot}${prefix}/bin/
 
-    # Install shell completions
-    xinstall -d -m 0755 ${destroot}${prefix}/share/bash-completion/completions
-    xinstall -m 0644 ${worksrcpath}/completions/${name}.bash \
-        ${destroot}${prefix}/share/bash-completion/completions/${name}
+        # Install shell completions
+        xinstall -d -m 0755 ${destroot}${prefix}/share/bash-completion/completions
+        xinstall -m 0644 ${worksrcpath}/completions/${name}.bash \
+            ${destroot}${prefix}/share/bash-completion/completions/${name}
 
-    xinstall -d -m 0755 ${destroot}${prefix}/share/fish/vendor_completions.d
-    xinstall -m 0644 ${worksrcpath}/completions/${name}.fish \
-        ${destroot}${prefix}/share/fish/vendor_completions.d/
+        xinstall -d -m 0755 ${destroot}${prefix}/share/fish/vendor_completions.d
+        xinstall -m 0644 ${worksrcpath}/completions/${name}.fish \
+            ${destroot}${prefix}/share/fish/vendor_completions.d/
 
-    xinstall -d -m 0755 ${destroot}${prefix}/share/zsh/site-functions
-    xinstall -m 0644 ${worksrcpath}/completions/${name}.zsh \
-        ${destroot}${prefix}/share/zsh/site-functions/_${name}
-}
+        xinstall -d -m 0755 ${destroot}${prefix}/share/zsh/site-functions
+        xinstall -m 0644 ${worksrcpath}/completions/${name}.zsh \
+            ${destroot}${prefix}/share/zsh/site-functions/_${name}
+    }
 
-github.livecheck.regex  {([\d.]+)}
-
-notes "
+    notes "
   To install atuin for zsh:
 
     $ echo 'eval \"\$(atuin init zsh)\"' >> ~/.zshrc
@@ -81,6 +80,35 @@ notes "
      $ echo 'eval \"\$(atuin init bash)\"' >> ~/.bashrc
 
 "
+}
+
+subport atuin-server {
+    description         Self-hosted sync server for atuin shell history
+
+    long_description    \
+        {*}${description}. Provides the atuin-server binary, which serves the \
+        encrypted record sync API consumed by atuin clients. The server was \
+        split out of the main atuin binary in atuin v18.12.0.
+
+    build.args-append   -p ${subport}
+
+    set atuin_server_bin \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${subport}
+
+    destroot {
+        xinstall -m 0755 ${atuin_server_bin} ${destroot}${prefix}/bin/
+    }
+
+    notes "
+  atuin-server reads its config from server.toml inside
+  \${ATUIN_CONFIG_DIR} (default: ~/.config/atuin/).
+
+  Bootstrap an example config:    atuin-server default-config
+  Start the server:               atuin-server start
+"
+}
+
+github.livecheck.regex  {([\d.]+)}
 
 cargo.crates \
     aead                             0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \


### PR DESCRIPTION
#### Description

Adds an `atuin-server` subport that builds and installs only the self-hosted sync server binary. The server was split out of the main `atuin` binary upstream in [atuin v18.12.0](https://github.com/atuinsh/atuin/releases/tag/v18.12.0):

> Important note for self-hosters: We've changed how the server works! Going forwards, the server is now a separate binary, rather than being bundled with the client.

- The `atuin` subport (default) is unchanged — same source, same destroot, same dependencies. Existing installs are not affected; revision stays 0.
- The new `atuin-server` subport reuses the same distfile and `cargo.crates` block, and builds only the `atuin-server` crate via `cargo build -p atuin-server`. Only the `atuin-server` binary is installed.
- No launchd plist in this PR; users run `atuin-server start` manually. Can be added in a follow-up PR if there is demand.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.3 17C529

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -vs install`?
- [x] tested basic functionality of all binary files?