### PR TITLE
fastfetch: disable lua to fix compile error

### DIFF
--- a/sysutils/fastfetch/Portfile
+++ b/sysutils/fastfetch/Portfile
@@ -43,7 +43,8 @@ legacysupport.newest_darwin_requires_legacy \
 configure.args-append \
                     -DENABLE_SYSTEM_YYJSON=ON \
                     -DENABLE_VULKAN=OFF \
-                    -DENABLE_OPENCL=OFF
+                    -DENABLE_OPENCL=OFF \
+                    -DENABLE_LUA=OFF
 
 compiler.c_standard     2011
 compiler.cxx_standard   2017


### PR DESCRIPTION
#### Description

Last fastfetch update (ba9f2e4) failed for me with compilation error:
```
:info:build In file included from /opt/local/var/macports/build/fastfetch-f7843894/work/fastfetch-2.64.0/src/common/impl/lua.c:3:
:info:build /opt/local/var/macports/build/fastfetch-f7843894/work/fastfetch-2.64.0/src/common/lua.h:159:33: error: conflicting types for 'lua_rawlen'
:info:build   159 | FF_A_ALWAYS_INLINE lua_Unsigned(lua_rawlen)(lua_State* L, int idx) {
:info:build       |                                 ^
:info:build /opt/local/include/lua.h:184:26: note: previous declaration is here
:info:build   184 | LUA_API size_t          (lua_rawlen) (lua_State *L, int idx);
```

Release notes for fastfetch ([2.64](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.64.0))  says:
>New optional build dependencies:
> - [libva](https://github.com/intel/libva) and [libvdpau](https://www.freedesktop.org/wiki/Software/VDPAU) for the new Codec module.
> -  [Lua 5.3 to 5.5](https://www.lua.org/) for Lua scripting support
>
> Features:
>[...]
> - Adds experimental Lua script support
>[...]
>Supported Lua versions: Lua 5.3 to 5.5 (Lua 5.1 and LuaJIT are not supported). The Lua version is auto-detected at build time. Once built, users can check the configured Lua version using fastfetch --list-features.

I have lua version 5.3.6 installed, but it does not compile as shown above.

Until some better fix this PR disables optional lua support to fix broken update.


###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 15.7.7 24G720 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
