### PR TITLE
qgis3: add patch for `grass` variant

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -104,7 +104,8 @@ qt5.depends_component \
 patchfiles-append   patch-app_info_plist_in.diff \
                     patch-CMakelists_txt.diff \
                     patch-MacBundleMacros.cmake.diff \
-                    patch-SIPMacros.cmake.diff
+                    patch-SIPMacros.cmake.diff \
+                    patch-grass_utils_py.diff
 
 post-patch {
     reinplace -E "s|@PREFIX@|${prefix}|g" \

--- a/gis/qgis3/files/patch-grass_utils_py.diff
+++ b/gis/qgis3/files/patch-grass_utils_py.diff
@@ -1,0 +1,24 @@
+Addressed upstream: https://github.com/qgis/QGIS/pull/66256
+
+--- python/plugins/grassprovider/grass_utils.py.orig	2026-05-27 20:53:22
++++ python/plugins/grassprovider/grass_utils.py	2026-05-28 09:33:11
+@@ -127,13 +127,12 @@
+             startupinfo=si if isWindows() else None,
+         ) as proc:
+             try:
+-                lines = proc.stdout.readlines()
+-                for line in lines:
+-                    if "GRASS GIS " in line:
+-                        line = line.split(" ")[-1].strip()
+-                        if line.startswith("7.") or line.startswith("8."):
+-                            GrassUtils.version = line
+-                            return GrassUtils.version
++                line = proc.stdout.readline()
++                if "GRASS " in line:
++                    line = line.split(" ")[-1].strip()
++                    if line.startswith("7.") or line.startswith("8."):
++                        GrassUtils.version = line
++                        return GrassUtils.version
+             except Exception:
+                 pass
+ 


### PR DESCRIPTION
#### Description

The QGIS version checking of GRASS fails with GRASS 8.5, after project rebranding from 'GRASS GIS'  to 'GRASS', causing the GRASS processing algorithms to be disabled.

Closes: https://trac.macports.org/ticket/74042


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.3.1 25D2128 arm64
Xcode 26.4.1 17E202

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
