### PR TITLE
jxrlib: Update to 1.3.9

### DIFF
--- a/graphics/jxrlib/Portfile
+++ b/graphics/jxrlib/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        mircomir jxrlib 1.3.8
+github.setup        mircomir jxrlib 1.3.9
 revision            0
 categories          graphics
 license             BSD
 maintainers         nomaintainer
 github.tarball_from archive
 
-description         xrlib is JPEG XR Image Codec reference implementation library
+description         jxrlib is JPEG XR Image Codec reference implementation library
 
 long_description    {*}${description}
 
@@ -23,9 +23,9 @@ distfiles           [lindex ${distfiles} 0]:github_${github.author}
 patchfiles          0001-Add-ability-to-build-using-cmake.patch:github_Gcenx
 
 checksums           [lindex [split [lindex ${distfiles} 0] :] 0] \
-                    rmd160  e6b684ff788f495fcb92b90daf0d2385ce8815dd \
-                    sha256  ffa732bb7e64ae3c65bc497efa98d5253e1737754c3ff0a5998d73e073ac7e91 \
-                    size    349159
+                    rmd160  4dd43d05de66bd919c4930a02fdc539cc99d3ebc \
+                    sha256  123e04fe9e06d55b985d1a2a938761a7f7580743c717594787734e9bc657b9f6 \
+                    size    349105
 
 checksums-append    [lindex [split [lindex ${patchfiles} 0] :] 0] \
                     rmd160  b26417c2fc5adbbb8c91aca194826d0d09957ed4 \


### PR DESCRIPTION
#### Description

* Update jxrlib 1.3.8 --> 1.3.9.
* Closes https://trac.macports.org/ticket/74044
* Fix minor typo in description field.
* Note:  Stopping at jxrlib version 1.3.9.  New upstream version 1.4.0 is broken.

###### Type(s)

- [x] bugfix

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?