### PR TITLE
claude-code: update to 2.1.152

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.150
+version             2.1.152
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  d6893c41e77dfb5cffb5fd863a0c6a0a3ca31de6 \
-                 sha256  c66d5721df38cce82cde03d244f8fa92768125fe06e8d1d38d4bfbadaf4a8d17 \
-                 size    215584912
+    checksums    rmd160  6d2988d57e03ae378a6b700de51e706a9c8d15c7 \
+                 sha256  e9ecf8da70518a4ff852baf36c9eac369762a4568ba3cd5078fa894303e39735 \
+                 size    216724240
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  5f3f23aa21f54e6982aaf274c6db1a7797db83d8 \
-                 sha256  2f8413ea1083f108587940496a17057751344109d261fb4239ab2d45b2285c99 \
-                 size    213070752
+    checksums    rmd160  689bbd16cc1d2e865ae75532fe95d1996dbdca93 \
+                 sha256  43cb9361f7bc48c39214d5f125003b8de0ebde5cd6a1173e6b74fcdd10966d46 \
+                 size    214210080
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.152.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?