### PR TITLE
jxrlib: Update to 1.4.0

### DIFF
--- a/graphics/jxrlib/Portfile
+++ b/graphics/jxrlib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        mircomir jxrlib 1.3.9
+github.setup        mircomir jxrlib 1.4.0
 revision            0
 categories          graphics
 license             BSD
@@ -15,22 +15,11 @@ description         jxrlib is JPEG XR Image Codec reference implementation libra
 
 long_description    {*}${description}
 
-master_sites        ${github.master_sites}:github_${github.author} \
-                    https://raw.githubusercontent.com/Gcenx/macports-wine/1b310a17497f9a49cc82789cc5afa2d22bb67c0c/graphics/jxrlib/files:github_Gcenx
+patchfiles          0001-Add-ability-to-build-using-cmake.patch
 
-distfiles           [lindex ${distfiles} 0]:github_${github.author}
-
-patchfiles          0001-Add-ability-to-build-using-cmake.patch:github_Gcenx
-
-checksums           [lindex [split [lindex ${distfiles} 0] :] 0] \
-                    rmd160  4dd43d05de66bd919c4930a02fdc539cc99d3ebc \
-                    sha256  123e04fe9e06d55b985d1a2a938761a7f7580743c717594787734e9bc657b9f6 \
-                    size    349105
-
-checksums-append    [lindex [split [lindex ${patchfiles} 0] :] 0] \
-                    rmd160  b26417c2fc5adbbb8c91aca194826d0d09957ed4 \
-                    sha256  beebe13d40bc5b0ce645db26b3c8f8409952d88495bbab8bc3bebc954bdecffe \
-                    size    6857
+checksums           rmd160  aea547d6890b8183984c267d192a7f28a12c535a \
+                    sha256  5cd7571fe621549b52c1fd64ab2309e3d04de95e6f1ad3f749230a95022efc4e \
+                    size    352072
 
 patch.pre_args-replace \
                     -p0 \
@@ -41,5 +30,5 @@ post-patch {
                     ${worksrcpath}/CMakeLists.txt
 }
 
-# Exclude beta versions.
+# Exclude pre-release versions.
 livecheck.regex     archive/refs/tags/(\[0-9.\]+)\.tar\.gz

--- a/graphics/jxrlib/files/0001-Add-ability-to-build-using-cmake.patch
+++ b/graphics/jxrlib/files/0001-Add-ability-to-build-using-cmake.patch
@@ -1,0 +1,223 @@
+Manually updated 2026 May 30, by Dave Allured for MacPorts
+For version 1.4.0 update to github.com/mircomir/jxrlib
+Add new C source file: sys/memory_lim.c
+
+Original 0001 patch file was from old version of github.com/Gcenx/macports-wine:
+https://raw.githubusercontent.com/Gcenx/macports-wine/1b310a17497f9a49cc82789cc5afa2d22bb67c0c/graphics/jxrlib/files/0001-Add-ability-to-build-using-cmake.patch
+See macports-ports history for jxrlib/Portfile.
+===============================================
+
+From 68a6e95de65ba6c6774586b73902eb8f47836f92 Mon Sep 17 00:00:00 2001
+From: Dean M Greer <gcenx83@gmail.com>
+Date: Tue, 24 Feb 2021 21:07:30 -0400
+Subject: [PATCH] Add ability to build using cmake
+
+---
+ CMakeLists.txt  | 142 ++++++++++++++++++++++++++++++++++++++++++++++++
+ JoinPaths.cmake |  26 +++++++++
+ jxrlib.pc.in    |  12 ++++
+ 3 files changed, 180 insertions(+)
+ create mode 100644 CMakeLists.txt
+ create mode 100644 JoinPaths.cmake
+ create mode 100644 jxrlib.pc.in
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..2d6cfac
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,142 @@
++# Copyright Mathieu Malaterre <malat@debian.org>
++# BSD (Same as jxrlib)
++# Based on https://jxrlib.codeplex.com/discussions/440294
++cmake_minimum_required(VERSION 2.8)
++project(jxrlib C)
++
++# Need shared libs for ABI
++set(BUILD_SHARED_LIBS ON)
++
++# helper macro to preserve original Makefile convention
++macro(JXR_MAKE_OBJ SET_NAME)
++  foreach(src ${SRC_${SET_NAME}})
++    list(APPEND OBJ_${SET_NAME} ${DIR_${SET_NAME}}/${src})
++  endforeach()
++endmacro()
++
++if(NOT MSVC)
++  add_definitions(-D__ANSI__)
++  add_compile_options(-Wno-error=implicit-function-declaration)
++endif()
++
++include(TestBigEndian)
++test_big_endian(ISBIGENDIAN)
++if(ISBIGENDIAN)
++  set(DEF_ENDIAN _BIG__ENDIAN_)
++endif()
++
++set(DIR_SYS image/sys)
++set(DIR_DEC image/decode)
++set(DIR_ENC image/encode)
++
++set(DIR_GLUE jxrgluelib)
++set(DIR_TEST jxrtestlib)
++set(DIR_EXEC jxrencoderdecoder)
++
++set(VERSION "@VERSION@")
++set(SOVERSION "0")
++
++if(NOT JXRLIB_INSTALL_BINDIR)
++  set(JXRLIB_INSTALL_BINDIR "bin")
++endif()
++
++if(NOT JXRLIB_INSTALL_LIBDIR)
++  set(JXRLIB_INSTALL_LIBDIR "lib")
++endif()
++
++if(NOT JXRLIB_INSTALL_INCLUDEDIR)
++  set(JXRLIB_INSTALL_INCLUDEDIR "include/jxrlib")
++endif()
++
++include_directories(
++  common/include
++  ${DIR_SYS}
++  ${DIR_GLUE}
++  ${DIR_TEST}
++)
++
++# JPEG-XR
++set(SRC_SYS adapthuff.c image.c memory_lim.c strcodec.c strPredQuant.c strTransform.c perfTimerANSI.c)
++JXR_MAKE_OBJ(SYS)
++set(SRC_DEC decode.c postprocess.c segdec.c strdec.c strInvTransform.c strPredQuantDec.c JXRTranscode.c)
++JXR_MAKE_OBJ(DEC)
++set(SRC_ENC encode.c segenc.c strenc.c strFwdTransform.c strPredQuantEnc.c)
++JXR_MAKE_OBJ(ENC)
++
++add_library(jpegxr ${OBJ_ENC} ${OBJ_DEC} ${OBJ_SYS})
++set_property(TARGET jpegxr
++  PROPERTY COMPILE_DEFINITIONS __ANSI__ DISABLE_PERF_MEASUREMENT ${DEF_ENDIAN}
++)
++set_property(TARGET jpegxr PROPERTY LINK_INTERFACE_LIBRARIES "")
++set_property(TARGET jpegxr PROPERTY COMPILE_FLAGS -w)
++set_property(TARGET jpegxr PROPERTY VERSION ${VERSION})
++set_property(TARGET jpegxr PROPERTY SOVERSION ${SOVERSION})
++install(TARGETS jpegxr
++  EXPORT JXRLibTargets
++  RUNTIME DESTINATION ${JXRLIB_INSTALL_BINDIR} COMPONENT Applications
++  LIBRARY DESTINATION ${JXRLIB_INSTALL_LIBDIR} COMPONENT Libraries
++)
++
++#¬†JXR-GLUE
++set(SRC_GLUE JXRGlue.c JXRMeta.c JXRGluePFC.c JXRGlueJxr.c)
++JXR_MAKE_OBJ(GLUE)
++set(SRC_TEST JXRTest.c JXRTestBmp.c JXRTestHdr.c JXRTestPnm.c JXRTestTif.c JXRTestYUV.c)
++JXR_MAKE_OBJ(TEST)
++
++add_library(jxrglue ${OBJ_GLUE} ${OBJ_TEST})
++set_property(TARGET jxrglue
++  PROPERTY COMPILE_DEFINITIONS __ANSI__ DISABLE_PERF_MEASUREMENT ${DEF_ENDIAN}
++)
++set_property(TARGET jxrglue PROPERTY COMPILE_FLAGS -w)
++set_property(TARGET jxrglue PROPERTY VERSION ${VERSION})
++set_property(TARGET jxrglue PROPERTY SOVERSION ${SOVERSION})
++install(TARGETS jxrglue
++  EXPORT JXRLibTargets
++  RUNTIME DESTINATION ${JXRLIB_INSTALL_BINDIR} COMPONENT Applications
++  LIBRARY DESTINATION ${JXRLIB_INSTALL_LIBDIR} COMPONENT Libraries
++)
++
++target_link_libraries(jxrglue PRIVATE jpegxr m)
++
++# Enc app files
++set(ENCAPP JxrEncApp)
++add_executable(${ENCAPP} ${DIR_EXEC}/${ENCAPP}.c)
++set_property(TARGET ${ENCAPP}
++  PROPERTY COMPILE_DEFINITIONS __ANSI__ DISABLE_PERF_MEASUREMENT ${DEF_ENDIAN}
++)
++set_property(TARGET ${ENCAPP} PROPERTY COMPILE_FLAGS -w)
++target_link_libraries(${ENCAPP} jxrglue) # jpegxr)
++install(TARGETS ${ENCAPP} RUNTIME DESTINATION ${JXRLIB_INSTALL_BINDIR})
++
++# Dec app files
++set(DECAPP JxrDecApp)
++add_executable(${DECAPP} ${DIR_EXEC}/${DECAPP}.c)
++set_property(TARGET ${DECAPP}
++  PROPERTY COMPILE_DEFINITIONS __ANSI__ DISABLE_PERF_MEASUREMENT ${DEF_ENDIAN}
++)
++set_property(TARGET ${DECAPP} PROPERTY COMPILE_FLAGS -w)
++target_link_libraries(${DECAPP} jxrglue) # jpegxr)
++install(TARGETS ${DECAPP} RUNTIME DESTINATION ${JXRLIB_INSTALL_BINDIR})
++
++# Generate pkgconfig file
++include(JoinPaths.cmake)
++join_paths(JXRLIB_PKGCONF_LIBDIR "\${prefix}" "${JXRLIB_INSTALL_LIBDIR}")
++join_paths(JXRLIB_PKGCONF_INCLUDEDIR "\${prefix}" "${JXRLIB_INSTALL_INCLUDEDIR}")
++configure_file(
++    "${PROJECT_SOURCE_DIR}/jxrlib.pc.in"
++    ${PROJECT_BINARY_DIR}/jxrlib.pc
++    @ONLY
++)
++install(
++    FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc
++    DESTINATION ${JXRLIB_INSTALL_LIBDIR}/pkgconfig
++)
++
++# install rules
++install(FILES jxrgluelib/JXRGlue.h jxrgluelib/JXRMeta.h jxrtestlib/JXRTest.h
++  image/sys/windowsmediaphoto.h
++  DESTINATION ${JXRLIB_INSTALL_INCLUDEDIR} COMPONENT Headers
++)
++install(DIRECTORY common/include/ DESTINATION ${JXRLIB_INSTALL_INCLUDEDIR}
++  FILES_MATCHING PATTERN "*.h"
++)
+diff --git a/JoinPaths.cmake b/JoinPaths.cmake
+new file mode 100644
+index 0000000..a767270
+--- /dev/null
++++ b/JoinPaths.cmake
+@@ -0,0 +1,26 @@
++# This module provides a function for joining paths
++# known from most languages
++#
++# SPDX-License-Identifier: (MIT OR CC0-1.0)
++# Copyright 2020 Jan Tojnar
++# https://github.com/jtojnar/cmake-snips
++#
++# Modelled after Python‚Äôs os.path.join
++# https://docs.python.org/3.7/library/os.path.html#os.path.join
++# Windows not supported
++function(join_paths joined_path first_path_segment)
++    set(temp_path "${first_path_segment}")
++    foreach(current_segment IN LISTS ARGN)
++        if(NOT ("${current_segment}" STREQUAL ""))
++            string(REGEX REPLACE "^${CMAKE_INSTALL_PREFIX}/?" "" new_segment "${current_segment}")
++            if(NOT ("${new_segment}" STREQUAL ""))
++                if(NOT IS_ABSOLUTE "${current_segment}" OR NOT "${current_segment}" MATCHES "^${new_segment}$")
++                    set(temp_path "${temp_path}/${new_segment}")
++                else()
++                    set(temp_path "${current_segment}")
++                endif()
++            endif()
++        endif()
++    endforeach()
++    set(${joined_path} "${temp_path}" PARENT_SCOPE)
++endfunction()
+diff --git a/jxrlib.pc.in b/jxrlib.pc.in
+new file mode 100644
+index 0000000..be9170c
+--- /dev/null
++++ b/jxrlib.pc.in
+@@ -0,0 +1,12 @@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=${prefix}
++libdir=@JXRLIB_PKGCONF_LIBDIR@
++includedir=@JXRLIB_PKGCONF_INCLUDEDIR@
++
++Name: jxrlib
++Description: A library for reading JPEG XR images.
++
++Version: @VERSION@
++Libs: -L${libdir} -ljpegxr -ljxrglue
++Libs.private: -lm
++Cflags: -I${includedir} -D__ANSI__ -DDISABLE_PERF_MEASUREMENT
+--
+2.24.3 (Apple Git-128)


### PR DESCRIPTION
#### Description

* Update jxrlib 1.3.9 --> 1.4.0.
* Bring remote patch file to local, and update for code change.
* Simplify port file because remote dependency was eliminated.

*** Please squash commits on merge ***

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?