### PR TITLE
cloudflare-speed-cli: update to 1.0.1

### DIFF
--- a/net/cloudflare-speed-cli/Portfile
+++ b/net/cloudflare-speed-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cargo  1.0
 
-github.setup            kavehtehrani cloudflare-speed-cli 0.6.14 v
+github.setup            kavehtehrani cloudflare-speed-cli 1.0.1 v
 github.tarball_from     archive
 
 revision                0
@@ -22,9 +22,9 @@ long_description        {*}${description}. Measures download and upload throughp
                         a specific network interface or source IP if required.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  9d336848cf6684a5fd1c1fa09353549464ca9e32 \
-                        sha256  122344843ea9d3cb06ab8fab3b6e148e8b854322747c7aa2974e0faf4b9269a4 \
-                        size    686132
+                        rmd160  6681fcfd8595fefb5871983c4b62f01ebd1c536c \
+                        sha256  14c718c89e9958d6f521ccb2973c8b33a74765106b21601332b9fbb0231deec7 \
+                        size    691184
 
 # The TUI feature requires the 'tui' cargo feature flag.
 build.args-append       --features tui


### PR DESCRIPTION
#### Description

•  Adds buffer grade and stability scores.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 26.5 25F71 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
I have:

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`? → see comment below.
- [x] tried a full install with `sudo port -vst install`? → fails when using the -t switch, I think this is a known issue?
- [x] tested basic functionality of all binary files?

`port lint` → 0 errors. Warnings are limited to per-crate `missing recommended checksum type: rmd160 / size`, which is the standard form used by every other Rust port in the tree (e.g. `audio/mp3rgain`, `textproc/ripgrep`, `sysutils/eza`).
