### PR TITLE
spirv-llvm-translator-22: update to 22.1.3

### DIFF
--- a/lang/llvm-22/Portfile
+++ b/lang/llvm-22/Portfile
@@ -195,16 +195,18 @@ if {${os.platform} eq "darwin" && ${os.major} <= 16} {
 }
 
 post-patch {
-    reinplace "s|@@PREFIX@@|${prefix}|" \
-        ${patch.dir}/clang/lib/Driver/ToolChains/Clang.cpp \
-        ${patch.dir}/clang/lib/Driver/ToolChains/CommonArgs.cpp
+    if {${subport} ne "spirv-llvm-translator-${llvm_version}"} {
+        reinplace "s|@@PREFIX@@|${prefix}|" \
+            ${patch.dir}/clang/lib/Driver/ToolChains/Clang.cpp \
+            ${patch.dir}/clang/lib/Driver/ToolChains/CommonArgs.cpp
 
-    reinplace "s|@CLANG_FORMAT_PATH@|${prefix}/bin/clang-format-${suffix}|g" \
-        ${patch.dir}/clang/tools/clang-format/clang-format-bbedit.applescript \
-        ${patch.dir}/clang/tools/clang-format/clang-format-diff.py            \
-        ${patch.dir}/clang/tools/clang-format/clang-format-sublime.py         \
-        ${patch.dir}/clang/tools/clang-format/clang-format.el                 \
-        ${patch.dir}/clang/tools/clang-format/clang-format.py
+        reinplace "s|@CLANG_FORMAT_PATH@|${prefix}/bin/clang-format-${suffix}|g" \
+            ${patch.dir}/clang/tools/clang-format/clang-format-bbedit.applescript \
+            ${patch.dir}/clang/tools/clang-format/clang-format-diff.py            \
+            ${patch.dir}/clang/tools/clang-format/clang-format-sublime.py         \
+            ${patch.dir}/clang/tools/clang-format/clang-format.el                 \
+            ${patch.dir}/clang/tools/clang-format/clang-format.py
+    }
 }
 
 livecheck.type      regex
@@ -393,8 +395,8 @@ if {${subport} eq "libclc-${llvm_version}"} {
 }
 
 subport spirv-llvm-translator-${llvm_version} {
-    version             ${llvm_version}.1.1
-    revision            1
+    version             ${llvm_version}.1.3
+    revision            0
     homepage            https://github.com/KhronosGroup/SPIRV-LLVM-Translator
     description         LLVM/SPIR-V Bi-Directional Translator
     long_description    A library and tool for translation between LLVM IR and \
@@ -403,22 +405,34 @@ subport spirv-llvm-translator-${llvm_version} {
     set dist            SPIRV-LLVM-Translator-${version}
     distfiles-append    $dist.tar.gz
     checksums-append    $dist.tar.gz \
-                        rmd160  a1f0f4c94021230237ba6a2082f47dd726e8c344 \
-                        sha256  83e7007b8b9b5536b30991661738a98e9cd607d4a203e9342b628aaea5ea32d7 \
-                        size    1866828
+                        rmd160  eae29f2f1902f5b8134f52fe52251d4ed857e76f \
+                        sha256  8d3d5c31c1ff355dbbf87046f1b94cd1ab5390439a817679ec71484df74cac18 \
+                        size    1871217
+    # Bundle the SPIRV-Headers commit required by this translator version;
+    # it postdates all released SPIRV-Headers tags.
+    set spirv_headers_commit b8a32968473ce852a809b9de5f04f02a5a9dfa78
+    master_sites-append https://github.com/KhronosGroup/SPIRV-Headers/archive/:spirv_headers
+    distfiles-append    ${spirv_headers_commit}.tar.gz:spirv_headers
+    checksums-append    ${spirv_headers_commit}.tar.gz \
+                        rmd160  6ff3b44d75ad4deace3898adaeba644fc5b05f8c \
+                        sha256  ac53436ab612fbc6e294c775a5031f5a6710ec10bb536dea333fb10c30ea24c3 \
+                        size    566287
     depends_build-append \
-                        port:spirv-headers \
                         port:spirv-tools
     depends_lib-append \
                         port:llvm-${llvm_version}
+    # Build standalone against installed llvm-${llvm_version}; skip the large
+    # LLVM source tarball and the LLVM-specific patches.
+    # SPIRV-LLVM-Translator uses RULE_LAUNCH_COMPILE to embed ccache in ninja
+    # rules directly; disable it via the upstream cmake variable.
+    configure.args-append \
+                        -DCCACHE_ALLOWED=OFF
     extract.cmd         gzip
-    # Out-of-tree build
-    worksrcdir          ${worksrcdir}/projects/SPIRV-LLVM-Translator
-    post-extract {
-        move ${workpath}/$dist ${worksrcpath}
-    }
+    extract.only        ${dist}.tar.gz ${spirv_headers_commit}.tar.gz
+    patchfiles          {}
+    worksrcdir          ${dist}
     configure.args-append   -DLLVM_SPIRV_INCLUDE_TESTS=OFF \
-                            -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${prefix}
+                            -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${workpath}/SPIRV-Headers-${spirv_headers_commit}
     build.target        llvm-spirv
     livecheck.url       ${homepage}/tags
     livecheck.regex     v([quotemeta ${llvm_version}.]\[\\d.\]+)\\.tar\\.gz


### PR DESCRIPTION
Also update spirv-llvm-translator-22 to 22.1.3.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5.1 25F80 x86_64
Xcode 26.5 17F42

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
