### PR TITLE
lcms2: update to 2.19.1, fix livecheck skipping minor versions

### DIFF
--- a/graphics/lcms2/Portfile
+++ b/graphics/lcms2/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem              1.0
 PortGroup               muniversal 1.0
+PortGroup               github 1.0
 
 name                    lcms2
-version                 2.19
+github.setup            mm2 Little-CMS 2.19.1 lcms
 revision                0
 worksrcdir              lcms2-${version}
 categories              graphics
@@ -22,12 +23,14 @@ long_description        LCMS is the Little Color Management System, a portable \
 
 homepage                https://littlecms.com/
 
+distname                ${name}-${version}
+github.tarball_from     releases
 master_sites            sourceforge:project/lcms/lcms/${version}/ \
                         ${homepage}
 
-checksums           rmd160  afdedef0b0cfd7860a63d6d9f89e68807dea7949 \
-                    sha256  49e7e134e4299733dd0eda434fa468997a28ab3d33fa397c642b03644f552216 \
-                    size    5726199
+checksums           rmd160  e89db66cf9e9396f58948edeaf4d7e64e6d89075 \
+                    sha256  bfc54f7bab59fbc921012014a8032e4cba4abd46db47d46b76416a8c0b2815c8 \
+                    size    5728743
 
 # Disable use of obsolete 'register' storage class; causes dependent build errors with newer compilers:
 # lcms2.h: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
@@ -46,6 +49,5 @@ if {[vercmp ${xcodeversion} 10.0] >= 0 && ${universal_possible} && [variant_isse
 test.run                yes
 test.target             check
 
-livecheck.type          regex
-livecheck.url           https://littlecms.com/tags/releases
-livecheck.regex         "Little CMS (\\d+(?:\\.\\d+)+)"
+# only allow numbers, to avoid pre-release versions
+github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Command Line Tools 26.5.0.0.1777544298

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
