### PR TITLE
GPXSee: update to 16.7

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 16.6
+github.setup        tumic0 GPXSee 16.7
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  18e5b324186b3f8b060b39e1ce012a5595a664db \
-                    sha256  e3320650a28ed2a45a583513f79e71c333d6010c93f7341843066f31d7096329 \
-                    size    6578429
+checksums           rmd160  2d6d40ee9353f05466221377430de07477cc805e \
+                    sha256  9b75b392464d4a00b69a7c7633893ed1a77e7cdb2075b693957ba939235d371a \
+                    size    6580001
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
