### PR TITLE
claude-code: update to 2.1.157

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.156
+version             2.1.157
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  c2f904a4dd182c925b93fa26a801faafab0961c2 \
-                 sha256  ccd608c694677324e24dec7d1253b51f887a7be838cdb75b22d5362c97351107 \
-                 size    217500304
+    checksums    rmd160  b80838474a08faa3a0d33da71fec01863aa503c2 \
+                 sha256  33b0e60e40351210f1bbb36a9478ce125474184ce0b6871f685f587f0be1b29a \
+                 size    217747984
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  7778fca45b4168cf845f39eb010eba042718f35c \
-                 sha256  9c1e8601031f5cbb3101e49dda22bf8ba31183692c705e267a6923585fa2ba09 \
-                 size    214986144
+    checksums    rmd160  0346048c71ac237438f5d0a98eac2087d3c7f7be \
+                 sha256  10f398510f0e6bd7c677ee25cfc698601bf8b1ec89658f823fa23a2f80a8a73f \
+                 size    215233824
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.157.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?