### PR TITLE
vivid: ignore pre-releases in livecheck

### DIFF
--- a/sysutils/vivid/Portfile
+++ b/sysutils/vivid/Portfile
@@ -6,6 +6,7 @@ PortGroup           github  1.0
 
 github.setup        sharkdp vivid 0.11.1 v
 github.tarball_from archive
+github.livecheck.regex {([0-9.]+)}
 revision            0
 
 description         A themeable LS_COLORS generator with a rich filetype datebase


### PR DESCRIPTION
#### Description

Override `github.livecheck.regex` to `{([0-9.]+)}` so that pre-release tags (e.g. `v0.11.1-pre`) are no longer reported as new versions by `port livecheck`.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.3 17C529

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] verified the new regex with `port livecheck` (no false-positive for `v0.11.1-pre`).

Livecheck-only change; build/install/tests are unaffected.