### PR TITLE
claude-code: update to 2.1.160

### DIFF
--- a/llm/claude-code/Portfile
+++ b/llm/claude-code/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                claude-code
-version             2.1.159
+version             2.1.160
 revision            0
 
 categories          llm
@@ -26,14 +26,14 @@ platforms           {darwin >= 22}
 
 if {${configure.build_arch} eq "x86_64"} {
     set arch_classifier x64
-    checksums    rmd160  f9855c8ccf08f639aa5e4c16f0a11d00c3667d6c \
-                 sha256  ababd6c754f7e028ab5e4bd74d4d6d3a802cafb57c9d41ea9178e897655c17bd \
-                 size    217764496
+    checksums    rmd160  1baa2cf321fc268a90582014098da4112ae1535a \
+                 sha256  2fb7c11111152f62ab36bd093776d71410fbe047e938fe37719ff65ab76c0714 \
+                 size    219944080
 } elseif {${configure.build_arch} eq "arm64"} {
     set arch_classifier arm64
-    checksums    rmd160  fda5b40927d78e85b07cdeb1dbc1ef2f632fbb79 \
-                 sha256  5adf7b4d349f743d669cd5adf2ce76dbb5e146d8ab99b3a63c5aef2ef15595f9 \
-                 size    215250336
+    checksums    rmd160  e28460129ee097d7343f7a7ca57ea63d460574ba \
+                 sha256  6c9069a9ee0e7b9b6ee43d006c3402e66815e19f87ac4313330cf03f83611968 \
+                 size    217429920
 } else {
     set arch_classifier unsupported_arch
     distfiles


### PR DESCRIPTION
#### Description

Update to Claude Code 2.1.160.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?