### PR TITLE
python/py-fastapi: update to 0.136.3

### DIFF
--- a/python/py-fastapi/Portfile
+++ b/python/py-fastapi/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-fastapi
-version             0.127.0
+version             0.136.3
 revision            0
 
 categories-append   devel
@@ -21,9 +21,9 @@ long_description    FastAPI is a modern, fast (high-performance), web \
 
 homepage            https://github.com/fastapi/fastapi
 
-checksums           rmd160  cf252d91326baa7bc1c3ba6a35dbad9b455b43db \
-                    sha256  5a9246e03dcd1fdb19f1396db30894867c1d630f5107dc167dcbc5ed1ea7d259 \
-                    size    369269
+checksums           rmd160  a3c141faa4048db6223fa8fe0e2ad6ea0419d926 \
+                    sha256  e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab \
+                    size    396410
 
 python.versions     310 311 312 313 314
 
@@ -33,5 +33,7 @@ if {${name} ne ${subport}} {
     depends_run-append \
                     port:py${python.version}-starlette \
                     port:py${python.version}-pydantic \
-                    port:py${python.version}-typing_extensions
+                    port:py${python.version}-typing_extensions \
+                    port:py${python.version}-typing-inspection \
+                    port:py${python.version}-annotated-doc
 }


### PR DESCRIPTION
## Summary

- Updates `py-fastapi` from 0.127.0 to 0.136.3
- Adds two new required runtime dependencies introduced in this version range: `py-typing-inspection` and `py-annotated-doc` (both already in MacPorts)
- Drops the implicit `starlette<0.51.0` upper-bound constraint — 0.136.3 declares `starlette>=0.46.0` with no ceiling, making it compatible with the recently-updated `py-starlette 1.2.1`

## Motivation

`py-starlette` was updated to 1.2.1 (a major version bump that removed the deprecated `on_startup`/`on_shutdown` parameters from `Router.__init__`). `py-fastapi 0.127.0` still passes those args internally (`routing.py:985-986`), causing any application using FastAPI to crash at import:

```
TypeError: Router.__init__() got an unexpected keyword argument 'on_startup'
```

FastAPI 0.136.3 is the current release and is compatible with Starlette 1.x.

## Test plan

- [ ] `sudo port install py312-fastapi` installs without errors
- [ ] `python3.12 -c "import fastapi; print(fastapi.__version__)"` prints `0.136.3`
- [ ] A simple FastAPI app instantiates without `TypeError`