### PR TITLE
google-cloud-sdk: update to 570.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             569.0.0
+version             570.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  252483e74f2afaacc59930998c210457bdeb8c28 \
-                    sha256  0c5ad3326f656fc652b148b340c17db51a4e5d7b3fef7452c59ca07e4c15224e \
-                    size    58961452
+    checksums       rmd160  d1dec37a6aff6db9be8596093a0ee3f47bcf9e81 \
+                    sha256  1ce3c123de7f23000ca88ebbcc98f9fe9a5b6720c9daefd01cbfa1e17ff52b87 \
+                    size    58994281
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  de978fa2b5d5e9a762017f70a97bfc221369b479 \
-                    sha256  71b8b53fd4551d85314cddaa32543d5859d22e204a9732e466104dce396c1916 \
-                    size    60611121
+    checksums       rmd160  06be7277961d2c2de24dbbdb97ba29173d91b7cf \
+                    sha256  ad2aad8f8e03d06a69b4d0aea28938bb34bb41f152093bb8ca1f8c8b64ce66be \
+                    size    60652003
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  4bf995d2ff54d57130f6c3ef18d324b8ba3d7ba9 \
-                    sha256  1d725d5e587a91c7c0fee1e24940b7427333c52ca2c62666d8be5c24c3b09d42 \
-                    size    60511521
+    checksums       rmd160  cc33b8295f1b8d10671d9f3a3c750844a5a3938a \
+                    sha256  faf31849cb6737fe5a2d4e56ab7f3941ac7107908a7b6c9ba6099a4ac95fc66e \
+                    size    60553706
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 570.0.0.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?