### PR TITLE
mvnd1: update to 1.0.6

### DIFF
--- a/java/mvnd1/Portfile
+++ b/java/mvnd1/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup select 1.0
 
-version         1.0.5
+version         1.0.6
 revision        0
 name            mvnd1
 categories      java
@@ -44,14 +44,14 @@ select.file     ${filespath}/${name}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier amd64
-    checksums       rmd160  75e8eb9abe427ac173ee074cb437a997e595a4f3 \
-                    sha256  5269ad9e5093c249108cecdee2c4a65aec3607ea827b64b1aeb8d7f842901ca5 \
-                    size    23394726
+    checksums       rmd160  0384f16a91214228cb60cb5e28831c7db61ca58b \
+                    sha256  8202c79bad529d519461b61d8db3f17de5731d3b47b45d294d4df84b346555ed \
+                    size    23490551
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier aarch64
-    checksums       rmd160  7502a9f4d21f80eefcc2b64323d6a42e250bf00c \
-                    sha256  43ca368cc7dcd4439a8565fcbd4c58aecebfb5e4fb0f6ec220d00d82410f7d9c \
-                    size    23512324
+    checksums       rmd160  89c8ed780c73d4a966d6b201defb946cee4429cd \
+                    sha256  371f008b91ff6ec54e960935974f3868ee7f18195a0ec874940d58353d8b2796 \
+                    size    23613514
 } else {
     set arch_classifier unsupported_arch
 }


### PR DESCRIPTION
#### Description

Update to Maven Daemon 1.0.6.

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?