### PR TITLE
libtorrent & rtorrent: update to 0.16.12

### DIFF
--- a/net/libtorrent/Portfile
+++ b/net/libtorrent/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 # Note - releases for libtorrent are provided at https://github.com/rakshasa/rtorrent
 # rather than at the projects own repo, https://github.com/rakshasa/libtorrent
-github.setup        rakshasa rtorrent 0.16.9 v
+github.setup        rakshasa rtorrent 0.16.12 v
 github.tarball_from releases
 name                libtorrent
 distname            libtorrent-${github.version}
@@ -23,9 +23,9 @@ long_description    libTorrent is a BitTorrent library written in C++ for \
                     *nix. It is designed to avoid redundant copying and \
                     storing of data that other clients and libraries suffer from.
 
-checksums           rmd160  fc4d09b77805b341b7f0472f62ffa2e0f76554e0 \
-                    sha256  2c4d8a4add7f14983414fcae3321300106af07c553848a2aaadd11f33764e077 \
-                    size    904418
+checksums           rmd160  a5892d006443076a266c2c09c90800e8c392dc88 \
+                    sha256  4e47701aebc37d6a700a77e759baeb3dc2be12e265d3e5e36716d9803e16e5d5 \
+                    size    907273
 
 use_autoreconf      yes
 

--- a/net/rtorrent/Portfile
+++ b/net/rtorrent/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 # strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        rakshasa rtorrent 0.16.9 v
+github.setup        rakshasa rtorrent 0.16.12 v
 github.tarball_from releases
 revision            0
 
@@ -17,9 +17,9 @@ categories          net
 maintainers         nomaintainer
 license             {GPL-2+ OpenSSLException}
 
-checksums           rmd160  bbda245a5e9c34b286401a476bd20cc382f64bcd \
-                    sha256  8eaadbc65ee80f195be170b0d12e5f3cce6e62bcfd69b80dc27a05898ff31237 \
-                    size    858107
+checksums           rmd160  a1dde64f8377c8365664cc4a779017cfea12c061 \
+                    sha256  46e8b5e9b6daadaf5d3002a3bc5cbde25d6bdc0eb2f17177641cf47ce2d3ef86 \
+                    size    859606
 
 description         console-based BitTorrent client
 


### PR DESCRIPTION
###### Tested on
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?