### PR TITLE
vte: update to 0.82.3 for recent and 0.76.6 for older OSes

### DIFF
--- a/gnome/vte/Portfile
+++ b/gnome/vte/Portfile
@@ -6,19 +6,41 @@ PortGroup           legacysupport 1.1
 PortGroup           meson 1.0
 
 gitlab.instance     https://gitlab.gnome.org
-gitlab.setup        GNOME vte 0.76.4
-revision            2
+
+# macOS versions using old Apple libc++ cannot build recent VTE.
+# VTE 0.83+ currently broken by https://github.com/GNOME/vte/commit/90fe47da9084ffc7d2cd71bb4fd2fbb5d9cab0bc
+# vtegtype.hh:137:10: error: '_g_type_once_init_type' does not name a type, etc.
+if {${os.platform} ne "darwin" || ${os.major} > 21 || ${configure.cxx_stdlib} ne "libc++"} {
+    gitlab.setup    GNOME vte 0.82.3
+    revision        0
+
+    checksums       rmd160  a559d242e4beda1c16d827b47ece24726b943f52 \
+                    sha256  9bfc61cd848345d9176f18e2c167446ca32ab8973f8f0bd9cfc2ec4a8d914c44 \
+                    size    672770
+
+    # base does not yet know about c++23 so manually blacklist certain Xcode clangs for now
+    compiler.cxx_standard   2023
+    compiler.blacklist-append {clang < 1600}
+} else {
+    gitlab.setup    GNOME vte 0.76.6
+    revision        0
+
+    checksums       rmd160  2a1e46391eccc48e8e3ce49c58c1a709a69490dd \
+                    sha256  b26441b8d0b1d87bdf5c4cd434bdc5350629b488048d199bd877b9e6102f55f0 \
+                    size    565933
+
+    compiler.cxx_standard   2020
+}
 
 categories          gnome
-license             LGPL
+license             LGPL-3+ GPL-3+
 maintainers         {devans @dbevans} {mascguy @mascguy} openmaintainer
 
 description         VTE is a library (libvte) implementing a terminal emulator widget for GTK+, \
                     and a minimal sample application (vte) using that.
 long_description    ${description} \
-                    Vte is mainly used in gnome-terminal, but can also be used to embed \
-                    a console/terminal in games, editors, IDEs, etc.
-homepage            https://wiki.gnome.org/Apps/Terminal/VTE
+                    VTE is mainly used in gnome-terminal, but can also be used to embed \
+                    a console/terminal in games, editors, IDEs, etcetera.
 
 set branch          [join [lrange [split $version .] 0 1] .]
 use_bzip2           yes
@@ -27,12 +49,12 @@ use_bzip2           yes
 legacysupport.newest_darwin_requires_legacy 16
 legacysupport.use_mp_libcxx                 yes
 
-checksums           rmd160  fcce3ff9b044853ed093dd6c304e5e9d5d766dea \
-                    sha256  09dfba043112066f8002bc37757dd6f70b346ff30ed30f0701bebb186e465565 \
-                    size    564972
-
 # Disable unexpected download of subprojects
 meson.wrap_mode     nodownload
+
+set py_ver          3.14
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+configure.python    ${prefix}/bin/python${py_ver}
 
 # Upstream doesn't (yet) support quieting compiler warnings via meson_options.txt,
 # so for now, patch meson.build to reduce the massive number of warnings.
@@ -41,37 +63,49 @@ patchfiles-append   patch-meson-warnings.diff
 # https://trac.macports.org/ticket/69963
 patchfiles-append   patch-F_DUPFD_CLOEXEC.diff
 
-depends_build-append \
-                    port:gettext \
-                    port:intltool \
-                    path:bin/vala:vala \
-                    path:bin/pkg-config:pkgconfig
+# This file appeared in 0.79.0:
+if {[vercmp ${version} >= 0.79.0]} {
+    post-patch {
+        reinplace -W ${worksrcpath} "s|/usr/bin/env python3|${configure.python}|" \
+            src/app/meson_desktopfile.py
+    }
+}
 
-depends_lib-append \
-                    path:lib/pkgconfig/cairo.pc:cairo \
+set libfmt_v        12
+configure.pkg_config_path-prepend \
+                    ${prefix}/lib/libfmt${libfmt_v}/pkgconfig
+
+depends_build-append \
+                    port:fast-float \
+                    port:gettext \
+                    path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
+                    port:intltool \
+                    path:bin/pkg-config:pkgconfig \
+                    port:python${py_ver_nodot} \
+                    path:bin/vala:vala
+
+# Python only needed for scripts
+depends_skip_archcheck-append \
+                    python${py_ver_nodot}
+
+depends_lib-append  path:lib/pkgconfig/cairo.pc:cairo \
+                    port:fribidi \
                     port:gettext-runtime \
+                    port:graphene \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
-                    path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
-                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
-                    port:fribidi \
                     path:lib/pkgconfig/icu-uc.pc:icu \
+                    port:libfmt${libfmt_v} \
                     port:lz4 \
                     path:lib/pkgconfig/pango.pc:pango \
                     port:pcre2 \
+                    port:simdutf \
                     port:zlib
 
-depends_run-append \
-                    port:adwaita-icon-theme
+depends_run-append  port:adwaita-icon-theme
 
-license_noconflict  vala
-
-# requires C++20
-compiler.cxx_standard 2020
-
-# base does not yet know about c++20 so manually blacklist Xcode clangs for now
-compiler.blacklist-append \
-                    clang
+compiler.c_standard 2011
+# compiler.cxx_standard set above, depending on the port version
 
 if {[vercmp $xcodeversion 4.3] < 0 && [string match "*macports*" ${configure.compiler}]} {
     # Xcode 4.2 fails with load commands in the newer toolchain
@@ -90,12 +124,22 @@ configure.args-append \
                     -Dgir=true \
                     -Dglade=false \
                     -Dgnutls=true \
-                    -Dgtk3=true \
+                    -Dgtk3=false \
                     -Dgtk4=false \
                     -Dvapi=true
 
+# Meson cannot figure out that it needs flags to use this -_-
+configure.cppflags-append \
+                    -I${prefix}/include/libfmt${libfmt_v}
+configure.ldflags-append \
+                    -L${prefix}/lib/libfmt${libfmt_v}
+
 configure.cflags-append \
                     -fstrict-aliasing
+
+# https://trac.macports.org/ticket/72780
+configure.cxxflags-append \
+                    -Wno-error=format
 
 variant docs description {Enable docs} {
     depends_build-append \
@@ -107,7 +151,7 @@ variant docs description {Enable docs} {
                     -Ddocs=true
 }
 
-variant glade description {Enable building of glade catalog items} {
+variant glade description "Enable building of glade catalog items" {
     depends_lib-append \
                     port:glade
 
@@ -116,8 +160,27 @@ variant glade description {Enable building of glade catalog items} {
                     -Dglade=true
 }
 
-# glade expects catalog modules and libraries to have a .so suffix
+variant gtk3 description "Build for GTK3" {
+    depends_lib-append \
+                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3
 
+    configure.args-replace \
+                    -Dgtk3=false \
+                    -Dgtk3=true
+}
+
+variant gtk4 description "Build for GTK4" {
+    depends_lib-append \
+                    path:lib/pkgconfig/gtk4.pc:gtk4
+
+    configure.args-replace \
+                    -Dgtk4=false \
+                    -Dgtk4=true
+}
+
+default_variants    +gtk3 +gtk4
+
+# glade expects catalog modules and libraries to have a .so suffix
 post-destroot {
     if {[variant_isset glade]} {
         set libdir ${prefix}/lib


### PR DESCRIPTION
#### Description
**vte**: update to latest (buildable) versions; inspired by @barracuda156 his [Portfile](https://github.com/macos-powerpc/powerpc-ports/blob/c8c183a3be164627a359831608cb7ab6a977c364/gnome/vte/Portfile#L10) but with some changes
- use Python 3.14
- update license
- correct/add dependencies and their types
- `gtk3` and `gtk4` variants do not conflict, build both of them by default so that dependents can just depend on the port instead of needing to use `active_variants` ; one could consider making them subports instead.

**simdutf**: new port, version 9.0.0


###### Tested on
macOS 26.5 25F71 x86_64
Xcode 26.5 17F42


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
