### PR TITLE
pinact: Update to 4.0.0

### DIFF
--- a/security/pinact/Portfile
+++ b/security/pinact/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/suzuki-shunsuke/pinact 3.10.1 v
+go.setup            github.com/suzuki-shunsuke/pinact 4.0.0 v
 go.offline_build    no
 categories          security
 maintainers         {macports.halostatue.ca:austin @halostatue} \
@@ -18,9 +18,9 @@ description         A CLI to edit GitHub Workflow and Composite action files and
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  577d840bd88e02b82d2b356f5440acf2517888e9 \
-                    sha256  e2661031b43e5980af34ca323ed10f72112c056fc0c495424dcccdd85ab6db2f \
-                    size    80538
+                    rmd160  07fde517a9807e0ca7e57633f622785a298d7a6d \
+                    sha256  880e29511209f1cb55ac53e4e72b9ee2c62c13340420ed3263b99302f9b71bd2 \
+                    size    105497
 
 livecheck.regex     {v(\d+\.\d+\.\d+)$}
 
@@ -51,4 +51,9 @@ destroot {
     xinstall -d ${destroot}${prefix}/${zsh_completions_dir}
     xinstall ${worksrcpath}/${name}.zsh \
         ${destroot}${prefix}/${zsh_completions_dir}/_${name}
+}
+
+notes {
+  Pinact 4 has several breaking changes covered in its release notes:
+    https://github.com/suzuki-shunsuke/pinact/releases/tag/v4.0.0
 }


### PR DESCRIPTION
#### Description

pinact: Update to 4.0.0


##### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
