### PR TITLE
Better fix for etags-program-name

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -132,29 +132,29 @@ if {$subport eq $name || $subport eq "emacs-app"} {
     checksums       rmd160  fefdd3fcd453d733114f609a3e122b2529cc7410 \
                     sha256  1d79a4ba4d6596f302a7146843fe59cf5caec798190bcc07c907e7ba244b076d \
                     size    83059014
+
+    # reported upstream as bug#81166
+    patchfiles-append   patch-gsettings-null-check.diff
 }
 
 patchfiles-append   patch-allow-powerpc.diff
-
-# reported upstream as bug#81166
-patchfiles-append   patch-gsettings-null-check.diff
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     PortGroup       github 1.0
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs cda03bebfc061174229bb8b9816f04a9ed537038
+    github.setup    emacs-mirror emacs 2db5a145acbbe84042128806d8b2e333495cf70e
     github.tarball_from archive
     epoch           5
-    version         20260522
-    revision        2
+    version         20260602
+    revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  0c95a3ae80348a1522ae281853828d0277720658 \
-                    sha256  bba69f1913b918e9c5544021562292d9a2db4e019135655bee06e817881a5ce6 \
-                    size    53888524
+    checksums       rmd160  e8e565e0518b40c77b309e78c1e30d09481e4adf \
+                    sha256  fd68bcb1d848d7267fda77d1fb84d2236c14941a0694d51d0f383ecdaa1f7c04 \
+                    size    53929116
 
     livecheck.type none
 

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -92,21 +92,6 @@ depends_lib-append     port:gmp \
 
 compiler.blacklist-append   *gcc-4.0 *gcc-4.2
 
-post-patch {
-    if {$subport eq $name || $subport eq "emacs-devel"} {
-        # Make etags-program-name match the etags binary, which we
-        # rename to etags-emacs in post-destroot to avoid conflicts
-        # with xemacs. See https://trac.macports.org/ticket/72136.
-        reinplace -E {s|(Vetags_program_name = build[a-z_]*_string )\("etags"\)|\1("etags-emacs")|} \
-            ${worksrcpath}/src/callproc.c
-        if {[catch {exec grep -qF {("etags-emacs")} ${worksrcpath}/src/callproc.c}]} {
-            return -code error "Failed to patch etags-program-name in src/callproc.c;\
-                upstream source may have changed. See\
-                https://trac.macports.org/ticket/72136"
-        }
-    }
-}
-
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/emacs/${version}/leim
     delete ${destroot}${prefix}/bin/ctags
@@ -116,6 +101,10 @@ post-destroot {
         # avoid conflicts with xemacs
         move ${destroot}${prefix}/bin/etags ${destroot}${prefix}/bin/etags-emacs
         move ${destroot}${prefix}/share/man/man1/etags.1.gz ${destroot}${prefix}/share/man/man1/etags-emacs.1.gz
+
+        file mkdir ${destroot}${prefix}/share/emacs/site-lisp
+        file copy ${filespath}/site-start.el \
+            ${destroot}${prefix}/share/emacs/site-lisp/site-start.el
     }
 }
 
@@ -139,7 +128,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         30.2
-    revision        10
+    revision        11
     checksums       rmd160  fefdd3fcd453d733114f609a3e122b2529cc7410 \
                     sha256  1d79a4ba4d6596f302a7146843fe59cf5caec798190bcc07c907e7ba244b076d \
                     size    83059014
@@ -291,6 +280,8 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
         file copy ${filespath}/site-start-app.el \
             ${destroot}${applications_dir}/Emacs.app/Contents/Resources/site-lisp/site-start.el
         reinplace "s|__PREFIX__|${prefix}|g" \
+            ${destroot}${applications_dir}/Emacs.app/Contents/Resources/site-lisp/site-start.el
+        reinplace "s|__APPLICATIONS_DIR__|${applications_dir}|g" \
             ${destroot}${applications_dir}/Emacs.app/Contents/Resources/site-lisp/site-start.el
     }
 

--- a/editors/emacs/files/site-start-app.el
+++ b/editors/emacs/files/site-start-app.el
@@ -16,3 +16,5 @@
 ;; Use the OS X Emoji font for Emoticons
 (when (fboundp 'set-fontset-font)
   (set-fontset-font t 'emoji '("Apple Color Emoji" . "iso10646-1") nil 'prepend))
+
+(setq etags-program-name "__APPLICATIONS_DIR__/Emacs.app/Contents/MacOS/bin/etags")

--- a/editors/emacs/files/site-start.el
+++ b/editors/emacs/files/site-start.el
@@ -1,0 +1,3 @@
+;;  -*- lexical-binding: t; -*-
+
+(setq etags-program-name "etags-emacs")


### PR DESCRIPTION
#### Description

https://trac.macports.org/ticket/72136

The previous fix was brittle and didn't address the -app subports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
