### PR TITLE
claude-code: update to 2.1.154

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.152
+version             2.1.154
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  6d2988d57e03ae378a6b700de51e706a9c8d15c7 \
-                 sha256  e9ecf8da70518a4ff852baf36c9eac369762a4568ba3cd5078fa894303e39735 \
-                 size    216724240
+    checksums    rmd160  79ab9a018a33d772b450299750a8dd53dd9ebb8b \
+                 sha256  1608d93261879201dcf77dd32dc173efbeea715187d3542fd05afcf7d5b5ec4d \
+                 size    217500304
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  689bbd16cc1d2e865ae75532fe95d1996dbdca93 \
-                 sha256  43cb9361f7bc48c39214d5f125003b8de0ebde5cd6a1173e6b74fcdd10966d46 \
-                 size    214210080
+    checksums    rmd160  39c10d5ef9501f118bd2622ab8cd5af41cb7d41e \
+                 sha256  bc9881b107d7be1743c64c8b72dd66798f5d0947dbc48ed0d77964c473661fd4 \
+                 size    214986144
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.154.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?