### PR TITLE
cproto: update to 4.8

### DIFF
--- a/devel/cproto/Portfile
+++ b/devel/cproto/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                cproto
-version             4.7y
+version             4.8
 revision            0
 categories          devel
 maintainers         nomaintainer
@@ -22,9 +22,9 @@ master_sites        https://invisible-island.net/archives/${name}/ \
 
 extract.suffix      .tgz
 
-checksums           rmd160  ab56ba8c8b00f6ed94cd25102d065233a0a87cbf \
-                    sha256  0bd1d8be8ff0a4ca43f947f95750d34f64eda93c9e2ca79100fd60140b7c6331 \
-                    size    197318
+checksums           rmd160  e954dc247d5f47d6e52f783adf53e29613056699 \
+                    sha256  0cccb93447682c7fdb4f0bdbfbe05d52a827331e0a19a5215d2c3cb85ad29258 \
+                    size    198444
 
 depends_lib         port:flex
 depends_build       port:bison


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?