### PR TITLE
oasdiff: Update to 1.18.1

### DIFF
--- a/devel/oasdiff/Portfile
+++ b/devel/oasdiff/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/Tufin/oasdiff 1.15.3 v
+go.setup            github.com/Tufin/oasdiff 1.18.1 v
 go.offline_build    no
 revision            0
 
@@ -20,9 +20,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  c76d7f6e36165144d2974af0ce164e335501b9a2 \
-                    sha256  9cd56674a6920aac77901c0009156184214d0269c7fa359fb488c1da1633c4cf \
-                    size    519994
+                    rmd160  c08f9ae682c4bbd9859d5fe0bc04c8ccc405df73 \
+                    sha256  55e69b83d75be4f9a9779e0ed04a68247d9cb80cf51206b9f96c8ffde090561b \
+                    size    571618
 
 post-build {
     system -W ${worksrcpath} "./${name} completion bash > ${name}.bash"


### PR DESCRIPTION
#### Description

oasdiff: Update to 1.18.1


##### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
