### PR TITLE
ocaml-lambda-term: update to 3.4.0

### DIFF
--- a/ocaml/ocaml-lambda-term/Portfile
+++ b/ocaml/ocaml-lambda-term/Portfile
@@ -5,8 +5,9 @@ PortGroup           github 1.0
 PortGroup           ocaml 1.1
 
 name                ocaml-lambda-term
-github.setup        ocaml-community lambda-term 3.3.2
-revision            1
+github.setup        ocaml-community lambda-term 3.4.0
+github.tarball_from archive
+revision            0
 categories          ocaml devel editors
 maintainers         nomaintainer
 license             BSD
@@ -14,10 +15,9 @@ description         Cross-platform library for manipulating the terminal
 long_description    Lambda-Term is a cross-platform library for manipulating the terminal. It provides \
                     an abstraction for keys, mouse events, colors, as well as a set of widgets to write curses-like applications.
 
-checksums           rmd160  6c814b1b86d606f280321f3d3ea9bda96f9c0416 \
-                    sha256  2d44f56d23db7ac56192f0e4f8b7b5c3d46d6c7e32e82cd112921c2fffeb5549 \
-                    size    142574
-github.tarball_from archive
+checksums           rmd160  f62f10b9b29fc4c8c600c237ce7f14665a472937 \
+                    sha256  5f11f5c4f2bfd448c647aa41b4709f06d02225e4f05e1a7d20754c0614454031 \
+                    size    142784
 
 depends_lib-append  port:ocaml-logs \
                     port:ocaml-lwt \


### PR DESCRIPTION
No .mli interface changes: no revision bump needed for ocaml-utop

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
