### PR TITLE
mise: Update to 2026.5.18

### DIFF
--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2026.5.13 v
+github.setup        jdx mise 2026.5.18 v
 github.tarball_from archive
 revision            0
 
@@ -26,9 +26,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  6cba6526412aae081d7e4430e9f05637c105aedf \
-                    sha256  6eaa2fdad3ce35accea2c120c5f8167856ba80a5566c1c44415b541b14b6ac19 \
-                    size    6946352
+                    rmd160  dd678392c370f945eba3bcab8e0e5fe47c918c5f \
+                    sha256  f1a3b31060484207b1618746b526571c29ee7150e509c4229f33b1e512b2d667 \
+                    size    6991207
 
 build.args-prepend  --no-default-features \
                     --features native-tls,vfox/vendored-lua
@@ -94,6 +94,7 @@ cargo.crates \
     ahash                               0.8.12  5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75 \
     aho-corasick                         1.1.4  ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301 \
     allocator-api2                      0.2.21  683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923 \
+    ambient-id                          0.0.11  c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e \
     android_system_properties            0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     ansi-str                             0.9.0  060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d \
     ansitok                              0.3.0  c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee \
@@ -105,13 +106,13 @@ cargo.crates \
     anyhow                             1.0.102  7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c \
     arbitrary                            1.4.2  c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1 \
     arc-swap                             1.9.1  6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207 \
-    archspec                             0.1.3  9db67cd9cf4f56a10d2cbae6a3b552e5bd36701fd37b74a18c14a231bdf446c7 \
+    archspec                             0.2.0  3ea6ba19ec651dfd93c3d00cf86048feca2eeab57e8e7cc218e053fe5d08fb33 \
     arrayref                             0.3.9  76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb \
     arrayvec                             0.7.6  7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50 \
     assert-json-diff                     2.0.2  47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12 \
-    astral-reqwest-middleware            0.4.2  638d02e24aeb92f9537897cd1ff82e2bc98fd9ac9575a503e27bb07cdf64d4d7 \
+    astral-reqwest-middleware            0.5.1  98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9 \
     astral-tokio-tar                     0.6.2  cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277 \
-    astral_async_http_range_reader       0.9.1  7ddaca0fbbf0d91103cca7c7611790c65f6eff1d456f7fe6bf565d436dc9b8f3 \
+    astral_async_http_range_reader      0.11.0  4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f \
     astral_async_zip                    0.0.17  ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba \
     async-backtrace                      0.2.7  4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198 \
     async-backtrace-attributes           0.2.7  affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7 \
@@ -122,7 +123,7 @@ cargo.crates \
     async-spooled-tempfile               0.1.0  5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5 \
     async-trait                         0.1.89  9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb \
     atomic-waker                         1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
-    autocfg                              1.5.0  c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8 \
+    autocfg                              1.5.1  f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53 \
     aws-config                          1.8.14  8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2 \
     aws-credential-types                1.2.13  6d203b0bf2626dcba8665f5cd0871d7c2c0930223d6b6be9097592fea21242d0 \
     aws-lc-fips-sys                    0.13.14  d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568 \
@@ -161,7 +162,6 @@ cargo.crates \
     beef                                 0.5.2  3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1 \
     bindgen                             0.72.1  993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895 \
     binstall-tar                        0.4.42  e3620d72763b5d8df3384f3b2ec47dc5885441c2abbd94dd32197167d08b014a \
-    bisection                            0.1.0  021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3 \
     bit-set                              0.6.0  f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f \
     bit-set                              0.8.0  08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3 \
     bit-vec                              0.7.0  d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22 \
@@ -176,8 +176,8 @@ cargo.crates \
     blowfish                             0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
     bs58                                 0.5.1  bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4 \
     bstr                                1.12.1  63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab \
-    built                                0.8.0  f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64 \
-    bumpalo                             3.20.2  5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb \
+    built                                0.8.1  5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9 \
+    bumpalo                             3.20.3  72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649 \
     bytecheck                            0.8.2  0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b \
     bytecheck_derive                     0.8.2  89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9 \
     bytecount                            0.6.9  175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e \
@@ -204,7 +204,7 @@ cargo.crates \
     chrono-tz-build                      0.3.0  0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1 \
     ci_info                            0.14.15  7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23 \
     cipher                               0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
-    cipher                               0.5.1  e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea \
+    cipher                               0.5.2  e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c \
     clang-sys                            1.8.1  0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4 \
     clap                                 4.6.1  1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51 \
     clap-sort                            1.0.3  3c9f374a541bd277ba6f4ccd08d955024ba09fda8dfc69ca1a750799ebed97a9 \
@@ -217,7 +217,7 @@ cargo.crates \
     cmov                                 0.5.3  3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746 \
     cmpv2                                0.2.0  961b955a666e25ee5a1091d219128d6e6401e3dab84efb1a2bf6b4035d797b39 \
     cms                                  0.2.3  7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730 \
-    coalesced_map                        0.1.2  7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b \
+    coalesced_map                        0.1.3  b0fe09392885c9af28aed39c6ddd06e41b43dbe98a850ccf0abe3f88d7cc75de \
     color-eyre                           0.6.5  e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d \
     color-print                          0.3.7  3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4 \
     color-print-proc-macro               0.3.7  692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22 \
@@ -261,7 +261,7 @@ cargo.crates \
     crossterm                           0.29.0  d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b \
     crossterm_winapi                     0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
     crypto-common                        0.1.7  78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a \
-    crypto-common                        0.2.1  77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710 \
+    crypto-common                        0.2.2  ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453 \
     ctor                                 1.0.6  6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5 \
     ctr                                  0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
     ctutils                              0.4.2  7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e \
@@ -297,7 +297,7 @@ cargo.crates \
     dyn-clone                           1.0.20  d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555 \
     ed25519                              2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
     ed25519-dalek                        2.2.0  70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9 \
-    either                              1.15.0  48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719 \
+    either                              1.16.0  91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e \
     elsa                                1.11.2  9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e \
     encode_unicode                       1.0.0  34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0 \
     encoding_rs                         0.8.35  75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3 \
@@ -321,7 +321,7 @@ cargo.crates \
     faster-hex                          0.10.0  7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73 \
     fastrand                             2.4.1  9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6 \
     fiat-crypto                          0.2.9  28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d \
-    file_url                             0.3.0  1e546758dbcde9d10c0d3bd8b83adb535b23fa81121cf4dc5c3e7b5907cc8eb8 \
+    file_url                             0.3.1  f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747 \
     filetime                            0.2.29  5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759 \
     filetime_creation                    0.2.0  c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f \
     find-crate                           0.6.3  59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2 \
@@ -445,7 +445,7 @@ cargo.crates \
     http-body                            0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-body                            1.0.1  1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184 \
     http-body-util                       0.1.3  b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a \
-    http-cache-semantics                 2.1.1  4311240f94cb6fe622337dc580b09ddd6ae4a891eb121dba20cf4f77ca4e7129 \
+    http-cache-semantics                 3.0.0  0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7 \
     http-content-range                   0.2.4  66cdb727cec723cee65912a74a7f9f0c3ad0c6f9df4f03d05a5c7a15398bbad1 \
     http-serde                           2.1.1  0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd \
     httparse                            1.10.1  6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87 \
@@ -494,12 +494,11 @@ cargo.crates \
     is_ci                                1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
     is_terminal_polyfill                1.70.2  a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695 \
     itertools                           0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
-    itertools                           0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
     itertools                           0.13.0  413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186 \
     itertools                           0.14.0  2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285 \
     itoa                                1.0.18  8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682 \
-    jiff                                0.2.24  f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d \
-    jiff-static                         0.2.24  e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7 \
+    jiff                                0.2.25  6835eea34fb6321b9b3aa7b685c2b433948c09447e389dc017fdf687d5d11e65 \
+    jiff-static                         0.2.25  3c22e04db9c58f5136eb1757f3d5c49a7b187f49e52185228cbd2f5acdfcc08c \
     jiff-tzdb                            0.1.6  c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076 \
     jiff-tzdb-platform                   0.1.3  875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8 \
     jni                                 0.22.4  5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498 \
@@ -507,14 +506,14 @@ cargo.crates \
     jni-sys                              0.4.1  c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2 \
     jni-sys-macros                       0.4.1  38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264 \
     jobserver                           0.1.34  9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33 \
-    js-sys                              0.3.98  67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08 \
+    js-sys                              0.3.99  142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11 \
     json-patch                           4.2.0  7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72 \
     jsonptr                              0.7.1  a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe \
     junction                             2.0.0  160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006 \
     kdl                                  6.5.0  81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e \
     known-folders                        1.4.2  7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638 \
     kstring                              2.0.2  558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1 \
-    landlock                             0.4.4  49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088 \
+    landlock                             0.4.5  635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d \
     lazy-regex                           3.6.0  6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496 \
     lazy-regex-proc_macros               3.6.0  4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358 \
     lazy_static                          1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
@@ -525,14 +524,14 @@ cargo.crates \
     libloading                           0.9.0  754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60 \
     libm                                0.2.16  b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981 \
     libredox                            0.1.16  e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c \
-    link-section                        0.17.1  0de704e04b8fdab2a6a633e7e9298211da1d6c73334fed54665559909064e58f \
+    link-section                        0.17.2  4d1e908a416d6e9f725743b84a36feea40c4c131e805fbc26d61f9f451f36080 \
     linktime-proc-macro                  0.1.0  a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81 \
     linux-raw-sys                       0.4.15  d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab \
     linux-raw-sys                       0.12.1  32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53 \
     litemap                              0.8.2  92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0 \
     litrs                                1.0.0  11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092 \
     lock_api                            0.4.14  224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965 \
-    log                                 0.4.29  5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897 \
+    log                                 0.4.30  616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5 \
     logos                               0.12.1  bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1 \
     logos-derive                        0.12.1  a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c \
     loom                                 0.5.6  ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5 \
@@ -542,7 +541,7 @@ cargo.crates \
     luajit-src                 210.6.6+707c12b  a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295 \
     lzma-rs                              0.3.0  297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e \
     lzma-rust                            0.1.7  5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661 \
-    lzma-rust2                          0.16.2  47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae \
+    lzma-rust2                          0.16.3  5e9ceaec84b54518262de7cf06b8b43e83c808349960f1610b21b0bfc9640f20 \
     lzma-sys                            0.1.20  5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27 \
     matchers                             0.2.0  d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9 \
     maybe-async                         0.2.11  746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c \
@@ -579,7 +578,7 @@ cargo.crates \
     num-bigint                           0.4.6  a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9 \
     num-bigint-dig                       0.8.6  e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7 \
     num-complex                          0.4.6  73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495 \
-    num-conv                             0.2.1  c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967 \
+    num-conv                             0.2.2  521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441 \
     num-integer                         0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
     num-iter                            0.1.45  1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf \
     num-rational                         0.4.2  f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824 \
@@ -606,10 +605,10 @@ cargo.crates \
     parking_lot                         0.12.5  93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a \
     parking_lot_core                    0.9.12  2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1 \
     parse-zoneinfo                       0.3.1  1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24 \
-    pastey                               0.2.2  c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a \
+    pastey                               0.2.3  2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4 \
     path-absolutize                      3.1.1  e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5 \
     path-dedot                           3.1.1  07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397 \
-    path_resolver                        0.2.8  bde05d7ef24e5a8818baa86a291018e17992292794f8d11ea2f5e9e1c33fb197 \
+    path_resolver                       0.2.10  2a9f07f388f2a58768a34000c2b956bbc44f51630aa39d84f1d362c6785075a1 \
     pbkdf2                              0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
     pbkdf2                              0.13.0  112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629 \
     pem                                  3.0.6  1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be \
@@ -676,20 +675,20 @@ cargo.crates \
     rand_core                            0.9.5  76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c \
     rand_core                           0.10.1  63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69 \
     rand_xorshift                        0.4.0  513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a \
-    rattler                             0.42.0  9bc96a27d6c39b6d2a22aa4bef52b2cf37077761ecb209f5ebd92657593a7189 \
-    rattler_cache                        0.7.1  05fb0beb355779982d60ffaf71d5330e1cafa31c7a5be8bf33c4ca597477cf03 \
-    rattler_conda_types                 0.46.1  1ce168319aa4284a026df19b0054bab8609e3447937f43ef1a496b7af6984324 \
-    rattler_digest                       1.2.4  fbab3541bf7e471550c91b70dad8edf392ffa9f57c6b0de4bbe6dd2c6c0d53d4 \
-    rattler_macros                      1.0.13  677367cf07dd4ca5b863a91cf060feea246f3b23d50af9e9fadf980db760d270 \
-    rattler_menuinst                    0.2.59  4874d056de91e23bf2c02c827fd8a7557d6e4ba032fdf6800efbe3ea9ff127dd \
-    rattler_networking                 0.26.12  17840c3642ef185ead62f4b7be5672fd6ab6c9ffeb9ce74cb1509d50eecbe96c \
-    rattler_package_streaming           0.25.1  8321ca30ccd49fed1c000d981a1d0f786f8b365c119b7c8bdd5f0bdbd870f04c \
-    rattler_pty                         0.2.10  da10b7f974ce38eaf00e0e1d29c13151fa10fa003ec03606bc1bf76e4d537dfd \
-    rattler_redaction                   0.1.15  40a5b2b5dc702c69f60fbf9ebf6bfe751854069918b24c48f64873ae31b72b84 \
-    rattler_repodata_gateway            0.28.2  8f6236f9cefc9a3219a2570d32d2250168d314faf2741e9bafd0c2f1feb3b984 \
-    rattler_shell                      0.26.12  88d7bca1c7fd2a6fac62f9716cfcf3967b1360c9a42ad5ab09759f34bba532a7 \
-    rattler_solve                        6.0.2  6b1b27732702160735cc8e81eccbf42209bd503b6fad471e8215713e97ac00f0 \
-    rattler_virtual_packages            2.3.21  7de0c7bae6b12ebc6ca640e97cc6be1f49609cd716d1af520cba2a7faffcad73 \
+    rattler                             0.43.2  188a5ce39ea764f92fb4868ac74a722e27d33a52f3aba18be8ec705fba911cbd \
+    rattler_cache                        0.8.2  c2aa78ff1be938e28fdcdb9837f90da858d090ec1147a00a2aab8490c077f557 \
+    rattler_conda_types                 0.46.4  6018a34d7edb8a6b97c971ba935e59d217a0986376d14f4d515fb238b28bdf02 \
+    rattler_digest                       1.3.0  3c44304c9353802e910fac1dbdf6e16df44c341d07b1850bc1fd8b03912cbaab \
+    rattler_macros                       1.1.0  9d44a87a904057524e32dc8beeb50197016cec467d487bce9d64e044adbcaeb5 \
+    rattler_menuinst                    0.2.62  0ac99b44fac7a9e6cb4bd65cee12c3ec281db52284f6c85fc929b1d1b775cea8 \
+    rattler_networking                  0.27.2  19984b40494bdbaf785525ba36fdb1fa487fe44a36b4214851af4428c69ecf27 \
+    rattler_package_streaming           0.26.2  eefa295dc7b49aa0b67d125400561d2b45b754c66c0f7a19e8fc375b1056bfa9 \
+    rattler_pty                         0.2.12  30f42171f331905af5752aeba3bd1a539b73a35d0754b7db9f7d06a314ad913e \
+    rattler_redaction                    0.2.1  2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b \
+    rattler_repodata_gateway            0.29.2  76d033dc7d25fedc1918719b6d084983436d1cea15621ab5f4c8d722c9020376 \
+    rattler_shell                       0.27.2  b57f7b11f6e6d0ef88e5d93b3ba5ea1c0cedeaa58195ec4e75680b465f38dc43 \
+    rattler_solve                        7.1.1  eef2142527283596cad4f0b89f4fa0c87a2e20831bf8ef51422d72c9fc6bc316 \
+    rattler_virtual_packages             2.4.1  b0820759e1171d6ef08237cc7683181cb7aa954d3586b24142333ffe8c7efb5b \
     rayon                               1.12.0  fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d \
     rayon-core                          1.13.0  22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91 \
     redox_syscall                       0.5.18  ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d \
@@ -705,7 +704,7 @@ cargo.crates \
     rend                                 0.5.3  cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6 \
     reqwest                            0.12.28  eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147 \
     reqwest                             0.13.3  62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0 \
-    resolvo                             0.10.2  57a085c6cecab01bf88df532b7a03f066d5ab92e461bf4614a9de13f562eb163 \
+    resolvo                             0.10.3  2985c35f7dd19ed00659031b77ce05d1828a12eb9c6b37104da21b09d218fc24 \
     retry-policies                       0.5.2  dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47 \
     ring                               0.17.14  a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7 \
     rkyv                                0.8.16  73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3 \
@@ -732,7 +731,6 @@ cargo.crates \
     rustls-pki-types                    1.14.1  30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9 \
     rustls-platform-verifier             0.7.0  26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0 \
     rustls-platform-verifier-android     0.1.1  f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f \
-    rustls-webpki                      0.102.8  64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9 \
     rustls-webpki                     0.103.13  61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e \
     rustversion                         1.0.22  b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d \
     rusty-fork                           0.3.1  cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2 \
@@ -766,7 +764,7 @@ cargo.crates \
     serde_derive                       1.0.228  d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79 \
     serde_derive_internals              0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
     serde_ignored                       0.1.14  115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798 \
-    serde_json                         1.0.149  83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86 \
+    serde_json                         1.0.150  e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9 \
     serde_json_canonicalizer             0.3.2  fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2 \
     serde_plain                          1.0.2  9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50 \
     serde_regex                          1.1.0  a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf \
@@ -797,14 +795,14 @@ cargo.crates \
     signal-hook                          0.4.4  b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d \
     signal-hook-registry                 1.4.8  c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b \
     signature                            2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
-    sigstore-bundle                      0.7.0  0bb2255028e90ba8e7abe7cc49fb04e6f824a8f7a061fc6922f67a48e84ab052 \
-    sigstore-crypto                      0.7.0  ac7172898e15789d69d12469bb3d33397aab0771fb4f8d32cd56972e97808bf3 \
-    sigstore-merkle                      0.7.0  5e86ee272adfcfa21a2248b2fbf05a79b6e39a1fb699ef70c578c814af16e4db \
-    sigstore-rekor                       0.7.0  2448f8a13b91c615c23badca4d7e51b0376539b8723a2a2d43d27c016f9cce08 \
-    sigstore-trust-root                  0.7.0  1bf02c1ab8f7a10db78dbf37cc80bb0f93d2afd636d5c37a572c815cb418b925 \
-    sigstore-tsa                         0.7.0  31ea02ad335b7386c9a72455aecd2be964bef1d7118199858ee4c6d679af48ed \
-    sigstore-types                       0.7.0  ce83bc56c60bbfb197a054d541839ff248c7e1aabf7016f704f8f3e6552fd13c \
-    sigstore-verify                      0.7.0  080e191482c7e040b9bdfd5bd60032915bb0052e5a0944c4881055ef41b6c2cb \
+    sigstore-bundle                      0.8.0  9a86d28a25d9e6107e02ca60fc60dfeb7cdc2b98251950d6fcd055f2afa31acb \
+    sigstore-crypto                      0.8.0  9cdc66f1480e176533425cc880bc5f8a8e0d88ae1fe2701e98de4fb68984b71c \
+    sigstore-merkle                      0.8.0  a4dbea5d8d5f293dfc2ed6abd06dc26a5ef017af126e53e3e36a6b2f7b7dac8c \
+    sigstore-rekor                       0.8.0  fbe0bf948de89bed9b3b5c9d62940264a4da60db3518006b952b107d0e71926f \
+    sigstore-trust-root                  0.8.0  54fdf65b1207f96d4b1e5b44028fe3e078d40a50f6316715f6ad97ae21b0bfeb \
+    sigstore-tsa                         0.8.0  860eb6a645e0a22fa316031b06e9e87f9310c21915743bfa83901472dd3e7146 \
+    sigstore-types                       0.8.0  7fb0334b69834c1f29757e57ade7e9bdbc42f5383cc22d003256d4d2df47af13 \
+    sigstore-verify                      0.8.0  c23f74b41da93e92dc1de793d5450b662fce5c8cea887daa46002a793d78bca9 \
     simd-adler32                         0.3.9  703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214 \
     simd-json                           0.17.0  4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3 \
     simd_cesu8                           1.1.1  94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33 \
@@ -846,7 +844,7 @@ cargo.crates \
     tabled_derive                       0.11.0  0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846 \
     tap                                  1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
     taplo                               0.14.0  c221a50eef1a5493074f11ca1ed62bef28c05a4d925002944cc686b2e783a5b3 \
-    tar                                 0.4.45  22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973 \
+    tar                                 0.4.46  3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840 \
     tempfile                            3.27.0  32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd \
     tera                                1.20.1  e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722 \
     termcolor                            1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
@@ -884,7 +882,7 @@ cargo.crates \
     toml_writer               1.1.1+spec-1.1.0  756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db \
     tough                               0.22.0  8031cff0872dd1c6312370515a6be8098f6ea5512f1bad725016046fc725f272 \
     tower                                0.5.3  ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4 \
-    tower-http                          0.6.10  68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51 \
+    tower-http                          0.6.11  4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840 \
     tower-layer                          0.3.3  121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e \
     tower-service                        0.3.3  8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3 \
     tracing                             0.1.44  63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100 \
@@ -922,7 +920,7 @@ cargo.crates \
     ureq-proto                           0.6.0  e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c \
     url                                  2.5.8  ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed \
     urlencoding                          2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
-    usage-lib                            3.3.0  f5be04c595c37441c24fa5575cd89869f4a7547264f5e3a8be81b73f1c71a66e \
+    usage-lib                            3.4.0  188a4fb4ad9e81729867ebb83ccbc06f850a06362c2467eea0f268fe4f6df609 \
     utf8-zero                            0.8.1  b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e \
     utf8_iter                            1.0.4  b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be \
     utf8parse                            0.2.2  06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821 \
@@ -940,17 +938,18 @@ cargo.crates \
     wasi         0.11.1+wasi-snapshot-preview1  ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b \
     wasip2                    1.0.3+wasi-0.2.9  20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6 \
     wasip3      0.4.0+wasi-0.3.0-rc-2026-01-06  5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5 \
-    wasm-bindgen                       0.2.121  49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790 \
-    wasm-bindgen-futures                0.4.71  96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8 \
-    wasm-bindgen-macro                 0.2.121  8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578 \
-    wasm-bindgen-macro-support         0.2.121  d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2 \
-    wasm-bindgen-shared                0.2.121  c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441 \
+    wasm-bindgen                       0.2.122  3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409 \
+    wasm-bindgen-futures                0.4.72  9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f \
+    wasm-bindgen-macro                 0.2.122  916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6 \
+    wasm-bindgen-macro-support         0.2.122  299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e \
+    wasm-bindgen-shared                0.2.122  9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437 \
     wasm-encoder                       0.244.0  990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319 \
     wasm-metadata                      0.244.0  bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909 \
     wasm-streams                         0.4.2  15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65 \
+    wasm-streams                         0.5.0  9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb \
     wasmparser                         0.244.0  47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe \
     wasmtimer                            0.4.3  1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b \
-    web-sys                             0.3.98  4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa \
+    web-sys                             0.3.99  6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436 \
     web-time                             1.1.0  5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb \
     webpki-root-certs                    1.0.7  f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c \
     webpki-roots                         1.0.7  52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d \


### PR DESCRIPTION
#### Description

mise: Update to 2026.5.18


##### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
