### PR TITLE
ralphex: update to 1.3.2

### DIFF
--- a/llm/ralphex/Portfile
+++ b/llm/ralphex/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/umputun/ralphex 1.2.0 v
+go.setup            github.com/umputun/ralphex 1.3.2 v
 revision            0
 categories          llm
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -19,9 +19,9 @@ build.pre_args-append \
                     TAG=v${version}
 build.args          build
 
-checksums           rmd160  3d744fa30c64a877a4e4f32ae6aa86bec49aed2c \
-                    sha256  9412ffc7aa02e49f7d8847022ea0fe99974a06e295ff6d544edba4c3ec56fb20 \
-                    size    8115586
+checksums           rmd160  6668267f9115ce8591cb9b2782b91fef82b0d359 \
+                    sha256  b04f5e72f3859a62d1e68bb5e46579ece3779e0e3dba95c80066bc3833e609e9 \
+                    size    8176854
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/.bin/ralphex.v${version} ${destroot}${prefix}/bin/ralphex


### PR DESCRIPTION
#### Description
https://github.com/umputun/ralphex/blob/v1.3.2/CHANGELOG.md

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
