### PR TITLE
ruby-build: Update to 20260520

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20260503 v
+github.setup        rbenv ruby-build 20260520 v
 revision            0
 github.tarball_from archive
 categories          ruby
@@ -17,9 +17,9 @@ maintainers         {macports.halostatue.ca:austin @halostatue} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  b3fe22d48d129b1410635c77692f0ac6fa12ad2f \
-                    sha256  115de494e26edb657b664de9b38dcce6a4afe321a54f66ee7a0b1051c65a6c16 \
-                    size    102849
+checksums           rmd160  36e450a2ea7356674b1ac82956fbada65cd26f7e \
+                    sha256  5ff9f795c3c751eec29aaca25f98d371c1c52c3408d76d8aefb8cc2fcdc8f118 \
+                    size    103026
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20260520


##### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42


##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
