### PR TITLE
llmfit: update to 0.9.29

### DIFF
--- a/llm/llmfit/Portfile
+++ b/llm/llmfit/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo 1.0
 
-github.setup            AlexsJones llmfit 0.9.27 v
+github.setup            AlexsJones llmfit 0.9.29 v
 github.tarball_from     archive
 revision                0
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  55927f4507df321ae1c6baf5f926c42ba953e0dd \
-                        sha256  5a3df0e9e76586ceb459b6266e717ebe76aac506a07ae24ccae0f79934d4d812 \
-                        size    3292424
+                        rmd160  73dab0562e0ed93d48821e5bb4bc2e4cdfbb92c0 \
+                        sha256  7949480d03849e5b05aec61c85c107daeb415de58af4097d17aed905c2a156be \
+                        size    3448613
 
 categories              llm
 platforms               macosx
@@ -481,8 +481,8 @@ cargo.crates \
     tao                             0.35.2  a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4 \
     tao-macros                       0.1.3  f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd \
     target-lexicon                 0.12.16  61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1 \
-    tauri                           2.11.0  d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66 \
-    tauri-build                      2.6.0  be9aa8c59a894f76c29a002501c589de5eb4987a5913d62a6e0a47f320901988 \
+    tauri                           2.11.2  437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28 \
+    tauri-build                      2.6.2  4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7 \
     tauri-codegen                    2.6.2  e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9 \
     tauri-macros                     2.6.2  ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924 \
     tauri-runtime                   2.11.2  48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef \
@@ -504,7 +504,7 @@ cargo.crates \
     time-core                        0.1.8  7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca \
     time-macros                     0.2.27  2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215 \
     tinystr                          0.8.3  c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d \
-    tokio                           1.52.2  110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386 \
+    tokio                           1.52.3  8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe \
     tokio-macros                     2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-rustls                    0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                    0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
