### PR TITLE
google-cloud-sdk: update to 571.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             570.0.0
+version             571.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     set arch_classifier x86
-    checksums       rmd160  d1dec37a6aff6db9be8596093a0ee3f47bcf9e81 \
-                    sha256  1ce3c123de7f23000ca88ebbcc98f9fe9a5b6720c9daefd01cbfa1e17ff52b87 \
-                    size    58994281
+    checksums       rmd160  ee0a72c5c5588189d6cf2a2637f1d70e2224f1c8 \
+                    sha256  c08136c499741c4c3e242366acd61bbf9f44e0fa4da7367ba8d2daab3323dff8 \
+                    size    59044287
 } elseif { ${configure.build_arch} eq "x86_64" } {
     set arch_classifier x86_64
-    checksums       rmd160  06be7277961d2c2de24dbbdb97ba29173d91b7cf \
-                    sha256  ad2aad8f8e03d06a69b4d0aea28938bb34bb41f152093bb8ca1f8c8b64ce66be \
-                    size    60652003
+    checksums       rmd160  940dc6074ff537a5b1a8a2fd2616e15e0035dd39 \
+                    sha256  d2a10cd9764049ca372be29664fdd4f12403d2b839937b36000709f7f57a2ddd \
+                    size    60702560
 } elseif { ${configure.build_arch} eq "arm64" } {
     set arch_classifier arm
-    checksums       rmd160  cc33b8295f1b8d10671d9f3a3c750844a5a3938a \
-                    sha256  faf31849cb6737fe5a2d4e56ab7f3941ac7107908a7b6c9ba6099a4ac95fc66e \
-                    size    60553706
+    checksums       rmd160  10ecc387ff19fa4c785b464183107fa4e727ad7b \
+                    sha256  8766ab5ed370cfd38db3c257cfe496c1e1e8356569d55928d5b1f935891bb7c0 \
+                    size    60608693
 } else {
     set arch_classifier invalid
 }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 571.0.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?