### PR TITLE
weechat: update to 4.9.1

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.9.0
+version             4.9.1
 revision            0
-checksums           rmd160  056d5c7cc42ca4c22d72784c445fdd7ba16e36c8 \
-                    sha256  7cbb9b27f25a7d2f1d8c426a08f8e625eefbc1d3e59bbf775925444f72394b6f \
-                    size    2792516
+checksums           rmd160  2df71c305caa04772f6ba1115b6e4b3584f521fe \
+                    sha256  04960b56e1dd86127f63cf8fd01bbff77c8142f40ae8a941ac3db642d310cde9 \
+                    size    2794772
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 4.9.1

###### Tested on
macOS 15.7.3 24G419 arm64
Xcode 26.2 17C52

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?