### PR TITLE
netatalk: update to 4.5.0

### DIFF
--- a/net/netatalk/Portfile
+++ b/net/netatalk/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson 1.0
 PortGroup           legacysupport 1.1
 
 name                netatalk
-version             4.4.3
+version             4.5.0
 revision            0
 categories          net
 description         Netatalk is a freely-available Open Source AFP fileserver.
@@ -15,8 +15,8 @@ long_description    Netatalk is a freely-available Open Source AFP fileserver. \
                     servers for Macintosh computers.
 
 if {${subport} eq ${name}} {
-    github.setup        Netatalk netatalk 4-4-3 netatalk-
-    version             4.4.3
+    github.setup        Netatalk netatalk 4-5-0 netatalk-
+    version             4.5.0
     revision            0
     github.tarball_from releases
     distname            netatalk-${version}
@@ -24,9 +24,9 @@ if {${subport} eq ${name}} {
 
     compiler.c_standard 2011
 
-    checksums       rmd160  309a3fb04e01bf4a5076318f9671cc064e74e6f4 \
-                    sha256  863d640ecc99f4923ead6c58e8d3406ab3a1ca9dd3b0d47ccdf6fdebb6efe3ab \
-                    size    1129884
+    checksums       rmd160  828049d176308bbb3f4e00e27d91992ccba44376 \
+                    sha256  62d77f5a491e69086c1706ff7d9e016912e0e48b43d0c3a7ae60c384b6d625b3 \
+                    size    1303408
     
     license             GPL-2+
     maintainers         {@trodemaster icloud.com:manuals-unread2u} openmaintainer
@@ -42,17 +42,14 @@ if {${subport} eq ${name}} {
                         port:libevent \
                         port:libgcrypt \
                         port:iniparser \
-                        port:tracker3 \
-                        port:dbus \
-                        port:talloc \
                         port:bstring
-    
+
     configure.args-append -Dwith-init-style=none \
                           -Dwith-pam-config-path=${prefix}/etc/pam.d \
                           -Dwith-lockfile-path=${prefix}/var/run \
                           -Dwith-cnid-backends=sqlite,dbd,mysql \
-                          -Dwith-cnid-default-backend=sqlite \
-                          -Dwith-spotlight=true
+                          -Dwith-spotlight=true \
+                          -Dwith-spotlight-backends=cnid
     
     startupitem.create  yes
     startupitem.executable  ${prefix}/sbin/netatalk -d -F ${prefix}/etc/afp.conf
@@ -68,7 +65,7 @@ if {${subport} eq ${name}} {
 subport netatalk4 {
     PortGroup           stub 1.0
 
-    version             4.4.3
+    version             4.5.0
     revision            0
     
     categories          net


### PR DESCRIPTION
#### Description

Update to 4.5.0. Spotlight now uses the cnid backend by default (no
Tracker/D-Bus required), afpstats was rewritten to use a Unix socket
dropping the D-Bus dependency, and -Dwith-cnid-default-backend was
removed (runtime setting in 4.5). Fixes 22 CVEs.

###### Tested on

macOS 15.7.7 24G720 arm64 / Command Line Tools 16.4.0.0.1.1747106510
macOS 26.5 25F71 arm64 / Command Line Tools 26.5.0.0.1777544298

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?