### PR TITLE
goto: new port

### DIFF
--- a/net/goto/Portfile
+++ b/net/goto/Portfile
@@ -1,0 +1,161 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/grafviktor/goto 1.5.1 v
+revision            0
+categories          net
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+license             MIT
+
+description         A simple SSH manager
+long_description    {*}${description}
+
+build.cmd           make
+build.args          build
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/dist/gg ${destroot}${prefix}/bin/
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  d54c294141e0b6f341f6639148ad5e6e8150e582 \
+                        sha256  4a796167a6fdf00f1ebffe1551ac2415dc534abb16f670bb2e8f4aba12f29b5c \
+                        size    2167768
+
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.4.0 \
+                        rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
+                        sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
+                        size    73231 \
+                    golang.org/x/text \
+                        lock    v0.19.0 \
+                        rmd160  af0cec09324b1d808d0611d619778231686d31e6 \
+                        sha256  d79cf17861409d200e3399f2af049446ee18b20b21fce9433f789582100ddc42 \
+                        size    8972460 \
+                    golang.org/x/sys \
+                        lock    v0.30.0 \
+                        rmd160  4cd711df5da2e159b6efbb7fa42ae0a3a3f6eb53 \
+                        sha256  76cfe40018bfa5418c1d19d47d8353c3375594013e2b2feea49f06018d2a3102 \
+                        size    1523466 \
+                    golang.org/x/sync \
+                        lock    v0.11.0 \
+                        rmd160  5f5e2d8060a9e83ab2b46126f341c2cd2a101aac \
+                        sha256  9b21cdaa445f07a2bd1eeeed58189cfd1cce5bcc563d4c4fae4d7ac2713ef428 \
+                        size    18142 \
+                    github.com/stretchr/testify \
+                        lock    v1.8.4 \
+                        rmd160  8e1645055c9b1d8e117df7974034e74b7f600d27 \
+                        sha256  6d0a77075bbe0f8f1c0cbed51dd4d174579db976fef39d9ae6b500aab8917d6a \
+                        size    104469 \
+                    github.com/samber/lo \
+                        lock    v1.47.0 \
+                        rmd160  ab322694b466dd636e3533506f54b23700dc0d91 \
+                        sha256  32e101a43c8d53f7f0bae747e878358e6b991632b6fab2c84534335dd81e2cb1 \
+                        size    47642 \
+                    github.com/sahilm/fuzzy \
+                        lock    v0.1.1 \
+                        rmd160  21d296675b1d7a4e3b0e2e351b4af696d8eb94b6 \
+                        sha256  a72443cf2524f3698c9a62ed78a6a8f885c7504807b67808afe117d8049b9d99 \
+                        size    3353393 \
+                    github.com/rivo/uniseg \
+                        lock    v0.4.7 \
+                        rmd160  a9056dc9a2a80aa9c46d0ff9e54f9e2e5a498c41 \
+                        sha256  abc6a2f17b64b34b8a0c56eb9d0b53886ebbe0c88d467755c09c7fa696a16677 \
+                        size    458166 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/muesli/termenv \
+                        lock    v0.15.2 \
+                        rmd160  92510cd14a2e3c0e723b77064fc1e3a51e5c3666 \
+                        sha256  bd0a1109c77528f0c1310814758ebf283a29c79df2eb9cc4e506d31afc41eb08 \
+                        size    422810 \
+                    github.com/muesli/cancelreader \
+                        lock    v0.2.2 \
+                        rmd160  cbc757f0d680959cea46000a5dd74e63ddbb8a15 \
+                        sha256  33f793cd6fbf7733ed7cba381920606b4917ba472148f85a5fd0965477146fc8 \
+                        size    9431 \
+                    github.com/muesli/ansi \
+                        lock    276c6243b2f6 \
+                        rmd160  bbc37c92ce2b54f538eb0d5f32edefd7074d540a \
+                        sha256  0b4beac5757eb25d0c45f9f931e2b241168e16c2bd58d21e5aafce7e33c669ee \
+                        size    5249 \
+                    github.com/mattn/go-runewidth \
+                        lock    v0.0.16 \
+                        rmd160  297825c4365b5f723ae485e726259ebb620ecd66 \
+                        sha256  6c9e81a6b46220612b97ebc35e8d29d1907fd225a9ce3e40b7cebd64cc58d09c \
+                        size    18496 \
+                    github.com/mattn/go-localereader \
+                        lock    v0.0.1 \
+                        rmd160  7afdbbc0f4978c6f54c25df0d86ff3c66db19ce2 \
+                        sha256  75a68e82a83b37aee40ad81dfcfce54d2f999945282bb198add16a49b8ec7f46 \
+                        size    1738 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.20 \
+                        rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
+                        sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
+                        size    4717 \
+                    github.com/lucasb-eyer/go-colorful \
+                        lock    v1.2.0 \
+                        rmd160  a4183d0625e6c94474942cdc544c1061d35c4e34 \
+                        sha256  fbad1aade4444bf51409f5b6a008cc14c7a7cdd1af856841fc1170605fae3914 \
+                        size    970841 \
+                    github.com/erikgeiser/coninput \
+                        lock    1c3628e74d0f \
+                        rmd160  77744cb442933c6c38c33aa830419834ba8e0ed6 \
+                        sha256  39ca6afc6b66e6c6a1772b497fdd0bb97471fac341c966fcae14ff6019629638 \
+                        size    8951 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
+                    github.com/charmbracelet/x/term \
+                        lock    term/v0.2.1 \
+                        rmd160  9b421c7662beb66fb61e79380038326ebc3633bd \
+                        sha256  5f9b486ad633575d90f003c9e7772076cb6289269bbd1d1ec224ae3d5f992358 \
+                        size    146770 \
+                    github.com/charmbracelet/x/ansi \
+                        lock    ansi/v0.8.0 \
+                        rmd160  7b44d4324c7ce054a0c9a47e4e5983e4819cb7c6 \
+                        sha256  a26409ce7068276b666a2dc74279a653f6495db8e5c847cd79ca33db26ed720b \
+                        size    236985 \
+                    github.com/charmbracelet/lipgloss \
+                        lock    v1.0.0 \
+                        rmd160  b4a8052a00570c33d05585d87b28a5e0c2f8a855 \
+                        sha256  d4539b433ef3156c3ba85bab9a3bf97a61c8a4cc1f409050b00ebfe08bb98b01 \
+                        size    77872 \
+                    github.com/charmbracelet/bubbletea \
+                        lock    v1.3.3 \
+                        rmd160  fb4a30dae12b3cc5f13f713fb8746f2e80a7d767 \
+                        sha256  6f9b8842761fd9ca03d23f315c89a6e90b8df3c22dd9375e7eab59f2d31ae186 \
+                        size    2187413 \
+                    github.com/charmbracelet/bubbles \
+                        lock    v0.20.0 \
+                        rmd160  51f43b7a0ef9ce31d129937ace6340fd0f06d32a \
+                        sha256  9f0f4ba39bf8fe1280fe240785f86554fdfbb4a9800ca6ca97cb54ae7149976d \
+                        size    73364 \
+                    github.com/caarlos0/env/v10 \
+                        lock    v10.0.0 \
+                        rmd160  b768a2c099c41007a1152112f191a79213743f47 \
+                        sha256  c08ae73739476b60c98baa93d974462fa130145793efd179a649856faca2a009 \
+                        size    22062 \
+                    github.com/aymanbagabas/go-osc52/v2 \
+                        lock    v2.0.1 \
+                        rmd160  8669f2bdcf2704bbc8df6af7e5fd396215737b9b \
+                        sha256  0904dc990e2f1e5bbe290e02f418940def4168b63e36914e3bf76ff2ac1fb2a5 \
+                        size    5889 \
+                    github.com/atotto/clipboard \
+                        lock    v0.1.4 \
+                        rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \
+                        sha256  6d474bab7ef589dd95a56d6fd571d447fdfbcc8c1985b7b4841cfa98edc0a97f \
+                        size    5023


### PR DESCRIPTION
#### Description
[**goto**](https://github.com/grafviktor/goto) - a simple SSH manager.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
