### PR TITLE
gdal, py-gdal: update to 3.13.0, backport plugin loading fix

### DIFF
--- a/R/R-gdalBindings/Portfile
+++ b/R/R-gdalBindings/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran caiohamamura gdalBindings 0.1.17
-revision            5
+revision            6
 categories-append   gis
 maintainers         nomaintainer
 license             GPL-3

--- a/R/R-gdalraster/Portfile
+++ b/R/R-gdalraster/Portfile
@@ -5,7 +5,7 @@ PortGroup           R 1.0
 
 # Revert to GitHub once updated there.
 R.setup             cran USDAForestService gdalraster 1.11.1 v
-revision            4
+revision            5
 categories-append   gis
 maintainers         nomaintainer
 license             MIT

--- a/R/R-mlr/Portfile
+++ b/R/R-mlr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran mlr-org mlr 2.19.2
-revision            2
+revision            3
 categories-append   math
 maintainers         nomaintainer
 license             BSD

--- a/R/R-rgdal/Portfile
+++ b/R/R-rgdal/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran r-forge rgdal 1.6-7
-revision            10
+revision            11
 categories-append   gis
 maintainers         nomaintainer
 license             GPL-2+

--- a/R/R-sf/Portfile
+++ b/R/R-sf/Portfile
@@ -6,7 +6,7 @@ PortGroup           R 1.0
 
 # GitHub version is old.
 R.setup             cran r-spatial sf 1.0-19
-revision            3
+revision            4
 categories-append   math
 maintainers         nomaintainer
 license             {GPL-2 MIT}

--- a/R/R-terra/Portfile
+++ b/R/R-terra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran rspatial terra 1.8-5
-revision            2
+revision            3
 categories-append   gis
 maintainers         nomaintainer
 license             GPL-3+

--- a/R/R-vapour/Portfile
+++ b/R/R-vapour/Portfile
@@ -5,7 +5,7 @@ PortGroup           R 1.0
 
 # Revert to GitHub once updated there.
 R.setup             cran hypertidy vapour 0.10.0 v
-revision            3
+revision            4
 categories-append   gis
 maintainers         nomaintainer
 license             GPL-3

--- a/databases/postgis/Portfile
+++ b/databases/postgis/Portfile
@@ -6,7 +6,7 @@ name                postgis
 categories          databases gis
 license             GPL-2+
 version             3.6.3
-revision            0
+revision            1
 maintainers         {yahoo.com:n_larsson @nilason} openmaintainer
 
 description         PostGIS is the spatial extension to the\

--- a/databases/postgis2/Portfile
+++ b/databases/postgis2/Portfile
@@ -8,7 +8,7 @@ categories          databases gis
 license             GPL-2+
 version             2.5.11
 epoch               1
-revision            1
+revision            2
 maintainers         {vince @Veence} openmaintainer
 
 deprecated.eol_version  yes

--- a/gis/gdal-plugin-grass/Portfile
+++ b/gis/gdal-plugin-grass/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake  1.1
 name                gdal-plugin-grass
 
 version             2.0.0
-revision            2
+revision            3
 
 distname            gdal-grass-${version}
 

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -7,12 +7,14 @@ PortGroup           legacysupport 1.1
 PortGroup           muniversal 1.0
 
 name                gdal
-version             3.12.3
-revision            1
+# keep version in sync with py-gdal; rev-bump dependents after an
+# install_name-changing update (typically when a or b changes in version a.b.c).
+version             3.13.0
+revision            0
 
-checksums           rmd160  738cac270cf467da7625fec91a2528545ba9cb12 \
-                    sha256  398a5a32ee6e75040598a7f8e895126a8225118317f272d715867c844f932848 \
-                    size    9619992
+checksums           rmd160  d85862aaee5c7e8943a469188e3435ee357f0f37 \
+                    sha256  1c537dd2f4d66f05534ae419bc2af495c2204ce13bb266c8cbd867dd6705f0c7 \
+                    size    9945444
 
 categories          gis
 license             MIT BSD
@@ -83,6 +85,8 @@ depends_lib-append \
                     port:webp \
                     port:zlib \
                     port:zstd
+
+patchfiles-append   patch-build_with_install_name_dir.diff
 
 # By default, disable all drivers
 configure.args-append                                        \

--- a/gis/gdal/files/patch-build_with_install_name_dir.diff
+++ b/gis/gdal/files/patch-build_with_install_name_dir.diff
@@ -1,0 +1,53 @@
+https://github.com/OSGeo/gdal/commit/18f84029c14d080343072b01793169ee19102209.patch
+
+From 4fc310dd6d0a95bedda003613cfa63ded090d5fa Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Tue, 26 May 2026 12:02:07 -0400
+Subject: [PATCH] CMake: set BUILD_WITH_INSTALL_NAME_DIR for macOS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CMake can either build shared libraries with a temporary install_name at
+build time, resetting it to the final name at install time
+(BUILD_WITH_INSTALL_NAME_DIR=NO, the default), or it can build them with
+the final name at build time (BUILD_WITH_INSTALL_NAME_DIR=YES).
+
+GDAL plugins link against libgdal as part of the build process, and if
+BUILD_WITH_INSTALL_NAME_DIR=NO, these plugins may be linked using an
+incorrect path to libgdal, taken from libgdal’s install_name. Those
+paths are not rewritten at install time, which can make it difficult to
+properly use GDAL plugins built in this way. For example, with GDAL
+built with a CMAKE_INSTALL_NAME_DIR set (as a downstream build may do),
+and PDF built as a plugin, `gdal info` on a PDF may fail with an error
+such as:
+
+```
+ERROR 1: dlopen(…/lib/gdalplugins/gdal_PDF.dylib, 0x0001): Library not loaded: @rpath/libgdal.39.dylib
+  Referenced from: <…> …/lib/gdalplugins/gdal_PDF.dylib
+  Reason: no LC_RPATH's found
+```
+
+Setting BUILD_WITH_INSTALL_NAME_DIR=YES overcomes this problem. This
+change should be noncontroversial, as the default GDAL build, without a
+CMAKE_INSTALL_NAME_DIR set, will use @rpath as the install_name_dir in
+both the build and installed trees, regardless of the setting of
+BUILD_WITH_INSTALL_NAME_DIR.
+---
+ gdal.cmake | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git gdal.cmake gdal.cmake
+index b629bdb1ab1c..63295bcd78c6 100644
+--- gdal.cmake
++++ gdal.cmake
+@@ -234,7 +234,8 @@ set_target_properties(
+              LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+              RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+              CXX_STANDARD 11
+-             CXX_STANDARD_REQUIRED YES)
++             CXX_STANDARD_REQUIRED YES
++             BUILD_WITH_INSTALL_NAME_DIR YES)
+ set_property(TARGET ${GDAL_LIB_TARGET_NAME} PROPERTY PLUGIN_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/gdalplugins")
+ file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/gdalplugins")
+ 

--- a/gis/grass/Portfile
+++ b/gis/grass/Portfile
@@ -8,7 +8,7 @@ epoch               1
 
 name                grass
 version             8.5.0
-revision            1
+revision            2
 
 maintainers         {yahoo.com:n_larsson @nilason} openmaintainer
 categories          gis

--- a/gis/grass7/Portfile
+++ b/gis/grass7/Portfile
@@ -14,7 +14,7 @@ github.setup        OSGeo grass 7.8.8
 github.tarball_from tarball
 name                grass7
 set main_version    [join [lrange [split ${version} "."] 0 1] ""]
-revision            12
+revision            13
 set realVersion     ${version}
 #distname           grass-${version}
 distname            grass-${realVersion}

--- a/gis/libosmium/Portfile
+++ b/gis/libosmium/Portfile
@@ -7,7 +7,7 @@ PortGroup           boost 1.0
 
 github.setup        osmcode libosmium 2.23.1 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          gis
 maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer

--- a/gis/mapnik/Portfile
+++ b/gis/mapnik/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 name                mapnik
 version             4.1.3
-revision            1
+revision            2
 categories          gis devel
 license             LGPL-2.1
 

--- a/gis/mapserver/Portfile
+++ b/gis/mapserver/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 
 name                mapserver
 version             8.0.2
-revision            4
+revision            5
 maintainers         hbaspecto.com:jea {yahoo.com:n_larsson @nilason} openmaintainer
 categories          gis
 license             permissive

--- a/gis/openorienteering-mapper/Portfile
+++ b/gis/openorienteering-mapper/Portfile
@@ -8,7 +8,7 @@ PortGroup           qt5 1.0
 github.setup        OpenOrienteering mapper 0.9.6 v
 github.tarball_from archive
 name                openorienteering-mapper
-revision            0
+revision            1
 
 categories          gis graphics
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer

--- a/gis/orfeotoolbox/Portfile
+++ b/gis/orfeotoolbox/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 name                orfeotoolbox
 version             9.1.1
-revision            2
+revision            3
 categories          gis graphics
 license             Apache-2
 

--- a/gis/pcraster/Portfile
+++ b/gis/pcraster/Portfile
@@ -8,7 +8,7 @@ PortGroup           qt5 1.0
 
 github.setup        pcraster pcraster 4.4.2 v
 github.tarball_from archive
-revision            1
+revision            2
 
 categories          gis
 license             GPL

--- a/gis/pdal/Portfile
+++ b/gis/pdal/Portfile
@@ -6,7 +6,7 @@ PortGroup           github        1.0
 PortGroup           legacysupport 1.1
 
 github.setup        PDAL PDAL 2.10.1
-revision            0
+revision            1
 
 name                pdal
 categories          gis

--- a/gis/qlandkartegt/Portfile
+++ b/gis/qlandkartegt/Portfile
@@ -12,7 +12,7 @@ license          GPL-3
 github.setup     mklein-de ${name} 1.8.1-macports-20200922
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision         13
+revision         14
 
 description      Use your Garmin GPS with Linux/Mac OS X
 long_description QLandkarte GT is the ultimate outdoor aficionado's tool. It \

--- a/gis/rsgislib/Portfile
+++ b/gis/rsgislib/Portfile
@@ -11,7 +11,7 @@ PortGroup           active_variants   1.1
 boost.version       1.81
 
 github.setup        remotesensinginfo rsgislib 5.2.3
-revision            0
+revision            1
 categories          gis
 license             GPL-3
 maintainers         {yahoo.com:n_larsson @nilason} openmaintainer

--- a/gis/t-rex/Portfile
+++ b/gis/t-rex/Portfile
@@ -8,7 +8,7 @@ PortGroup           cargo 1.0
 github.setup        t-rex-tileserver t-rex 0.14.3 v
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
-revision            10
+revision            11
 categories          gis
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Vector tile server specialized on publishing MVT tiles

--- a/graphics/OpenSceneGraph-devel/Portfile
+++ b/graphics/OpenSceneGraph-devel/Portfile
@@ -11,7 +11,7 @@ github.setup            openscenegraph OpenSceneGraph ${git_commit}
 github.tarball_from     archive
 name                    OpenSceneGraph-devel
 version                 3.7.0-${git_date}
-revision                0
+revision                1
 conflicts               OpenSceneGraph
 categories              graphics
 maintainers             nomaintainer

--- a/graphics/OpenSceneGraph/Portfile
+++ b/graphics/OpenSceneGraph/Portfile
@@ -9,7 +9,7 @@ PortGroup               ffmpeg 1.0
 github.setup            openscenegraph OpenSceneGraph 3.6.5 OpenSceneGraph-
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from     tarball
-revision                21
+revision                22
 conflicts               OpenSceneGraph-devel
 categories              graphics
 maintainers             nomaintainer

--- a/graphics/VirtualPlanetBuilder/Portfile
+++ b/graphics/VirtualPlanetBuilder/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 github.setup            openscenegraph VirtualPlanetBuilder 0.9.13 VirtualPlanetBuilder-
-revision                7
+revision                8
 checksums               rmd160  078e0b0d99b8b985f2f10aff5aaa558968434fad \
                         sha256  0e23fc772ff348ea0be2b6f6468ee9f6f0e4c4c907581b4518313033e2777263 \
                         size    228406

--- a/graphics/opencv3-devel/Portfile
+++ b/graphics/opencv3-devel/Portfile
@@ -27,7 +27,7 @@ conflicts           opencv3
 set my_name         opencv3
 version             3.4.20
 # NOTE: Separate revisions maintained for Python subports, later in portfile
-revision            0
+revision            1
 
 categories          graphics science
 license             BSD

--- a/graphics/opencv3/Portfile
+++ b/graphics/opencv3/Portfile
@@ -27,7 +27,7 @@ conflicts           opencv3-devel
 set my_name         opencv3
 version             3.4.20
 # NOTE: Separate revisions maintained for Python subports, later in portfile
-revision            0
+revision            1
 
 categories          graphics science
 license             BSD

--- a/graphics/opencv4-devel/Portfile
+++ b/graphics/opencv4-devel/Portfile
@@ -54,7 +54,7 @@ if {${os.major} > 12} {
 if {${opencv_latest}} {
     github.setup    opencv opencv 4.9.0
     github.tarball_from releases
-    revision        8
+    revision        9
     epoch           1
 
     checksums-append \
@@ -65,7 +65,7 @@ if {${opencv_latest}} {
 } else {
     github.setup    opencv opencv 4.5.0
     github.tarball_from releases
-    revision        34
+    revision        35
 
     checksums-append \
                     ${distname}${extract.suffix} \
@@ -303,7 +303,7 @@ configure.args-append \
                     -DPYTHON_EXECUTABLE:FILEPATH=${default_python_path} \
                     -DPYTHON_DEFAULT_EXECUTABLE:FILEPATH=${default_python_path}
 
-if {${name} eq ${subport}} {
+if {${name} 1{subport}} {
     # generate pkg-config file
      configure.args-append \
                     -DOPENCV_GENERATE_PKGCONFIG=YES

--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -54,7 +54,7 @@ if {${os.major} > 12} {
 if {${opencv_latest}} {
     github.setup    opencv opencv 4.9.0
     github.tarball_from releases
-    revision        8
+    revision        9
     epoch           1
 
     checksums-append \
@@ -65,7 +65,7 @@ if {${opencv_latest}} {
 } else {
     github.setup    opencv opencv 4.5.0
     github.tarball_from releases
-    revision        39
+    revision        40
 
     checksums-append \
                     ${distname}${extract.suffix} \

--- a/octave/octave-mapping/Portfile
+++ b/octave/octave-mapping/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           octave 1.0
 
 octave.setup        sourceforge octave mapping 1.4.3
-revision            1
+revision            2
 
 license             GPL-3+
 maintainers         {mps @Schamschula} openmaintainer

--- a/python/py-fiona/Portfile
+++ b/python/py-fiona/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-fiona
 version             1.10.1
-revision            3
+revision            4
 categories-append   gis
 license             BSD
 

--- a/python/py-gdal/Portfile
+++ b/python/py-gdal/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 name                py-gdal
 # keep version in sync with gdal; rebuilt after gdal update
-version             3.12.2
+version             3.13.0
 revision            0
 
 categories-append   gis
@@ -19,9 +19,9 @@ long_description    This Python package and extensions are a number of tools for
 
 homepage            https://www.gdal.org
 
-checksums           rmd160  a3dbc5aecf9a8002d73b89159ac7acabe77cea2a \
-                    sha256  a5afa8e55a19b296a004a15d38fe3ad60cc380f1f090e2aab5d35331008c970f \
-                    size    899232
+checksums           rmd160  aac72ef3131c62464e4f24d063d05944da74b667 \
+                    sha256  b440bcecbcdb96690a74da223142f2d51c6a540ee78674e10f9dca933d0e9006 \
+                    size    940507
 
 python.versions     310 311 312 313 314
 

--- a/python/py-pyogrio/Portfile
+++ b/python/py-pyogrio/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pyogrio
 version             0.12.1
-revision            0
+revision            1
 
 categories-append   science gis
 license             MIT

--- a/python/py-rasterio/Portfile
+++ b/python/py-rasterio/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_wrapper 1.0
 
 name                py-rasterio
 version             1.5.0
-revision            0
+revision            1
 categories-append   gis
 license             BSD
 
@@ -41,7 +41,7 @@ if {${name} ne ${subport}} {
 
     if {${python.version} <= 311} {
         version             1.4.3
-        revision            3
+        revision            4
         checksums           rmd160  4bdeb32a8b07867227a1405bcbbdd6910f777146 \
                             sha256  201f05dbc7c4739dacb2c78a1cf4e09c0b7265b0a4d16ccbd1753ce4f2af350a \
                             size    442990

--- a/science/gerbil/Portfile
+++ b/science/gerbil/Portfile
@@ -10,7 +10,7 @@ github.setup        gerbilvis gerbil 5a7705fe1170f812a6cd0e79a1a853f4d8aec2cf
 # Change github.tarball_from to 'releases' or 'archive' next update
 github.tarball_from tarball
 version             2020-05-06-5a7705f
-revision            19
+revision            20
 checksums           rmd160  9b3f9ac2589a4f3b2ae12db6b02fdcd924886ec4 \
                     sha256  1eb67522c0629a885f940ce333880982528c0ef23ee5a3b27aaddf9facf72d6f \
                     size    2301204

--- a/science/gmt4/Portfile
+++ b/science/gmt4/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                gmt4
 version             4.5.18
-revision            23
+revision            24
 categories          science
 maintainers         {takeshi @tenomoto} openmaintainer
 license             GPL-2

--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -12,7 +12,7 @@ name                gmt5
 github.setup        GenericMappingTools gmt 5.4.5
 github.tarball_from releases
 distname            ${github.project}-${github.version}-src
-revision            23
+revision            24
 
 categories          science
 maintainers         {me.com:remko.scharroo @remkos} openmaintainer

--- a/science/gmt6/Portfile
+++ b/science/gmt6/Portfile
@@ -8,7 +8,7 @@ name                gmt6
 github.setup        GenericMappingTools gmt 6.6.0
 github.tarball_from releases
 distname            ${github.project}-${github.version}-src
-revision            1
+revision            2
 epoch               1
 
 categories          science

--- a/science/ncarg/Portfile
+++ b/science/ncarg/Portfile
@@ -11,7 +11,7 @@ compilers.allow_arguments_mismatch \
 
 name                        ncarg
 version                     6.6.2
-revision                    36
+revision                    37
 epoch                       1
 set version_no_dot [join [split ${version} "."] ""]
 categories                  science

--- a/science/xastir/Portfile
+++ b/science/xastir/Portfile
@@ -17,7 +17,7 @@ github.tarball_from archive
 checksums           rmd160  3db74760bfc66accd4bf9302c3c222020f9d9f2e \
                     sha256  e80d1640ef2b8071984a633d45beae878c120d6012cb371405b160a06b328542 \
                     size    2246995
-revision            1
+revision            2
 
 use_autoconf        yes
 autoconf.cmd        ./bootstrap.sh


### PR DESCRIPTION
#### Description

This updates gdal to the latest released version. It also backports https://github.com/OSGeo/gdal/commit/18f84029c14d080343072b01793169ee19102209 (from https://github.com/OSGeo/gdal/pull/14660), as the bug it fixes also affects MacPorts-installed gdal’s use of plugins:

>CMake can either build shared libraries with a temporary install_name at build time, resetting it to the final name at install time (`BUILD_WITH_INSTALL_NAME_DIR=NO`, the default), or it can build them with the final name at build time (`BUILD_WITH_INSTALL_NAME_DIR=YES`).
>
> GDAL plugins link against libgdal as part of the build process, and if `BUILD_WITH_INSTALL_NAME_DIR=NO`, these plugins may be linked using an incorrect path to libgdal, taken from libgdal’s install_name. Those paths are not rewritten at install time, which can make it difficult to properly use GDAL plugins built in this way. For example, with GDAL built with a `CMAKE_INSTALL_NAME_DIR` set (as a downstream build may do), and PDF built as a plugin, `gdal info` on a PDF may fail with an error such as:
>
> ```
> ERROR 1: dlopen(…/lib/gdalplugins/gdal_PDF.dylib, 0x0001): Library not loaded: @rpath/libgdal.39.dylib
>   Referenced from: <…> …/lib/gdalplugins/gdal_PDF.dylib
>   Reason: no LC_RPATH's found
> ```
>
> Setting `BUILD_WITH_INSTALL_NAME_DIR=YES` overcomes this problem. This change should be noncontroversial, as the default GDAL build, without a `CMAKE_INSTALL_NAME_DIR` set, will use @rpath as the install_name_dir in both the build and installed trees, regardless of the setting of `BUILD_WITH_INSTALL_NAME_DIR`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
