### PR TITLE
opencode: update to 1.15.12

### DIFF
--- a/llm/opencode/Portfile
+++ b/llm/opencode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                opencode
-version             1.15.11
+version             1.15.12
 revision            0
 
 categories          llm
@@ -28,6 +28,6 @@ homepage            https://opencode.ai
 
 npm.rootname        opencode-ai
 
-checksums           rmd160  f6f7a15d80a1cab38f27a7e4021f2115314e7b7f \
-                    sha256  f0e8911f1b3c73e5b04d3ea6180be21b24c139525782779ab199c77bedd2fc5c \
+checksums           rmd160  6c0db3820b6161b0316f35d7e96191e84d8c6704 \
+                    sha256  ec862cd599874843b23aa37df9399e22179aa3b6fcad4125ef157475e5ff5308 \
                     size    3043


### PR DESCRIPTION
#### Description

Update to OpenCode 1.15.12.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?