### PR TITLE
lychee: Update to 0.24.2

### DIFF
--- a/devel/lychee/Portfile
+++ b/devel/lychee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo  1.0
 PortGroup           github 1.0
 
-github.setup        lycheeverse lychee 0.24.1 lychee-v
+github.setup        lycheeverse lychee 0.24.2 lychee-v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ long_description    {*}${description} \
     reStructuredText, or any other text file or website!
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  20b457476e9d218b3896ff2784047c799f604de1 \
-                    sha256  51bf8e1ca4da4ea3a326bbfa163ef68920bbc8dc3b84bd094bc86e43fd674e36 \
-                    size    1026519
+                    rmd160  b955d6164c7aaf7d4231f0dc8778fdc5a1afc868 \
+                    sha256  62687c0a84ceec76d17e30e494dcf8e65c7099a2e24a6a521a41854b8eb3759d \
+                    size    1029540
 
 depends_lib         path:lib/libssl.dylib:openssl
 
@@ -45,7 +45,7 @@ cargo.crates \
     anyhow                             1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     arc-swap                             1.8.1  9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73 \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
-    assert_cmd                           2.2.0  9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9 \
+    assert_cmd                           2.2.1  39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd \
     async-compression                   0.4.37  d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40 \
     async-smtp                          0.10.2  55219982f938e74491ba85dc4e49cefe8096b1e8f49348c67180a7d244988dca \
     async-stream                         0.3.6  0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476 \
@@ -77,10 +77,10 @@ cargo.crates \
     ciborium                             0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                          0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                          0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                                 4.6.0  b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351 \
+    clap                                 4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap_builder                         4.6.0  714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f \
-    clap_complete                        4.6.1  406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9 \
-    clap_derive                          4.6.0  1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a \
+    clap_complete                        4.6.3  660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3 \
+    clap_derive                          4.6.1  f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9 \
     clap_lex                             1.0.0  3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831 \
     clap_mangen                          0.3.0  d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07 \
     cmake                               0.1.57  75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d \
@@ -90,7 +90,7 @@ cargo.crates \
     compression-core                    0.4.31  75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d \
     console                             0.16.3  d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87 \
     const-oid                            0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
-    const_format                        0.2.35  7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad \
+    const_format                        0.2.36  4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e \
     const_format_proc_macros            0.2.34  1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744 \
     cookie                              0.18.1  4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747 \
     cookie_store                        0.22.1  15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206 \
@@ -242,6 +242,8 @@ cargo.crates \
     jobserver                           0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
     js-sys                              0.3.85  8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3 \
     jsonwebtoken                        10.3.0  0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1 \
+    konst                               0.2.20  128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb \
+    konst_macro_rules                   0.2.19  a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37 \
     lazy_static                          1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
     leb128fmt                            0.1.0  09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2 \
     libc                               0.2.184  48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af \
@@ -276,7 +278,7 @@ cargo.crates \
     num-traits                          0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                            1.17.0  91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b \
     numeric-sort                         0.1.5  f2dcb6053ab98da45585315f79932c5c9821fab8efa4301c0d7b637c91630eb7 \
-    octocrab                            0.49.7  63f6687a23731011d0117f9f4c3cdabaa7b5e42ca671f42b5cc0657c492540e3 \
+    octocrab                            0.49.9  4ddbc3bb87e8c680febf16f56855bbd8b44a38e18c913334213ab34908e71a09 \
     once_cell                           1.21.3  42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d \
     once_cell_polyfill                  1.70.2  384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe \
     oorandom                            11.1.5  d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e \
@@ -350,7 +352,7 @@ cargo.crates \
     regex-automata                      0.4.14  6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f \
     regex-syntax                         0.8.9  a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c \
     relative-path                        1.9.3  ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2 \
-    reqwest                             0.13.2  ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801 \
+    reqwest                             0.13.3  62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0 \
     reqwest_cookie_store                0.10.0  beb98c4d52ae6ceed18a0dff0564717623dd75fae08619ae0927332f0a81abbc \
     resolv-conf                          0.7.6  1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7 \
     rfc6979                              0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
@@ -443,7 +445,7 @@ cargo.crates \
     tinytemplate                         1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
     tinyvec                             1.10.0  bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa \
     tinyvec_macros                       0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                               1.51.1  f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c \
+    tokio                               1.52.1  b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6 \
     tokio-macros                         2.7.0  385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496 \
     tokio-rustls                        0.26.4  1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61 \
     tokio-stream                        0.1.18  32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70 \
@@ -476,7 +478,7 @@ cargo.crates \
     utf-8                                0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
-    uuid                                1.23.0  5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9 \
+    uuid                                1.23.1  ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76 \
     version_check                        0.9.5  0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a \
     vte                                 0.14.1  231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077 \
     wait-timeout                         0.2.1  09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11 \


### PR DESCRIPTION
#### Description

lychee: Update to 0.24.2


##### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
