### PR TITLE
pango, pango-devel: fix livecheck always returning 1.90

### DIFF
--- a/x11/pango-devel/Portfile
+++ b/x11/pango-devel/Portfile
@@ -158,5 +158,8 @@ post-destroot {
         ${destroot}${docdir}
 }
 
-livecheck.type          gnome-with-unstable
-livecheck.name          ${my_name}
+#we use regex because `livecheck.type gnome` always returns 1.90
+#(also, unlike other gnome projects, there is no unstable/stable distinction)
+livecheck.type          regex
+livecheck.url           https://gitlab.gnome.org/GNOME/pango/-/tags
+livecheck.regex         {/-/tags/([0-9.]+)"}

--- a/x11/pango/Portfile
+++ b/x11/pango/Portfile
@@ -157,5 +157,8 @@ post-destroot {
         ${destroot}${docdir}
 }
 
-livecheck.type          gnome
-livecheck.name          ${my_name}
+#we use regex because `livecheck.type gnome` always returns 1.90
+#(also, unlike other gnome projects, there is no unstable/stable distinction)
+livecheck.type          regex
+livecheck.url           https://gitlab.gnome.org/GNOME/pango/-/tags
+livecheck.regex         {/-/tags/([0-9.]+)"}


### PR DESCRIPTION
Should fix this message from ports.macports.org:

<img width="360" height="153" alt="Captura de Tela 2026-06-04 às 13 18 18" src="https://github.com/user-attachments/assets/0209ad45-2bb0-44f8-80ba-eb4fdb795415" />

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 26.5 25F71 arm64
Command Line Tools 26.5.0.0.1777544298

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? (-x11 +quartz`)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
