### PR TITLE
openspec: update to 1.4.1

### DIFF
--- a/llm/openspec/Portfile
+++ b/llm/openspec/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                openspec
-version             1.4.0
+version             1.4.1
 revision            0
 
 categories          llm
@@ -23,6 +23,6 @@ homepage            https://openspec.dev
 npm.rootname        @fission-ai/${name}
 distname            ${name}-${version}
 
-checksums           rmd160  03dde7857eb7be6e87e44f50fecafecb7b176c5c \
-                    sha256  b0ed5b14e3ff20ed45e1f7b5f1a37c847db437386b5fa2c98097fff8a0537f78 \
-                    size    291850
+checksums           rmd160  aa0f514f668473cf4ec20c331740f2a7b699560e \
+                    sha256  c039b617a961499f49466791842619189998edddc8b05cfedb22c32142a0c77a \
+                    size    291917


### PR DESCRIPTION
#### Description

Update to OpenSpec 1.4.1.

###### Tested on

macOS 26.5.1 25F80 arm64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?