### PR TITLE
libxslt: add tracing and debugger variants

### DIFF
--- a/textproc/libxslt/Portfile
+++ b/textproc/libxslt/Portfile
@@ -66,9 +66,12 @@ variant doc description {Install extra documentation} {
     patchfiles-delete   no-doc.patch
 }
 
-variant debug description {Enable debug support} {
-    configure.cflags-append -O0 -g
-    configure.args-append --with-debugger
+variant tracing description {Enable debug tracing support} {
+    configure.args-append   --with-debug
+}
+
+variant debugger description {Enable debugger support} {
+    configure.args-append   --with-debugger
 }
     livecheck.type  gnome-with-unstable
 } else {


### PR DESCRIPTION
#### Description

The --with-debug flag enables verbose logging and --with-debugger enables the debugger. Both were enabled by default prior to 1.1.43.
    
The "debug" variant is renamed to avoid confusion with compiling in debug mode.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?