### PR TITLE
hugo: update to 0.162.1

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.162.0 v
+go.setup            github.com/gohugoio/hugo 0.162.1 v
 go.offline_build    no
 revision            0
 
-checksums           rmd160  543ade0a6483cbcc206c7b3144816c95318c7070 \
-                    sha256  eca552a365606499e3be6c9b7d04d50560825455db5cf0cc070b5af5b8f36573 \
-                    size    18539659
+checksums           rmd160  e117a1c5b2f621bc6ba0f14dfa6c0a2b5c873ad1 \
+                    sha256  17bb39e6af89d9b176bbfb0c06caf382d2f2af7644b769e2eab28cc084c91381 \
+                    size    18539263
 
 categories          www
 installs_libs       no


### PR DESCRIPTION
#### Description
hugo: update to 0.162.1

###### Tested on
macOS 15.7.3 24G419 arm64
Xcode 26.2 17C52

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?