### PR TITLE
jenkins-cli: update to 0.0.47

### DIFF
--- a/devel/jenkins-cli/Portfile
+++ b/devel/jenkins-cli/Portfile
@@ -3,10 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/jenkins-zh/jenkins-cli 0.0.46 v
-# Delete this on next update to use golang PortGroup's default ('archive')
-github.tarball_from tarball
-set git_commit      bd33a1b
+go.setup            github.com/jenkins-zh/jenkins-cli 0.0.47 v
+revision            0
+set git_commit      c926d60
 categories          devel
 license             MIT
 
@@ -22,9 +21,9 @@ set short           jcli
 homepage            https://${short}.jenkins-zh.cn
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  6ecfe78efa3c764cb2ae29dfb758f4f2a46c3a86 \
-                        sha256  084e721ef9edd6880dfbdbad9f0224f29a06dd42252c9768e0847c94061deab0 \
-                        size    224132
+                        rmd160  3ad5e43ded1301cbdf6b5ad5c68720976818b559 \
+                        sha256  4e78600e214c357c08a0a83fe9cc59214b0d050de07dbb469d9f226c8c37eabc \
+                        size    227265
 
 # Allows for version number, last commit and build date in `jcli version`
 # Suppress build date for reproducible builds


### PR DESCRIPTION
#### Description
https://github.com/jenkins-zh/jenkins-cli/releases/tag/v0.0.47

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
