### PR TITLE
cdo: Update to 2.6.1

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,7 +5,7 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.1
 
 name                        cdo
-version                     2.6.0
+version                     2.6.1
 revision                    0
 maintainers                 {takeshi @tenomoto} \
                             {me.com:remko.scharroo @remkos} \
@@ -14,11 +14,11 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/30182
+master_sites                https://code.mpimet.mpg.de/attachments/download/30210
 
-checksums           rmd160  c5680c655c272a227d8dbf286fe4963212cdb54a \
-                    sha256  752d5cda6fa3fdb8a04dcea16af5918e5f9f54657d9a5d2e35ae34f5755c31d8 \
-                    size    13654519
+checksums           rmd160  3921412c349ff7271c577dda7f2be2b2adec8b7b \
+                    sha256  ccf5f3bd5800f703c031bb5b10ae0cd3feac34d8eba7956661ff1ba6deb5985f \
+                    size    13661502
 
 long_description \
     CDO is a collection of command line Operators               \
@@ -32,9 +32,16 @@ fetch.ignore_sslcert        yes
 # https://code.mpimet.mpg.de/news/536
 compiler.cxx_standard       2020
 
+# workerthread.h:31:8: error: no type named 'jthread' in namespace 'std'
+# https://libcxx.llvm.org/Status/Cxx20.html#cxx20-status:
+# jthread = P0660R10, Stop Token and Joining Thread, Rev 10
+# Use blacklist. -fexperimental-library does not work with some clang versions.
+compiler.blacklist-append   {clang < 1800}
+
+# Historical note only.  Superseded by 1800 above.
 # fatal error: 'ranges' file not found. Retrying the clang limits set previously.
 # See discussion https://github.com/macports/macports-ports/pull/32476
-compiler.blacklist-append   {clang < 1500}
+# compiler.blacklist-append   {clang < 1500}
 
 compiler.thread_local_storage yes
 compilers.choose            cc cxx


### PR DESCRIPTION
#### Description

* Update CDO 2.6.0 --> 2.6.1.
* Require newer clang versions, because C++20 jthreads usage was added.
* Jthreads support was delayed in clang and Xcode clang c++20 versions.
* This may be due to delayed jthreads support in libc++.

###### Type(s)

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?