### PR TITLE
kotlin: update to 2.4.0

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 2.3.21 v
+github.setup        JetBrains kotlin 2.4.0 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,12 +24,12 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  d3fccd3d034b98135c731b8da0a36cab7f0928d6 \
-                    sha256  a8cfc1d62cd4d0de4d04f42575e40135bd620588c17d568a20eb9c7c259af14f \
-                    size    83084350
+checksums           rmd160  ccd68a9978280291e9105be6ca74b68c48f0ee44 \
+                    sha256  ba1b9e6eb6ddc3275079224f2e9ea4a2b02eef7d59ce2d38404f04b22613c20a \
+                    size    87073707
 
 java.version        1.8+
-java.fallback       openjdk21
+java.fallback       openjdk25
 
 worksrcdir          kotlinc
 


### PR DESCRIPTION
#### Description

Update to Kotlin 2.4.0.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?