### PR TITLE
nccmp: Update to 1.11.0.0

### DIFF
--- a/science/nccmp/Portfile
+++ b/science/nccmp/Portfile
@@ -6,11 +6,11 @@ PortGroup           gitlab 1.0
 # this port can optionally be built with cmake (but then tests are run in a different way)
 #PortGroup          cmake 1.1
 
-gitlab.setup        remikz nccmp 1.10.0.0
+gitlab.setup        remikz nccmp 1.11.0.0
 revision            0
-checksums           rmd160  b65c81e56a0112e6675469b9b04b7c0ce57a12cb \
-                    sha256  cc3b5bb1331b08529e076fc9c007907320d2248dd5f4fd3feb99461644a9bfe8 \
-                    size    318500
+checksums           rmd160  b1f8f1876e57964ba3c4bf3aec10883796cb3da8 \
+                    sha256  98d8500a0176edcf5004a46d50fbe5b6b98ea7724cf740e4ade043b545da0f1d \
+                    size    322971
 
 categories          science
 maintainers         {noaa.gov:dave.allured @Dave-Allured} openmaintainer


### PR DESCRIPTION
#### Description

Update nccmp 1.10.0.0 --> 1.11.0.0.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?