### PR TITLE
mp3rgain: update to 2.7.3

### DIFF
--- a/audio/mp3rgain/Portfile
+++ b/audio/mp3rgain/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        M-Igashi mp3rgain 2.7.2 v
+github.setup        M-Igashi mp3rgain 2.7.3 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ long_description    ${name} is a modern Rust reimplementation of the classic \
                     aacgain port.
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  323018ca9c3c8f408ee47965b0de2f08deae4ea8 \
-                    sha256  0ef074ce77a2e499d975b4e797624fd58453ed1bf372de1d6c3e82d9c1ec36e0 \
-                    size    333542
+                    rmd160  8141aa539acb2f7960cf90552beec8226327dd0b \
+                    sha256  28e136b33217b5c30701232a532b382fa426fdd061ab5c10f9a421aee6fc6be4 \
+                    size    333449
 
 cargo.crates \
     adler2                       2.0.1            320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa \


### PR DESCRIPTION
Update `audio/mp3rgain` to version 2.7.3.

- Bumped `github.setup` to 2.7.3, reset `revision` to 0
- Recomputed rmd160 / sha256 / size for the v2.7.3 source tarball
- `cargo.crates` unchanged (no dependency updates since 2.7.2)

Release notes: https://github.com/M-Igashi/mp3rgain/releases/tag/v2.7.3