### PR TITLE
gtk3, gtk3-devel: fix livecheck pointing to old gtk

### DIFF
--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -344,7 +344,8 @@ post-activate {
 }
 
 livecheck.type      gnome
-livecheck.name      gtk+
+# versions 3.24.48+ are not stored on historic gtk+ dir anymore
+livecheck.name      ${proj_name}
 # versions 3.89.1+ are snapshots of unstable development leading to GTK+ 4
 # and are not compatible with gtk3
 livecheck.regex     "LATEST-IS-(${port_ver_major}\\.\[0-7\]\[02468\](?:\\.\\d+)*)"

--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -343,7 +343,8 @@ post-activate {
 }
 
 livecheck.type      gnome
-livecheck.name      gtk+
+# versions 3.24.48+ are not stored on historic gtk+ dir anymore
+livecheck.name      ${proj_name}
 # versions 3.89.1+ are snapshots of unstable development leading to GTK+ 4
 # and are not compatible with gtk3
 livecheck.regex     "LATEST-IS-(${port_ver_major}\\.\[0-7\]\[02468\](?:\\.\\d+)*)"


### PR DESCRIPTION
Should fix this error from ports.macports.org:

<img width="363" height="189" alt="Captura de Tela 2026-06-04 às 10 52 54" src="https://github.com/user-attachments/assets/e522a632-80b3-407a-abb1-3863a57dfb29" />

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Command Line Tools 26.5.0.0.1777544298

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
