### PR TITLE
h3: update to 4.5.0

### DIFF
--- a/gis/h3/Portfile
+++ b/gis/h3/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        uber h3 4.4.1 v
+github.setup        uber h3 4.5.0 v
 github.tarball_from archive
 revision            0
-checksums           rmd160  f05a55cfb58440e2b0993f012b5fbf75856ecaf7 \
-                    sha256  9df719eb878f218c203e424dc5ffca9b98eca4d78ba83928773987649ead404d \
-                    size    18337226
+checksums           rmd160  e3bfb4b9322937ce94d5b01befbd7f1496f44a0a \
+                    sha256  0da8a392a6ff77e76b60e6a331a49497d0935b6b7b6899da7a3e2786139b0441 \
+                    size    18362500
 
 description         A hexagonal hierarchical geospatial indexing system
 


### PR DESCRIPTION
#### Description
h3: update to 4.5.0

###### Tested on
macOS 15.7.3 24G419 arm64
Xcode 26.0.1 17A400

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?