### PR TITLE
wine-devel,staging: Update to 11.10

### DIFF
--- a/emulators/wine-devel/Portfile
+++ b/emulators/wine-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup                   muniversal 1.1
 
 # Keep the wine-stable, wine-devel and wine-crossover portfiles as similar as possible.
 
-github.setup                wine-mirror wine 11.9 wine-
+github.setup                wine-mirror wine 11.10 wine-
 github.tarball_from         archive
 name                        wine-devel
 conflicts                   wine-stable wine-staging wine-crossover
@@ -35,9 +35,9 @@ long_description \
 
 checksums \
     ${distname}${extract.suffix} \
-    rmd160  5b94a101d016af99a329e9dcb68650d4e120a3b9 \
-    sha256  453f287e2fb9e4d94efd283888942a687224f93d0f373e215e17cff6fbbce867 \
-    size    73782223
+    rmd160  f7520f6235bb44486d71232c00962760c6984f23 \
+    sha256  2b397723540418de950f4ebceb0d853369e947cb0aa83fe0404e5f21c9332cbf \
+    size    73914941
 
 depends_build \
     port:bison \
@@ -135,9 +135,9 @@ subport wine-staging {
 
     checksums-append \
         ${wine_staging_distfile} \
-        rmd160  9af7d04dec2aa4b2cd7dfc6810510dfd1593fc78 \
-        sha256  fd953f5d78473a58f77140912b57bcdd60a78a7982cac919bf62988be8d514fa \
-        size    9323349
+        rmd160  628a92c7c250e57cd5839b418b2a5eacae4676ed \
+        sha256  102b9d401d9286a654eb437fdd68b02bd4c007532a203dea66367e55e7287e89 \
+        size    9259352
 
     depends_patch-append    port:autoconf
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
