### PR TITLE
claude-code: update to 2.1.156

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.154
+version             2.1.156
 revision            0
 
 categories          llm
@@ -26,13 +26,13 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  79ab9a018a33d772b450299750a8dd53dd9ebb8b \
-                 sha256  1608d93261879201dcf77dd32dc173efbeea715187d3542fd05afcf7d5b5ec4d \
+    checksums    rmd160  c2f904a4dd182c925b93fa26a801faafab0961c2 \
+                 sha256  ccd608c694677324e24dec7d1253b51f887a7be838cdb75b22d5362c97351107 \
                  size    217500304
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  39c10d5ef9501f118bd2622ab8cd5af41cb7d41e \
-                 sha256  bc9881b107d7be1743c64c8b72dd66798f5d0947dbc48ed0d77964c473661fd4 \
+    checksums    rmd160  7778fca45b4168cf845f39eb010eba042718f35c \
+                 sha256  9c1e8601031f5cbb3101e49dda22bf8ba31183692c705e267a6923585fa2ba09 \
                  size    214986144
 } else {
     set arch_classifier unsupported_arch


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.156.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?